### PR TITLE
fix(config): percent-encode DB credentials when building the DSN

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -334,30 +335,27 @@ func (c *DBConfig) GetConnectionString() string {
 	// 2. Build connection string from atomic parameters if all required fields are present
 	if c.Host != "" && c.Port != "" && c.Database != "" && c.Username != "" {
 		// Format: postgresql://username:password@host:port/database?sslmode=...
-		connStr := fmt.Sprintf(
-			"postgresql://%s:%s@%s:%s/%s",
-			c.Username,
-			c.Password,
-			c.Host,
-			c.Port,
-			c.Database,
-		)
-
-		// Add query parameters
-		params := []string{}
-
-		// Default to TLS when sslmode is omitted. Local compose sets disable explicitly.
+		//
+		// Credentials and the database name are percent-encoded via net/url
+		// rather than interpolated raw. A password containing reserved URL
+		// characters (most dangerously '@' or '/') would otherwise corrupt the
+		// DSN — e.g. a password "p@ss/0" makes the parser read a different host,
+		// which at best fails to connect and at worst silently redirects the
+		// connection to an attacker-influenced endpoint. url.UserPassword +
+		// url.URL.String() escape every component correctly.
 		sslMode := c.SSLMode
 		if sslMode == "" {
+			// Default to TLS when sslmode is omitted. Local compose sets disable explicitly.
 			sslMode = "require"
 		}
-		params = append(params, fmt.Sprintf("sslmode=%s", sslMode))
-
-		if len(params) > 0 {
-			connStr += "?" + strings.Join(params, "&")
+		u := url.URL{
+			Scheme:   "postgresql",
+			User:     url.UserPassword(c.Username, c.Password),
+			Host:     net.JoinHostPort(c.Host, c.Port),
+			Path:     "/" + c.Database,
+			RawQuery: url.Values{"sslmode": {sslMode}}.Encode(),
 		}
-
-		return connStr
+		return u.String()
 	}
 
 	// 3. No URL and incomplete atomic parameters - return empty (caller handles defaults)

--- a/config/dsn_encoding_test.go
+++ b/config/dsn_encoding_test.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetConnectionString_URLEncodesCredentials(t *testing.T) {
+	t.Parallel()
+
+	c := &DBConfig{
+		Host:     "db.internal",
+		Port:     "5432",
+		Database: "billing",
+		Username: "open rails",          // space is reserved
+		Password: "p@ss/w:rd?#",         // '@' and '/' would corrupt a raw DSN
+	}
+
+	dsn := c.GetConnectionString()
+
+	// Must parse back to exactly the inputs — proving no host hijack via '@'.
+	u, err := url.Parse(dsn)
+	require.NoError(t, err)
+	require.Equal(t, "postgresql", u.Scheme)
+	require.Equal(t, "db.internal:5432", u.Host)
+	require.Equal(t, "/billing", u.Path)
+	require.Equal(t, "open rails", u.User.Username())
+	pw, _ := u.User.Password()
+	require.Equal(t, "p@ss/w:rd?#", pw)
+	require.Equal(t, "require", u.Query().Get("sslmode"))
+
+	// The raw '@' in the password must not appear unescaped before the host.
+	require.NotContains(t, dsn[:len("postgresql://")+len("open%20rails")+40], "/w:rd?#@db.internal")
+}
+
+func TestGetConnectionString_URLPassthroughAndSSLMode(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "postgres://x/y", (&DBConfig{URL: "postgres://x/y"}).GetConnectionString())
+
+	c := &DBConfig{Host: "h", Port: "1", Database: "d", Username: "u", Password: "p", SSLMode: "disable"}
+	u, err := url.Parse(c.GetConnectionString())
+	require.NoError(t, err)
+	require.Equal(t, "disable", u.Query().Get("sslmode"))
+}


### PR DESCRIPTION
## Problem
`DBConfig.GetConnectionString` built the Postgres DSN by interpolating `username`/`password`/`database` raw into a `postgresql://` URL with `fmt.Sprintf`. Credentials containing reserved URL characters corrupt the DSN.

## Why it matters (security + correctness)
A `@` or `/` in the password is the dangerous case: `postgresql://user:p@ss/0@host/db` makes `net/url` parse a **different host**. At best the connection fails; at worst it can be redirected to an attacker-influenced endpoint (the app would then send credentials/queries to the wrong server). Spaces and other reserved chars simply break startup.

## Approach
Build the URL with `url.UserPassword(...)` + `url.URL.String()` so every component is escaped correctly, and `net.JoinHostPort` for IPv6 safety. Behaviour is byte-identical for credentials with no reserved characters, so existing deployments are unaffected. Adds `dsn_encoding_test.go` (round-trips a hostile password, asserts no host hijack). Full `config` package tests + `go vet` pass.

~40 lines.

_Produced by an automated daily security/architecture review._