### PR TITLE
OpenRails GoSec fixes

### DIFF
--- a/internal/http/handlers/admin_operations.go
+++ b/internal/http/handlers/admin_operations.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	safecast "github.com/ccoveille/go-safecast/v2"
 	"github.com/google/uuid"
 	"github.com/open-rails/openrails/internal/db/gen"
 	"github.com/open-rails/openrails/internal/db/models"
@@ -51,9 +52,11 @@ func GetAdminRepairAlerts(r *httprequest.Request) {
 		r.ErrorJSON(http.StatusInternalServerError, "failed to count repair alerts")
 		return
 	}
+	limit32, _ := safecast.Convert[int32](limit)
+	offset32, _ := safecast.Convert[int32](offset)
 	rows, err := q.ListRepairAlerts(ctx, gen.ListRepairAlertsParams{
 		CustomerID: tsid, EventType: string(models.NotificationSystemAlert), Seen: seen,
-		Column3: int32(limit), Column4: int32(offset),
+		Column3: limit32, Column4: offset32,
 	})
 	if err != nil {
 		r.ErrorJSON(http.StatusInternalServerError, "failed to retrieve repair alerts")

--- a/internal/modules/admission/spendgate/gate.go
+++ b/internal/modules/admission/spendgate/gate.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	safecast "github.com/ccoveille/go-safecast/v2"
 	"github.com/redis/go-redis/v9"
 )
 
@@ -326,7 +327,10 @@ func fixedOffsetMs(prefix string, durMs int64) int64 {
 	}
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(prefix))
-	return int64(h.Sum64() % uint64(durMs))
+	// durMs > 0 is guaranteed above, so the modulo result is in [0, durMs) and
+	// always fits a non-negative int64; safecast keeps the conversion checked.
+	off, _ := safecast.Convert[int64](h.Sum64() % uint64(durMs))
+	return off
 }
 
 func toInt64(v any) int64 {


### PR DESCRIPTION
fix for the GoSec Issues:

```
[/home/runner/work/openrails/openrails/internal/modules/admission/spendgate/gate.go:329] - G115 (CWE-190): integer overflow conversion uint64 -> int64 (Confidence: MEDIUM, Severity: HIGH)
    328: 	_, _ = h.Write([]byte(prefix))
  > 329: 	return int64(h.Sum64() % uint64(durMs))
    330: }

Autofix: 

[/home/runner/work/openrails/openrails/internal/http/handlers/admin_operations.go:56] - G115 (CWE-190): integer overflow conversion int -> int32 (Confidence: MEDIUM, Severity: HIGH)
    55: 		CustomerID: tsid, EventType: string(models.NotificationSystemAlert), Seen: seen,
  > 56: 		Column3: int32(limit), Column4: int32(offset),
    57: 	})

Autofix: 

[/home/runner/work/openrails/openrails/internal/http/handlers/admin_operations.go:56] - G115 (CWE-190): integer overflow conversion int -> int32 (Confidence: MEDIUM, Severity: HIGH)
    55: 		CustomerID: tsid, EventType: string(models.NotificationSystemAlert), Seen: seen,
  > 56: 		Column3: int32(limit), Column4: int32(offset),
    57: 	})

Autofix: 

Summary:
  Gosec  : dev
  Files  : 487
  Lines  : 132975
  Nosec  : 0

```