### PR TITLE
fix(migrations): add rails column to existing prices tables

### DIFF
--- a/migrations/postgres/003_prices_rails_column.up.sql
+++ b/migrations/postgres/003_prices_rails_column.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE openrails.prices ADD COLUMN IF NOT EXISTS rails jsonb;


### PR DESCRIPTION
## Summary

- The `processor→rail` rename (#582) added `rails jsonb` to `CREATE TABLE openrails.prices` in `001_schema.up.sql`
- Any database that had already applied `001_schema.up.sql` won't see the new column — migratekit tracks applied migrations by filename and skips files already recorded in `public.migrations`
- This migration adds the missing column to existing databases

## Test plan

- [ ] Run `task db:migrate APP=doujins ENV=dev DB=postgres` and confirm pod boots without the `column "rails" does not exist` error
- [ ] Verify `SELECT rails FROM openrails.prices LIMIT 1` returns without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)