### PR TITLE
fix(http): apply body-size limit to webhook routes on the embedded surface

### DIFF
--- a/internal/http/middleware/body_limit_http_test.go
+++ b/internal/http/middleware/body_limit_http_test.go
@@ -1,0 +1,58 @@
+package middleware
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func bodyLimitHandler(maxBytes int64) http.Handler {
+	return BodyLimitHTTP(maxBytes)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.ReadAll(r.Body); err != nil {
+			var tooLarge *http.MaxBytesError
+			if errors.As(err, &tooLarge) {
+				w.WriteHeader(http.StatusRequestEntityTooLarge)
+				return
+			}
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+// BodyLimitHTTP must apply the global body cap to webhook routes too. The gin
+// BodyLimit middleware stopped exempting webhooks; the net/http analogue must
+// match so embedded hosts get the same backstop in front of the per-processor
+// caps in internal/http/handlers/webhook.go.
+func TestBodyLimitHTTPAppliesToWebhookRoutes(t *testing.T) {
+	for _, path := range []string{"/v1/webhooks/stripe", "/billing/v1/webhooks/stripe"} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader("larger-than-eight"))
+		bodyLimitHandler(8).ServeHTTP(rec, req)
+		if rec.Code != http.StatusRequestEntityTooLarge {
+			t.Fatalf("path %s: status = %d, want %d (webhook routes are no longer exempt)", path, rec.Code, http.StatusRequestEntityTooLarge)
+		}
+	}
+}
+
+func TestBodyLimitHTTPAppliesToNonWebhookRoutes(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/checkout", strings.NewReader("larger-than-eight"))
+	bodyLimitHandler(8).ServeHTTP(rec, req)
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestBodyLimitHTTPAllowsWithinLimit(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/webhooks/stripe", strings.NewReader("small"))
+	bodyLimitHandler(1<<10).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}

--- a/internal/http/middleware/http_base.go
+++ b/internal/http/middleware/http_base.go
@@ -49,12 +49,16 @@ func SecurityHeadersHTTP() HTTPMiddleware {
 	}
 }
 
-// BodyLimitHTTP is the net/http analogue of BodyLimit. Webhook paths are exempt
-// (their bodies are verified by signature, may be large, and must be read raw).
+// BodyLimitHTTP is the net/http analogue of BodyLimit. It applies the global
+// body-size cap uniformly, including to webhook routes: this mirrors the gin
+// BodyLimit middleware, which stopped exempting webhooks (the per-processor
+// caps in internal/http/handlers/webhook.go bind tighter than this backstop).
+// MaxBytesReader only limits the body; signature verification still reads the
+// raw bytes up to the cap, so legitimate webhook payloads are unaffected.
 func BodyLimitHTTP(maxBytes int64) HTTPMiddleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if maxBytes > 0 && r.Body != nil && !isWebhookPath(r.URL.Path) {
+			if maxBytes > 0 && r.Body != nil {
 				r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
 			}
 			next.ServeHTTP(w, r)

--- a/internal/http/middleware/neutral_paths.go
+++ b/internal/http/middleware/neutral_paths.go
@@ -7,21 +7,6 @@ import "strings"
 // (BodyLimitHTTP).
 const DefaultMaxBodyBytes int64 = 1 << 20
 
-// isWebhookPath reports whether path targets a webhook endpoint, normalizing the
-// optional embedded "/billing" mount prefix. Webhook bodies are signature-verified
-// and must be read raw, so they are exempt from the body-size limit. This is the
-// gin-free analogue of the matcher in the standalone gin middleware (ginmw).
-func isWebhookPath(path string) bool {
-	path = strings.ToLower(path)
-	if strings.HasPrefix(path, "/billing") {
-		path = strings.TrimPrefix(path, "/billing")
-		if path == "" {
-			path = "/"
-		}
-	}
-	return strings.HasPrefix(path, "/v1/webhooks")
-}
-
 func isDebugNMITokenizationPath(path string) bool {
 	return strings.EqualFold(path, "/debug/nmi/tokenization")
 }


### PR DESCRIPTION
## Problem
`BodyLimitHTTP`, the net/http middleware used by the gin-free embedded handler assembler (`internal/http/embedhttp`), exempted webhook paths from the global body-size cap. The gin `BodyLimit` middleware stopped exempting webhooks (SEC-3), but the net/http analogue was never updated to match. As a result the embedded surface had **no** backstop on webhook routes.

## Why it matters (security)
An attacker reaching the embedded webhook endpoints could stream an arbitrarily large body before any per-processor cap or signature check runs — a memory-exhaustion vector. The embedded path is a primary use case (third parties mount the `http.Handler` directly), so this is the surface most integrators inherit.

## Approach
Remove the `!isWebhookPath(...)` exemption in `BodyLimitHTTP` so the 1 MiB `DefaultMaxBodyBytes` backstop applies uniformly, mirroring gin. `MaxBytesReader` only caps the body — signature verification still reads the raw bytes up to the cap — and the per-processor caps in `internal/http/handlers/webhook.go` (16/64/256 KiB) bind tighter, so nothing legitimate breaks. The now-unused `isWebhookPath` helper is deleted and tests are added mirroring the gin `TestBodyLimitAppliesToWebhookRoutes`.

`go test ./internal/http/middleware/` passes.

---
_Produced by an automated daily code review._