### PR TITLE
fix(config): require https auth issuer outside development

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1099,6 +1099,13 @@ func Validate(cfg *Config) error {
 			if issuer == "" || issuer == "http://localhost:8080" || issuer == "http://api:2052" || issuer == "http://issuer:8080" {
 				return fmt.Errorf("default auth issuer is not allowed outside development")
 			}
+			// The issuer is the root of trust: the verifier derives the JWKS URI
+			// from it and fetches signing keys over its scheme. A plaintext-HTTP
+			// issuer lets an on-path attacker serve forged keys and mint accepted
+			// JWTs, so require https outside development.
+			if !strings.HasPrefix(strings.ToLower(issuer), "https://") {
+				return fmt.Errorf("auth issuer %q must use https outside development", issuer)
+			}
 		}
 		if len(cfg.CorsOrigins) == 0 {
 			return fmt.Errorf("cors_origins must be configured outside development")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -385,6 +385,20 @@ func TestProductionTestEnvValidation(t *testing.T) {
 		assert.NoError(t, Validate(cfg))
 	})
 
+	t.Run("prod env rejects http auth issuer", func(t *testing.T) {
+		cfg := GetDefaultBillingConfig()
+		cfg.Env = "prod"
+		cfg.Mode = ModeFull
+		cfg.DB.Username = "billing_app"
+		cfg.DB.Password = "production-db-password"
+		cfg.Auth.Issuers = []string{"http://issuer.example.com"}
+		cfg.CorsOrigins = []string{"https://app.example.com"}
+		cfg.ClickHouse.Username = "prod_analytics"
+		cfg.ClickHouse.Password = "production-clickhouse-password"
+		assembleDBURL(cfg)
+		assert.ErrorContains(t, Validate(cfg), "must use https outside development")
+	})
+
 	t.Run("prod env rejects missing auth audience", func(t *testing.T) {
 		cfg := GetDefaultBillingConfig()
 		cfg.Env = "prod"


### PR DESCRIPTION
## Problem
Production config validation (`config/config.go`) rejected empty and known-default localhost issuers, but accepted any other value — including plaintext `http://` URLs.

## Why it matters (security)
The issuer is the root of trust: `internal/auth/verifier.go` derives the JWKS URI from it (`issuer + "/.well-known/jwks.json"`) and fetches signing keys over whatever scheme the issuer carries. A plaintext-HTTP issuer lets an on-path attacker serve attacker-controlled signing keys and forge JWTs accepted as valid users/admins — a full authn bypass. This is an insecure-by-omission default precisely where a third-party integrator is likely to trip.

## Approach
Add a fail-fast check in the production validation branch requiring each configured issuer to use `https://`, matching the existing fail-fast posture for default creds, empty audience, and empty CORS. Added a `prod env rejects http auth issuer` sub-test to `TestProductionTestEnvValidation`.

`go test ./config/` passes.

---
_Produced by an automated daily code review._