### PR TITLE
security(cors): stop pairing reflected Origin with credentials in allow-all mode

### DIFF
--- a/internal/http/middleware/cors_http_test.go
+++ b/internal/http/middleware/cors_http_test.go
@@ -1,0 +1,67 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func corsHandler(origins []string) http.Handler {
+	return CORSHTTP(origins)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+// In allow-all mode the middleware must NOT reflect the caller's Origin together
+// with Access-Control-Allow-Credentials: true — that combination lets any site
+// make authenticated cross-origin requests and read the response. A bare "*"
+// (which browsers refuse to pair with credentials) is the safe behaviour.
+func TestCORSHTTPAllowAllDoesNotReflectOriginWithCredentials(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "https://evil.example")
+
+	corsHandler(nil).ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want %q (must not reflect arbitrary origin)", got, "*")
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Credentials"); got != "" {
+		t.Fatalf("Access-Control-Allow-Credentials = %q, want empty in allow-all mode", got)
+	}
+}
+
+// An explicitly allow-listed origin is reflected and may carry credentials.
+func TestCORSHTTPAllowListedOriginGetsCredentials(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "https://app.example")
+
+	corsHandler([]string{"https://app.example"}).ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://app.example" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want the allow-listed origin", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Fatalf("Access-Control-Allow-Credentials = %q, want %q", got, "true")
+	}
+	if got := rec.Header().Get("Vary"); got != "Origin" {
+		t.Fatalf("Vary = %q, want Origin", got)
+	}
+}
+
+// A non-allow-listed origin in restricted mode gets no CORS grant at all.
+func TestCORSHTTPRestrictedRejectsUnknownOrigin(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "https://evil.example")
+
+	corsHandler([]string{"https://app.example"}).ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("Access-Control-Allow-Origin = %q, want empty for non-allow-listed origin", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Credentials"); got != "" {
+		t.Fatalf("Access-Control-Allow-Credentials = %q, want empty", got)
+	}
+}

--- a/internal/http/middleware/http_base.go
+++ b/internal/http/middleware/http_base.go
@@ -80,20 +80,37 @@ func CORSHTTP(allowedOrigins []string) HTTPMiddleware {
 	)
 	maxAge := strconv.Itoa(int((12 * time.Hour).Seconds()))
 
+	setCommon := func(h http.Header) {
+		h.Set("Access-Control-Allow-Headers", allowHeaders)
+		h.Set("Access-Control-Allow-Methods", allowMethods)
+		h.Set("Access-Control-Expose-Headers", exposeHeaders)
+		h.Set("Access-Control-Max-Age", maxAge)
+	}
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			origin := r.Header.Get("Origin")
 			if origin != "" {
-				_, ok := allowed[origin]
-				if allowAll || ok {
-					h := w.Header()
+				h := w.Header()
+				if _, ok := allowed[origin]; ok {
+					// Explicitly allow-listed origin: safe to reflect it and
+					// grant credentials.
 					h.Set("Access-Control-Allow-Origin", origin)
 					h.Add("Vary", "Origin")
 					h.Set("Access-Control-Allow-Credentials", "true")
-					h.Set("Access-Control-Allow-Headers", allowHeaders)
-					h.Set("Access-Control-Allow-Methods", allowMethods)
-					h.Set("Access-Control-Expose-Headers", exposeHeaders)
-					h.Set("Access-Control-Max-Age", maxAge)
+					setCommon(h)
+				} else if allowAll {
+					// Allow-all (no origins configured, e.g. development): emit a
+					// wildcard and DO NOT set Access-Control-Allow-Credentials.
+					// Reflecting the caller's Origin together with
+					// credentials=true is the classic CORS misconfiguration — it
+					// lets any site issue authenticated cross-origin requests with
+					// the user's credentials and read the response, defeating the
+					// same-origin policy. A bare "*" cannot carry credentials, so
+					// browsers keep cross-origin reads anonymous. This matches the
+					// effective behaviour of the gin CORS path (AllowAllOrigins).
+					h.Set("Access-Control-Allow-Origin", "*")
+					setCommon(h)
 				}
 			}
 			if r.Method == http.MethodOptions {


### PR DESCRIPTION
## Problem
`CORSHTTP` (the net/http middleware used by the embedded engine, `internal/http/embedhttp`) reflected the caller's `Origin` header into `Access-Control-Allow-Origin` **and** set `Access-Control-Allow-Credentials: true` whenever no allow-list was configured — the "allow-all / development" mode that is reached in production any time a self-hoster never sets `AllowedCORSOrigins`.

Reflecting an arbitrary origin together with `credentials=true` is the textbook CORS misconfiguration: any website can issue authenticated cross-origin requests carrying the user's credentials and read the response, defeating the same-origin policy.

## Why it matters (security)
This is a billing server. The allow-all branch is the default for unconfigured self-hosted instances, so the hole ships on by default for that population.

## Approach
In allow-all mode, emit a bare `*` and **omit** `Access-Control-Allow-Credentials`. Browsers refuse to pair `*` with credentials, so cross-origin reads stay anonymous — dev convenience is preserved for non-credentialed use. Explicitly allow-listed origins are still reflected with credentials, exactly as before. This also aligns the net/http path with the gin CORS path's effective `AllowAllOrigins` behaviour.

Tests cover allow-all (expects `*`, no credentials), allow-listed (reflected + credentials + `Vary: Origin`), and non-allow-listed (no grant). `./internal/http/middleware` suite passes.