### PR TITLE
fix(remote): reject empty/nil path identifiers client-side

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -152,8 +152,12 @@ func (c *remote) HoldCredits(ctx context.Context, req HoldCreditsRequest) (*Cred
 
 // CaptureHold implements Client (handler ServiceCaptureHold).
 func (c *remote) CaptureHold(ctx context.Context, req CaptureHoldRequest) (*CreditTransaction, error) {
+	requestID := strings.TrimSpace(req.RequestID)
+	if requestID == "" {
+		return nil, fmt.Errorf("%w: capture_hold requires request_id", ErrInvalid)
+	}
 	var out CreditTransaction
-	path := "/v1/service/credits/holds/" + url.PathEscape(strings.TrimSpace(req.RequestID)) + "/capture"
+	path := "/v1/service/credits/holds/" + url.PathEscape(requestID) + "/capture"
 	if err := c.do(ctx, http.MethodPost, path, map[string]any{"amount": req.Amount}, &out); err != nil {
 		return nil, err
 	}
@@ -162,7 +166,11 @@ func (c *remote) CaptureHold(ctx context.Context, req CaptureHoldRequest) (*Cred
 
 // ReleaseHold implements Client (handler ServiceReleaseHold).
 func (c *remote) ReleaseHold(ctx context.Context, requestID string) error {
-	return c.do(ctx, http.MethodPost, "/v1/service/credits/holds/"+url.PathEscape(strings.TrimSpace(requestID))+"/release", map[string]any{}, nil)
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		return fmt.Errorf("%w: release_hold requires request_id", ErrInvalid)
+	}
+	return c.do(ctx, http.MethodPost, "/v1/service/credits/holds/"+url.PathEscape(requestID)+"/release", map[string]any{}, nil)
 }
 
 // WithdrawCredits implements Client (handler ServiceWithdrawCredits).
@@ -236,7 +244,7 @@ type captureBody struct {
 // request_id. A nil error means OpenRails accepted the capture.
 func (c *remote) Capture(ctx context.Context, requestID string, capturedAmount int64, usage *CaptureUsage) error {
 	if strings.TrimSpace(requestID) == "" {
-		return fmt.Errorf("openrails: capture requires request_id")
+		return fmt.Errorf("%w: capture requires request_id", ErrInvalid)
 	}
 	body := captureBody{Amount: capturedAmount}
 	if usage != nil && strings.TrimSpace(usage.EventType) != "" {
@@ -254,7 +262,7 @@ func (c *remote) Capture(ctx context.Context, requestID string, capturedAmount i
 // request_id. Used when the work fails after a successful authorize/admit.
 func (c *remote) Release(ctx context.Context, requestID string) error {
 	if strings.TrimSpace(requestID) == "" {
-		return fmt.Errorf("openrails: release requires request_id")
+		return fmt.Errorf("%w: release requires request_id", ErrInvalid)
 	}
 	path := "/v1/service/credits/holds/" + url.PathEscape(strings.TrimSpace(requestID)) + "/release"
 	return c.do(ctx, http.MethodPost, path, nil, nil)
@@ -559,6 +567,9 @@ func (c *remote) SettleWindowItems(ctx context.Context, items []WindowSettleItem
 
 // RefillWindow implements Client (handler ServiceRefillCreditWindow).
 func (c *remote) RefillWindow(ctx context.Context, windowID uuid.UUID, amount, ttlSeconds int64) (*CreditWindow, error) {
+	if windowID == uuid.Nil {
+		return nil, fmt.Errorf("%w: refill_window requires a non-nil window_id", ErrInvalid)
+	}
 	body := map[string]any{"amount": amount, "ttl_seconds": ttlSeconds}
 	var out CreditWindow
 	if err := c.do(ctx, http.MethodPost, "/v1/service/credits/windows/"+windowID.String()+"/refill", body, &out); err != nil {
@@ -569,6 +580,9 @@ func (c *remote) RefillWindow(ctx context.Context, windowID uuid.UUID, amount, t
 
 // CloseWindow implements Client (handler ServiceCloseCreditWindow).
 func (c *remote) CloseWindow(ctx context.Context, windowID uuid.UUID) (*CreditWindow, error) {
+	if windowID == uuid.Nil {
+		return nil, fmt.Errorf("%w: close_window requires a non-nil window_id", ErrInvalid)
+	}
 	var out CreditWindow
 	if err := c.do(ctx, http.MethodPost, "/v1/service/credits/windows/"+windowID.String()+"/close", map[string]any{}, &out); err != nil {
 		return nil, err

--- a/remote_pathid_validation_test.go
+++ b/remote_pathid_validation_test.go
@@ -1,0 +1,57 @@
+package openrails
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestPathIDValidationFailsFast ensures the remote client rejects empty hold
+// request_ids and nil window ids CLIENT-SIDE (as ErrInvalid) instead of
+// constructing a malformed URL (e.g. /holds//capture) or a zero-UUID path that
+// would hit an unintended route on the server.
+func TestPathIDValidationFailsFast(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := NewRemote(srv.URL,
+		WithTokenProvider(func(context.Context) (string, error) { return "tok", nil }),
+	)
+	ctx := context.Background()
+
+	checks := []struct {
+		name string
+		call func() error
+	}{
+		{"CaptureHold", func() error { _, e := c.CaptureHold(ctx, CaptureHoldRequest{RequestID: "  "}); return e }},
+		{"ReleaseHold", func() error { return c.ReleaseHold(ctx, "") }},
+		{"Capture", func() error { return c.Capture(ctx, "", 1, nil) }},
+		{"Release", func() error { return c.Release(ctx, "") }},
+		{"RefillWindow", func() error { _, e := c.RefillWindow(ctx, uuid.Nil, 1, 1); return e }},
+		{"CloseWindow", func() error { _, e := c.CloseWindow(ctx, uuid.Nil); return e }},
+	}
+
+	for _, tc := range checks {
+		err := tc.call()
+		if err == nil {
+			t.Fatalf("%s: expected client-side validation error, got nil", tc.name)
+		}
+		if !errors.Is(err, ErrInvalid) {
+			t.Fatalf("%s: expected ErrInvalid, got %v", tc.name, err)
+		}
+	}
+
+	if got := atomic.LoadInt32(&hits); got != 0 {
+		t.Fatalf("expected no requests to reach the server, got %d", got)
+	}
+}


### PR DESCRIPTION
_Produced by an automated daily code review._

## Problem
`CaptureHold`, `ReleaseHold`, `RefillWindow`, and `CloseWindow` interpolated the caller's hold `request_id` / window UUID straight into the URL path with no guard. An empty `request_id` produced a malformed `/holds//capture`; a `uuid.Nil` window id produced a real-looking all-zero-UUID path. Both reach the server as a different/non-existent route and fail with a confusing 404/405. This was inconsistent with `Capture`/`Release`, which already guarded.

## Why it matters
Clean, predictable failure modes on the public client surface: integrators get an immediate, descriptive error instead of a misleading server-side status, and no malformed request leaves the process.

## Approach
Added client-side guards to all four methods and aligned the two existing guards so every client-side validation error wraps the `ErrInvalid` sentinel (uniform `errors.Is(err, ErrInvalid)`). Added a regression test asserting all six methods fail fast and that zero requests reach the server.

`go build ./...` passes; new test `TestPathIDValidationFailsFast` passes. ~75 lines.
