### PR TITLE
refactor(subscriptions): extract default billing cycle into a named constant

### DIFF
--- a/internal/db/models/subscription.go
+++ b/internal/db/models/subscription.go
@@ -22,6 +22,11 @@ const (
 	StatusCancelled SubscriptionStatus = "cancelled" // Will never rebill again (user cancelled, max retries, admin cancelled, expired)
 )
 
+// DefaultBillingCycle is the fallback billing period applied when a Price has
+// no explicit BillingCycleDays. Kept at 30 days to match the historical
+// behaviour callers relied on before the constant was extracted.
+const DefaultBillingCycle = 30 * 24 * time.Hour
+
 // CancelType represents who/what caused the cancellation
 type CancelType string
 
@@ -87,18 +92,14 @@ func (s *Subscription) updateCurrentPeriods(billingCycle *time.Duration) {
 
 	if s.CurrentPeriodEndsAt != nil && !s.CurrentPeriodEndsAt.IsZero() {
 		periodStartsAt = *s.CurrentPeriodEndsAt
-		if billingCycle != nil {
-			periodEndsAt = periodStartsAt.Add(*billingCycle)
-		} else {
-			periodEndsAt = periodStartsAt.Add(30 * 24 * time.Hour)
-		}
 	} else {
 		periodStartsAt = time.Now()
-		if billingCycle != nil {
-			periodEndsAt = periodStartsAt.Add(*billingCycle)
-		} else {
-			periodEndsAt = periodStartsAt.Add(30 * 24 * time.Hour)
-		}
+	}
+
+	if billingCycle != nil {
+		periodEndsAt = periodStartsAt.Add(*billingCycle)
+	} else {
+		periodEndsAt = periodStartsAt.Add(DefaultBillingCycle)
 	}
 
 	s.CurrentPeriodStartsAt = &periodStartsAt

--- a/internal/db/models/subscription_test.go
+++ b/internal/db/models/subscription_test.go
@@ -21,3 +21,37 @@ func TestSubscriptionClearRetrySchedule(t *testing.T) {
 		t.Fatalf("expected retry schedule fields to be cleared")
 	}
 }
+
+func TestDefaultBillingCycleIs30Days(t *testing.T) {
+	if got, want := DefaultBillingCycle, 30*24*time.Hour; got != want {
+		t.Fatalf("DefaultBillingCycle = %v, want %v", got, want)
+	}
+}
+
+func TestUpdateCurrentPeriodsFallsBackToDefaultCycle(t *testing.T) {
+	priorEnd := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	sub := &Subscription{CurrentPeriodEndsAt: &priorEnd}
+
+	sub.updateCurrentPeriods(nil)
+
+	if sub.CurrentPeriodStartsAt == nil || !sub.CurrentPeriodStartsAt.Equal(priorEnd) {
+		t.Fatalf("CurrentPeriodStartsAt = %v, want %v", sub.CurrentPeriodStartsAt, priorEnd)
+	}
+	wantEnd := priorEnd.Add(DefaultBillingCycle)
+	if sub.CurrentPeriodEndsAt == nil || !sub.CurrentPeriodEndsAt.Equal(wantEnd) {
+		t.Fatalf("CurrentPeriodEndsAt = %v, want %v", sub.CurrentPeriodEndsAt, wantEnd)
+	}
+}
+
+func TestUpdateCurrentPeriodsHonoursExplicitCycle(t *testing.T) {
+	priorEnd := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	sub := &Subscription{CurrentPeriodEndsAt: &priorEnd}
+	cycle := 7 * 24 * time.Hour
+
+	sub.updateCurrentPeriods(&cycle)
+
+	wantEnd := priorEnd.Add(cycle)
+	if sub.CurrentPeriodEndsAt == nil || !sub.CurrentPeriodEndsAt.Equal(wantEnd) {
+		t.Fatalf("CurrentPeriodEndsAt = %v, want %v (explicit cycle must override default)", sub.CurrentPeriodEndsAt, wantEnd)
+	}
+}

--- a/internal/modules/subscriptions/lifecycle_service.go
+++ b/internal/modules/subscriptions/lifecycle_service.go
@@ -277,7 +277,7 @@ func (s *SubscriptionLifecycleService) createMembershipCore(ctx context.Context,
 	} else if price.BillingCycleDays != nil && *price.BillingCycleDays > 0 {
 		periodEndsAt = now.Add(time.Duration(*price.BillingCycleDays) * 24 * time.Hour)
 	} else {
-		periodEndsAt = now.Add(30 * 24 * time.Hour)
+		periodEndsAt = now.Add(models.DefaultBillingCycle)
 	}
 	product, err := productService.GetByID(ctx, price.ProductID)
 	if err != nil {


### PR DESCRIPTION
## Summary

Companion cleanup from the cozy.art Stripe review (cozy-creator/cozy.art#188). The 30-day billing-cycle fallback was duplicated across three production sites:

- `internal/db/models/subscription.go` — two branches of `updateCurrentPeriods`
- `internal/modules/subscriptions/lifecycle_service.go` — `CreateMembership`

Pull it into a single `models.DefaultBillingCycle` constant, collapse the duplicated branches in `updateCurrentPeriods`, and add unit tests that pin both the constant's value (30 days) and the fallback path through `updateCurrentPeriods`.

No behaviour change — the constant equals the literal it replaces.

## Test plan

- [ ] `go test ./internal/db/models/...` passes locally
- [ ] `go build ./...` succeeds
- [ ] `models.DefaultBillingCycle == 30 * 24 * time.Hour` (test added)
- [ ] `updateCurrentPeriods(nil)` falls back to the default; an explicit billing cycle overrides it (tests added)

## Notes

I do not have direct push access to `open-rails/openrails`, so this PR ships from my fork (`rodrigodsluz/openrails`). Happy to redo it from a branch in this repo if a maintainer pushes it over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)