### PR TITLE
fix(remote): bound and sanitize unrecognized error response bodies

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 )
@@ -707,7 +709,12 @@ func statusErrorFromBody(status int, raw []byte) error {
 		}
 	}
 	if code == "" && message == "" {
-		message = strings.TrimSpace(string(raw))
+		// No recognized error envelope: the body is an opaque/foreign payload
+		// (a proxy's HTML error page, an upstream stack trace, etc.). Surface a
+		// short, single-line excerpt rather than dumping the whole body into the
+		// error string — an unbounded body can be large, contain newlines/control
+		// characters, or echo internal detail into the caller's logs.
+		message = excerptErrorBody(raw)
 	}
 	if status >= 500 {
 		// 5xx is server-side fault: also unreachable for fail-policy purposes
@@ -716,6 +723,48 @@ func statusErrorFromBody(status int, raw []byte) error {
 		return newStatusError(status, code, message, ErrUnreachable)
 	}
 	return newStatusError(status, code, message)
+}
+
+// maxErrorMessageBytes bounds the excerpt taken from an unrecognized (non-
+// envelope) error body before it becomes a StatusError message.
+const maxErrorMessageBytes = 512
+
+// excerptErrorBody turns an opaque error body into a safe, single-line excerpt:
+// it strips control characters (collapsing runs of whitespace), trims, and
+// truncates to maxErrorMessageBytes with an ellipsis. This keeps a foreign
+// upstream payload (HTML page, stack trace) from polluting the caller's error
+// strings/logs while preserving a useful hint.
+func excerptErrorBody(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(raw))
+	prevSpace := false
+	for _, r := range string(raw) {
+		if r == '\uFFFD' {
+			continue
+		}
+		if r == '\n' || r == '\r' || r == '\t' || unicode.IsControl(r) || unicode.IsSpace(r) {
+			if !prevSpace {
+				b.WriteByte(' ')
+				prevSpace = true
+			}
+			continue
+		}
+		b.WriteRune(r)
+		prevSpace = false
+	}
+	msg := strings.TrimSpace(b.String())
+	if len(msg) > maxErrorMessageBytes {
+		// Truncate on a rune boundary.
+		cut := maxErrorMessageBytes
+		for cut > 0 && !utf8.RuneStart(msg[cut]) {
+			cut--
+		}
+		msg = strings.TrimSpace(msg[:cut]) + "…"
+	}
+	return msg
 }
 
 // doRaw issues a single authed request and returns (status, body) for 2xx and

--- a/remote_error_body_test.go
+++ b/remote_error_body_test.go
@@ -1,0 +1,47 @@
+package openrails
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExcerptErrorBodyCollapsesAndTruncates(t *testing.T) {
+	// Multi-line "foreign" body (e.g. a proxy HTML page or a stack trace) must
+	// become a single-line, bounded excerpt.
+	raw := []byte("upstream error\n\tat foo()\r\n\tat bar()\n")
+	got := excerptErrorBody(raw)
+	if strings.ContainsAny(got, "\n\r\t") {
+		t.Fatalf("excerpt still contains control whitespace: %q", got)
+	}
+	if got != "upstream error at foo() at bar()" {
+		t.Fatalf("unexpected excerpt: %q", got)
+	}
+}
+
+func TestExcerptErrorBodyBounded(t *testing.T) {
+	raw := []byte(strings.Repeat("A", 5000))
+	got := excerptErrorBody(raw)
+	// Must not exceed the cap (+ a few bytes for the ellipsis rune).
+	if len(got) > maxErrorMessageBytes+4 {
+		t.Fatalf("excerpt not bounded: len=%d", len(got))
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("expected truncation ellipsis, got %q", got[len(got)-8:])
+	}
+}
+
+func TestStatusErrorFromBodyUsesExcerpt(t *testing.T) {
+	// A non-envelope 400 body should be excerpted into the StatusError message.
+	body := []byte("<html><body>Bad Gateway\n\n  detail  </body></html>")
+	err := statusErrorFromBody(400, body)
+	se, ok := err.(*StatusError)
+	if !ok {
+		t.Fatalf("expected *StatusError, got %T", err)
+	}
+	if strings.ContainsAny(se.Message, "\n\r\t") {
+		t.Fatalf("message not sanitized: %q", se.Message)
+	}
+	if se.Message == "" {
+		t.Fatalf("expected a non-empty excerpt message")
+	}
+}


### PR DESCRIPTION
_Produced by an automated daily code review._

## Problem
When a non-2xx response carried no recognized error envelope (a proxy's HTML error page, an upstream stack trace, a foreign payload), `statusErrorFromBody` dumped the entire raw body verbatim into `StatusError.Message`.

## Why it matters
Although `doRaw` caps the body at 1MiB, a multi-KiB, multi-line excerpt with control characters still propagates into every caller's error strings and logs — noisy, log-injection-prone, and a channel for echoing unexpected upstream/internal detail into the integrator's logs.

## Approach
Added `excerptErrorBody`: strips control characters, collapses whitespace runs, trims, and truncates to 512 bytes on a rune boundary with an ellipsis. Recognized OpenRails `code`/`message` envelopes are unaffected.

`go build ./...` passes; 3 new tests pass. ~97 lines (logic ~40, rest tests).
