### PR TITLE
Security hardening: enforce stored authority on service JWT permissions

### DIFF
--- a/internal/controlplane/bnd_c1_permission_intersection_test.go
+++ b/internal/controlplane/bnd_c1_permission_intersection_test.go
@@ -1,0 +1,77 @@
+package controlplane
+
+// BND-C1 regression: service-JWT permissions must be intersected against
+// stored authority; a token cannot self-assert permissions that were never
+// granted (e.g. openrails:admin).
+
+import "testing"
+
+func TestIntersectPermissions_EmptyStoredDeniesAll(t *testing.T) {
+	// Stored authority is empty → no permissions survive, regardless of what
+	// the token claims (including openrails:admin).
+	claimed := []string{PermAdmin, PermCreditsRead, PermCreditsWrite}
+	got := intersectPermissions(claimed, nil)
+	if len(got) != 0 {
+		t.Errorf("intersectPermissions with empty stored = %v, want empty", got)
+	}
+}
+
+func TestIntersectPermissions_EmptyClaimedYieldsEmpty(t *testing.T) {
+	stored := []string{PermCreditsRead, PermCreditsWrite}
+	got := intersectPermissions(nil, stored)
+	if len(got) != 0 {
+		t.Errorf("intersectPermissions with empty claimed = %v, want empty", got)
+	}
+}
+
+func TestIntersectPermissions_OnlyGrantedPermissionsSurvive(t *testing.T) {
+	stored := []string{PermCreditsRead}
+	claimed := []string{PermCreditsRead, PermCreditsWrite, PermAdmin}
+	got := intersectPermissions(claimed, stored)
+	if len(got) != 1 || got[0] != PermCreditsRead {
+		t.Errorf("intersectPermissions = %v, want [%q]", got, PermCreditsRead)
+	}
+}
+
+func TestIntersectPermissions_AdminNotGrantedUnlessStored(t *testing.T) {
+	// The critical BND-C1 case: a token self-asserts openrails:admin but the
+	// remote_application's stored authority only grants credits:read. The admin
+	// claim must be stripped.
+	stored := []string{PermCreditsRead}
+	claimed := []string{PermAdmin}
+	got := intersectPermissions(claimed, stored)
+	if len(got) != 0 {
+		t.Errorf("self-asserted admin survived intersection: got %v, want empty", got)
+	}
+}
+
+func TestIntersectPermissions_AdminGrantedWhenStored(t *testing.T) {
+	// If an operator EXPLICITLY grants openrails:admin to a remote_application
+	// (unusual but valid), the token may claim it and it should pass through.
+	stored := []string{PermAdmin, PermCreditsRead}
+	claimed := []string{PermAdmin}
+	got := intersectPermissions(claimed, stored)
+	if len(got) != 1 || got[0] != PermAdmin {
+		t.Errorf("explicitly stored admin should survive: got %v", got)
+	}
+}
+
+func TestIntersectPermissions_OrderFollowsClaimed(t *testing.T) {
+	stored := []string{"b", "a", "c"}
+	claimed := []string{"c", "a"}
+	got := intersectPermissions(claimed, stored)
+	if len(got) != 2 || got[0] != "c" || got[1] != "a" {
+		t.Errorf("intersectPermissions order = %v, want [c a]", got)
+	}
+}
+
+func TestIntersectPermissions_NoDuplicates(t *testing.T) {
+	// cleanPermissionList handles dedup before intersection; this verifies
+	// intersectPermissions doesn't re-introduce dupes from the stored side.
+	stored := []string{"a", "a"}
+	claimed := []string{"a"}
+	got := intersectPermissions(claimed, stored)
+	if len(got) != 1 {
+		t.Errorf("intersectPermissions produced duplicates: %v", got)
+	}
+}

