### PR TITLE
Control plane mandatory in standalone — remove verifier-only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,13 @@ The rule across both modes is: **one credential per trust domain.**
   uses its normal session credential for everything, including the mounted billing routes.
   Your code verifies it and hands OpenRails the resulting identity through a Go interface.
   **One token.** OpenRails never parses your credential at all.
-- **Standalone:** OpenRails is a separate system across a network boundary. Identity claims
-  that cross that boundary must be independently verifiable, so each caller class gets a
-  credential scoped to exactly what it may do:
+- **Standalone:** OpenRails is a separate system across a network boundary, and it always
+  runs its own AuthKit control plane — the in-process authority that issues and verifies
+  these credentials, holds the runtime tenant/issuer registry, and gates admin routes.
+  (There is no control-plane-less "verifier-only" standalone; a private deployment keeps
+  `public_user_registration` / `public_tenant_registration` closed, which is the default.)
+  Identity claims that cross that boundary must be independently verifiable, so each caller
+  class gets a credential scoped to exactly what it may do:
   - your **backend** uses a **service token** (`openrails_st_...`) or a first-party OIDC
     service JWT — server-to-server, never sent to browsers;
   - your **frontend** uses a short-lived **delegated access token** that *your own backend*
@@ -378,7 +382,8 @@ plain `NewHTTPHandler` mux carries the user/admin/webhook groups.
 
 Admin authority is the **live `openrails:admin` permission in the caller's own tenant**,
 checked per request against the control plane — OpenRails never interprets your role names,
-and there is no role-string fallback. The control plane is opt-in for embedded hosts
+and there is no role-string fallback. The standalone service always runs the control plane;
+for embedded hosts it is opt-in
 (`pkg/embedded/controlplane.Attach`); if you don't attach one, mount with
 `IncludeAdmin: false` and run admin operations through the in-process `Service()` facade
 or your own tooling instead — admin routes without a permission checker fail closed.

--- a/agents/progress.md
+++ b/agents/progress.md
@@ -7,7 +7,19 @@
 > replacement — never rewrite the whole file.
 
 
-next_id: 470
+next_id: 471
+
+---
+
+# #470: Fix stale TestDunningWorkerLimitedModeTakesNoAction (pre-#366 semantics) 
+
+**Completed:** no
+
+`tests/dunning_worker_test.go` `TestDunningWorkerLimitedModeTakesNoAction` still asserts the pre-#366 limited-mode contract (subscription stays `past_due`, `next_retry_at` non-nil — i.e. "takes no action"). Commit a67cc3f5 (#366 limited-mode materialize) changed the behavior deliberately: limited mode now materializes decisions — local window-expiry cancellations APPLY (subscription cancelled, entitlements revoked, remote processor sub left alive for reconciliation), and charge intents enqueue PARKED. The test was never updated and fails on every integration run (found during #469 verification; NOT a #469 regression — confirmed via a67cc3f5 history).
+
+**Tasks:**
+- [ ] Rewrite the test to assert #366 semantics: window-expired sub → cancelled locally + entitlements revoked + NO provider writes + parked charge intents; rename accordingly (e.g. TestDunningWorkerLimitedModeMaterializesWithoutProviderWrites)
+- [ ] Keep/add a companion assertion that a NON-expired past_due sub takes no action in limited mode (the surviving half of the old contract)
 
 ---
 
@@ -70,7 +82,7 @@ progress/future/completed; this issue took #469 and reset next_id to 470.
 - [x] Delete nil-resolver fork in ginmw/delegated.go (+ equivalent forks elsewhere); self-service surface always mounted
 - [x] Prune pkg/embedded/authkit + pkg/embedded/controlplane to what's actually used post-cut — both kept (used by standalone wiring + embedded opt-in); only the enabled-check/nil-tolerant paths inside them were cut
 - [x] Docs hard cut: README auth-model section, config.example.yaml, principal-boundary-audit.md (no DEVSERVER.md exists)
-- [ ] Collapse test matrix; go build/vet/test green
+- [x] Collapse test matrix; go build/vet/test green — build/vet/unit suites green. Integration suite (`-tags=integration ./tests/`): verbose run completed all #469-relevant tests green; ONE failure, `TestDunningWorkerLimitedModeTakesNoAction`, confirmed PRE-EXISTING (encodes pre-#366 "takes no action" semantics; behavior changed in a67cc3f5 — filed as #470; clean HEAD can't even build the integration tests, fixed in this tree). Suite also exceeded a 45m wall under heavy concurrent machine load (3 sibling agent runs + dev compose); re-run on a quiet machine before tagging.
 
 ---
 

--- a/cmd/billing/bootstrap_apply.go
+++ b/cmd/billing/bootstrap_apply.go
@@ -101,9 +101,9 @@ const startupBootstrapLockKey = int64(0x6f72_626f_6f74) // "orboot"
 // ArchiveMissingProducts:false, so nothing is ever removed — so reapplying on
 // every boot is safe and lets a mounted bootstrap file converge an existing
 // control plane (e.g. register a delegated issuer that was added after the DB
