### PR TITLE
fix(auth): don't leak raw verifier errors to unauthenticated callers

### DIFF
--- a/internal/auth/verifier.go
+++ b/internal/auth/verifier.go
@@ -73,6 +73,12 @@ func FormatVerifierError(err error) string {
 	case strings.Contains(msg, "invalid_token"):
 		return "invalid_or_expired_token"
 	default:
-		return msg
+		// Do NOT echo the raw verifier error to unauthenticated callers: it can
+		// carry internal detail (JWKS fetch URLs/failures, key-id lookups, parse
+		// internals) that aids an attacker and leaks deployment topology. The
+		// caller (internal/auth/ginauth) already logs the underlying error
+		// server-side, so collapse anything unrecognised to a single generic,
+		// non-revealing code.
+		return "invalid_or_expired_token"
 	}
 }

--- a/internal/auth/verifier_error_test.go
+++ b/internal/auth/verifier_error_test.go
@@ -1,0 +1,39 @@
+package auth
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatVerifierError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil error yields empty string", func(t *testing.T) {
+		require.Equal(t, "", FormatVerifierError(nil))
+	})
+
+	t.Run("maps known verifier codes", func(t *testing.T) {
+		cases := map[string]string{
+			"missing_token":             "missing_token",
+			"bad_issuer for token":      "invalid_issuer",
+			"bad_audience":              "invalid_audience",
+			"invalid_token: expired":    "invalid_or_expired_token",
+		}
+		for in, want := range cases {
+			require.Equal(t, want, FormatVerifierError(errors.New(in)), "input %q", in)
+		}
+	})
+
+	// Security: an unrecognised verifier error MUST NOT be echoed verbatim to
+	// the client. Anything with internal detail collapses to a generic code.
+	t.Run("unknown error does not leak internal detail", func(t *testing.T) {
+		leaky := errors.New("fetch https://idp.internal.example/.well-known/jwks.json: dial tcp 10.0.0.5:443: connection refused")
+		got := FormatVerifierError(leaky)
+		require.Equal(t, "invalid_or_expired_token", got)
+		require.NotContains(t, got, "10.0.0.5")
+		require.NotContains(t, got, "jwks.json")
+		require.NotContains(t, got, "internal")
+	})
+}


### PR DESCRIPTION
## Problem
`auth.FormatVerifierError`'s `default` branch returned the raw, lower-cased verifier error string, which `internal/auth/ginauth` writes straight into the 401 response body via `response.UnauthorizedWithMessage`. Any verifier failure that doesn't match a known substring (`missing_token`/`bad_issuer`/`bad_audience`/`invalid_token`) is therefore echoed verbatim to an **unauthenticated** caller.

## Why it matters (security)
Unrecognised verifier errors commonly carry internal detail — JWKS fetch URLs and failures, key-id lookups, JWT parse internals, dial errors with internal IPs. Returning them to anonymous callers leaks deployment topology and aids attacker reconnaissance (info disclosure).

## Approach
Collapse the `default` case to the existing generic, non-revealing code `invalid_or_expired_token`. The underlying error is already logged server-side in `ginauth` (`log.WithError(err).Warn("jwt verification failed")`), so no diagnostic value is lost. Known mapped cases are unchanged. Adds `verifier_error_test.go` asserting no internal detail (IPs, JWKS URLs) survives formatting.

~30 lines. `go test ./internal/auth/` passes.

_Produced by an automated daily security/architecture review._