### PR TITLE
fix(#364): checkout resolves tenant subjects instead of deriving — un-breaks legacy (non-UUID) subjects

### DIFF
--- a/internal/db/repo/payment.go
+++ b/internal/db/repo/payment.go
@@ -102,6 +102,15 @@ func (r *PaymentRepo) Create(ctx context.Context, payment *models.Payment) error
 	return nil
 }
 
+// EnsureSubjectID resolves-or-creates the payable tenant-subject id for a raw
+// user/subject string (#364). UUID subjects map to themselves; non-UUID legacy
+// subjects get (or reuse) a materialized tenant_subjects row. Commerce writers
+// must stamp this id — deriving via identity.TenantSubjectIDFromString yields
+// uuid.Nil for legacy subjects and mis-attributes the row.
+func (r *PaymentRepo) EnsureSubjectID(ctx context.Context, userID string) (uuid.UUID, error) {
+	return EnsureTenantSubjectID(ctx, r.db.Qx(ctx), uuid.Nil, userID)
+}
+
 func (r *PaymentRepo) CreateIfNotExists(ctx context.Context, payment *models.Payment) (bool, error) {
 	if err := ensureTenantSubjectRow(ctx, r.db.Qx(ctx), uuid.Nil, payment.TenantSubjectID); err != nil {
 		return false, err

--- a/internal/db/repo/subscription.go
+++ b/internal/db/repo/subscription.go
@@ -101,6 +101,18 @@ func (r *SubscriptionRepo) Create(ctx context.Context, s *models.Subscription) e
 	return nil
 }
 
+// EnsureSubjectID resolves-or-creates the payable tenant-subject id for a raw
+// user/subject string (#364) — the write-path companion of ResolveSubjectID.
+func (r *SubscriptionRepo) EnsureSubjectID(ctx context.Context, userID string) (uuid.UUID, error) {
+	return EnsureTenantSubjectID(ctx, r.db.Qx(ctx), uuid.Nil, userID)
+}
+
+// ResolveSubjectID resolves the payable tenant-subject id for a raw user/subject
+// string WITHOUT creating a row (#364). Unknown legacy subjects yield uuid.Nil.
+func (r *SubscriptionRepo) ResolveSubjectID(ctx context.Context, userID string) (uuid.UUID, error) {
+	return ResolveTenantSubjectID(ctx, r.db.Qx(ctx), uuid.Nil, userID)
+}
+
 func (r *SubscriptionRepo) Update(ctx context.Context, s *models.Subscription) error {
 	return r.UpdateAt(ctx, s, time.Now())
 }

--- a/internal/modules/checkout/nmi_sale_service.go
+++ b/internal/modules/checkout/nmi_sale_service.go
@@ -15,7 +15,6 @@ import (
 	"github.com/open-rails/openrails/internal/modules/payments"
 	"github.com/open-rails/openrails/internal/modules/vault"
 	"github.com/open-rails/openrails/internal/shared/uuidutil"
-	"github.com/open-rails/openrails/pkg/identity"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -131,9 +130,15 @@ func (s *CheckoutNMISaleService) Process(ctx context.Context, req *CheckoutReque
 		return nil, fmt.Errorf("load NMI sale attempt: %w", err)
 	}
 
+	subjectID, err := s.PurchaseService.PaymentService.EnsureSubjectID(ctx, user.ID)
+	if err != nil {
+		_ = s.IdempotencyStore.Fail(ctx, idempOp, idempotencyKey, err)
+		return nil, fmt.Errorf("resolve tenant subject for NMI sale attempt: %w", err)
+	}
+
 	attempt, err := s.PurchaseService.PaymentService.ReserveProviderAttempt(ctx, &models.Payment{
 		ID:              uuidutil.NewV7(),
-		TenantSubjectID: identity.TenantSubjectIDFromString(user.ID).UUID(),
+		TenantSubjectID: subjectID,
 		PriceID:         price.ID,
 		Processor:       models.Processor(provider),
 		TransactionID:   attemptTransactionID,

--- a/internal/modules/checkout/purchase_service.go
+++ b/internal/modules/checkout/purchase_service.go
@@ -17,7 +17,6 @@ import (
 	"github.com/open-rails/openrails/internal/modules/productaccess"
 	"github.com/open-rails/openrails/internal/shared/timeutil"
 	"github.com/open-rails/openrails/internal/shared/uuidutil"
-	"github.com/open-rails/openrails/pkg/identity"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -365,10 +364,15 @@ func (s *CheckoutPurchaseService) RegisterPurchase(ctx context.Context, req *pay
 		purchasedAt = req.PurchasedAt.UTC()
 	}
 
+	subjectID, err := s.PaymentService.EnsureSubjectID(ctx, req.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve tenant subject: %w", err)
+	}
+
 	paymentID := uuidutil.NewV7()
 	payment := &models.Payment{
 		ID:                       paymentID,
-		TenantSubjectID:          identity.TenantSubjectIDFromString(req.UserID).UUID(),
+		TenantSubjectID:          subjectID,
 		PriceID:                  price.ID,
 		SubscriptionID:           req.SubscriptionID,
 		Processor:                models.Processor(req.Processor),

--- a/internal/modules/checkout/service.go
+++ b/internal/modules/checkout/service.go
@@ -33,7 +33,6 @@ import (
 	"github.com/open-rails/openrails/internal/shared/timeutil"
 	"github.com/open-rails/openrails/internal/shared/uuidutil"
 	"github.com/open-rails/openrails/pkg/api"
-	"github.com/open-rails/openrails/pkg/identity"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -663,9 +662,18 @@ func (s *CheckoutService) processNMISubscription(
 		}
 	}
 
+	// Resolve-or-create the payable tenant-subject id: deriving via
+	// identity.TenantSubjectIDFromString yields uuid.Nil for legacy (non-UUID)
+	// subjects and mis-attributes the attempt row (#364).
+	subjectID, err := s.PaymentService.EnsureSubjectID(ctx, user.ID)
+	if err != nil {
+		_ = s.IdempotencyService.Fail(ctx, idempOp, idempotencyKey, err)
+		return nil, fmt.Errorf("resolve tenant subject for NMI subscription attempt: %w", err)
+	}
+
 	attempt, err := s.PaymentService.ReserveProviderAttempt(ctx, &models.Payment{
 		ID:              uuidutil.NewV7(),
-		TenantSubjectID: identity.TenantSubjectIDFromString(user.ID).UUID(),
+		TenantSubjectID: subjectID,
 		PriceID:         price.ID,
 		Processor:       models.Processor(provider),
 		TransactionID:   nmiSubscriptionAttemptTransactionID(orderID),
@@ -786,6 +794,11 @@ func (s *CheckoutService) completeNMISubscriptionRegistration(ctx context.Contex
 		return nil, fmt.Errorf("load existing subscription: %w", err)
 	}
 
+	subjectID, err := s.SubscriptionService.EnsureSubjectID(ctx, user.ID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve tenant subject for NMI subscription: %w", err)
+	}
+
 	now := s.now().UTC()
 	var emailPtr *string
 	if req.Email != "" {
@@ -793,7 +806,7 @@ func (s *CheckoutService) completeNMISubscriptionRegistration(ctx context.Contex
 	}
 	subscription := &models.Subscription{
 		ID:                       subscriptionID,
-		TenantSubjectID:          identity.TenantSubjectIDFromString(user.ID).UUID(),
+		TenantSubjectID:          subjectID,
 		ProductID:                price.ProductID,
 		PriceID:                  price.ID,
 		EntitlementsSpecSnapshot: models.CloneEntitlementsSpec(product.EntitlementsSpec),
@@ -1714,6 +1727,14 @@ func (s *CheckoutService) processUpgrade(
 		return nil, err
 	}
 
+	// Resolve the payable tenant-subject id BEFORE any processor side-effects so
+	// a resolution failure cannot strand a charged-but-unrecorded upgrade (#364).
+	subjectID, err := s.SubscriptionService.EnsureSubjectID(ctx, user.ID)
+	if err != nil {
+		_ = s.IdempotencyService.Fail(ctx, idempOp, idempotencyKey, err)
+		return nil, fmt.Errorf("resolve tenant subject for upgrade: %w", err)
+	}
+
 	// Step 1: Create the successor subscription at NMI before charging/cancelling.
 	newSubscriptionID := uuidutil.NewV7()
 
@@ -1814,7 +1835,7 @@ func (s *CheckoutService) processUpgrade(
 
 	newSubscription := &models.Subscription{
 		ID:                       newSubscriptionID,
-		TenantSubjectID:          identity.TenantSubjectIDFromString(user.ID).UUID(),
+		TenantSubjectID:          subjectID,
 		ProductID:                newPrice.ProductID,
 		PriceID:                  newPrice.ID,
 		EntitlementsSpecSnapshot: models.CloneEntitlementsSpec(newProduct.EntitlementsSpec),
@@ -2235,8 +2256,15 @@ func (s *CheckoutService) TierChange(ctx context.Context, req *TierChangeRequest
 		if err != nil {
 			return nil, &TierChangeError{HTTPStatus: http.StatusNotFound, Message: "subscription not found"}
 		}
-		// Verify ownership
-		if existingSub.TenantSubjectID.String() != user.ID {
+		// Verify ownership against the RESOLVED payable tenant-subject id:
+		// legacy (non-UUID) subjects are materialized rows whose id never equals
+		// the raw subject string, so comparing against user.ID directly 404s the
+		// legitimate owner (#364).
+		callerSubjectID, rerr := s.SubscriptionService.ResolveSubjectID(ctx, user.ID)
+		if rerr != nil {
+			return nil, &TierChangeError{HTTPStatus: http.StatusInternalServerError, Message: "failed to verify subscription ownership"}
+		}
+		if callerSubjectID == uuid.Nil || existingSub.TenantSubjectID != callerSubjectID {
 			return nil, &TierChangeError{HTTPStatus: http.StatusNotFound, Message: "subscription not found"}
 		}
 	} else {

--- a/internal/modules/checkout/session_service.go
+++ b/internal/modules/checkout/session_service.go
@@ -31,7 +31,6 @@ import (
 	"github.com/open-rails/openrails/internal/shared/timeutil"
 	"github.com/open-rails/openrails/internal/shared/uuidutil"
 	"github.com/open-rails/openrails/pkg/api"
-	"github.com/open-rails/openrails/pkg/identity"
 	"github.com/open-rails/openrails/pkg/tenant"
 )
 
@@ -395,9 +394,14 @@ func (s *CheckoutSessionService) createSessionWithValidation(ctx context.Context
 	if processor == "ccbill" || processor == "stripe" {
 		ttl = redirectCheckoutSessionTTL
 	}
+	subjectID, err := s.ensureSubjectID(ctx, user.ID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve tenant subject for checkout session: %w", err)
+	}
+
 	session := &models.CheckoutSession{
 		ID:              uuidutil.NewV7(),
-		TenantSubjectID: identity.TenantSubjectIDFromString(user.ID).UUID(),
+		TenantSubjectID: subjectID,
 		PriceID:         price.ID,
 		Mode:            mode,
 		Processor:       models.Processor(processor),
@@ -547,6 +551,13 @@ func (s *CheckoutSessionService) resolveMode(mode string, processor string, pric
 // keeps the validation contract from drifting out of sync with what the
 // processor's executor actually consumes — the drift that previously made Stripe
 // demand billing fields its hosted-checkout path never reads.
+// ensureSubjectID resolves-or-creates the payable tenant-subject id for a raw
+// user/subject string (#364): deriving via identity.TenantSubjectIDFromString
+// yields uuid.Nil for legacy (non-UUID) subjects and mis-attributes the session.
+func (s *CheckoutSessionService) ensureSubjectID(ctx context.Context, userID string) (uuid.UUID, error) {
+	return repo.EnsureTenantSubjectID(ctx, s.db.Qx(ctx), uuid.Nil, userID)
+}
+
 func (s *CheckoutSessionService) validatePayment(ctx context.Context, processor string, payment *CheckoutSessionPaymentRequest, user *UserIdentity) error {
 	switch {
 	case processors.IsNMIBacked(processor):
@@ -1169,9 +1180,14 @@ func (s *CheckoutSessionService) createSolanaLifecycleSession(ctx context.Contex
 
 	now := s.now()
 	expiresAt := now.Add(defaultCheckoutSessionTTL)
+	subjectID, err := s.ensureSubjectID(ctx, user.ID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve tenant subject for checkout session: %w", err)
+	}
+
 	session := &models.CheckoutSession{
 		ID:              uuidutil.NewV7(),
-		TenantSubjectID: identity.TenantSubjectIDFromString(user.ID).UUID(),
+		TenantSubjectID: subjectID,
 		PriceID:         sessionPriceID,
 		Mode:            mode,
 		Processor:       models.ProcessorSolana,

--- a/internal/modules/payments/payment.go
+++ b/internal/modules/payments/payment.go
@@ -22,6 +22,13 @@ type PaymentService struct {
 	clock clockwork.Clock
 }
 
+// EnsureSubjectID resolves-or-creates the payable tenant-subject id for a raw
+// user/subject string (#364). See repo.EnsureTenantSubjectID for the identity
+// scheme (UUID subjects are their own id; legacy subjects use a generated row).
+func (s *PaymentService) EnsureSubjectID(ctx context.Context, userID string) (uuid.UUID, error) {
+	return s.repo.EnsureSubjectID(ctx, userID)
+}
+
 const (
 	PaymentStatusPendingValue   = "pending"
 	PaymentStatusCompletedValue = "completed"

--- a/internal/modules/subscriptions/subscription.go
+++ b/internal/modules/subscriptions/subscription.go
@@ -272,6 +272,19 @@ func (s *SubscriptionService) GetSubscriptionsByProcessorAndUserID(ctx context.C
 	return s.subscriptionRepo.GetSubscriptionsByProcessorAndUserID(ctx, userID, processor)
 }
 
+// EnsureSubjectID resolves-or-creates the payable tenant-subject id for a raw
+// user/subject string (#364). UUID subjects map to themselves; non-UUID legacy
+// subjects get (or reuse) a materialized tenant_subjects row.
+func (s *SubscriptionService) EnsureSubjectID(ctx context.Context, userID string) (uuid.UUID, error) {
+	return s.subscriptionRepo.EnsureSubjectID(ctx, userID)
+}
+
+// ResolveSubjectID resolves the payable tenant-subject id for a raw user/subject
+// string WITHOUT creating a row (#364). Unknown legacy subjects yield uuid.Nil.
+func (s *SubscriptionService) ResolveSubjectID(ctx context.Context, userID string) (uuid.UUID, error) {
+	return s.subscriptionRepo.ResolveSubjectID(ctx, userID)
+}
+
 // GetActiveSubscription retrieves the active subscription for a user
 func (s *SubscriptionService) GetActiveSubscription(ctx context.Context, userID string) (*models.Subscription, error) {
 	return s.subscriptionRepo.GetActiveSubscriptionAt(ctx, userID, s.now())


### PR DESCRIPTION
> Produced by the automated daily review (2026-06-12).

## Problem

Issue #364 (filed by the #363 investigation): `identity.TenantSubjectIDFromString(user.ID)` maps UUID subjects to themselves but returns `uuid.Nil` for any non-UUID legacy/self-service subject. The write path materializes those subjects via `EnsureTenantSubjectID` (generated row id), so checkout code that *re-derives* instead of *resolving* can never match:

- **Ownership check** (`service.go` ChangeTier): `existingSub.TenantSubjectID.String() != user.ID` — the legitimate owner of a subscription gets **404 on change-tier**.
- **Money writes** at `service.go` (NMI attempt, pending subscription, upgrade successor), `purchase_service.go`, `nmi_sale_service.go`, and both `session_service.go` session writers — rows stamped with `uuid.Nil` / mismatched subject ids for legacy subjects.

This is identity code on the payment hot path: wrong attribution breaks tenant reporting and, under RLS, row visibility.

## Approach

Resolve-not-derive, the same fix #363 applied to `tests/seed_data.go` (985ba867):

- New `EnsureSubjectID` / `ResolveSubjectID` on `PaymentRepo`/`SubscriptionRepo` (thin wrappers over the existing `EnsureTenantSubjectID`/`ResolveTenantSubjectID` from #317), surfaced on `PaymentService`/`SubscriptionService`; `CheckoutSessionService` uses its own `db` handle.
- All 7 derive call sites in `internal/modules/checkout` replaced: **writes** use resolve-or-create (`Ensure…`), the **ownership check** uses resolve-only (`Resolve…`) and 404s on unknown subjects (`uuid.Nil`).
- `processUpgrade` resolves **before any NMI side-effects**, so a resolution failure cannot strand a charged-but-unrecorded upgrade; failure paths feed the existing idempotency `Fail` hooks.
- UUID subjects keep their deterministic self-id (per #317), so existing self-service behavior is unchanged.

## Verification

- `go build ./...` clean; `go vet` clean on touched packages.
- Unit tests pass: `internal/modules/checkout`, `payments`, `subscriptions`.
- `TestChangeTierEndpoint` / `TestCheckoutBlocksTierChanges` (named in #364) live in the testcontainers suite, which this environment cannot run (no Docker) — please run the legacy `tests/` suite before merging. The `agents/future.md` #364 section was intentionally left for the verifying run to close out.