--- a/internal/controlplane/delegated.go
+++ b/internal/controlplane/delegated.go
@@ -208,7 +208,7 @@ func (c *ControlPlane) ResolveDelegated(ctx context.Context, token string) (*Res
 	// The token carries no merchant claims (issuer-only profile, authkit v0.23.0):
 	// the issuer registry is the SOLE source of merchant identity, so slug renames
 	// never invalidate in-flight tokens.
-	tid, tslug, _, _, err := c.merchantForIssuer(ctx, issuer)
+	tid, tslug, _, _, _, err := c.merchantForIssuer(ctx, issuer)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controlplane/issuer_registry.go
+++ b/internal/controlplane/issuer_registry.go
@@ -46,25 +46,25 @@ func (c *ControlPlane) ReloadRemoteApplications(ctx context.Context) error {
 //
 // Returns ErrDelegatedIssuerUnknown when the issuer is unregistered, controls no
 // org, or that org owns no active merchant (fail closed).
-func (c *ControlPlane) merchantForIssuer(ctx context.Context, issuer string) (merchantID merchant.ID, merchantSlug, ownerOrgID, ownerOrgSlug string, err error) {
+func (c *ControlPlane) merchantForIssuer(ctx context.Context, issuer string) (merchantID merchant.ID, merchantSlug, ownerOrgID, ownerOrgSlug, remoteApplicationID string, err error) {
 	issuer = strings.TrimSpace(issuer)
 	if issuer == "" {
-		return merchant.ID{}, "", "", "", ErrDelegatedIssuerUnknown
+		return merchant.ID{}, "", "", "", "", ErrDelegatedIssuerUnknown
 	}
 	if c == nil || c.Core() == nil || c.pool == nil {
-		return merchant.ID{}, "", "", "", errors.New("controlplane: control plane unavailable for issuer resolution")
+		return merchant.ID{}, "", "", "", "", errors.New("controlplane: control plane unavailable for issuer resolution")
 	}
 
 	ra, err := c.Core().GetRemoteApplication(ctx, issuer)
 	if err != nil || ra == nil || !ra.Enabled {
-		return merchant.ID{}, "", "", "", ErrDelegatedIssuerUnknown
+		return merchant.ID{}, "", "", "", "", ErrDelegatedIssuerUnknown
 	}
 
 	// The org(s) the remote_application controls (its memberships). Resolve the
 	// first one that owns exactly one active merchant namespace.
 	memberships, err := c.Core().RemoteApplicationOrgRoles(ctx, ra.ID)
 	if err != nil {
-		return merchant.ID{}, "", "", "", err
+		return merchant.ID{}, "", "", "", "", err
 	}
 	for _, m := range memberships {
 		t, terr := c.Core().ResolveOrgBySlug(ctx, m.Org)
@@ -73,11 +73,11 @@ func (c *ControlPlane) merchantForIssuer(ctx context.Context, issuer string) (me
 		}
 		mid, mslug, merr := c.merchantDirectoryRow(ctx, `owner_org_id = $1`, t.ID)
 		if merr == nil {
-			return mid, mslug, t.ID, t.Slug, nil
+			return mid, mslug, t.ID, t.Slug, ra.ID, nil
 		}
 		if !errors.Is(merr, pgx.ErrNoRows) {
-			return merchant.ID{}, "", "", "", merr
+			return merchant.ID{}, "", "", "", "", merr
 		}
 	}
-	return merchant.ID{}, "", "", "", ErrDelegatedIssuerUnknown
+	return merchant.ID{}, "", "", "", "", ErrDelegatedIssuerUnknown
 }

--- a/internal/controlplane/service_jwt.go
+++ b/internal/controlplane/service_jwt.go
@@ -2,6 +2,7 @@ package controlplane
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	authcore "github.com/open-rails/authkit/core"
@@ -11,14 +12,13 @@ import (
 // ResolveServiceJWT validates a first-party OIDC service JWT and resolves the
 // effective OpenRails service principal.
 //
-// Authorization model: registering an issuer to a tenant IS the authorization.
-// A tenant has full authority over its OWN resources, so a validly-signed token
-// from a registered issuer is trusted; the token's permission claims are
-// authoritative (self-assigned least-privilege markers chosen by the caller for
-// the step it is performing), NOT a request intersected against a separate
-// server-side grant. The ONLY hard boundary is that every resource the token
-// acts on must belong to the issuer's own tenant — a tenant can never reach
-// another tenant's resources.
+// Authorization model: the token's cryptographic signature proves issuer identity;
+// the issuer's STORED authority (direct permission grants + org-role expansion in
+// AuthKit) is the source of truth for what that issuer MAY do. The token's
+// self-asserted `permissions` claim is treated as a REQUESTED SUBSET — it is
+// intersected against stored authority so a compromised or malicious issuer
+// cannot escalate by self-claiming permissions (including openrails:admin) that
+// were never explicitly granted.
 func (c *ControlPlane) ResolveServiceJWT(ctx context.Context, token string) (*ResolvedServiceToken, error) {
 	if c == nil || c.delegatedVerifier == nil {
 		return nil, ErrNoControlPlane
@@ -30,13 +30,23 @@ func (c *ControlPlane) ResolveServiceJWT(ctx context.Context, token string) (*Re
 
 	// The validated issuer (remote_application) resolves, via the org it
 	// controls, to the merchant namespace that org owns (#500). That merchant is
-	// the token's only reachable resource scope.
-	mid, mslug, ownerOrgID, ownerOrgSlug, err := c.merchantForIssuer(ctx, principal.Issuer)
+	// the token's only reachable resource scope. raID is the AuthKit
+	// remote_application UUID used to look up stored authority below.
+	mid, mslug, ownerOrgID, ownerOrgSlug, raID, err := c.merchantForIssuer(ctx, principal.Issuer)
 	if err != nil {
 		return nil, err
 	}
 
-	permissions := cleanPermissionList(principal.Permissions)
+	// BND-C1: intersect the token's self-asserted permissions against the
+	// remote_application's STORED authority. A service JWT may only DOWN-SCOPE
+	// its stored grants, never widen them. This prevents a merchant from minting
+	// a token that claims openrails:admin (or any other permission not explicitly
+	// granted to their remote_application).
+	_, storedPerms, err := c.Core().ResolveRemoteApplicationAuthority(ctx, raID)
+	if err != nil {
+		return nil, fmt.Errorf("controlplane: cannot resolve authority for issuer %s: %w", principal.Issuer, err)
+	}
+	permissions := intersectPermissions(cleanPermissionList(principal.Permissions), storedPerms)
 	if len(permissions) == 0 {
 		return nil, ErrServiceTokenScopeDenied
 	}
@@ -61,6 +71,25 @@ func (c *ControlPlane) ResolveServiceJWT(ctx context.Context, token string) (*Re
 		Permissions:  permissions,
 		Resources:    resources,
 	}, nil
+}
+
+// intersectPermissions returns the elements of claimed that also appear in
+// stored. Order follows claimed so the caller gets its preferred subset.
+func intersectPermissions(claimed, stored []string) []string {
+	if len(stored) == 0 || len(claimed) == 0 {
+		return nil
+	}
+	grant := make(map[string]bool, len(stored))
+	for _, p := range stored {
+		grant[p] = true
+	}
+	out := make([]string, 0, len(claimed))
+	for _, p := range claimed {
+		if grant[p] {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 func cleanPermissionList(in []string) []string {

--- a/internal/integrationharness/harness.go
+++ b/internal/integrationharness/harness.go
@@ -520,11 +520,19 @@ func (s *Surface) RegisterServiceJWTIssuer(slug, ownerOrgSlug string, permission
 	})
 	require.NoError(h.t, err, "register service-JWT issuer")
 	require.NoError(h.t, core.AddRemoteApplicationMember(h.ctx, ownerOrgSlug, ra.ID, "member"), "assign org membership")
-	require.NoError(h.t, cp.ReloadRemoteApplications(h.ctx), "reload remote_applications")
 
 	if len(permissions) == 0 {
 		permissions = []string{controlplane.PermCreditsWrite}
 	}
+	// BND-C1: grant each requested permission as a STORED direct grant so the
+	// authority intersection in ResolveServiceJWT can approve the token's
+	// self-asserted permissions. Without this, every service JWT would be
+	// rejected (empty intersection → ErrServiceTokenScopeDenied).
+	for _, perm := range permissions {
+		require.NoError(h.t, core.AddRemoteApplicationPermission(h.ctx, ra.ID, perm), "grant stored permission %q to %s", perm, slug)
+	}
+	require.NoError(h.t, cp.ReloadRemoteApplications(h.ctx), "reload remote_applications")
+
 	token, _, err := authcore.MintServiceJWT(h.ctx, issuer.Signer(), issuer.URL(), authcore.ServiceJWTMintOptions{
 		Subject:     "service:" + slug,
 		Audiences:   []string{"openrails-app"},


### PR DESCRIPTION
# Security hardening: enforce stored authority on service JWT permissions

## Overview

Service JWTs are first-party JWTs signed by a registered `remote_application` issuer (a merchant integration). The token's `permissions` claim was previously trusted verbatim — whatever the signing key asserted was accepted as the effective permission set with no cross-check against what was actually granted server-side. This allowed any merchant that controls its own signing key to self-assert operator-level permissions, including `openrails:admin`, and pass every downstream authorization check within their merchant.

---

## Problem

OpenRails accepts three credential types on its service surface. The opaque service token path reads permissions from the database row created by the platform operator — those are trustworthy by construction. The `remote_application` self-token path intersects claimed permissions against stored authority before accepting them. The service JWT path did neither: it took the token's `permissions` claim directly from `principal.Permissions` with no intersection and no catalog gate.

Because a merchant integration controls its own signing key (that is how JWKS-based issuers work), it can mint any token shape it chooses. A service JWT with `"permissions": ["openrails:admin"]` would pass signature verification (the key is valid), pass `merchantForIssuer` (the issuer maps to a real merchant), and then resolve with a permission set containing `openrails:admin`. Since `HasPermission` returns `true` for every permission check when `PermAdmin` is present, this amounted to full operator access on the merchant — write/mint credits, manage customers, capture payments, manage other issuers — from a credential that was meant to scope-down a service call, not elevate it.

The merchant containment wall (`merchantForIssuer`, `validateServiceTokenResources`) remained intact: the escalation was bounded to the attacker's own merchant. But within that merchant it was a complete authorization bypass with direct financial impact.

---

## Fix

**`internal/controlplane/issuer_registry.go`**

`merchantForIssuer` now returns the AuthKit `remote_application` UUID (`ra.ID`) as a fifth return value alongside the existing merchant and org identifiers. This is the key needed to look up what was actually granted to that issuer in the AuthKit permission store.

**`internal/controlplane/service_jwt.go`**

`ResolveServiceJWT` now treats the token's `permissions` claim as a *requested subset*, not an authority source:

1. After resolving the merchant via `merchantForIssuer`, it calls `c.Core().ResolveRemoteApplicationAuthority(ctx, raID)` to fetch the issuer's stored permission grants (direct grants plus any org-role expansion).
2. It intersects the token's claimed permissions against those stored grants via `intersectPermissions`. Only permissions that appear in both sets survive.
3. If the intersection is empty — because the token claimed only permissions that were never granted — `ErrServiceTokenScopeDenied` is returned. A token claiming `openrails:admin` from an issuer that was never granted admin authority produces an empty intersection and is rejected.

The `intersectPermissions` helper follows the claimed order (the caller's preferred narrowing), uses a set lookup over stored grants for O(n) performance, and returns `nil` rather than an empty slice on a miss so callers get consistent nil-checks.

**`internal/controlplane/delegated.go`**

Updated to ignore the new fifth return value of `merchantForIssuer` — the delegated path has its own separate permission gate (`WithPermissionCatalog`) and does not need stored-authority intersection.

**`internal/integrationharness/harness.go`**

`RegisterServiceJWTIssuer` now calls `core.AddRemoteApplicationPermission(ctx, ra.ID, perm)` for each permission in the requested set before minting the test JWT. This seeds the stored authority in the test database so the intersection produces the expected result. Without this, every service JWT in integration tests would produce an empty intersection and be rejected.

**`internal/controlplane/bnd_c1_permission_intersection_test.go`** *(new)*

Seven unit tests covering the intersection logic in isolation:
- Empty stored authority denies everything the token claims (including admin)
- Empty claimed set yields empty result
- Only permissions present in both sets survive
- Self-asserted admin is stripped when admin was never stored
- Explicitly stored admin passes through when granted by the platform
- Output order follows the claimed order
- No duplicates are introduced from the stored side

---

## What did not change

- The merchant containment wall is unchanged: `merchantForIssuer` still pins the token to its issuer's own merchant and `validateServiceTokenResources` still rejects any cross-merchant resource reference.
- The opaque service token path (`ResolveServiceToken`) is unchanged — it already reads permissions from the DB row directly.
- The delegated access token path (`ResolveDelegated`) is unchanged — it already enforces the `openrails:self:*` / `openrails:merchant:*` catalog gate.
- `HasPermission` and `PermAdmin` wildcard behaviour are unchanged — the fix prevents `openrails:admin` from ever appearing in `ResolvedServiceToken.Permissions` unless the platform explicitly granted it to that issuer.

---

## Test plan

- [ ] `go test ./internal/controlplane/... ./internal/integrationharness/...` — all existing and new tests pass
- [ ] Confirm a service JWT claiming `openrails:admin` from an issuer that was never granted admin resolves to `ErrServiceTokenScopeDenied`
- [ ] Confirm a service JWT claiming `credits:read` from an issuer that was granted `credits:read` still resolves successfully
- [ ] Confirm a service JWT claiming `credits:read,credits:write` from an issuer granted only `credits:read` resolves with only `credits:read` in the effective permission set
- [ ] Run integration test suite against a live database to verify `AddRemoteApplicationPermission` and the harness setup are consistent
