### PR TITLE
fix(integrations): bound untrusted upstream JSON response bodies

### DIFF
--- a/internal/captcha/captcha.go
+++ b/internal/captcha/captcha.go
@@ -3,7 +3,6 @@ package captcha
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -15,6 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/shared/httpx"
 )
 
 const (
@@ -127,7 +127,9 @@ func (v *siteVerifyVerifier) Verify(ctx context.Context, req VerifyRequest) (*Ve
 		Hostname   string   `json:"hostname"`
 		ErrorCodes []string `json:"error-codes"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+	// Cap the upstream body even though siteverify is normally a trusted provider:
+	// defence-in-depth against a compromised/MITM'd endpoint exhausting memory.
+	if err := httpx.DecodeJSONLimited(resp.Body, 0, &payload); err != nil {
 		return nil, fmt.Errorf("decode captcha verify response: %w", err)
 	}
 

--- a/internal/integrations/fx/exchange_api.go
+++ b/internal/integrations/fx/exchange_api.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/open-rails/openrails/internal/shared/httpx"
 	"github.com/open-rails/openrails/internal/shared/timeutil"
 )
 
@@ -96,7 +97,9 @@ func (p *ExchangeAPIProvider) fetchRate(ctx context.Context, baseURL, currency, 
 
 	// Parse the response - it's a dynamic structure where the currency code is a key
 	var raw map[string]json.RawMessage
-	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+	// Cap the upstream body: a buggy/compromised/MITM'd FX endpoint must not be
+	// able to stream an unbounded body into memory on a money-affecting path.
+	if err := httpx.DecodeJSONLimited(resp.Body, 0, &raw); err != nil {
 		return 0, time.Time{}, fmt.Errorf("failed to decode response: %w", err)
 	}
 

--- a/internal/integrations/pyth/client.go
+++ b/internal/integrations/pyth/client.go
@@ -2,7 +2,6 @@ package pyth
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math"
 	"net/http"
@@ -10,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/open-rails/openrails/internal/shared/httpx"
 )
 
 const defaultHTTPTimeout = 5 * time.Second
@@ -144,7 +145,9 @@ func (c *Client) LatestPrice(ctx context.Context, symbol string) (Price, error) 
 	}
 
 	var decoded latestPriceResponse
-	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+	// Cap the upstream body: Pyth Hermes feeds a crypto pricing decision, so an
+	// unbounded response must not be read straight into memory.
+	if err := httpx.DecodeJSONLimited(resp.Body, 0, &decoded); err != nil {
 		return Price{}, fmt.Errorf("decode pyth price for %s: %w", normalizedSymbol, err)
 	}
 

--- a/internal/shared/httpx/httpx.go
+++ b/internal/shared/httpx/httpx.go
@@ -1,0 +1,53 @@
+// Package httpx holds small, dependency-free helpers for talking to external
+// HTTP endpoints safely. It is a stdlib-only leaf package so it can be shared by
+// any integration without risking an import cycle.
+package httpx
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// DefaultMaxResponseBytes is a conservative cap for JSON responses from external
+// providers whose payloads are small, fixed-shape documents (FX quotes, price
+// oracle reads, captcha siteverify results). 1 MiB is far larger than any
+// legitimate response while still bounding memory use.
+const DefaultMaxResponseBytes int64 = 1 << 20 // 1 MiB
+
+// ErrResponseTooLarge is returned when an upstream body exceeds the cap.
+var ErrResponseTooLarge = errors.New("httpx: response body exceeds maximum allowed size")
+
+// DecodeJSONLimited reads at most maxBytes from r, then JSON-decodes the result
+// into v. It exists so callers never hand an unbounded io.Reader (such as
+// http.Response.Body) straight to json.NewDecoder: a compromised, MITM'd, or
+// simply buggy upstream could otherwise stream an arbitrarily large or
+// never-ending body and exhaust process memory.
+//
+// If maxBytes <= 0, DefaultMaxResponseBytes is used. When the body is larger
+// than the limit, ErrResponseTooLarge is returned rather than a partial decode.
+func DecodeJSONLimited(r io.Reader, maxBytes int64, v any) error {
+	if r == nil {
+		return errors.New("httpx: nil reader")
+	}
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxResponseBytes
+	}
+
+	// Read one extra byte so we can distinguish "exactly at the limit" from
+	// "over the limit" without trusting Content-Length.
+	limited := io.LimitReader(r, maxBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return fmt.Errorf("httpx: read response: %w", err)
+	}
+	if int64(len(data)) > maxBytes {
+		return ErrResponseTooLarge
+	}
+
+	if err := json.Unmarshal(data, v); err != nil {
+		return fmt.Errorf("httpx: decode json: %w", err)
+	}
+	return nil
+}

--- a/internal/shared/httpx/httpx_test.go
+++ b/internal/shared/httpx/httpx_test.go
@@ -1,0 +1,61 @@
+package httpx
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestDecodeJSONLimited_OK(t *testing.T) {
+	var out struct {
+		Name string `json:"name"`
+	}
+	if err := DecodeJSONLimited(strings.NewReader(`{"name":"ok"}`), 1024, &out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Name != "ok" {
+		t.Fatalf("got %q want %q", out.Name, "ok")
+	}
+}
+
+func TestDecodeJSONLimited_TooLarge(t *testing.T) {
+	// Body larger than the 8-byte cap must be rejected before decoding.
+	big := `{"name":"` + strings.Repeat("a", 100) + `"}`
+	var out map[string]any
+	err := DecodeJSONLimited(strings.NewReader(big), 8, &out)
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Fatalf("got %v want ErrResponseTooLarge", err)
+	}
+}
+
+func TestDecodeJSONLimited_ExactlyAtLimit(t *testing.T) {
+	body := `{"a":1}` // 7 bytes
+	var out map[string]int
+	if err := DecodeJSONLimited(strings.NewReader(body), int64(len(body)), &out); err != nil {
+		t.Fatalf("body exactly at limit should decode: %v", err)
+	}
+	if out["a"] != 1 {
+		t.Fatalf("got %v", out)
+	}
+}
+
+func TestDecodeJSONLimited_DefaultCap(t *testing.T) {
+	var out map[string]string
+	if err := DecodeJSONLimited(strings.NewReader(`{"k":"v"}`), 0, &out); err != nil {
+		t.Fatalf("default cap should allow small body: %v", err)
+	}
+}
+
+func TestDecodeJSONLimited_NilReader(t *testing.T) {
+	var out map[string]any
+	if err := DecodeJSONLimited(nil, 0, &out); err == nil {
+		t.Fatal("expected error for nil reader")
+	}
+}
+
+func TestDecodeJSONLimited_BadJSON(t *testing.T) {
+	var out map[string]any
+	if err := DecodeJSONLimited(strings.NewReader(`{not json`), 1024, &out); err == nil {
+		t.Fatal("expected decode error")
+	}
+}


### PR DESCRIPTION
## Summary
Bounds untrusted upstream JSON response bodies for three external-provider clients.

## Problem
The FX rate provider (`internal/integrations/fx`), the Pyth Hermes price oracle (`internal/integrations/pyth`), and the captcha siteverify client (`internal/captcha`) each decoded their HTTP response with `json.NewDecoder(resp.Body)` — which reads the body with **no size limit**. A compromised, MITM'd, or simply buggy upstream could stream an arbitrarily large (or never-ending) body and exhaust process memory.

Two of these feed **money-affecting** decisions (FX conversion, crypto pricing); the third gates abuse control.

## Approach
Add a small stdlib-only helper `internal/shared/httpx.DecodeJSONLimited(r, maxBytes, v)` that reads at most N bytes (default **1 MiB**, far above any legitimate payload) via `io.LimitReader` before decoding, returning `ErrResponseTooLarge` instead of a partial decode when the body is oversized. Apply it at the three external decode sites.

Stripe/NMI paths already cap or trust their bodies and are out of scope here.

## Tests
New unit tests for the helper (ok / too-large / exactly-at-limit / default-cap / nil / bad-json). `go build`, `go vet`, and `go test` pass for all touched packages.

---
🤖 Produced by an automated daily security/architecture review.
