### PR TITLE
fix(remote): enforce WithTimeout via per-call context deadline

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -33,7 +33,10 @@ type remote struct {
 type RemoteOption func(*remote)
 
 // WithHTTPClient injects a transport (tests, custom TLS/conn pooling). When
-// unset a client bounded by the configured timeout is created.
+// unset a client bounded by the configured timeout is created. The per-call
+// timeout (WithTimeout) is enforced via a per-request context deadline
+// REGARDLESS of the injected client, so a custom client that omits
+// http.Client.Timeout still cannot stall the hot path.
 func WithHTTPClient(hc *http.Client) RemoteOption {
 	return func(r *remote) { r.client = hc }
 }
@@ -51,9 +54,12 @@ func WithTokenProvider(fn func(context.Context) (string, error)) RemoteOption {
 	return func(r *remote) { r.tokenFn = fn }
 }
 
-// WithTimeout bounds EVERY hot-path call. A short value is the point — a slow
-// OpenRails must not stall the request hot path; on timeout the fail-policy
-// decides (ErrUnreachable). Defaults to 2s.
+// WithTimeout bounds EVERY hot-path call via a per-request context deadline
+// (independent of the http.Client, so WithHTTPClient cannot silently drop it).
+// A short value is the point — a slow OpenRails must not stall the request hot
+// path; on timeout the fail-policy decides (ErrUnreachable). A non-positive
+// value disables the per-call deadline (rely on ctx / the client transport).
+// Defaults to 2s.
 func WithTimeout(d time.Duration) RemoteOption {
 	return func(r *remote) { r.timeout = d }
 }
@@ -729,6 +735,14 @@ func (c *remote) doRaw(ctx context.Context, method, path string, body any) (int,
 		if merr != nil {
 			return 0, nil, fmt.Errorf("openrails: marshal request: %w", merr)
 		}
+	}
+	// Enforce the per-call timeout via a context deadline so it holds even when
+	// the host injected its own http.Client (which may have no Timeout). Only
+	// shorten, never extend, an existing caller deadline.
+	if c.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.timeout)
+		defer cancel()
 	}
 	bearer, berr := c.bearer(ctx)
 	if berr != nil {

--- a/remote_timeout_test.go
+++ b/remote_timeout_test.go
@@ -1,0 +1,46 @@
+package openrails
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestWithTimeoutEnforcedWithCustomClient guards the per-call deadline: even
+// when the host injects its own *http.Client that has NO Timeout set,
+// WithTimeout must still bound the call (it is applied as a per-request context
+// deadline in doRaw). A slow upstream therefore fails fast with ErrUnreachable
+// instead of stalling the hot path.
+func TestWithTimeoutEnforcedWithCustomClient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := NewRemote(srv.URL,
+		// Custom client with NO Timeout — the pre-fix code would block until the
+		// server responded (500ms) instead of honoring WithTimeout.
+		WithHTTPClient(&http.Client{}),
+		WithTimeout(50*time.Millisecond),
+		WithTokenProvider(func(context.Context) (string, error) { return "tok", nil }),
+	)
+
+	start := time.Now()
+	_, err := c.Balance(context.Background(), "11111111-1111-1111-1111-111111111111")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("expected timeout error, got nil")
+	}
+	if !errors.Is(err, ErrUnreachable) {
+		t.Fatalf("expected ErrUnreachable, got %v", err)
+	}
+	if elapsed > 300*time.Millisecond {
+		t.Fatalf("call was not bounded by WithTimeout: took %s", elapsed)
+	}
+}


### PR DESCRIPTION
_Produced by an automated daily code review._

## Problem
`WithTimeout` is documented to bound **every** hot-path call (default 2s), but it was only applied via `http.Client.Timeout` on the *default* client. When an integrator injected their own transport with `WithHTTPClient` (a primary, documented integration path), the timeout was silently dropped.

## Why it matters
A custom client with no `Timeout` set would block on a slow/hung OpenRails until the OS TCP timeout, stalling the caller's request hot path and defeating the fail-policy (`ErrUnreachable`) design. This is both a reliability/DoS concern and a broken-contract issue on a core embed seam.

## Approach
Apply the configured timeout as a per-request `context.WithTimeout` inside `doRaw`, so it holds regardless of which `http.Client` is used. It only shortens an existing caller deadline; a non-positive value disables it. Updated `WithTimeout`/`WithHTTPClient` godoc and added a regression test proving a client with no `Timeout` still fails fast as `ErrUnreachable`.

`go build ./...` passes; new test `TestWithTimeoutEnforcedWithCustomClient` passes. ~64 lines.
