### PR TITLE
provision merchant secrets through the encrypted secret store, not plaintext 

### DIFF
--- a/internal/bootstrap/merchant_manifest.go
+++ b/internal/bootstrap/merchant_manifest.go
@@ -18,6 +18,7 @@ import (
 	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/merchants"
 	"github.com/open-rails/openrails/internal/modules/merchantconfig"
+	"github.com/open-rails/openrails/internal/secretstore"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
 
@@ -104,7 +105,12 @@ func ReconcileMerchantManifestData(ctx context.Context, cfg *config.Config, cp *
 	if err != nil {
 		return err
 	}
-	secretStore, err := merchants.NewDBSecretStore(cp.Pool())
+	// OR-CFG-001: build the secret store via the shared constructor — the SAME
+	// wiring the runtime read path uses — so provisioning never writes provider /
+	// processor / Solana secrets less protected (e.g. plaintext) than the runtime
+	// expects. Vault-backed when configured, otherwise per-merchant envelope
+	// encryption with a plaintext-Solana write-block.
+	secretStore, _, err := secretstore.Build(ctx, cfg, cp.Pool())
 	if err != nil {
 		return fmt.Errorf("merchant bootstrap: build secret store: %w", err)
 	}

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -13,25 +13,19 @@ import (
 	"github.com/open-rails/openrails/internal/app"
 	"github.com/open-rails/openrails/internal/captcha"
 	"github.com/open-rails/openrails/internal/controlplane"
-	"github.com/open-rails/openrails/internal/crypto"
 	dbrepo "github.com/open-rails/openrails/internal/db/repo"
 	"github.com/open-rails/openrails/internal/http/embedhttp"
 	"github.com/open-rails/openrails/internal/http/middleware"
 	ginmw "github.com/open-rails/openrails/internal/http/middleware/ginmw"
 	solanaint "github.com/open-rails/openrails/internal/integrations/solana"
-	"github.com/open-rails/openrails/internal/integrations/vault"
 	"github.com/open-rails/openrails/internal/merchants"
 	"github.com/open-rails/openrails/internal/modules/solana/recurring"
 	"github.com/open-rails/openrails/internal/platform"
+	"github.com/open-rails/openrails/internal/secretstore"
 	"github.com/open-rails/openrails/pkg/authprovider/ginauth"
 	"github.com/open-rails/openrails/pkg/billingauth"
 	"github.com/open-rails/openrails/pkg/cache"
 	"github.com/open-rails/openrails/pkg/merchant"
-)
-
-const (
-	vaultKVMount      = "secret"
-	vaultTransitMount = "transit"
 )
 
 type Dependencies struct {
@@ -189,53 +183,12 @@ func New(deps Dependencies) (*Server, error) {
 	// store is the self-hosted default and needs no live Vault; a managed
 	// deployment swaps in the Vault-backed store with the same addressing.
 	{
-		var secretStore merchants.MerchantSecretStore
-		var solanaTransit solanaint.TransitClient
-
-		if deps.Config != nil && deps.Config.Vault != nil && deps.Config.Vault.Enabled {
-			// Managed: Vault KV-v2 backend (#251), same (tenant, name) addressing.
-			// Vault encrypts at rest, so no envelope wrapper. Transit keeps the
-			// per-tenant Solana key non-extractable.
-			vc := deps.Config.Vault
-			vclient, verr := vault.Login(context.Background(), vault.Config{
-				Address: vc.Address, AuthMethod: vc.AuthMethod, Token: vc.Token, RoleID: vc.RoleID,
-				SecretID: vc.SecretID, K8sRole: vc.K8sRole,
-			})
-			if verr != nil {
-				return nil, fmt.Errorf("vault login: %w", verr)
-			}
-			secretStore = merchants.NewVaultSecretStore(vaultKVMount, vault.NewKVv2Adapter(vclient, vaultKVMount), merchants.NewDBMerchantSlugResolver(deps.ControlPlane.Pool()))
-			solanaTransit = vault.NewTransitAdapter(vclient, vaultTransitMount)
-		} else {
-			// Self-hosted default: DB-backed store + per-tenant envelope encryption
-			// (issue #227). With no master key, most secrets keep the legacy
-			// plaintext behavior, but Solana private keys are write-blocked below so
-			// recurring signing keys are never newly stored plaintext.
-			dbStore, sserr := merchants.NewDBSecretStore(deps.ControlPlane.Pool())
-			if sserr != nil {
-				return nil, fmt.Errorf("build tenant secret store: %w", sserr)
-			}
-			var masterKey string
-			if deps.Config != nil && deps.Config.Encryption != nil {
-				masterKey = deps.Config.Encryption.MasterKey
-			}
-			dekStore, dkerr := crypto.NewDBDEKStore(deps.ControlPlane.Pool())
-			if dkerr != nil {
-				return nil, fmt.Errorf("build tenant DEK store: %w", dkerr)
-			}
-			enc, encerr := crypto.NewEncryptor(masterKey, dekStore)
-			if encerr != nil {
-				return nil, fmt.Errorf("build tenant encryptor: %w", encerr)
-			}
-			secretStore, sserr = merchants.NewEncryptedSecretStore(dbStore, enc)
-			if sserr != nil {
-				return nil, fmt.Errorf("wrap tenant secret store with encryption: %w", sserr)
-			}
-			if !enc.Enabled() {
-				secretStore = merchants.NewWriteRestrictedSecretStore(secretStore, map[string]string{
-					solanaint.SecretSolanaPrivateKey: "ENCRYPTION_MASTER_KEY is required before storing DB-backed Solana private keys",
-				})
-			}
+		// Build the secret store via the shared constructor so this runtime read
+		// path and the bootstrap/provisioning write path can never diverge in how
+		// secrets are protected at rest (OR-CFG-001).
+		secretStore, solanaTransit, sserr := secretstore.Build(context.Background(), deps.Config, deps.ControlPlane.Pool())
+		if sserr != nil {
+			return nil, sserr
 		}
 
 		// Front the chosen store with an in-process TTL cache (#251/#322) so workers

--- a/internal/secretstore/secretstore.go
+++ b/internal/secretstore/secretstore.go
@@ -1,0 +1,90 @@
+// Package secretstore builds the canonical merchant secret store from config.
+//
+// It is the single source of truth for how provider/processor/Solana secrets are
+// protected at rest, used by BOTH the long-lived HTTP server runtime and the
+// bootstrap / push-merchant-config provisioning path. Centralizing the wiring
+// here closes OR-CFG-001: before this, the provisioning path constructed a raw
+// DB store and wrote secrets in plaintext, bypassing the envelope encryption and
+// the plaintext-Solana write-block that the runtime read path enforces. With one
+// constructor the write path can never store secrets less protected than the read
+// path expects.
+//
+// Layout matches the runtime exactly:
+//   - Vault enabled  → Vault KV-v2 backend (encrypts at rest) + Transit signer.
+//   - otherwise      → DB-backed store wrapped in per-merchant envelope
+//     encryption; when no master key is configured, Solana private keys are
+//     write-blocked so recurring signing keys are never newly stored plaintext.
+package secretstore
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/crypto"
+	"github.com/open-rails/openrails/internal/db"
+	solanaint "github.com/open-rails/openrails/internal/integrations/solana"
+	"github.com/open-rails/openrails/internal/integrations/vault"
+	"github.com/open-rails/openrails/internal/merchants"
+)
+
+const (
+	vaultKVMount      = "secret"
+	vaultTransitMount = "transit"
+
+	// solanaPlaintextWriteBlockReason is surfaced when a DB-backed Solana private
+	// key write is rejected because envelope encryption is not configured.
+	solanaPlaintextWriteBlockReason = "envelope encryption master key is required before storing DB-backed Solana private keys"
+)
+
+// Build constructs the merchant secret store and, when Vault is enabled, the
+// Solana Transit signing client (nil otherwise). The returned store is NOT
+// wrapped in the in-process TTL cache — long-lived callers add that themselves;
+// one-shot callers (bootstrap) use it directly.
+func Build(ctx context.Context, cfg *config.Config, pool *db.Pool) (merchants.MerchantSecretStore, solanaint.TransitClient, error) {
+	if cfg != nil && cfg.Vault != nil && cfg.Vault.Enabled {
+		// Managed: Vault KV-v2 backend (#251), same (tenant, name) addressing.
+		// Vault encrypts at rest, so no envelope wrapper. Transit keeps the
+		// per-tenant Solana key non-extractable.
+		vc := cfg.Vault
+		vclient, err := vault.Login(ctx, vault.Config{
+			Address: vc.Address, AuthMethod: vc.AuthMethod, Token: vc.Token, RoleID: vc.RoleID,
+			SecretID: vc.SecretID, K8sRole: vc.K8sRole,
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("vault login: %w", err)
+		}
+		store := merchants.NewVaultSecretStore(vaultKVMount, vault.NewKVv2Adapter(vclient, vaultKVMount), merchants.NewDBMerchantSlugResolver(pool))
+		return store, vault.NewTransitAdapter(vclient, vaultTransitMount), nil
+	}
+
+	// Self-hosted default: DB-backed store + per-tenant envelope encryption
+	// (issue #227). With no master key, most secrets keep the legacy plaintext
+	// behavior, but Solana private keys are write-blocked below so recurring
+	// signing keys are never newly stored plaintext.
+	dbStore, err := merchants.NewDBSecretStore(pool)
+	if err != nil {
+		return nil, nil, fmt.Errorf("build tenant secret store: %w", err)
+	}
+	var masterKey string
+	if cfg != nil && cfg.Encryption != nil {
+		masterKey = cfg.Encryption.MasterKey
+	}
+	dekStore, err := crypto.NewDBDEKStore(pool)
+	if err != nil {
+		return nil, nil, fmt.Errorf("build tenant DEK store: %w", err)
+	}
+	enc, err := crypto.NewEncryptor(masterKey, dekStore)
+	if err != nil {
+		return nil, nil, fmt.Errorf("build tenant encryptor: %w", err)
+	}
+	store, err := merchants.NewEncryptedSecretStore(dbStore, enc)
+	if err != nil {
+		return nil, nil, fmt.Errorf("wrap tenant secret store with encryption: %w", err)
+	}
+	if !enc.Enabled() {
+		blocked := map[string]string{solanaint.SecretSolanaPrivateKey: solanaPlaintextWriteBlockReason}
+		store = merchants.NewWriteRestrictedSecretStore(store, blocked)
+	}
+	return store, nil, nil
+}


### PR DESCRIPTION
# openrails: provision merchant secrets through the encrypted secret store, not plaintext (OR-CFG-001)

## Summary

The merchant provisioning path (`push-merchant-config` / bootstrap manifest
reconcile) built its secret store with the **raw DB store** and wrote every
declared provider secret — Stripe/NMI/CCBill processor keys and **Solana private
keys** — straight into `openrails.merchant_secrets` in plaintext. The runtime
read path, by contrast, wraps the same DB store in per-merchant envelope
encryption (or a Vault backend) and blocks plaintext Solana key writes when no
master key is configured. The two paths had diverged, so the documented
onboarding command silently stored the system's most sensitive credentials
unprotected.

This PR introduces a single shared secret-store constructor and routes **both**
the runtime and the provisioning path through it, so the write path can never
again store secrets less protected than the read path expects.

## Severity

High. Affects merchants onboarded through the standard provisioning command.
Exposure paths: a database dump, a read-replica, or a backup leak yields live,
money-moving processor credentials and Solana signing keys in cleartext.
Secondary operational failure: when `ENCRYPTION_MASTER_KEY` *is* set, secrets
seeded as plaintext then fail to decrypt on the runtime read path, breaking the
affected merchant's billing.

## Root cause

`ReconcileMerchantManifestData` constructed `merchants.NewDBSecretStore(...)`
directly and called `secretStore.Put(...)` with resolved plaintext values. It
never applied:
- the Vault-backed store (when `cfg.Vault.Enabled`),
- `NewEncryptedSecretStore` (per-merchant envelope encryption, issue #227), or
- `NewWriteRestrictedSecretStore` (the plaintext-Solana write block).

The correct wiring already existed — but only inline in `internal/http/server.go`,
where it could (and did) drift out of sync with the provisioning path.

## Changes

**New: `internal/secretstore/secretstore.go`**
- `secretstore.Build(ctx, cfg, pool)` — the single source of truth for
  secret-store construction:
  - Vault enabled → Vault KV-v2 backend (encrypts at rest) + Transit signer.
  - otherwise → DB-backed store wrapped in per-merchant envelope encryption;
    when no master key is configured, Solana private keys are write-blocked.
- Returns the (uncached) store and, when Vault is enabled, the Solana Transit
  client. Long-lived callers add the in-process TTL cache themselves; one-shot
  callers use the store directly.
- Lives in a dedicated leaf package to avoid an import cycle (`merchants` uses
  dependency-inverted interfaces and does not import `vault`/`solana`).

**`internal/http/server.go`**
- Replaces the inline Vault-vs-encrypted construction block with a call to
  `secretstore.Build(...)`, preserving identical runtime behaviour (the TTL
  cache wrap and the `solanaTransit` consumption downstream are unchanged).
- Removes the now-unused `crypto` and `vault` imports and the
  `vaultKVMount`/`vaultTransitMount` constants (moved into the shared package).

**`internal/bootstrap/merchant_manifest.go`**
- `ReconcileMerchantManifestData` now builds its secret store via
  `secretstore.Build(ctx, cfg, cp.Pool())` instead of `NewDBSecretStore`. The
  `cfg` argument it already receives (previously unused on this path) supplies
  the Vault/encryption configuration.

## Behaviour after the fix

| Deployment | Before | After |
|------------|--------|-------|
| Vault enabled | plaintext into Postgres `merchant_secrets`; Vault unused | secrets stored in Vault KV-v2 |
| Master key set | plaintext, then unreadable at runtime (decrypt fails) | per-merchant envelope-encrypted, runtime reads succeed |
| No master key | plaintext incl. Solana keys | non-Solana secrets plaintext (legacy back-compat); **Solana private-key writes rejected** with a clear error |

## Tests / verification

- `go build ./...` and `go vet ./internal/secretstore/... ./internal/bootstrap/... ./internal/http/...` clean.
- The runtime path is unchanged in behaviour (same constructor inputs/outputs),
  so existing server/integration tests continue to exercise it.
- Manual verification for the provisioning path:
  - With a master key configured, run `push-merchant-config` against a manifest
    declaring a provider secret and confirm the stored
    `openrails.merchant_secrets` value is ciphertext (not the plaintext input)
    and that the runtime resolves it.
  - With no master key, confirm a manifest declaring a Solana private key is
    rejected at provisioning time with the write-block error, matching runtime.

## Compatibility / rollout

- No schema change.
- Self-hosted deployments **with** `ENCRYPTION_MASTER_KEY` set: any secrets
  previously seeded in plaintext by the old path cannot be decrypted and should
  be re-provisioned (re-run `push-merchant-config`) so they are written
  encrypted. Recommend rotating any processor/Solana credential that was
  previously written in cleartext, since it may exist unprotected in backups.
- Vault deployments: previously-seeded plaintext rows in
  `openrails.merchant_secrets` should be migrated into Vault and removed from the
  table.

## Reviewer notes

- The shared constructor is intentionally the *only* place this wiring lives; the
  goal is that the provisioning (write) path and the runtime (read) path can
  never diverge again. Please flag any future call site that constructs a secret
  store by hand instead of calling `secretstore.Build`.