-// was first provisioned). No-op when no manifest is configured/present or the
-// control plane is disabled. Concurrent replicas serialize on a session-level
-// advisory lock (#342); the lock auto-releases if the holder dies.
+// was first provisioned). No-op when no manifest is configured/present.
+// Concurrent replicas serialize on a session-level advisory lock (#342); the
+// lock auto-releases if the holder dies.
 func applyStartupBootstrap(ctx context.Context, cfg *config.Config, a *app.App) error {
 	path := resolveBootstrapManifestPath(cfg)
 	if path == "" {
@@ -111,7 +111,7 @@ func applyStartupBootstrap(ctx context.Context, cfg *config.Config, a *app.App) 
 	}
 	cp := embcp.Get(a)
 	if cp == nil {
-		return nil // verifier-only mode; nothing to provision
+		return fmt.Errorf("startup bootstrap: control plane not attached (#469: it is mandatory in standalone mode)")
 	}
 	manifest, err := bootstrap.LoadBootstrapManifest(path)
 	if err != nil {
@@ -171,7 +171,7 @@ func applyBootstrapManifest(ctx context.Context, cfg *config.Config, a *app.App,
 		} else {
 			cp := embcp.Get(a)
 			if cp == nil {
-				return fmt.Errorf("tenant bootstrap requires auth.control_plane.enabled")
+				return fmt.Errorf("tenant bootstrap: control plane not attached")
 			}
 			if err := bootstrap.ReconcileTenantManifestData(ctx, cfg, cp, manifest.TenantManifest(), bootstrap.TenantManifestReconcileOptions{}); err != nil {
 				return fmt.Errorf("tenant bootstrap: %w", err)
@@ -318,7 +318,7 @@ func contextForBootstrapCatalog(ctx context.Context, a *app.App, catalogName str
 	}
 	cp := embcp.Get(a)
 	if cp == nil || cp.Pool() == nil {
-		return nil, fmt.Errorf("catalog %q declares a tenant name but auth.control_plane.enabled is not available", catalogName)
+		return nil, fmt.Errorf("catalog %q declares a tenant name but the control plane is not attached", catalogName)
 	}
 	var id string
 	if err := cp.Pool().QueryRow(ctx, `SELECT id::text FROM billing.tenants WHERE lower(slug) = lower($1)`, slug).Scan(&id); err != nil {

--- a/cmd/billing/main.go
+++ b/cmd/billing/main.go
@@ -215,17 +215,17 @@ func runServer(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
-	// Opt into the OpenRails-owned AuthKit control plane (#284): the embedded core
-	// no longer builds it, so the standalone attaches it here (no-op in
-	// verifier-only mode) before bootstrapping.
+	// Attach the OpenRails-owned AuthKit control plane (#284). MANDATORY in
+	// standalone mode (#469): construction failure exits non-zero — there is no
+	// verifier-only downgrade.
 	if err := embcp.Attach(context.Background(), embeddedApp.App(), cfg, nil); err != nil {
 		cleanupOnError = true
 		return fmt.Errorf("attach control plane: %w", err)
 	}
 
-	// Bootstrap the OpenRails-owned AuthKit control plane (#224) when enabled.
-	// Idempotent + a no-op in verifier-only mode. Runs after migrations have been
-	// applied (migrations are a separate `billing migrate` step) and at startup.
+	// Bootstrap the OpenRails-owned AuthKit control plane (#224). Idempotent;
+	// runs after migrations have been applied (migrations are a separate
+	// `billing migrate` step) and at startup.
 	if res, err := embcp.RunBootstrap(context.Background(), embeddedApp.App(), controlplane.BootstrapOptions{MintInitialServiceToken: true}); err != nil {
 		cleanupOnError = true
 		return fmt.Errorf("control plane bootstrap: %w", err)

--- a/cmd/billing/mint_operator_jwt.go
+++ b/cmd/billing/mint_operator_jwt.go
@@ -47,7 +47,7 @@ func mintOperatorJWT(cmd *cobra.Command, _ []string) error {
 	}
 	cp := embcp.Get(embeddedApp.App())
 	if cp == nil || cp.Core() == nil {
-		return fmt.Errorf("control plane is not enabled (set auth.control_plane.enabled + issuer)")
+		return fmt.Errorf("control plane unavailable (set auth.control_plane.issuer)")
 	}
 	core := cp.Core()
 

--- a/cmd/billing/mint_operator_service_token.go
+++ b/cmd/billing/mint_operator_service_token.go
@@ -32,7 +32,7 @@ func mintOperatorServiceToken(cmd *cobra.Command, _ []string) error {
 	}
 	cp := embcp.Get(embeddedApp.App())
 	if cp == nil || cp.Core() == nil {
-		return fmt.Errorf("control plane is not enabled")
+		return fmt.Errorf("control plane unavailable (set auth.control_plane.issuer)")
 	}
 
 	authorityTenantSlug, err := cmd.Flags().GetString("org")

--- a/cmd/billing/mint_tenant_subject_service_token.go
+++ b/cmd/billing/mint_tenant_subject_service_token.go
@@ -33,7 +33,7 @@ func mintTenantSubjectServiceToken(cmd *cobra.Command, _ []string) error {
 	}
 	cp := embcp.Get(embeddedApp.App())
 	if cp == nil || cp.Core() == nil {
-		return fmt.Errorf("control plane is not enabled")
+		return fmt.Errorf("control plane unavailable (set auth.control_plane.issuer)")
 	}
 
 	bootstrapTenant, err := cmd.Flags().GetString("org")

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -151,13 +151,22 @@ redis:
   db: 0                 # Redis database number (default: 0)
 
 # =============================================================================
-# AUTHENTICATION (JWT Verifier)
+# AUTHENTICATION
 # =============================================================================
-# Billing is a JWT verifier (not issuer). It verifies tokens from your IdP.
+# Standalone OpenRails has ONE auth model (#469): it always runs its own
+# AuthKit control plane (delegated browser tokens, service tokens, the runtime
+# tenant/issuer registry, /auth routes, admin authority), with both
+# registration axes CLOSED by default. There is no "verifier-only" mode.
+#
+# auth.issuers is the config-declared FIRST-PARTY issuer allowlist for the
+# user/admin JWT surface: host-app-issued JWTs verify against each issuer's
+# {issuer}/.well-known/jwks.json (OIDC). It is an input to the auth stack, not
+# an alternative mode. Delegated/service credentials use the control plane's
+# live issuer registry instead (register via POST /v1/service/tenant/issuers
+# or the bootstrap manifest).
 
 auth:
-  # Issuers - array of token issuer URLs
-  # Billing fetches public keys from each {issuer}/.well-known/jwks.json per OIDC spec
+  # First-party issuers - array of token issuer URLs for host-app user JWTs.
   issuers:
     - "http://localhost:8080"
     - "http://localhost:8081"
@@ -169,20 +178,25 @@ auth:
   expected_audience: "openrails-app"
 
   # ---------------------------------------------------------------------------
-  # OpenRails-owned AuthKit control plane (#224). OPTIONAL and OFF by default.
-  # When omitted/disabled, OpenRails is a pure JWT verifier (current behavior).
-  # When enabled, OpenRails builds an in-process AuthKit control plane:
+  # OpenRails-owned AuthKit control plane (#224). ALWAYS ON in standalone mode
+  # (#469): this section tunes it, it cannot switch it off. The control plane
   #   * selectively mounts only intentional AuthKit route groups under /auth
-  #     (NEVER AuthKit DefaultAPI in locked-down mode),
-  #   * disables public native-user registration + public tenant registration,
+  #     (NEVER AuthKit DefaultAPI in the locked-down posture),
+  #   * issues + verifies delegated browser tokens and tenant service tokens,
   #   * provides the in-process AuthKit core used by tenant manifest bootstrap.
-  # The control plane needs a database holding AuthKit's profiles.* schema.
+  # It needs a database holding AuthKit's profiles.* schema (`billing migrate up`
+  # applies those migrations).
+  #
+  # `issuer` is REQUIRED outside development; in development it defaults to
+  # api_url (or http://localhost:<port>). Private/self-hosted posture is the
+  # registration axes below (both default false = closed) — never a disabled
+  # control plane.
   # ---------------------------------------------------------------------------
   # control_plane:
-  #   enabled: true
   #   issuer: "https://openrails.mysite.com" # AuthKit token issuer this CP signs as
   #   token_prefix: "openrails"               # generated service token brand prefix -> openrails_st_...
-  #   locked_down: true                       # self-hosted posture (default true)
+  #   # public_user_registration: false       # default false: native-user signup is admin/bootstrap-only
+  #   # public_tenant_registration: false     # default false: tenant onboarding is admin/bootstrap-only
   #   # issued_audiences: ["openrails-app"]   # defaults to expected_audience
   #   # expected_audiences: ["openrails-app"]
 

--- a/config/config.go
+++ b/config/config.go
@@ -658,7 +658,13 @@ func (c *Config) AllowedCORSOrigins() []string {
 }
 
 type AuthConfig struct {
-	Issuers          []string `koanf:"issuers"`           // List of expected token issuers (e.g., ["https://issuer.example.com"])
+	// Issuers is the config-declared allowlist of FIRST-PARTY token issuers for
+	// the user/admin JWT surface: OpenRails fetches each issuer's JWKS and
+	// verifies host-app-issued user JWTs against it. This is an INPUT to the
+	// always-on auth stack — NOT a standalone auth mode (#469 removed the
+	// "verifier-only" deployment). Delegated browser tokens use the control
+	// plane's live issuer registry instead.
+	Issuers          []string `koanf:"issuers"`
 	ExpectedAudience string   `koanf:"expected_audience"` // Accept token only if it contains this audience (e.g., "openrails-app")
 
 	// HARDCUT (#312): there is no `auth.operator_tenant_slug` /
@@ -669,26 +675,26 @@ type AuthConfig struct {
 	// deprecated keys.
 
 	// ControlPlane configures OpenRails' OpenRails-owned AuthKit control plane
-	// (issue #224). When nil/disabled, OpenRails behaves as a pure JWT verifier
-	// (current default). When enabled, OpenRails builds an in-process AuthKit
-	// core/service, can selectively mount AuthKit route groups, and bootstraps
-	// the default tenant's operator tenant + roles + permission catalog + initial
-	// operator service token.
+	// (issue #224). HARD CUT (#469): the control plane is MANDATORY in standalone
+	// mode — there is no "verifier-only" deployment. Standalone boot always
+	// builds the in-process AuthKit core/service, mounts the selective AuthKit
+	// route groups, and runs control-plane bootstrap; construction failure is
+	// fatal. Load materializes this section when omitted (dev defaults the
+	// issuer); the former `enabled` knob is rejected. Private/self-hosted
+	// posture is expressed by the registration axes below, never by removing
+	// the control plane.
 	ControlPlane *ControlPlaneConfig `koanf:"control_plane,omitempty"`
 }
 
 // ControlPlaneConfig configures the OpenRails-owned AuthKit control plane
-// (issue #224). It is OPTIONAL and OFF by default: a deployment that only
-// verifies externally-issued JWTs does not set this. A self-hosted, locked-down
-// deployment enables it to own user/org/role/service token operations in-process.
+// (issue #224). HARD CUT (#469): the control plane is always on in standalone
+// mode. The section tunes it (issuer, audiences, registration posture); it does
+// not switch it off. pkg/embedded hosts that want it opt in by calling
+// pkg/embedded/controlplane.Attach.
 type ControlPlaneConfig struct {
-	// Enabled turns on the in-process AuthKit control plane. When false (the
-	// default), OpenRails does not construct an AuthKit core/service and does not
-	// run control-plane bootstrap.
-	Enabled bool `koanf:"enabled,omitempty"`
-
 	// Issuer is the AuthKit token issuer this OpenRails control plane signs as
-	// (e.g. "https://billing.mysite.com"). Required when Enabled.
+	// (e.g. "https://billing.mysite.com"). Required outside development; in
+	// development Load defaults it to api_url (or http://localhost:<port>).
 	Issuer string `koanf:"issuer,omitempty"`
 
 	// IssuedAudiences are the audiences placed on tokens this control plane
@@ -717,11 +723,6 @@ type ControlPlaneConfig struct {
 	// "openrails-bootstrap-admin".
 	BootstrapAdminServiceTokenName string `koanf:"bootstrap_admin_service_token_name,omitempty"`
 
-	// OperatorServiceTokenName is a deprecated compatibility field for older
-	// committed OpenRails call sites. It is intentionally not loadable from
-	// config; new deployments use BootstrapAdminServiceTokenName.
-	OperatorServiceTokenName string `koanf:"-"`
-
 	// PlatformTenantSlug is the AuthKit tenant slug for the managed-hosting PLATFORM
 	// superadmin org (issue #226), DISTINCT from any tenant operator tenant. The
 	// platform tenant holds the openrails-platform-superadmin role with the
@@ -742,30 +743,6 @@ type ControlPlaneConfig struct {
 // surface is not mounted and no platform-superadmin is bootstrapped.
 func (cp *ControlPlaneConfig) PlatformTenantEnabled() bool {
 	return cp != nil && strings.TrimSpace(cp.PlatformTenantSlug) != ""
-}
-
-// ControlPlaneEnabled reports whether the OpenRails-owned AuthKit control plane
-// is enabled for this deployment.
-func (c *AuthConfig) ControlPlaneEnabled() bool {
-	return c != nil && c.ControlPlane != nil && c.ControlPlane.Enabled
-}
-
-// OperatorTenantEnabled is a deprecated compatibility shim for pre-#312 call
-// sites that still compile against the operator-tenant helper names.
-func (c *AuthConfig) OperatorTenantEnabled() bool {
-	return c.ControlPlaneEnabled()
-}
-
-// EffectiveOperatorTenantSlug is a deprecated compatibility shim for pre-#312
-// call sites. Deprecated operator-tenant config keys are still rejected by Load.
-func (c *AuthConfig) EffectiveOperatorTenantSlug() string {
-	return "operator"
-}
-
-// EffectiveOperatorTenantAdminRoles is a deprecated compatibility shim for
-// pre-#312 call sites. New admin authorization uses live openrails:admin grants.
-func (c *AuthConfig) EffectiveOperatorTenantAdminRoles() []string {
-	return []string{"owner", "admin"}
 }
 
 // UserRegistrationOpen reports whether public native-user self-registration is
@@ -1809,6 +1786,16 @@ func Load(configPath string) (*Config, error) {
 		return nil, fmt.Errorf("loading environment variables: %w", err)
 	}
 
+	// HARD CUT (#469): the AuthKit control plane is always on in standalone
+	// mode; the verifier-only deployment mode is gone. The former
+	// auth.control_plane.enabled knob is rejected — not silently ignored — so a
+	// deployment that believed it was toggling the control plane finds out at
+	// load time. Private posture is the registration axes, not a disabled
+	// control plane.
+	if k.Exists("auth.control_plane.enabled") {
+		return nil, fmt.Errorf("auth.control_plane.enabled was removed (#469): the control plane is always on in standalone mode — delete the key; use auth.control_plane.public_user_registration / public_tenant_registration to keep registration closed")
+	}
+
 	// Unmarshal into config struct (overlay onto defaults)
 	if err := k.Unmarshal("", cfg); err != nil {
 		return nil, fmt.Errorf("unmarshaling config: %w", err)
@@ -1863,6 +1850,30 @@ func Load(configPath string) (*Config, error) {
 			normalized[key] = proc
 		}
 		cfg.Processors = normalized
+	}
+
+	// The control plane is mandatory in standalone mode (#469): materialize the
+	// config section when omitted. In development the issuer defaults to the
+	// deployment's own base URL so zero-config dev boots; outside development a
+	// missing issuer fails fast at control-plane construction.
+	if cfg.Auth == nil {
+		cfg.Auth = &AuthConfig{}
+	}
+	if cfg.Auth.ControlPlane == nil {
+		cfg.Auth.ControlPlane = &ControlPlaneConfig{}
+	}
+	if strings.TrimSpace(cfg.Auth.ControlPlane.Issuer) == "" {
+		if isDev := cfg.Env == "development" || cfg.Env == "dev" || cfg.Env == ""; isDev {
+			issuer := strings.TrimSpace(cfg.APIURL)
+			if issuer == "" {
+				port := int(cfg.Port)
+				if port == 0 {
+					port = 2053
+				}
+				issuer = fmt.Sprintf("http://localhost:%d", port)
+			}
+			cfg.Auth.ControlPlane.Issuer = strings.TrimRight(issuer, "/")
+		}
 	}
 
 	// Assemble DB URL from pieces if not explicitly set

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -103,6 +103,52 @@ clickhouse:
 	assert.Equal(t, "envclickhouse:9000", cfg.ClickHouse.ClientAddr)
 }
 
+func TestLoad_RejectsRemovedControlPlaneEnabledKnob(t *testing.T) {
+	// HARD CUT (#469): the control plane is always on; auth.control_plane.enabled
+	// is a load error, not an ignored key — whichever way it was set.
+	for _, val := range []string{"true", "false"} {
+		dir := t.TempDir()
+		cfgPath := filepath.Join(dir, "config.yaml")
+		require.NoError(t, os.WriteFile(cfgPath, []byte(`
+auth:
+  control_plane:
+    enabled: `+val+`
+    issuer: "https://billing.example.com"
+`), 0o600))
+
+		_, err := Load(cfgPath)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "auth.control_plane.enabled was removed")
+	}
+}
+
+func TestLoad_ControlPlaneMaterializedWithDevIssuerDefault(t *testing.T) {
+	// The control plane section is materialized even when omitted (#469); in
+	// development the issuer defaults to the deployment's own base URL.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("env: development\n"), 0o600))
+
+	cfg, err := Load(cfgPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Auth)
+	require.NotNil(t, cfg.Auth.ControlPlane)
+	require.Equal(t, "http://localhost:2053", cfg.Auth.ControlPlane.Issuer)
+	// Registration axes default closed.
+	require.False(t, cfg.Auth.ControlPlane.UserRegistrationOpen())
+	require.False(t, cfg.Auth.ControlPlane.TenantRegistrationOpen())
+}
+
+func TestLoad_ControlPlaneIssuerFromAPIURLInDev(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte("env: development\napi_url: \"http://openrails:2053/\"\n"), 0o600))
+
+	cfg, err := Load(cfgPath)
+	require.NoError(t, err)
+	require.Equal(t, "http://openrails:2053", cfg.Auth.ControlPlane.Issuer)
+}
+
 func TestLoad_RequiresExplicitTypeForCustomProcessors(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")

--- a/docs/principal-boundary-audit.md
+++ b/docs/principal-boundary-audit.md
@@ -5,8 +5,8 @@ server-to-server machine credentials.
 
 ## Service credential surface
 
-`/v1/service/*` is mounted only when the OpenRails AuthKit control plane exists.
-Every route is behind `ServiceTokenRequired`. That middleware accepts either:
+`/v1/service/*` is always mounted (the OpenRails AuthKit control plane is
+mandatory in standalone mode, #469). Every route is behind `ServiceTokenRequired`. That middleware accepts either:
 
 - a generated OpenRails/AuthKit opaque service token; or
 - a first-party OIDC service JWT from a registered tenant issuer.
@@ -57,9 +57,10 @@ separate "operator"/"admin"/"platform" AuthKit *tenant* acting as the admin
 authority, no JWT role-claim gate, and no global-admin DB fallback. The default
 tenant hosts its own admin role. Initial generated admin service tokens are
 minted only through explicit operator/admin token-minting commands, not through
-declarative bootstrap YAML. `/v1/admin/*` (and `/v1/admin/tenants/*`) fail
-closed when no control plane is wired (verifier-only mode), because there is then
-no live authority to evaluate.
+declarative bootstrap YAML. The control plane is always present in standalone
+mode (#469); `/v1/admin/*` (and `/v1/admin/tenants/*`) fail closed for embedded
+hosts that wire no control plane, because there is then no live authority to
+evaluate.
 
 Canonical identity vocabulary lives in
 `docs/authkit-tenant-oidc-glossary.md`. New docs and route examples should use

--- a/docs/tenant-provisioning.md
+++ b/docs/tenant-provisioning.md
@@ -18,8 +18,8 @@ bookkeeping). It is additive and idempotent.
 
 ## Lifecycle service — `tenancy.Service`
 
-Built in the HTTP server only when the control plane is present (it reuses the
-control plane's pgx pool and tenant provisioner). All operations are
+Built in the HTTP server (the control plane is always present, #469); it reuses
+the control plane's pgx pool and tenant provisioner. All operations are
 idempotent.
 
 | Operation | Behaviour |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -38,15 +38,16 @@ type App struct {
 
 	// ControlPlane is OpenRails' OpenRails-owned AuthKit control plane (#224),
 	// held as `any` so the embedded CORE (internal/app, pkg/embedded, embedhttp)
-	// imports neither internal/controlplane nor — through it — AuthKit (#284). It
-	// is nil in verifier-only mode. The standalone/opt-in path attaches the
-	// concrete *controlplane.ControlPlane via SetControlPlane and recovers it with
-	// a type assertion (see pkg/embedded/controlplane).
+	// imports neither internal/controlplane nor — through it — AuthKit (#284).
+	// It is nil only for embedded hosts that never attach one; the standalone
+	// path ALWAYS attaches the concrete *controlplane.ControlPlane via
+	// SetControlPlane (#469) and recovers it with a type assertion (see
+	// pkg/embedded/controlplane).
 	ControlPlane any
 
 	stopRedisMonitor context.CancelFunc
 	// controlPlanePool is an OpenRails-owned pgx pool backing the control plane,
-	// created only when the control plane is enabled and no pool was injected. It
+	// created only when the control plane is attached and no pool was injected. It
 	// is attached together with ControlPlane via SetControlPlane and closed here.
 	controlPlanePool *pgxpool.Pool
 }

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -46,10 +46,11 @@ type Runtime struct {
 
 	// AdminChecker, when set, evaluates the LIVE openrails:admin permission for a
 	// caller's OWN tenant (#312). It is used by mixed public/admin read endpoints
-	// (e.g. showing inactive catalog rows to admins). nil in verifier-only mode;
-	// the control plane satisfies it. Declared as an inline interface so this
-	// package does not import internal/auth/policy (which imports app via
-	// internal/http/request, which would cycle).
+	// (e.g. showing inactive catalog rows to admins). The control plane satisfies
+	// it; it is nil only for embedded hosts without one (admin reads then fail
+	// closed). Declared as an inline interface so this package does not import
+	// internal/auth/policy (which imports app via internal/http/request, which
+	// would cycle).
 	AdminChecker interface {
 		HasAdminPermission(ctx context.Context, tenantSlug, userID, perm string) (bool, error)
 	}

--- a/internal/auth/policy/admin.go
+++ b/internal/auth/policy/admin.go
@@ -39,9 +39,9 @@ type PlatformSuperadminChecker interface {
 // IsLiveAdmin reports whether the given UserContext holds the live openrails:admin
 // permission in its OWN tenant (#312). It is the soft-authorization helper used
 // by mixed public/admin read endpoints (e.g. showing inactive catalog rows to
-// admins). When checker is nil (verifier-only mode) or the caller carries no
-// tenant context, it returns false — there is no operator-tenant or DB-role
-// fallback.
+// admins). When checker is nil (an embedded host with no control plane) or the
+// caller carries no tenant context, it returns false — there is no
+// operator-tenant or DB-role fallback.
 func IsLiveAdmin(ctx context.Context, checker AdminPermissionChecker, uc authprovider.UserContext) (bool, error) {
 	if checker == nil || strings.TrimSpace(uc.UserID) == "" || strings.TrimSpace(uc.Tenant) == "" {
 		return false, nil

--- a/internal/auth/policy/ginmw/admin_test.go
+++ b/internal/auth/policy/ginmw/admin_test.go
@@ -55,7 +55,7 @@ func TestAdminPermissionRequired(t *testing.T) {
 			wantBody:   "authentication required",
 		},
 		{
-			name:       "nil checker -> 500 (verifier-only mode fails closed)",
+			name:       "nil checker -> 500 (no control plane wired fails closed)",
 			checker:    nil,
 			uc:         authprovider.UserContext{UserID: "user-1", Tenant: "acme"},
 			wantStatus: http.StatusInternalServerError,

--- a/internal/auth/verifier.go
+++ b/internal/auth/verifier.go
@@ -15,7 +15,12 @@ type Verifier interface {
 	Verify(token string) (authhttp.Claims, error)
 }
 
-// NewVerifier builds an authkit-backed verifier using billing auth config.
+// NewVerifier builds an authkit-backed verifier over the config-declared
+// FIRST-PARTY issuer allowlist (auth.issuers): host-app-issued user/admin JWTs
+// verify against each issuer's published JWKS. This is an input to the always-on
+// auth stack — not a deployment mode (#469 removed "verifier-only" standalone;
+// the AuthKit control plane always runs alongside it and owns delegated/service
+// credentials via its live issuer registry).
 // Supports multiple issuers to accept tokens from multiple IdPs/environments.
 func NewVerifier(cfg *config.AuthConfig) (Verifier, error) {
 	if cfg == nil {

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -22,8 +22,7 @@ type Options struct {
 	Authenticator billingauth.Authenticator
 	// DelegatedAuthenticator is the optional host-pluggable identity seam for
 	// the delegated self-service surface (#339). When nil, that surface
-	// authenticates via the control plane's delegated-token verifier (and is
-	// not mounted in verifier-only mode).
+	// authenticates via the control plane's delegated-token verifier.
 	DelegatedAuthenticator billingauth.DelegatedAuthenticator
 	Cache                  cache.Cache
 	Clock                  clockwork.Clock

--- a/internal/bootstrap/ginboot/ginboot.go
+++ b/internal/bootstrap/ginboot/ginboot.go
@@ -40,9 +40,11 @@ func NewServer(cfg *config.Config, opts *bootstrap.Options) (*Result, error) {
 		}
 	}()
 
-	// Standalone opts in to the AuthKit verifier (#284): the embedded core no
-	// longer builds a default verifier, so when no Authenticator was injected we
-	// construct the AuthKit-backed one from config here.
+	// Standalone wires the AuthKit first-party JWT verifier (#284): the embedded
+	// core no longer builds a default verifier, so when no Authenticator was
+	// injected we construct the AuthKit-backed one from the config-declared
+	// first-party issuers (auth.issuers) here. This is an input to the user/admin
+	// JWT surface, not an auth mode (#469).
 	if application.Authenticator == nil && cfg.Auth != nil && len(cfg.Auth.Issuers) > 0 {
 		authn, aerr := embauthkit.NewVerifierAuthenticatorFromConfig(cfg.Auth)
 		if aerr != nil {
@@ -51,9 +53,8 @@ func NewServer(cfg *config.Config, opts *bootstrap.Options) (*Result, error) {
 		application.Authenticator = authn
 	}
 
-	// Standalone opts in to the OpenRails-owned AuthKit control plane (#284):
-	// build it (when enabled in config) and attach to the app, reusing an injected
-	// pool when present. No-op in verifier-only mode.
+	// Standalone always attaches the OpenRails-owned AuthKit control plane
+	// (#284/#469), reusing an injected pool when present. Failure is fatal.
 	var injectedPool = func() *pgxpool.Pool {
 		if opts != nil {
 			return opts.PGXPool

--- a/internal/bootstrap/tenant_manifest_integration_test.go
+++ b/internal/bootstrap/tenant_manifest_integration_test.go
@@ -242,7 +242,6 @@ func newTenantManifestControlPlane(t *testing.T, pool *pgxpool.Pool) *controlpla
 		Auth: &config.AuthConfig{
 			ExpectedAudience: "openrails",
 			ControlPlane: &config.ControlPlaneConfig{
-				Enabled:     true,
 				Issuer:      "https://openrails.test",
 				TokenPrefix: "openrails",
 			},

--- a/internal/controlplane/authority.go
+++ b/internal/controlplane/authority.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 )
 
-// ErrNoControlPlane is returned by authority checks when the control plane is
-// not configured (verifier-only mode), so callers can fall back to the legacy
-// JWT/role policy explicitly rather than silently allowing or denying.
+// ErrNoControlPlane is returned by authority checks invoked on a nil control
+// plane (an embedded host that never attached one), so callers fail closed
+// explicitly rather than silently allowing or denying.
 var ErrNoControlPlane = errors.New("controlplane: not configured")
 
 // HasAdminPermission reports whether the given user holds perm in the caller's

--- a/internal/controlplane/bootstrap_integration_test.go
+++ b/internal/controlplane/bootstrap_integration_test.go
@@ -108,14 +108,13 @@ func applyBootstrapTestSchema(t *testing.T, ctx context.Context, pool *pgxpool.P
 	require.NoError(t, err)
 }
 
-func newEnabledControlPlane(t *testing.T, pool *pgxpool.Pool) *ControlPlane {
+func newTestControlPlane(t *testing.T, pool *pgxpool.Pool) *ControlPlane {
 	t.Helper()
 	cfg := &config.Config{
 		Env: "test",
 		Auth: &config.AuthConfig{
 			ExpectedAudience: "openrails-app",
 			ControlPlane: &config.ControlPlaneConfig{
-				Enabled:     true,
 				Issuer:      "https://billing.test",
 				TokenPrefix: "openrails",
 			},
@@ -130,7 +129,7 @@ func newEnabledControlPlane(t *testing.T, pool *pgxpool.Pool) *ControlPlane {
 func TestBootstrap_Idempotent(t *testing.T) {
 	ctx := context.Background()
 	pool := newBootstrapTestPool(t)
-	cp := newEnabledControlPlane(t, pool)
+	cp := newTestControlPlane(t, pool)
 
 	// First run: creates the operator tenant, seeds role/perms, mints service token, records tenant.
 	res1, err := cp.Bootstrap(ctx, BootstrapOptions{MintInitialServiceToken: true})
@@ -200,7 +199,7 @@ func resourceIDs(resources []authcore.ServiceTokenResource, kind string) []strin
 func TestBootstrap_SeedsPermissionCatalog(t *testing.T) {
 	ctx := context.Background()
 	pool := newBootstrapTestPool(t)
-	cp := newEnabledControlPlane(t, pool)
+	cp := newTestControlPlane(t, pool)
 
 	_, err := cp.Bootstrap(ctx, BootstrapOptions{MintInitialServiceToken: false})
 	require.NoError(t, err)
@@ -236,7 +235,6 @@ func TestBootstrapPlatform_SeedsSuperadminInSeparateTenant(t *testing.T) {
 		Auth: &config.AuthConfig{
 			ExpectedAudience: "openrails-app",
 			ControlPlane: &config.ControlPlaneConfig{
-				Enabled:            true,
 				Issuer:             "https://billing.test",
 				TokenPrefix:        "openrails",
 				PlatformTenantSlug: "openrails-platform",
@@ -300,7 +298,7 @@ func TestBootstrapPlatform_SeedsSuperadminInSeparateTenant(t *testing.T) {
 func TestDelegatedTenantResolution(t *testing.T) {
 	ctx := context.Background()
 	pool := newBootstrapTestPool(t)
-	cp := newEnabledControlPlane(t, pool)
+	cp := newTestControlPlane(t, pool)
 
 	// A second, suspended tenant owned by a distinct AuthKit tenant (uuid+slug linked).
 	_, err := pool.Exec(ctx, `

--- a/internal/controlplane/delegated.go
+++ b/internal/controlplane/delegated.go
@@ -84,9 +84,9 @@ func (r *ResolvedDelegated) HasPermission(perm string) bool {
 	return false
 }
 
-// ErrDelegatedNotConfigured indicates the deployment has no delegated-token
-// verifier (verifier-only / no control plane). The self-service surface is not
-// mounted in that mode, so this is a defensive guard.
+// ErrDelegatedNotConfigured indicates the control plane has no delegated-token
+// verifier. That is a wiring bug (#469: the standalone always builds one), so
+// this is a defensive fail-closed guard.
 var ErrDelegatedNotConfigured = errors.New("controlplane: delegated access verifier not configured")
 
 // ErrDelegatedInvalid is the sanitized error for any delegated-token rejection
@@ -94,9 +94,8 @@ var ErrDelegatedNotConfigured = errors.New("controlplane: delegated access verif
 // internal verifier detail to the response.
 var ErrDelegatedInvalid = errors.New("controlplane: invalid delegated access token")
 
-// DelegatedVerifier returns the control plane's delegated-access-token verifier,
-// or nil when the deployment is verifier-only. Exposed for the middleware and
-// tests.
+// DelegatedVerifier returns the control plane's delegated-access-token verifier.
+// Exposed for the middleware and tests.
 func (c *ControlPlane) DelegatedVerifier() *authhttp.Verifier {
 	if c == nil {
 		return nil

--- a/internal/controlplane/service.go
+++ b/internal/controlplane/service.go
@@ -21,9 +21,9 @@ import (
 // wraps an AuthKit http.Service (which exposes selectable route groups) and its
 // underlying core.Service (used for in-process tenant/role/service-token bootstrap calls).
 //
-// It is constructed only when auth.control_plane.enabled is true. In pure
-// verifier mode this is never built and OpenRails keeps acting as an external
-// JWT verifier.
+// HARD CUT (#469): the control plane is mandatory in standalone mode — the
+// standalone binary always constructs it at boot and a construction failure is
+// fatal. pkg/embedded hosts opt in via pkg/embedded/controlplane.Attach.
 type ControlPlane struct {
 	cfg     *config.Config
 	authSvc *authhttp.Service
@@ -70,20 +70,20 @@ func registrationMode(locked bool) authcore.RegistrationMode {
 // schema (in self-hosted mode this is the same database OpenRails uses). The
 // caller owns the pool lifecycle.
 //
-// Returns (nil, nil) when the control plane is disabled — callers should treat
-// a nil ControlPlane as "verifier-only mode".
+// The control plane is mandatory in standalone mode (#469): every input is
+// required and a failure here is a boot failure, never a silent downgrade.
 func New(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool) (*ControlPlane, error) {
-	if cfg == nil || cfg.Auth == nil || !cfg.Auth.ControlPlaneEnabled() {
-		return nil, nil
+	if cfg == nil || cfg.Auth == nil || cfg.Auth.ControlPlane == nil {
+		return nil, errors.New("controlplane: auth.control_plane configuration is required (the control plane is mandatory in standalone mode, #469)")
 	}
 	if pool == nil {
-		return nil, errors.New("controlplane: pgx pool is required when the control plane is enabled")
+		return nil, errors.New("controlplane: pgx pool is required")
 	}
 	cp := cfg.Auth.ControlPlane
 
 	issuer := strings.TrimSpace(cp.Issuer)
 	if issuer == "" {
-		return nil, errors.New("controlplane: auth.control_plane.issuer is required when enabled")
+		return nil, errors.New("controlplane: auth.control_plane.issuer is required")
 	}
 
 	// Audiences default to the verifier's expected audience so issued/accepted

--- a/internal/controlplane/service_test.go
+++ b/internal/controlplane/service_test.go
@@ -7,56 +7,27 @@ import (
 	"github.com/open-rails/openrails/config"
 )
 
-func TestNew_DisabledReturnsNil(t *testing.T) {
-	// No auth config at all.
-	cp, err := New(context.Background(), &config.Config{}, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+func TestNew_RequiresControlPlaneConfig(t *testing.T) {
+	// HARD CUT (#469): the control plane is mandatory — a missing
+	// auth.control_plane section is a construction error, never a nil control
+	// plane ("verifier-only mode" is gone).
+	if _, err := New(context.Background(), &config.Config{}, nil); err == nil {
+		t.Fatal("expected error when auth.control_plane is missing")
 	}
-	if cp != nil {
-		t.Fatal("expected nil control plane when disabled")
-	}
-
-	// Auth present but control plane disabled.
-	cfg := &config.Config{Auth: &config.AuthConfig{}}
-	cp, err = New(context.Background(), cfg, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cp != nil {
-		t.Fatal("expected nil control plane when control plane disabled")
+	if _, err := New(context.Background(), &config.Config{Auth: &config.AuthConfig{}}, nil); err == nil {
+		t.Fatal("expected error when auth.control_plane is missing")
 	}
 }
 
-func TestNew_EnabledRequiresPool(t *testing.T) {
+func TestNew_RequiresPool(t *testing.T) {
 	cfg := &config.Config{Auth: &config.AuthConfig{
 		ExpectedAudience: "openrails-app",
 		ControlPlane: &config.ControlPlaneConfig{
-			Enabled: true,
-			Issuer:  "https://billing.example.com",
+			Issuer: "https://billing.example.com",
 		},
 	}}
 	if _, err := New(context.Background(), cfg, nil); err == nil {
-		t.Fatal("expected error when pool is nil and control plane enabled")
-	}
-}
-
-func TestControlPlaneEnabled(t *testing.T) {
-	var a *config.AuthConfig
-	if a.ControlPlaneEnabled() {
-		t.Error("nil auth config should not enable control plane")
-	}
-	a = &config.AuthConfig{}
-	if a.ControlPlaneEnabled() {
-		t.Error("empty auth config should not enable control plane")
-	}
-	a.ControlPlane = &config.ControlPlaneConfig{Enabled: false}
-	if a.ControlPlaneEnabled() {
-		t.Error("disabled control plane should report disabled")
-	}
-	a.ControlPlane.Enabled = true
-	if !a.ControlPlaneEnabled() {
-		t.Error("enabled control plane should report enabled")
+		t.Fatal("expected error when pool is nil")
 	}
 }
 

--- a/internal/http/embedhttp/embedhttp.go
+++ b/internal/http/embedhttp/embedhttp.go
@@ -60,8 +60,9 @@ type Assembler struct {
 	Runtime *app.Runtime
 	// AdminChecker is the live admin permission checker (#312), held as the neutral
 	// authpolicy.AdminPermissionChecker interface so this core package imports
-	// neither internal/controlplane nor AuthKit (#284). nil in verifier-only mode.
-	// The concrete *controlplane.ControlPlane satisfies it.
+	// neither internal/controlplane nor AuthKit (#284). nil for embedded hosts
+	// without a control plane (admin routes then fail closed). The concrete
+	// *controlplane.ControlPlane satisfies it.
 	AdminChecker  authpolicy.AdminPermissionChecker
 	CaptchaStore  *captcha.ChallengeStore
 	Authenticator billingauth.Authenticator

--- a/internal/http/middleware/ginmw/delegated.go
+++ b/internal/http/middleware/ginmw/delegated.go
@@ -26,8 +26,8 @@ const (
 
 // DelegatedResolver validates a presented browser-direct delegated access token
 // against live AuthKit + tenant-directory state. The control plane implements
-// it; tests can inject a fake. nil resolver => the deployment is not delegated-
-// token-capable (verifier-only mode), and the self-service surface is not mounted.
+// it; tests can inject a fake. A nil resolver is a wiring bug (#469: the
+// standalone always has a control plane) and the middleware fails closed.
 type DelegatedResolver interface {
 	// ResolveDelegated verifies the delegated access token (aud=openrails, no
 	// sub, self-permissions) and resolves its tenant + acting user

--- a/internal/http/middleware/ginmw/service_token.go
+++ b/internal/http/middleware/ginmw/service_token.go
@@ -25,7 +25,8 @@ const (
 
 // ServiceTokenResolver validates a presented OpenRails-issued service token against live AuthKit +
 // tenant-directory state. The control plane implements it; tests can inject a
-// fake. nil resolver => the deployment is not service token-capable (verifier-only mode).
+// fake. A nil resolver is a wiring bug (#469: the standalone always has a
+// control plane) and the middleware fails closed.
 type ServiceTokenResolver interface {
 	// LooksLikeServiceToken reports whether token carries this deployment's service token marker.
 	LooksLikeServiceToken(token string) bool

--- a/internal/http/routes/ginroutes/issuers.go
+++ b/internal/http/routes/ginroutes/issuers.go
@@ -15,9 +15,7 @@ import (
 )
 
 // DelegatedIssuerAdmin manages a tenant's FEDERATED delegated-token issuers
-// (issue #259). The control plane implements it; tests inject a fake. nil => the
-// deployment cannot manage issuers (verifier-only mode) and the routes are not
-// mounted.
+// (issue #259). The control plane implements it; tests inject a fake.
 type DelegatedIssuerAdmin interface {
 	RegisterDelegatedIssuer(ctx context.Context, p controlplane.RegisterDelegatedIssuerParams) error
 	DisableDelegatedIssuer(ctx context.Context, tenantID tenant.ID, issuer string) error

--- a/internal/http/routes/ginroutes/self_service_host_principal_test.go
+++ b/internal/http/routes/ginroutes/self_service_host_principal_test.go
@@ -18,9 +18,10 @@ import (
 
 // These tests pin the HOST-PLUGGABLE identity seam for the self-service
 // surface (issue #339): a host-supplied billingauth.DelegatedAuthenticator
-// authenticates /v1/self/* with NO control plane anywhere (the previously
-// impossible verifier-only case), and the explicit-mapping contract is
-// enforced fail-closed (empty tenant/subject/permissions => 401; permissions
+// authenticates /v1/self/* with NO control plane wired in the test fixture
+// (the host seam overrides the control-plane verifier), and the
+// explicit-mapping contract is enforced fail-closed (empty
+// tenant/subject/permissions => 401; permissions
 // outside the delegated catalog => 401; missing write permission => 403 on
 // the settings PUT).
 

--- a/internal/http/routes/routes.go
+++ b/internal/http/routes/routes.go
@@ -19,8 +19,9 @@ type Options struct {
 
 	// AdminPermissionChecker is the LIVE authority for admin routes (#312): admin
 	// routes require the openrails:admin permission evaluated live against the
-	// CALLER'S OWN tenant. nil in verifier-only mode, in which case admin routes
-	// fail closed (there is no operator-tenant or role-claim fallback).
+	// CALLER'S OWN tenant. nil for embedded hosts without a control plane, in
+	// which case admin routes fail closed (there is no operator-tenant or
+	// role-claim fallback).
 	AdminPermissionChecker authpolicy.AdminPermissionChecker
 }
 
@@ -130,8 +131,8 @@ func RegisterUserRoutes(rr router.Router, rt *app.Runtime, opts Options) {
 func RegisterAdminRoutes(rr router.Router, rt *app.Runtime, opts Options) {
 	// HARDCUT (#312): admin authority is the LIVE openrails:admin permission held
 	// in the caller's OWN tenant — evaluated at request time by the control plane,
-	// not a claim-based operator-tenant gate. When no control plane is wired
-	// (verifier-only mode) the checker is nil and the gate fails closed.
+	// not a claim-based operator-tenant gate. When an embedded host wires no
+	// control plane the checker is nil and the gate fails closed.
 	mw := []router.Middleware{
 		opts.requiredMW(),
 		authpolicy.AdminPermissionRequiredMW(opts.AdminPermissionChecker, authpolicy.PermAdmin),

--- a/internal/http/routes_controlplane.go
+++ b/internal/http/routes_controlplane.go
@@ -14,11 +14,8 @@ const ControlPlaneAuthPrefix = "/auth"
 // registerControlPlaneAuthRoutes selectively mounts the AuthKit route groups
 // OpenRails intentionally exposes (#224 task 4). In locked-down/self-hosted mode
 // this is only the login/session/user groups; AuthKit DefaultAPI() is never
-// mounted. No-op when the control plane is disabled (verifier-only mode).
+// mounted.
 func (s *Server) registerControlPlaneAuthRoutes(e *gin.Engine) {
-	if s == nil || s.controlPlane == nil || e == nil {
-		return
-	}
 	group := e.Group(ControlPlaneAuthPrefix)
 	n := cpginroutes.MountAuthRoutes(s.controlPlane, group)
 	log.WithFields(log.Fields{

--- a/internal/http/routes_platform.go
+++ b/internal/http/routes_platform.go
@@ -23,13 +23,9 @@ import (
 const PlatformPrefix = "/platform"
 
 // registerPlatformRoutes mounts the platform-superadmin cross-tenant API. No-op
-// when the control plane / platform services are absent (verifier-only mode), or
-// when no platform tenant is configured (the superadmin gate could never pass, so
-// the surface stays closed).
+// when no platform tenant is configured (the superadmin gate could never pass,
+// so the surface stays closed).
 func (s *Server) registerPlatformRoutes(e *gin.Engine) {
-	if s.controlPlane == nil || s.tenancy == nil || s.platformAudit == nil {
-		return
-	}
 	if s.controlPlane.PlatformTenantSlug() == "" {
 		// No platform tenant configured: do not mount a surface nobody can pass.
 		log.Info("platform superadmin routes not mounted: no platform tenant configured")

--- a/internal/http/routes_self.go
+++ b/internal/http/routes_self.go
@@ -18,20 +18,14 @@ import (
 // logged-in end-user; the browser calls OpenRails directly with it. Every
 // operation is scoped to the token's delegated_sub + resolved tenant.
 //
-// IDENTITY IS HOST-PLUGGABLE (issue #339): the surface is mounted when EITHER
-// the OpenRails-owned AuthKit control plane (the default delegated-token
-// verifier) OR a host-supplied billingauth.DelegatedAuthenticator is
-// configured. A host running OpenRails as a subsystem verifies its own
-// credential and supplies the explicitly mapped principal — one system, one
-// credential; the host-supplied seam takes precedence when both are present.
-// With neither configured there is no delegated identity source and the
-// surface is not mounted.
+// The surface is ALWAYS mounted (#469): the OpenRails-owned AuthKit control
+// plane is the default delegated-token verifier. IDENTITY IS HOST-PLUGGABLE
+// (issue #339): a host-supplied billingauth.DelegatedAuthenticator overrides
+// the control-plane verifier — a host running OpenRails as a subsystem
+// verifies its own credential and supplies the explicitly mapped principal,
+// one system, one credential.
 func (s *Server) registerSelfServiceRoutes(e *gin.Engine) {
 	delegatedMW := s.delegatedMiddleware()
-	if delegatedMW == nil {
-		log.Info("no delegated identity source (control plane or host delegated authenticator); self-service API routes will not be mounted")
-		return
-	}
 
 	group := e.Group(StandaloneV1Prefix + httproutes.SelfRoutePrefix)
 	httproutes.RegisterSelfServiceRoutes(group, s.runtime, delegatedMW)
@@ -53,13 +47,10 @@ func (s *Server) registerSelfServiceRoutes(e *gin.Engine) {
 // delegatedMiddleware picks the delegated-identity middleware for the
 // self-service + tenant-admin surfaces (#339): the host-supplied
 // DelegatedAuthenticator when present (an explicit override), else the
-// control plane's delegated-token verifier, else nil (surface not mounted).
+// control plane's delegated-token verifier (always available, #469).
 func (s *Server) delegatedMiddleware() gin.HandlerFunc {
 	if s.delegatedAuthenticator != nil {
 		return ginmw.DelegatedPrincipalRequired(s.delegatedAuthenticator)
 	}
-	if s.controlPlane != nil {
-		return ginmw.DelegatedSelfRequired(s.controlPlane)
-	}
-	return nil
+	return ginmw.DelegatedSelfRequired(s.controlPlane)
 }

--- a/internal/http/routes_self_test.go
+++ b/internal/http/routes_self_test.go
@@ -15,23 +15,10 @@ import (
 	tenantpkg "github.com/open-rails/openrails/pkg/tenant"
 )
 
-// Issue #339: the self-service surface mounts when EITHER the control plane
-// (the default delegated-token verifier) OR a host-supplied
-// DelegatedAuthenticator is configured. These tests pin the gate at the
+// Issue #339: the self-service surface is always mounted (#469); a
+// host-supplied DelegatedAuthenticator overrides the control plane's
+// delegated-token verifier. This test pins the override at the
 // server-registration level without a live control plane.
-
-func TestRegisterSelfServiceRoutes_NotMountedWithoutAnyDelegatedIdentitySource(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	srv := &Server{cfg: &config.Config{}} // no control plane, no host authenticator
-	e := gin.New()
-	srv.registerSelfServiceRoutes(e)
-
-	req := httptest.NewRequest(http.MethodGet, "/v1/self/status", nil)
-	w := httptest.NewRecorder()
-	e.ServeHTTP(w, req)
-	require.Equal(t, http.StatusNotFound, w.Code)
-}
 
 type mountTestDelegatedAuthenticator struct{}
 
@@ -46,7 +33,8 @@ func (mountTestDelegatedAuthenticator) AuthenticateDelegated(context.Context, *h
 func TestRegisterSelfServiceRoutes_MountedWithHostDelegatedAuthenticatorOnly(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	// The previously impossible case: control plane nil, host authenticator set.
+	// Host authenticator set: it takes precedence, so no control plane is
+	// needed to register the surface in this unit test.
 	srv := &Server{cfg: &config.Config{}, delegatedAuthenticator: mountTestDelegatedAuthenticator{}}
 	e := gin.New()
 	srv.registerSelfServiceRoutes(e)

--- a/internal/http/routes_service.go
+++ b/internal/http/routes_service.go
@@ -14,15 +14,9 @@ import (
 // no separate trust surface or port — machine callers present a service token as a Bearer
 // token on the one public tenant API.
 //
-// Mounted only when the OpenRails-owned AuthKit control plane is configured (it is
-// what resolves and authorizes service tokens). In verifier-only mode there is no service token issuer
-// and the service surface is not mounted.
+// The OpenRails-owned AuthKit control plane is what resolves and authorizes
+// service tokens; it is always present on this surface (#469).
 func (s *Server) registerServiceRoutes(e *gin.Engine) {
-	if s.controlPlane == nil {
-		log.Info("control plane disabled; service token service API routes will not be mounted")
-		return
-	}
-
 	group := e.Group(StandaloneV1Prefix + httproutes.ServiceRoutePrefix)
 	httproutes.RegisterServiceRoutes(group, s.runtime, ginmw.ServiceTokenRequired(s.controlPlane), s.controlPlane)
 

--- a/internal/http/routes_service_test.go
+++ b/internal/http/routes_service_test.go
@@ -8,29 +8,14 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 
-	"github.com/open-rails/openrails/config"
 	httproutes "github.com/open-rails/openrails/internal/http/routes/ginroutes"
 )
 
 // Issue #222: the private/mTLS service trust surface is removed. The
-// server-to-server surface is now service token-authenticated and lives on the PUBLIC
-// engine under /v1/service/*, and is mounted ONLY when the OpenRails-owned
-// AuthKit control plane is configured (it resolves service tokens). These tests assert that
-// removal + gating without requiring a live control plane.
-
-func TestRegisterServiceRoutes_NotMountedWithoutControlPlane(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-
-	srv := &Server{cfg: &config.Config{}} // controlPlane is nil (verifier-only mode)
-	e := gin.New()
-	srv.registerServiceRoutes(e)
-
-	// No control plane => no service token issuer => the service surface is not mounted.
-	req := httptest.NewRequest(http.MethodGet, "/v1/service/tenant-subjects/00000000-0000-0000-0000-000000000001/entitlements", nil)
-	w := httptest.NewRecorder()
-	e.ServeHTTP(w, req)
-	require.Equal(t, http.StatusNotFound, w.Code)
-}
+// server-to-server surface is service token-authenticated and lives on the
+// PUBLIC engine under /v1/service/*; the always-present control plane (#469)
+// resolves service tokens. This test asserts the service-token gate without
+// requiring a live control plane.
 
 func TestRegisterServiceRoutes_ServiceTokenAuthGatesMountedSurface(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/internal/http/routes_tenant_admin.go
+++ b/internal/http/routes_tenant_admin.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gin-gonic/gin"
 	log "github.com/sirupsen/logrus"
 
-	authpolicy "github.com/open-rails/openrails/internal/auth/policy"
 	policyginmw "github.com/open-rails/openrails/internal/auth/policy/ginmw"
 	"github.com/open-rails/openrails/internal/controlplane"
 	"github.com/open-rails/openrails/internal/platform"
@@ -25,21 +24,13 @@ import (
 const TenantAdminPrefix = "/admin/tenants"
 
 // registerTenantAdminRoutes mounts the admin-gated tenant provisioning API.
-// No-op without the tenancy service (verifier-only mode).
 func (s *Server) registerTenantAdminRoutes(e *gin.Engine) {
-	if s.tenancy == nil {
-		return
-	}
 	group := e.Group(StandaloneV1Prefix + TenantAdminPrefix)
 	group.Use(s.authProvider.Required())
 	// HARDCUT (#312): tenant provisioning is gated by the LIVE openrails:admin
 	// permission held in the caller's own tenant — not a claim-based operator
-	// tenant. A nil checker (verifier-only mode) fails closed.
-	var adminChecker authpolicy.AdminPermissionChecker
-	if s.controlPlane != nil {
-		adminChecker = s.controlPlane
-	}
-	group.Use(policyginmw.AdminPermissionRequired(adminChecker, controlplane.PermAdmin))
+	// tenant. The control plane (always present, #469) is the checker.
+	group.Use(policyginmw.AdminPermissionRequired(s.controlPlane, controlplane.PermAdmin))
 
 	group.POST("", s.tenantProvisionHandler())
 	group.GET("/:id", s.tenantGetHandler())
@@ -65,11 +56,9 @@ func (s *Server) registerTenantAdminRoutes(e *gin.Engine) {
 // mutations means every cross-tenant tenant-lifecycle change is recorded with
 // actor, target tenant, action, reason, and before/after where applicable.
 //
-// The audit log is nil in verifier-only mode (no control-plane pool); the helper
-// is then a no-op so the admin routes keep working. A persisted-audit failure on
-// a real platform deployment is logged but does not fail the request the
-// mutation already succeeded; platform-superadmin break-glass grants, by
-// contrast, treat audit failure as fatal.
+// A persisted-audit failure on a real platform deployment is logged but does
+// not fail the request — the mutation already succeeded; platform-superadmin
+// break-glass grants, by contrast, treat audit failure as fatal.
 func (s *Server) auditTenantMutation(c *gin.Context, action string, target *tenant.ID, reason string, before, after any) {
 	if s.platformAudit == nil {
 		return

--- a/internal/http/routes_tenant_webhook.go
+++ b/internal/http/routes_tenant_webhook.go
@@ -23,14 +23,9 @@ import (
 // the trust boundary — OpenRails always re-derives the secret and re-verifies.
 const TenantWebhookPrefix = "/t/:tenant/webhooks"
 
-// registerTenantWebhookRoutes mounts the tenant-scoped webhook surface. No-op
-// without the tenancy service (verifier-only mode), where the single default
-// tenant continues to use the global /v1/webhooks/:provider surface.
+// registerTenantWebhookRoutes mounts the tenant-scoped webhook surface. The
+// single default tenant may still use the global /v1/webhooks/:provider surface.
 func (s *Server) registerTenantWebhookRoutes(e *gin.Engine) {
-	if s.tenancy == nil {
-		log.Info("tenancy service disabled; tenant-scoped webhook routes will not be mounted")
-		return
-	}
 	group := e.Group(StandaloneV1Prefix + TenantWebhookPrefix)
 	group.POST("/:provider", s.tenantWebhookHandler())
 	log.WithField("prefix", StandaloneV1Prefix+TenantWebhookPrefix).

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -39,16 +39,15 @@ type Dependencies struct {
 	// reconstructed from it via ginauth.ProviderFromAuthenticator (#285).
 	Authenticator billingauth.Authenticator
 	// ControlPlane is OpenRails' OpenRails-owned AuthKit control plane (#224).
-	// nil in verifier-only mode. When present, the server selectively mounts the
+	// REQUIRED (#469): the standalone gin surface always runs with a control
+	// plane — there is no verifier-only mode. The server selectively mounts the
 	// intentional AuthKit route groups (never DefaultAPI in locked-down mode).
 	ControlPlane *controlplane.ControlPlane
 	// DelegatedAuthenticator is the OPTIONAL host-pluggable identity seam for
 	// the browser-direct self-service surface (issue #339). When set, the host
 	// verifies the incoming credential itself and supplies the explicitly
-	// mapped principal; /v1/self/* + /v1/tenant-admin/* are then mounted even
-	// without a control plane, authenticated by this seam. When both this and
-	// the control plane are configured, the host-supplied authenticator wins
-	// (an explicit override of the default control-plane verifier).
+	// mapped principal for /v1/self/* + /v1/tenant-admin/*, OVERRIDING the
+	// control plane's default delegated-token verifier.
 	DelegatedAuthenticator billingauth.DelegatedAuthenticator
 }
 
@@ -71,18 +70,17 @@ type Server struct {
 	captchaStore           *captcha.ChallengeStore
 
 	// tenancy is the tenant provisioning + lifecycle + per-tenant secret service
-	// (issue #225). Built only when the control plane is present (it owns the
-	// billing.* control-plane pool and the operator-tenant provisioner). nil in
-	// verifier-only mode: the tenant webhook + provisioning admin routes are then
-	// not mounted and the single default tenant continues via the global webhook.
+	// (issue #225). It reuses the control plane's pgx pool (the billing.*
+	// control-plane DB) and operator-tenant provisioner, and is always built
+	// (#469: the control plane is mandatory on this surface).
 	tenancy *tenancy.Service
 
 	// Platform superadmin layer (issue #226), DISTINCT from per-tenant operator
-	// admin. Built only when the control plane is present (they share the
-	// billing.* control-plane pool). platformAudit records every cross-tenant
-	// superadmin mutation; platformBreakGlass manages time-boxed elevation;
-	// platformMetrics aggregates platform-wide tenant metrics. nil in
-	// verifier-only mode: the /v1/platform/* surface is then not mounted.
+	// admin, sharing the billing.* control-plane pool. platformAudit records
+	// every cross-tenant superadmin mutation; platformBreakGlass manages
+	// time-boxed elevation; platformMetrics aggregates platform-wide tenant
+	// metrics. The /v1/platform/* surface itself is mounted only when a
+	// platform tenant is configured.
 	platformAudit      *platform.AuditLog
 	platformBreakGlass *platform.BreakGlass
 	platformMetrics    *platform.Metrics
@@ -146,6 +144,15 @@ func New(deps Dependencies) (*Server, error) {
 	if deps.Authenticator == nil {
 		return nil, fmt.Errorf("authenticator is required")
 	}
+	// HARD CUT (#469): the standalone surface always runs with the AuthKit
+	// control plane; a missing control plane is a boot failure, not a degraded
+	// "verifier-only" server.
+	if deps.ControlPlane == nil {
+		return nil, fmt.Errorf("control plane is required (#469: standalone always runs the AuthKit control plane)")
+	}
+	if deps.ControlPlane.Pool() == nil {
+		return nil, fmt.Errorf("control plane pool is required")
+	}
 
 	s := &Server{
 		cfg:     deps.Config,
@@ -164,18 +171,15 @@ func New(deps Dependencies) (*Server, error) {
 
 	// Wire the live admin-permission checker onto the runtime so mixed
 	// public/admin read endpoints (e.g. catalog inactive rows) can evaluate
-	// openrails:admin for the caller's own tenant (#312). Only when the control
-	// plane is present, to avoid boxing a typed-nil pointer into the interface.
-	if deps.ControlPlane != nil && deps.Runtime != nil {
-		deps.Runtime.AdminChecker = deps.ControlPlane
-	}
+	// openrails:admin for the caller's own tenant (#312).
+	deps.Runtime.AdminChecker = deps.ControlPlane
 
-	// Build the tenant provisioning/lifecycle/secret service when the control
-	// plane is present (issue #225). It reuses the control plane's pgx pool (the
-	// OpenRails-owned billing.* control-plane DB) and operator-tenant provisioner. The
-	// DB-backed secret store is the self-hosted default and needs no live Vault; a
-	// managed deployment swaps in the Vault-backed store with the same addressing.
-	if deps.ControlPlane != nil && deps.ControlPlane.Pool() != nil {
+	// Build the tenant provisioning/lifecycle/secret service (issue #225). It
+	// reuses the control plane's pgx pool (the OpenRails-owned billing.*
+	// control-plane DB) and operator-tenant provisioner. The DB-backed secret
+	// store is the self-hosted default and needs no live Vault; a managed
+	// deployment swaps in the Vault-backed store with the same addressing.
+	{
 		var secretStore tenancy.TenantSecretStore
 		var solanaTransit solanaint.TransitClient
 
@@ -406,28 +410,25 @@ func New(deps Dependencies) (*Server, error) {
 
 	// Selective AuthKit route mounting (#224). In locked-down mode this mounts
 	// ONLY the intentional AuthKit route groups (login/session/user) under
-	// /auth — never AuthKit DefaultAPI. No-op in verifier-only mode.
+	// /auth — never AuthKit DefaultAPI.
 	s.registerControlPlaneAuthRoutes(s.publicHandler)
 
-	// Server-to-server service API: service token-authenticated, on the SAME public engine
-	// (issue #222). No private port, no mTLS listener. No-op without a control
-	// plane (verifier-only mode has no service token issuer).
+	// Server-to-server service API: service token-authenticated, on the SAME
+	// public engine (issue #222). No private port, no mTLS listener.
 	s.registerServiceRoutes(s.publicHandler)
 
 	// Browser-direct self-service API: delegated-access-token-authenticated, on
-	// the SAME public engine (issue #222 browser tier). Mounted when the control
-	// plane OR a host-supplied DelegatedAuthenticator is configured (#339);
-	// no-op otherwise.
+	// the SAME public engine (issue #222 browser tier). Always mounted (#469);
+	// a host-supplied DelegatedAuthenticator overrides the control plane's
+	// delegated-token verifier (#339).
 	s.registerSelfServiceRoutes(s.publicHandler)
 
 	// Tenant-scoped webhook routing (issue #225): /v1/t/:tenant/webhooks/:provider
 	// resolves the tenant from the path slug, then loads THAT tenant's signing
-	// secret and verifies the signature AFTER tenant resolution. No-op without the
-	// tenancy service (verifier-only mode).
+	// secret and verifies the signature AFTER tenant resolution.
 	s.registerTenantWebhookRoutes(s.publicHandler)
 
-	// Operator-gated tenant provisioning/lifecycle admin API (issue #225). No-op
-	// without the tenancy service.
+	// Operator-gated tenant provisioning/lifecycle admin API (issue #225).
 	s.registerTenantAdminRoutes(s.publicHandler)
 
 	// Platform-superadmin cross-tenant admin API (issue #226), gated by
@@ -473,12 +474,9 @@ func (s *Server) newHTTPHandlerMux(opts HTTPHandlerOptions) http.Handler {
 		CaptchaStore:  s.captchaStore,
 		Authenticator: s.embeddedAuthenticator(),
 	}
-	// Only set the live admin-permission checker when the control plane is
-	// actually present (#284): a nil *controlplane.ControlPlane boxed into the
-	// AdminPermissionChecker interface would be non-nil and misfire.
-	if s.controlPlane != nil {
-		asm.AdminChecker = s.controlPlane
-	}
+	// The control plane is always present on this surface (#469); it is the
+	// live admin-permission checker.
+	asm.AdminChecker = s.controlPlane
 	return asm.NewHTTPHandler(embedhttp.Options{
 		IncludeUser:     opts.IncludeUser,
 		IncludeAdmin:    opts.IncludeAdmin,

--- a/pkg/authprovider/ginauth/provider.go
+++ b/pkg/authprovider/ginauth/provider.go
@@ -10,8 +10,9 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// Provider is the app-facing auth boundary for verification middleware.
-// Billing is a verifier-only service; it does not mount AuthKit routes or mint tokens.
+// Provider is the app-facing auth boundary for the user/admin JWT verification
+// middleware. It only VERIFIES the first-party credential; minting delegated /
+// service credentials is the control plane's job.
 //
 // The middleware must set the user context in the Gin context using:
 //

--- a/pkg/embedded/authkit/authkit.go
+++ b/pkg/embedded/authkit/authkit.go
@@ -20,8 +20,11 @@ import (
 // issuers, optionally constraining the token audience. Pass the returned value
 // as embedded.Options.Authenticator.
 //
-// This is the verifier-only ("pure verifier") auth mode that used to be wired
-// implicitly from Config.Auth.Issuers inside the embedded core. It is now opt-in.
+// This is the first-party issuer verifier that used to be wired implicitly
+// from Config.Auth.Issuers inside the embedded core. It is an INPUT to the
+// auth stack (the user/admin JWT surface), not a standalone auth mode — #469
+// removed the "verifier-only" deployment; standalone always also runs the
+// AuthKit control plane.
 func NewVerifierAuthenticator(issuers []string, expectedAud string) (billingauth.Authenticator, error) {
 	return auth.NewAuthenticator(&config.AuthConfig{
 		Issuers:          issuers,

--- a/pkg/embedded/controlplane/controlplane.go
+++ b/pkg/embedded/controlplane/controlplane.go
@@ -1,9 +1,11 @@
-// Package controlplane is the OPT-IN OpenRails AuthKit control-plane helper for
-// the standalone binary and AuthKit-using embedded hosts (#284). The embedded
-// CORE (pkg/embedded.New -> bootstrap.NewApp -> internal/app) deliberately does
-// NOT import internal/controlplane (and through it AuthKit): control-plane /
-// tenant-management is standalone-only. Importing THIS package is what pulls the
-// control plane (and AuthKit) onto a host's graph.
+// Package controlplane wires the OpenRails AuthKit control plane onto an app
+// graph (#284). The embedded CORE (pkg/embedded.New -> bootstrap.NewApp ->
+// internal/app) deliberately does NOT import internal/controlplane (and through
+// it AuthKit): embedded hosts are host-authenticated and opt in by importing
+// THIS package, which is what pulls the control plane (and AuthKit) onto a
+// host's graph. The STANDALONE binary, by contrast, always attaches the control
+// plane (#469): there is no verifier-only standalone mode, and an Attach
+// failure is fatal at boot.
 //
 // The control plane is held on app.App as `any` (App.ControlPlane); this package
 // builds the concrete *controlplane.ControlPlane, attaches it via
@@ -22,8 +24,8 @@ import (
 )
 
 // Get recovers the concrete *controlplane.ControlPlane attached to the app, or
-// nil when the control plane is disabled (verifier-only mode) or the field holds
-// some other type.
+// nil when no control plane has been attached (an embedded host that never
+// called Attach) or the field holds some other type.
 func Get(a *app.App) *controlplane.ControlPlane {
 	if a == nil {
 		return nil
@@ -32,21 +34,15 @@ func Get(a *app.App) *controlplane.ControlPlane {
 	return cp
 }
 
-// Attach builds the OpenRails-owned AuthKit control plane (#224) when enabled in
-// config and attaches it to the app. It is a no-op (control plane left nil) when
-// cfg.Auth.ControlPlaneEnabled() is false. injectedPool, when non-nil, is reused
+// Attach builds the OpenRails-owned AuthKit control plane (#224) and attaches it
+// to the app. Construction always happens (#469: there is no disabled state);
+// any failure — missing issuer, bad keys, unreachable DB — is returned so the
+// standalone boot path can exit non-zero. injectedPool, when non-nil, is reused
 // as the control-plane pool; otherwise Attach creates an OpenRails-owned pool
 // whose lifecycle App.Close manages.
-//
-// This is the construction that used to live in internal/app.BootstrapWithOptions
-// (#284); the standalone/opt-in path now calls it explicitly after building the
-// app.
 func Attach(ctx context.Context, a *app.App, cfg *config.Config, injectedPool *pgxpool.Pool) error {
 	if a == nil || cfg == nil {
-		return nil
-	}
-	if cfg.Auth == nil || !cfg.Auth.ControlPlaneEnabled() {
-		return nil
+		return fmt.Errorf("control plane: app and config are required")
 	}
 
 	// The control plane needs a pgx pool over the database holding AuthKit's
@@ -80,15 +76,16 @@ func Attach(ctx context.Context, a *app.App, cfg *config.Config, injectedPool *p
 
 // RunBootstrap idempotently bootstraps the OpenRails-owned AuthKit control plane
 // (#224): ensures the bootstrap authority, OpenRails operator role, the
-// openrails.* permission catalog, and an initial operator service token. It is
-// a no-op when the control plane is disabled.
+// openrails.* permission catalog, and an initial operator service token.
+// Calling it without an attached control plane is a wiring error (#469: the
+// standalone always attaches one first).
 //
 // Call it AFTER migrations have run (so billing.tenants and profiles.* exist) and
 // at startup. Safe to re-run. This was App.RunControlPlaneBootstrap before #284.
 func RunBootstrap(ctx context.Context, a *app.App, opts controlplane.BootstrapOptions) (*controlplane.BootstrapResult, error) {
 	cp := Get(a)
 	if cp == nil {
-		return nil, nil
+		return nil, fmt.Errorf("control plane bootstrap: no control plane attached (call Attach first)")
 	}
 	if !opts.MintInitialServiceToken {
 		opts.MintInitialServiceToken = true

--- a/pkg/embedded/embedded.go
+++ b/pkg/embedded/embedded.go
@@ -35,9 +35,8 @@ type Options struct {
 	// {tenant, subject, permissions} principal; the standalone/gin handler then
 	// mounts the self surface authenticated by it, even without a control
 	// plane. When nil, the surface authenticates via the control plane's
-	// delegated-token verifier (the default), and is not mounted in
-	// verifier-only mode. See billingauth.DelegatedAuthenticatorFunc for a
-	// closure example.
+	// delegated-token verifier (the default). See
+	// billingauth.DelegatedAuthenticatorFunc for a closure example.
 	DelegatedAuthenticator billingauth.DelegatedAuthenticator
 	Cache                  cache.Cache
 }

--- a/pkg/embedded/gin/gin.go
+++ b/pkg/embedded/gin/gin.go
@@ -117,11 +117,12 @@ func routeAuthenticator(e *embedded.Embedded, opts RouteOptions) billingauth.Aut
 
 // newServer constructs the gin billing server graph from the embedded app.
 //
-// This is the standalone/opt-in surface, so it opts into the AuthKit verifier and
-// the OpenRails-owned control plane (#284) that the embedded core no longer wires
-// implicitly: it builds the verifier from config when none was injected and
-// attaches the control plane when enabled. Both are no-ops if already present /
-// disabled.
+// This is the standalone surface, so it wires the AuthKit verifier and the
+// OpenRails-owned control plane (#284) that the embedded core does not wire
+// implicitly: it builds the first-party JWT verifier from config when none was
+// injected and ALWAYS attaches the control plane (#469 — there is no
+// verifier-only standalone mode; attach failure is fatal). Both steps are
+// no-ops if already present.
 func newServer(e *embedded.Embedded) (*server.Server, error) {
 	a := e.App()
 	if a == nil {

--- a/tests/deferred_delete_followups_test.go
+++ b/tests/deferred_delete_followups_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -72,6 +73,12 @@ func (r *recordingDeferredDeleteScheduler) ScheduleNMIDelete(_ context.Context, 
 
 func (r *recordingDeferredDeleteScheduler) CancelNMIDelete(context.Context, string, uuid.UUID) error {
 	return nil
+}
+
+// WithTx satisfies subscriptions.DeferredDeleteScheduler; the recorder has no
+// transactional state, so the same instance keeps recording.
+func (r *recordingDeferredDeleteScheduler) WithTx(pgx.Tx) subscriptions.DeferredDeleteScheduler {
+	return r
 }
 
 // TestMarkerConversionSweepEnqueuesIntents verifies the #358 startup sweep

--- a/tests/testcontainer_suite.go
+++ b/tests/testcontainer_suite.go
@@ -252,7 +252,6 @@ func (suite *TestContainerSuite) initializeDatabaseConnections() {
 			// control plane wired with the test admin granted openrails:admin, so
 			// the suite enables it here exactly like a production standalone boot.
 			ControlPlane: &config.ControlPlaneConfig{
-				Enabled:     true,
 				Issuer:      "https://controlplane.openrails.test",
 				TokenPrefix: "openrails",
 			},


### PR DESCRIPTION
## Summary
- Standalone OpenRails always builds + attaches the AuthKit control plane; construction failure is fatal at boot (no silent downgrade to a bare verifier)
- The "verifier-only" / "pure JWT verifier" deployment mode is REMOVED, not deprecated: `auth.control_plane.enabled` is gone (setting it is now a config load error per the deprecated-key pattern), `ControlPlaneEnabled()`/`OperatorTenantEnabled()` shims deleted, every nil-control-plane / nil-resolver fork cut (incl. the "nil resolver => self-service surface not mounted" fork in `ginmw/delegated.go`) — the self-service surface is always mounted
- `auth.issuers` survives with one narrow meaning: first-party user/admin JWT input (host `AUTH_ISSUERS` keeps working). Delegated + service credentials resolve exclusively against the control plane's live issuer registry
- Self-hosted/private posture is expressed by the existing registration axes (`public_user_registration` / `public_tenant_registration`, both default false) — not by amputating the control plane
- `pkg/embedded` core contract untouched (host-authenticated, authkit-free); the `pkg/embedded/authkit` + `pkg/embedded/controlplane` opt-in helpers kept but their enabled-check/nil-tolerant paths removed
- Docs hard cut: README auth-model section + standalone/embedded matrix, `config.example.yaml` control-plane block ("OPTIONAL and OFF by default" framing deleted)
- Bonus: fixes the integration-test build, which was broken on HEAD (`deferred_delete_followups_test.go` recorder missing `WithTx`)

Tracker: `agents/progress.md` #469 (all tasks checked, verification verdict recorded).

## Verification
- `go build ./...`, `go vet ./...`, unit suites: green
- Integration suite (`-tags=integration ./tests/`): all #469-touched paths green. One failure, `TestDunningWorkerLimitedModeTakesNoAction`, is PRE-EXISTING (asserts pre-#366 limited-mode semantics changed deliberately in a67cc3f5) — filed as #470
- Suite exceeded a 45m wall once under heavy concurrent machine load; recommend one quiet-machine full run before tagging the release that doujins/hentai0 `embed-openrails` branches will pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)