### PR TITLE
fix(webhook): cap Coinbase USDC-funding webhook body size

### DIFF
--- a/internal/http/handlers/webhook.go
+++ b/internal/http/handlers/webhook.go
@@ -39,9 +39,10 @@ import (
 //     line items) and can be tens of KiB, so 256 KiB.
 //   - NMI JSON transaction webhooks are modest; 64 KiB is ample.
 const (
-	maxCCBillWebhookBytes int64 = 16 << 10  // 16 KiB
-	maxStripeWebhookBytes int64 = 256 << 10 // 256 KiB
-	maxNMIWebhookBytes    int64 = 64 << 10  // 64 KiB
+	maxCCBillWebhookBytes   int64 = 16 << 10  // 16 KiB
+	maxStripeWebhookBytes   int64 = 256 << 10 // 256 KiB
+	maxNMIWebhookBytes      int64 = 64 << 10  // 64 KiB
+	maxCoinbaseWebhookBytes int64 = 64 << 10  // 64 KiB; Hook0 USDC-funding events are small JSON
 )
 
 // readLimitedWebhookBody reads the request body capped at maxBytes via
@@ -222,9 +223,8 @@ func applyCoinbaseUSDCFundingWebhook(r *httprequest.Request) bool {
 		r.ErrorJSON(http.StatusServiceUnavailable, "Webhook processing is not configured")
 		return false
 	}
-	body, err := readRequestBody(r.Request.Body)
-	if err != nil {
-		r.ErrorJSON(http.StatusInternalServerError, "Failed to read request body")
+	body, ok := readLimitedWebhookBody(r, maxCoinbaseWebhookBytes)
+	if !ok {
 		return false
 	}
 	cfg := r.State.Config.USDCFunding

--- a/internal/http/handlers/webhook_test.go
+++ b/internal/http/handlers/webhook_test.go
@@ -53,6 +53,22 @@ func TestReadLimitedWebhookBodyAcceptsWithinLimit(t *testing.T) {
 	}
 }
 
+// The Coinbase USDC-funding webhook now reads through readLimitedWebhookBody
+// with maxCoinbaseWebhookBytes instead of an unbounded io.ReadAll, matching the
+// per-processor cap discipline of the CCBill/Stripe/NMI paths.
+func TestCoinbaseWebhookBodyCapRejectsOversized(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/webhooks/coinbase", strings.NewReader(strings.Repeat("a", int(maxCoinbaseWebhookBytes)+1)))
+	r := httprequest.NewHTTP(w, req, nil)
+
+	if _, ok := readLimitedWebhookBody(r, maxCoinbaseWebhookBytes); ok {
+		t.Fatalf("expected oversized Coinbase body to be rejected")
+	}
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d", w.Code)
+	}
+}
+
 func TestFirstPresentHeader(t *testing.T) {
 	header := http.Header{}
 	header.Set("X-NMI-Signature", "sig-123")


### PR DESCRIPTION
## Problem
`applyCoinbaseUSDCFundingWebhook` read the request body with an unbounded `io.ReadAll` (via `readRequestBody`), making it the lone webhook processor without a per-processor size cap. CCBill, Stripe, and NMI all go through `readLimitedWebhookBody` with explicit caps (16/256/64 KiB).

## Why it matters (security)
On the embedded surface this read was fully unbounded; even on gin it relied solely on the global backstop. It's a memory-exhaustion vector and a consistency gap future processors are likely to copy.

## Approach
Add `maxCoinbaseWebhookBytes = 64 KiB` (Hook0 USDC-funding events are small JSON) and route the Coinbase handler through `readLimitedWebhookBody`, which fails closed with 413 on oversized payloads — matching the other processors. Added `TestCoinbaseWebhookBodyCapRejectsOversized`.

`go test ./internal/http/handlers/` passes. Best landed alongside the embedded body-limit parity PR but independently correct.

---
_Produced by an automated daily code review._