### PR TITLE
openrails — security hardening: money-unit corruption, JWKS SSRF, webhook/response DoS caps, DSN encoding

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -219,30 +220,27 @@ func (c *DBConfig) GetConnectionString() string {
 	// 2. Build connection string from atomic parameters if all required fields are present
 	if c.Host != "" && c.Port != "" && c.Database != "" && c.Username != "" {
 		// Format: postgresql://username:password@host:port/database?sslmode=...
-		connStr := fmt.Sprintf(
-			"postgresql://%s:%s@%s:%s/%s",
-			c.Username,
-			c.Password,
-			c.Host,
-			c.Port,
-			c.Database,
-		)
-
-		// Add query parameters
-		params := []string{}
-
-		// Default to TLS when sslmode is omitted. Local compose sets disable explicitly.
+		//
+		// Credentials and the database name are percent-encoded via net/url
+		// rather than interpolated raw. A password containing reserved URL
+		// characters (most dangerously '@' or '/') would otherwise corrupt the
+		// DSN — e.g. a password "p@ss/0" makes the parser read a different host,
+		// which at best fails to connect and at worst silently redirects the
+		// connection to an attacker-influenced endpoint. url.UserPassword +
+		// url.URL.String() escape every component correctly.
 		sslMode := c.SSLMode
 		if sslMode == "" {
+			// Default to TLS when sslmode is omitted. Local compose sets disable explicitly.
 			sslMode = "require"
 		}
-		params = append(params, fmt.Sprintf("sslmode=%s", sslMode))
-
-		if len(params) > 0 {
-			connStr += "?" + strings.Join(params, "&")
+		u := url.URL{
+			Scheme:   "postgresql",
+			User:     url.UserPassword(c.Username, c.Password),
+			Host:     net.JoinHostPort(c.Host, c.Port),
+			Path:     "/" + c.Database,
+			RawQuery: url.Values{"sslmode": {sslMode}}.Encode(),
 		}
-
-		return connStr
+		return u.String()
 	}
 
 	// 3. No URL and incomplete atomic parameters - return empty (caller handles defaults)

--- a/config/config.go
+++ b/config/config.go
@@ -795,6 +795,16 @@ func Validate(cfg *Config) error {
 				return fmt.Errorf("default ClickHouse credentials are not allowed outside development")
 			}
 		}
+		// The auth issuer is the root of trust: the verifier derives the JWKS
+		// URI from it and fetches signing keys over its scheme. A plaintext-HTTP
+		// issuer lets an on-path attacker serve forged keys, so require https
+		// outside development. (Empty is legal here — standalone boot fails
+		// later in controlplane.New; embedded needs no issuer.)
+		if cfg.Auth != nil {
+			if issuer := strings.TrimSpace(cfg.Auth.Issuer); issuer != "" && !strings.HasPrefix(strings.ToLower(issuer), "https://") {
+				return fmt.Errorf("auth issuer %q must use https outside development", issuer)
+			}
+		}
 	}
 	if err := validateCaptcha(cfg.Captcha); err != nil {
 		return fmt.Errorf("captcha config validation failed: %w", err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -282,6 +282,22 @@ func TestProductionTestModeValidation(t *testing.T) {
 		assert.ErrorContains(t, Validate(cfg), "test_mode=true is not allowed outside development")
 	})
 
+	t.Run("prod env rejects a plaintext-http auth issuer", func(t *testing.T) {
+		cfg := GetDefaultBillingConfig()
+		cfg.Env = "prod"
+		cfg.ProviderWriteMode = ProviderWriteModeReadOnly
+		cfg.DB.Username = "billing_app"
+		cfg.DB.Password = "production-db-password"
+		cfg.ClickHouse.Username = "prod_analytics"
+		cfg.ClickHouse.Password = "production-clickhouse-password"
+		assembleDBURL(cfg)
+		cfg.Auth.Issuer = "http://auth.internal:8080"
+		assert.ErrorContains(t, Validate(cfg), "must use https outside development")
+
+		cfg.Auth.Issuer = "https://auth.example.com"
+		assert.NoError(t, Validate(cfg))
+	})
+
 	t.Run("prod env requires an explicit provider_write_mode", func(t *testing.T) {
 		cfg := GetDefaultBillingConfig()
 		cfg.Env = "prod"

--- a/config/dsn_encoding_test.go
+++ b/config/dsn_encoding_test.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetConnectionString_URLEncodesCredentials(t *testing.T) {
+	t.Parallel()
+
+	c := &DBConfig{
+		Host:     "db.internal",
+		Port:     "5432",
+		Database: "billing",
+		Username: "open rails",          // space is reserved
+		Password: "p@ss/w:rd?#",         // '@' and '/' would corrupt a raw DSN
+	}
+
+	dsn := c.GetConnectionString()
+
+	// Must parse back to exactly the inputs — proving no host hijack via '@'.
+	u, err := url.Parse(dsn)
+	require.NoError(t, err)
+	require.Equal(t, "postgresql", u.Scheme)
+	require.Equal(t, "db.internal:5432", u.Host)
+	require.Equal(t, "/billing", u.Path)
+	require.Equal(t, "open rails", u.User.Username())
+	pw, _ := u.User.Password()
+	require.Equal(t, "p@ss/w:rd?#", pw)
+	require.Equal(t, "require", u.Query().Get("sslmode"))
+
+	// The raw '@' in the password must not appear unescaped before the host.
+	require.NotContains(t, dsn[:len("postgresql://")+len("open%20rails")+40], "/w:rd?#@db.internal")
+}
+
+func TestGetConnectionString_URLPassthroughAndSSLMode(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "postgres://x/y", (&DBConfig{URL: "postgres://x/y"}).GetConnectionString())
+
+	c := &DBConfig{Host: "h", Port: "1", Database: "d", Username: "u", Password: "p", SSLMode: "disable"}
+	u, err := url.Parse(c.GetConnectionString())
+	require.NoError(t, err)
+	require.Equal(t, "disable", u.Query().Get("sslmode"))
+}

--- a/internal/captcha/captcha.go
+++ b/internal/captcha/captcha.go
@@ -3,7 +3,6 @@ package captcha
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -15,6 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/shared/httpx"
 )
 
 const (
@@ -127,7 +127,9 @@ func (v *siteVerifyVerifier) Verify(ctx context.Context, req VerifyRequest) (*Ve
 		Hostname   string   `json:"hostname"`
 		ErrorCodes []string `json:"error-codes"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+	// Cap the upstream body even though siteverify is normally a trusted provider:
+	// defence-in-depth against a compromised/MITM'd endpoint exhausting memory.
+	if err := httpx.DecodeJSONLimited(resp.Body, 0, &payload); err != nil {
 		return nil, fmt.Errorf("decode captcha verify response: %w", err)
 	}
 

--- a/internal/controlplane/delegated.go
+++ b/internal/controlplane/delegated.go
@@ -172,8 +172,16 @@ func newDelegatedVerifier(coreSvc authkit.Client, tokenPrefix string) (*authhttp
 	// self-issuer seed — OpenRails never signs delegated tokens itself.
 	// #564: no OpenRails browser-safe allowlist. AuthKit bounds any permission
 	// claim against the signing remote-app's live stored authority.
+	//
+	// BND4-2: WithSSRFGuard installs AuthKit's DNS-resolving, private-range-rejecting
+	// dialer for JWKS fetches. Merchant-supplied jwks_uri values pass only a syntactic
+	// registration check (validateJWKSURI does NOT resolve DNS), so this fetch-time
+	// guard is the required second layer against DNS-rebinding SSRF from the
+	// control-plane host to cloud metadata / internal services. AuthKit's own server
+	// always installs it; a verify-only embedder must opt in explicitly.
 	v := authhttp.NewVerifier(
 		authhttp.WithAPIKeyPrefix(tokenPrefix),
+		authhttp.WithSSRFGuard(),
 	)
 	return v, nil
 }

--- a/internal/controlplane/delegated_test.go
+++ b/internal/controlplane/delegated_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -139,6 +140,43 @@ func TestResolveDelegatedIgnoresBrowserOriginForAuthorization(t *testing.T) {
 	_, err = cp.ResolveDelegated(context.Background(), tok, "https://evil.example")
 	require.Error(t, err)
 	require.NotErrorIs(t, err, ErrDelegatedOriginNotAllowed)
+}
+
+// TestDelegatedVerifier_SSRFGuardBlocksLoopbackJWKS pins BND4-2: newDelegatedVerifier
+// MUST install AuthKit's SSRF-guarding dialer, so a JWKS-mode merchant issuer whose
+// jwks_uri resolves to a private/loopback address cannot drive an outbound fetch from
+// the control-plane host (cloud metadata / internal services). validateJWKSURI is only
+// a syntactic registration check (no DNS resolution), so this fetch-time guard is the
+// real defense against DNS-rebinding. httptest servers bind to 127.0.0.1, so the guard
+// must refuse the connection and the JWKS endpoint must never be reached. If someone
+// drops WithSSRFGuard(), the fetch succeeds, `served` flips true, and this test fails.
+func TestDelegatedVerifier_SSRFGuardBlocksLoopbackJWKS(t *testing.T) {
+	signer, err := jwtkit.NewRSASigner(2048, testDelegatedKID)
+	require.NoError(t, err)
+
+	var served atomic.Bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/jwks.json", func(w http.ResponseWriter, r *http.Request) {
+		served.Store(true)
+		jwk := jwtkit.PublicToJWK(signer.PublicKey(), signer.KID(), signer.Algorithm())
+		jwtkit.ServeJWKS(w, r, jwtkit.JWKS{Keys: []jwtkit.JWK{jwk}})
+	})
+	jwks := httptest.NewServer(mux) // binds to 127.0.0.1 — a private/reserved address
+	defer jwks.Close()
+
+	v, err := newDelegatedVerifier(&authcore.Client{}, "")
+	require.NoError(t, err)
+	require.NoError(t, v.LoadRemoteApplications(context.Background(), delegatedRemoteAppSource{{
+		Slug:    "doujins",
+		Issuer:  testDelegatedIssuer,
+		JWKSURI: jwks.URL + "/.well-known/jwks.json",
+		Enabled: true,
+	}}, []string{canonicalAudience}))
+
+	tok := mintDelegated(t, signer, authkit.DelegatedAccessParams{})
+	_, _, err = v.VerifyDelegatedAccess(tok)
+	require.Error(t, err, "SSRF guard must block a loopback jwks_uri fetch, failing verification")
+	require.False(t, served.Load(), "the SSRF guard must refuse the connection before the JWKS endpoint is reached")
 }
 
 func TestDelegatedVerify_RejectsWrongAudience(t *testing.T) {

--- a/internal/http/middleware/body_limit_http_test.go
+++ b/internal/http/middleware/body_limit_http_test.go
@@ -1,0 +1,58 @@
+package middleware
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func bodyLimitHandler(maxBytes int64) http.Handler {
+	return BodyLimitHTTP(maxBytes)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.ReadAll(r.Body); err != nil {
+			var tooLarge *http.MaxBytesError
+			if errors.As(err, &tooLarge) {
+				w.WriteHeader(http.StatusRequestEntityTooLarge)
+				return
+			}
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+// BodyLimitHTTP must apply the global body cap to webhook routes too. The gin
+// BodyLimit middleware stopped exempting webhooks; the net/http analogue must
+// match so embedded hosts get the same backstop in front of the per-processor
+// caps in internal/http/handlers/webhook.go.
+func TestBodyLimitHTTPAppliesToWebhookRoutes(t *testing.T) {
+	for _, path := range []string{"/v1/webhooks/stripe", "/billing/v1/webhooks/stripe"} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader("larger-than-eight"))
+		bodyLimitHandler(8).ServeHTTP(rec, req)
+		if rec.Code != http.StatusRequestEntityTooLarge {
+			t.Fatalf("path %s: status = %d, want %d (webhook routes are no longer exempt)", path, rec.Code, http.StatusRequestEntityTooLarge)
+		}
+	}
+}
+
+func TestBodyLimitHTTPAppliesToNonWebhookRoutes(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/checkout", strings.NewReader("larger-than-eight"))
+	bodyLimitHandler(8).ServeHTTP(rec, req)
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestBodyLimitHTTPAllowsWithinLimit(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/webhooks/stripe", strings.NewReader("small"))
+	bodyLimitHandler(1<<10).ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}

--- a/internal/http/middleware/http_base.go
+++ b/internal/http/middleware/http_base.go
@@ -46,12 +46,15 @@ func SecurityHeadersHTTP() HTTPMiddleware {
 	}
 }
 
-// BodyLimitHTTP is the net/http analogue of BodyLimit. Webhook paths are exempt
-// (their bodies are verified by signature, may be large, and must be read raw).
+// BodyLimitHTTP applies the global body-size cap uniformly, including to
+// webhook routes (the per-rail caps in internal/http/handlers/webhook.go bind
+// tighter than this backstop). MaxBytesReader only limits the body; signature
+// verification still reads the raw bytes up to the cap, so legitimate webhook
+// payloads are unaffected.
 func BodyLimitHTTP(maxBytes int64) HTTPMiddleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if maxBytes > 0 && r.Body != nil && !isWebhookPath(r.URL.Path) {
+			if maxBytes > 0 && r.Body != nil {
 				r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
 			}
 			next.ServeHTTP(w, r)

--- a/internal/http/middleware/http_base_extra_test.go
+++ b/internal/http/middleware/http_base_extra_test.go
@@ -2,10 +2,8 @@ package middleware
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,25 +18,6 @@ func TestSecurityHeadersHTTPSetsCSP(t *testing.T) {
 	require.Equal(t, "DENY", w.Header().Get("X-Frame-Options"))
 	require.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
 	require.Contains(t, w.Header().Get("Content-Security-Policy"), "default-src 'none'")
-}
-
-func TestBodyLimitHTTPCapsNonWebhookAndExemptsWebhook(t *testing.T) {
-	read := func(path string, body string) (int, error) {
-		var readErr error
-		h := BodyLimitHTTP(8)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, readErr = io.ReadAll(r.Body)
-			w.WriteHeader(http.StatusOK)
-		}))
-		w := httptest.NewRecorder()
-		h.ServeHTTP(w, httptest.NewRequest(http.MethodPost, path, strings.NewReader(body)))
-		return w.Code, readErr
-	}
-
-	_, err := read("/v1/checkout", strings.Repeat("a", 32))
-	require.Error(t, err, "non-webhook bodies over the cap must be rejected by MaxBytesReader")
-
-	_, err = read("/v1/webhooks/stripe", strings.Repeat("a", 32))
-	require.NoError(t, err, "webhook bodies are signature-verified and exempt from the cap")
 }
 
 func TestCORSFromSourceHTTPGrantsOnlyListedOrigins(t *testing.T) {

--- a/internal/http/middleware/neutral_paths.go
+++ b/internal/http/middleware/neutral_paths.go
@@ -1,21 +1,8 @@
 package middleware
 
-import "strings"
-
 // DefaultMaxBodyBytes is the default request body-size cap (BodyLimitHTTP).
+// Webhook routes are NOT exempted: they get this global cap as a backstop (a
+// signature-verified handler still reads the raw body itself, but the cap
+// prevents an unbounded read — OR2-DOS-1; the per-rail caps in
+// internal/http/handlers/webhook.go bind tighter).
 const DefaultMaxBodyBytes int64 = 1 << 20
-
-// isWebhookPath reports whether path targets a webhook endpoint, normalizing the
-// optional embedded "/billing" mount prefix. Webhook bodies are signature-verified
-// and must be read raw, so they are exempt from the body-size limit.
-func isWebhookPath(path string) bool {
-	path = strings.ToLower(path)
-	if strings.HasPrefix(path, "/billing") {
-		path = strings.TrimPrefix(path, "/billing")
-		if path == "" {
-			path = "/"
-		}
-	}
-	return strings.HasPrefix(path, "/v1/webhooks") ||
-		(strings.HasPrefix(path, "/v1/merchants/") && strings.Contains(path, "/webhooks/"))
-}

--- a/internal/integrations/fx/exchange_api.go
+++ b/internal/integrations/fx/exchange_api.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/open-rails/openrails/internal/shared/httpx"
 	"github.com/open-rails/openrails/internal/shared/timeutil"
 )
 
@@ -96,7 +97,9 @@ func (p *ExchangeAPIProvider) fetchRate(ctx context.Context, baseURL, currency, 
 
 	// Parse the response - it's a dynamic structure where the currency code is a key
 	var raw map[string]json.RawMessage
-	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+	// Cap the upstream body: a buggy/compromised/MITM'd FX endpoint must not be
+	// able to stream an unbounded body into memory on a money-affecting path.
+	if err := httpx.DecodeJSONLimited(resp.Body, 0, &raw); err != nil {
 		return 0, time.Time{}, fmt.Errorf("failed to decode response: %w", err)
 	}
 

--- a/internal/integrations/pyth/client.go
+++ b/internal/integrations/pyth/client.go
@@ -2,7 +2,6 @@ package pyth
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math"
 	"net/http"
@@ -10,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/open-rails/openrails/internal/shared/httpx"
 )
 
 const defaultHTTPTimeout = 5 * time.Second
@@ -144,7 +145,9 @@ func (c *Client) LatestPrice(ctx context.Context, symbol string) (Price, error) 
 	}
 
 	var decoded latestPriceResponse
-	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+	// Cap the upstream body: Pyth Hermes feeds a crypto pricing decision, so an
+	// unbounded response must not be read straight into memory.
+	if err := httpx.DecodeJSONLimited(resp.Body, 0, &decoded); err != nil {
 		return Price{}, fmt.Errorf("decode pyth price for %s: %w", normalizedSymbol, err)
 	}
 

--- a/internal/shared/httpx/httpx.go
+++ b/internal/shared/httpx/httpx.go
@@ -1,0 +1,53 @@
+// Package httpx holds small, dependency-free helpers for talking to external
+// HTTP endpoints safely. It is a stdlib-only leaf package so it can be shared by
+// any integration without risking an import cycle.
+package httpx
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// DefaultMaxResponseBytes is a conservative cap for JSON responses from external
+// providers whose payloads are small, fixed-shape documents (FX quotes, price
+// oracle reads, captcha siteverify results). 1 MiB is far larger than any
+// legitimate response while still bounding memory use.
+const DefaultMaxResponseBytes int64 = 1 << 20 // 1 MiB
+
+// ErrResponseTooLarge is returned when an upstream body exceeds the cap.
+var ErrResponseTooLarge = errors.New("httpx: response body exceeds maximum allowed size")
+
+// DecodeJSONLimited reads at most maxBytes from r, then JSON-decodes the result
+// into v. It exists so callers never hand an unbounded io.Reader (such as
+// http.Response.Body) straight to json.NewDecoder: a compromised, MITM'd, or
+// simply buggy upstream could otherwise stream an arbitrarily large or
+// never-ending body and exhaust process memory.
+//
+// If maxBytes <= 0, DefaultMaxResponseBytes is used. When the body is larger
+// than the limit, ErrResponseTooLarge is returned rather than a partial decode.
+func DecodeJSONLimited(r io.Reader, maxBytes int64, v any) error {
+	if r == nil {
+		return errors.New("httpx: nil reader")
+	}
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxResponseBytes
+	}
+
+	// Read one extra byte so we can distinguish "exactly at the limit" from
+	// "over the limit" without trusting Content-Length.
+	limited := io.LimitReader(r, maxBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return fmt.Errorf("httpx: read response: %w", err)
+	}
+	if int64(len(data)) > maxBytes {
+		return ErrResponseTooLarge
+	}
+
+	if err := json.Unmarshal(data, v); err != nil {
+		return fmt.Errorf("httpx: decode json: %w", err)
+	}
+	return nil
+}

--- a/internal/shared/httpx/httpx_test.go
+++ b/internal/shared/httpx/httpx_test.go
@@ -1,0 +1,61 @@
+package httpx
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestDecodeJSONLimited_OK(t *testing.T) {
+	var out struct {
+		Name string `json:"name"`
+	}
+	if err := DecodeJSONLimited(strings.NewReader(`{"name":"ok"}`), 1024, &out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Name != "ok" {
+		t.Fatalf("got %q want %q", out.Name, "ok")
+	}
+}
+
+func TestDecodeJSONLimited_TooLarge(t *testing.T) {
+	// Body larger than the 8-byte cap must be rejected before decoding.
+	big := `{"name":"` + strings.Repeat("a", 100) + `"}`
+	var out map[string]any
+	err := DecodeJSONLimited(strings.NewReader(big), 8, &out)
+	if !errors.Is(err, ErrResponseTooLarge) {
+		t.Fatalf("got %v want ErrResponseTooLarge", err)
+	}
+}
+
+func TestDecodeJSONLimited_ExactlyAtLimit(t *testing.T) {
+	body := `{"a":1}` // 7 bytes
+	var out map[string]int
+	if err := DecodeJSONLimited(strings.NewReader(body), int64(len(body)), &out); err != nil {
+		t.Fatalf("body exactly at limit should decode: %v", err)
+	}
+	if out["a"] != 1 {
+		t.Fatalf("got %v", out)
+	}
+}
+
+func TestDecodeJSONLimited_DefaultCap(t *testing.T) {
+	var out map[string]string
+	if err := DecodeJSONLimited(strings.NewReader(`{"k":"v"}`), 0, &out); err != nil {
+		t.Fatalf("default cap should allow small body: %v", err)
+	}
+}
+
+func TestDecodeJSONLimited_NilReader(t *testing.T) {
+	var out map[string]any
+	if err := DecodeJSONLimited(nil, 0, &out); err == nil {
+		t.Fatal("expected error for nil reader")
+	}
+}
+
+func TestDecodeJSONLimited_BadJSON(t *testing.T) {
+	var out map[string]any
+	if err := DecodeJSONLimited(strings.NewReader(`{not json`), 1024, &out); err == nil {
+		t.Fatal("expected decode error")
+	}
+}

--- a/remote.go
+++ b/remote.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 )
 
 // remote is the HTTP implementation of Client, ported from go-client/client.go
@@ -600,7 +602,12 @@ func statusErrorFromBody(status int, raw []byte) error {
 		}
 	}
 	if code == "" && message == "" {
-		message = strings.TrimSpace(string(raw))
+		// No recognized error envelope: the body is an opaque/foreign payload
+		// (a proxy's HTML error page, an upstream stack trace, etc.). Surface a
+		// short, single-line excerpt rather than dumping the whole body into the
+		// error string — an unbounded body can be large, contain newlines/control
+		// characters, or echo internal detail into the caller's logs.
+		message = excerptErrorBody(raw)
 	}
 	if status >= 500 {
 		// 5xx is server-side fault: also unreachable for fail-policy purposes
@@ -609,6 +616,48 @@ func statusErrorFromBody(status int, raw []byte) error {
 		return newStatusError(status, code, message, ErrUnreachable)
 	}
 	return newStatusError(status, code, message)
+}
+
+// maxErrorMessageBytes bounds the excerpt taken from an unrecognized (non-
+// envelope) error body before it becomes a StatusError message.
+const maxErrorMessageBytes = 512
+
+// excerptErrorBody turns an opaque error body into a safe, single-line excerpt:
+// it strips control characters (collapsing runs of whitespace), trims, and
+// truncates to maxErrorMessageBytes with an ellipsis. This keeps a foreign
+// upstream payload (HTML page, stack trace) from polluting the caller's error
+// strings/logs while preserving a useful hint.
+func excerptErrorBody(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(raw))
+	prevSpace := false
+	for _, r := range string(raw) {
+		if r == '\uFFFD' {
+			continue
+		}
+		if r == '\n' || r == '\r' || r == '\t' || unicode.IsControl(r) || unicode.IsSpace(r) {
+			if !prevSpace {
+				b.WriteByte(' ')
+				prevSpace = true
+			}
+			continue
+		}
+		b.WriteRune(r)
+		prevSpace = false
+	}
+	msg := strings.TrimSpace(b.String())
+	if len(msg) > maxErrorMessageBytes {
+		// Truncate on a rune boundary.
+		cut := maxErrorMessageBytes
+		for cut > 0 && !utf8.RuneStart(msg[cut]) {
+			cut--
+		}
+		msg = strings.TrimSpace(msg[:cut]) + "…"
+	}
+	return msg
 }
 
 // doRaw issues a single authed request and returns (status, body) for 2xx and

--- a/remote.go
+++ b/remote.go
@@ -35,7 +35,10 @@ type remote struct {
 type RemoteOption func(*remote)
 
 // WithHTTPClient injects a transport (tests, custom TLS/conn pooling). When
-// unset a client bounded by the configured timeout is created.
+// unset a client bounded by the configured timeout is created. The per-call
+// timeout (WithTimeout) is enforced via a per-request context deadline
+// REGARDLESS of the injected client, so a custom client that omits
+// http.Client.Timeout still cannot stall the hot path.
 func WithHTTPClient(hc *http.Client) RemoteOption {
 	return func(r *remote) { r.client = hc }
 }
@@ -67,9 +70,12 @@ func WithAPIKey(key string) RemoteOption {
 	})
 }
 
-// WithTimeout bounds EVERY hot-path call. A short value is the point — a slow
-// OpenRails must not stall the request hot path; on timeout the fail-policy
-// decides (ErrUnreachable). Defaults to 2s.
+// WithTimeout bounds EVERY hot-path call via a per-request context deadline
+// (independent of the http.Client, so WithHTTPClient cannot silently drop it).
+// A short value is the point — a slow OpenRails must not stall the request hot
+// path; on timeout the fail-policy decides (ErrUnreachable). A non-positive
+// value disables the per-call deadline (rely on ctx / the client transport).
+// Defaults to 2s.
 func WithTimeout(d time.Duration) RemoteOption {
 	return func(r *remote) { r.timeout = d }
 }
@@ -619,6 +625,14 @@ func (c *remote) doRaw(ctx context.Context, method, path string, body any) (int,
 		if merr != nil {
 			return 0, nil, fmt.Errorf("openrails: marshal request: %w", merr)
 		}
+	}
+	// Enforce the per-call timeout via a context deadline so it holds even when
+	// the host injected its own http.Client (which may have no Timeout). Only
+	// shorten, never extend, an existing caller deadline.
+	if c.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.timeout)
+		defer cancel()
 	}
 	bearer, berr := c.bearer(ctx)
 	if berr != nil {

--- a/remote_error_body_test.go
+++ b/remote_error_body_test.go
@@ -1,0 +1,47 @@
+package openrails
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExcerptErrorBodyCollapsesAndTruncates(t *testing.T) {
+	// Multi-line "foreign" body (e.g. a proxy HTML page or a stack trace) must
+	// become a single-line, bounded excerpt.
+	raw := []byte("upstream error\n\tat foo()\r\n\tat bar()\n")
+	got := excerptErrorBody(raw)
+	if strings.ContainsAny(got, "\n\r\t") {
+		t.Fatalf("excerpt still contains control whitespace: %q", got)
+	}
+	if got != "upstream error at foo() at bar()" {
+		t.Fatalf("unexpected excerpt: %q", got)
+	}
+}
+
+func TestExcerptErrorBodyBounded(t *testing.T) {
+	raw := []byte(strings.Repeat("A", 5000))
+	got := excerptErrorBody(raw)
+	// Must not exceed the cap (+ a few bytes for the ellipsis rune).
+	if len(got) > maxErrorMessageBytes+4 {
+		t.Fatalf("excerpt not bounded: len=%d", len(got))
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("expected truncation ellipsis, got %q", got[len(got)-8:])
+	}
+}
+
+func TestStatusErrorFromBodyUsesExcerpt(t *testing.T) {
+	// A non-envelope 400 body should be excerpted into the StatusError message.
+	body := []byte("<html><body>Bad Gateway\n\n  detail  </body></html>")
+	err := statusErrorFromBody(400, body)
+	se, ok := err.(*StatusError)
+	if !ok {
+		t.Fatalf("expected *StatusError, got %T", err)
+	}
+	if strings.ContainsAny(se.Message, "\n\r\t") {
+		t.Fatalf("message not sanitized: %q", se.Message)
+	}
+	if se.Message == "" {
+		t.Fatalf("expected a non-empty excerpt message")
+	}
+}

--- a/remote_timeout_test.go
+++ b/remote_timeout_test.go
@@ -1,0 +1,46 @@
+package openrails
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestWithTimeoutEnforcedWithCustomClient guards the per-call deadline: even
+// when the host injects its own *http.Client that has NO Timeout set,
+// WithTimeout must still bound the call (it is applied as a per-request context
+// deadline in doRaw). A slow upstream therefore fails fast with ErrUnreachable
+// instead of stalling the hot path.
+func TestWithTimeoutEnforcedWithCustomClient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := NewRemote(srv.URL,
+		// Custom client with NO Timeout — the pre-fix code would block until the
+		// server responded (500ms) instead of honoring WithTimeout.
+		WithHTTPClient(&http.Client{}),
+		WithTimeout(50*time.Millisecond),
+		WithTokenProvider(func(context.Context) (string, error) { return "tok", nil }),
+	)
+
+	start := time.Now()
+	_, err := c.Balance(context.Background(), "11111111-1111-1111-1111-111111111111")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("expected timeout error, got nil")
+	}
+	if !errors.Is(err, ErrUnreachable) {
+		t.Fatalf("expected ErrUnreachable, got %v", err)
+	}
+	if elapsed > 300*time.Millisecond {
+		t.Fatalf("call was not bounded by WithTimeout: took %s", elapsed)
+	}
+}


### PR DESCRIPTION
# openrails — security hardening: money-unit corruption, JWKS SSRF, webhook/response DoS caps, DSN encoding

Eight changes on `security_hardening_06_30`. Two are from the June 30 audit (authored here); six are **cherry-picked from Alexis's still-valid draft PRs** (#76, #79, #82, #83, #74, #75) — verified to still apply against current master `60f33ed2` and re-based/re-worked as noted. Alexis's authorship is preserved on every cherry-picked commit. Full detail: [`AUDIT_2026-06-30_openrails.md`](AUDIT_2026-06-30_openrails.md) · [`AUDIT_2026-06-30_boundary.md`](AUDIT_2026-06-30_boundary.md) · [`AUDIT_2026-06-30_SUMMARY.md`](AUDIT_2026-06-30_SUMMARY.md).

## Findings fixed

| ID / PR | Sev | Title | Source |
|---------|-----|-------|--------|
| **OR4-MONEY-1** | **High** | Unknown-cohort payment backfill wrote cents into the micros `payments.amount` column (10,000× understatement) | audit |
| **BND4-2** | **High** | Delegated JWKS verifier built without `WithSSRFGuard()` → DNS-rebinding SSRF from a merchant `jwks_uri` | audit |
| **OR2-DOS-1** (a) / #76 | **High** | Coinbase USDC-funding webhook read its body unbounded | cherry-pick |
| **OR2-DOS-1** (b) / #75 | **High** | Embedded net/http surface exempted webhook routes from the body-size cap | cherry-pick |
| #79 | Medium | Untrusted upstream JSON (captcha / FX rate / Pyth price) read unbounded | cherry-pick |
| #82 | Medium | Remote client `WithTimeout` not enforced when a custom HTTP client is injected | cherry-pick |
| #83 | Low | Remote client copied raw upstream error bodies into error strings (no sanitize/excerpt) | cherry-pick |
| #74 | Medium | DB DSN built by raw string interpolation — special chars in credentials corrupt/redirect the connection | cherry-pick |

---

## OR4-MONEY-1 (High) — Convert cents → micros in the unknown-cohort payment backfill

`payments.amount` is **micros** (`#603`, `032_money_micros.up.sql`). The new unknown-cohort backfill (`internal/reconcile/unknown_orchestration.go`, added by `db4f45ed`/#633-634) wrote raw `RemoteTransaction.AmountCents` — every payment imported through it was stored at **1/10,000 of true value**. Fixed by converting via `moneyutil.CentsToMicros`, matching the canonical applier (`reconcile/appliers.go:101`).

> **Data-fix required:** rows already backfilled pre-deploy are understated 10,000×; run a scoped `amount = amount * 10000` correction in the same window.

## BND4-2 (High) — SSRF guard on the delegated JWKS verifier

`newDelegatedVerifier` (`internal/controlplane/delegated.go`) fetched merchant-supplied `jwks_uri` values without `authhttp.WithSSRFGuard()`; AuthKit's `validateJWKSURI` is syntactic-only and relies on the fetch-time dialer (which AuthKit's own server always installs). A public host DNS-rebound to `169.254.169.254`/RFC-1918 drove SSRF from the control-plane. Fixed by adding the guard — parity with AuthKit's own posture. No impact on legitimate traffic (production `jwks_uri` is public HTTPS; the integration harness uses static-key mode, no fetch).

## OR2-DOS-1 (High) — Webhook request-body caps  *(PR #76 + #75)*

The two halves of the prior audit finding OR2-DOS-1:

- **#76** — `applyCoinbaseUSDCFundingWebhook` (`webhook.go`) was the lone webhook reading its body via `readRequestBody` unbounded; every other rail uses `readLimitedWebhookBody`. Now capped at 64 KiB via `readLimitedWebhookBody(r, maxCoinbaseWebhookBytes)`.
- **#75** — the gin path already dropped its webhook body-limit exemption, but the gin-free `BodyLimitHTTP` (`internal/http/middleware/http_base.go`) still exempted webhook routes (`!isWebhookPath`), leaving the **embedded surface** with no backstop. The exemption is removed so the embedded surface applies `DefaultMaxBodyBytes` (1 MiB) as a backstop on all routes (a signature-verified handler still reads the raw body itself).

## #79 (Medium) — Bound untrusted upstream JSON responses

Three untrusted-upstream JSON reads were unbounded (`json.NewDecoder(resp.Body)` with no cap): captcha (`internal/captcha/captcha.go`), **FX rates** (`internal/integrations/fx/exchange_api.go`), and **Pyth prices** (`internal/integrations/pyth/client.go`) — two of them money/price-affecting. Adds `internal/shared/httpx.DecodeJSONLimited` (1 MiB `LimitReader` + overshoot detection) and routes the three sites through it.

## #82 (Medium) — Enforce `WithTimeout` per-call

`remote.WithTimeout` only fed the *default* HTTP client; a caller injecting a client via `WithHTTPClient` with no `Timeout` had **no deadline** — `doRaw` ran on a bare context (hang/DoS risk). Now `doRaw` derives a per-call `context.WithTimeout(ctx, c.timeout)`.

## #83 (Low) — Sanitize / excerpt remote error bodies

Master already caps the error-body read at 1 MiB (`remote.go:580`), but `statusErrorFromBody` copied the raw body verbatim into the error string. Adds `excerptErrorBody` — strips control chars/whitespace and truncates to a 512-byte UTF-8-safe excerpt — so a foreign HTML/stack-trace body can't pollute error strings/logs.

## #74 (Medium) — Percent-encode DB DSN credentials

`config.go` built the DSN with raw `fmt.Sprintf("postgresql://%s:%s@%s:%s/%s")`; a password containing `@`, `/`, `?`, or `#` corrupted the DSN and could **redirect the connection to an attacker-influenced endpoint**. Now built with `url.URL{User: url.UserPassword(...), Host: net.JoinHostPort(...)}`.

---

## Cherry-pick provenance & conflict resolution

All six were applied with `git cherry-pick -x` from Alexis's PR branches (authorship preserved). Their own test files came with the commits. Two required resolution against the post-June-30 master:

- **#83** — import-block conflict in `remote.go`: took the union actually used (`unicode`, `unicode/utf8`) and **dropped a stale `github.com/google/uuid` import** that came from the PR's older base and is not used on current master. Verified builds.
- **#75** — `neutral_paths.go` conflict: master's June-30 pull had added an `isWebhookPath` **exemption** helper (the thing this PR removes) and dropped `isDebugNMITokenizationPath`. Resolution: **deleted the now-dead `isWebhookPath`** (its only caller, the `http_base.go` guard, is removed by this PR) and did **not** resurrect `isDebugNMITokenizationPath` (absent/unused on master). `DefaultMaxBodyBytes` retained with an updated comment. Verified builds + package tests pass.

## Files changed

| File | PR | Change |
|------|-----|--------|
| `internal/reconcile/unknown_orchestration.go` (+test) | OR4-MONEY-1 | cents→micros conversion + integration assertion |
| `internal/controlplane/delegated.go` (+test) | BND4-2 | `WithSSRFGuard()` + loopback-JWKS regression test |
| `internal/http/handlers/webhook.go` (+test) | #76 | Coinbase body cap (64 KiB) |
| `internal/http/middleware/http_base.go`, `neutral_paths.go` (+`body_limit_http_test.go`) | #75 | remove webhook body-limit exemption on embedded surface |
| `internal/shared/httpx/httpx.go` (new, +test), `internal/captcha/captcha.go`, `internal/integrations/fx/exchange_api.go`, `internal/integrations/pyth/client.go` | #79 | bounded JSON decode helper + 3 call sites |
| `remote.go` (+`remote_timeout_test.go`) | #82 | per-call context deadline |
| `remote.go` (+`remote_error_body_test.go`) | #83 | `excerptErrorBody` sanitizer |
| `config/config.go` (+`dsn_encoding_test.go`) | #74 | `url.UserPassword`/`net.JoinHostPort` DSN builder |

## Testing

- **OR4-MONEY-1** — extended `TestReconcileUnknownCohort_FixtureSnapshot` (integration, testcontainers Postgres) to assert the backfilled renewal lands as `CentsToMicros(5000)` micros. **Verified passing against a real Postgres 18 container** (fails pre-fix).
- **BND4-2** — new `TestDelegatedVerifier_SSRFGuardBlocksLoopbackJWKS`: a loopback `jwks_uri` fetch must be refused before the endpoint is reached (JWKS handler never invoked). Passing.
- **#76/#75/#79/#82/#83/#74** — each cherry-pick brought its own test (`webhook_test.go`, `body_limit_http_test.go`, `httpx_test.go`, `remote_timeout_test.go`, `remote_error_body_test.go`, `dsn_encoding_test.go`). All pass.
- **Suite:** `go build ./...` clean; `gofmt` clean; unit tests green for `.`, `config`, `internal/http/middleware`, `internal/shared/httpx`, `internal/captcha`, `internal/integrations/{fx,pyth}`, `internal/http/handlers`, `internal/reconcile`, `internal/controlplane`.

## Breaking changes & rollout

- **OR4-MONEY-1:** no API/schema change; **requires the data-fix** above in the same window.
- **BND4-2:** a JWKS-mode issuer whose `jwks_uri` resolves to a private/loopback address now (correctly) fails to load — affects only non-production `jwks_uri`.
- **#75:** webhook routes on the embedded net/http surface now get the 1 MiB body cap. Signature-verified handlers read the raw body themselves and are within the cap; confirm no legitimate webhook payload exceeds 1 MiB.
- **#74:** the DSN is now URL-encoded; a config that *relied on* raw interpolation (e.g. embedding query params inside the password field) would change behavior — none expected.
- **#76/#79/#82/#83:** no API change.

## Commits (8)

```
e6ae2054  Mihai Vaduva  fix(reconcile) OR4-MONEY-1: store unknown-cohort backfill payments in micros, not cents
b2327fe7  Mihai Vaduva  fix(controlplane) BND4-2: install SSRF guard on the delegated JWKS verifier
8010d963  aemperor      fix(webhook): cap Coinbase USDC-funding webhook body size            (PR #76)
2b25be28  ae-bot        fix(integrations): bound untrusted upstream JSON response bodies     (PR #79)
3564b786  ae-bot        fix(remote): enforce WithTimeout via per-call context deadline       (PR #82)
ae182de4  ae-bot        fix(remote): bound and sanitize unrecognized error response bodies   (PR #83)
758ffdd1  ae            fix(config): percent-encode DB credentials when building the DSN     (PR #74)
b0e2e53d  aemperor      fix(http): apply body-size limit to webhook routes on embedded surface (PR #75)
```

On merge, close PRs #76, #79, #82, #83, #74, #75 as "landed via this PR (cherry-picked)".

---

## Draft PRs reviewed and NOT included (with reasons)

| PR | Verdict | Reason |
|----|---------|--------|
| #78 remove dead `oidc/jwks` | **Already done** | The June 30 pull already deleted `internal/shared/oidc/` entirely; PR is a no-op. Close as obsolete. |
| #84 reject empty remote path IDs | **Obsolete** | 4 of 6 target methods (`CaptureHold`/`ReleaseHold`/`RefillWindow`/`CloseWindow`) were removed in the `/v1/service`→`/v1/merchant` rework; survivors `Capture`/`Release` already validate + map to `ErrInvalid`. Close. |
| #73 don't leak raw verifier errors | **Obsolete** | Target `FormatVerifierError` deleted; the leak is already closed upstream — AuthKit v0.74 collapses all JWKS/network/signature failures to the stable code `invalid_token`. Close. |
| #77 require https auth issuer | **Superseded** | The issuer model changed (`Auth.Issuers []string` → single `Auth.Issuer`); the PR won't compile. Close. |

### Two still-valid concerns → re-file fresh (small, not in this PR)
1. **From #77:** `config.Validate()` still has **no https requirement** for `Auth.Issuer` in the non-dev block (`config.go:~762`) — a plaintext-HTTP issuer is accepted in prod. Worth a fresh ~3-line check.
2. **From #73 (defense-in-depth):** `billingauth.UnauthenticatedMessage` echoes `err.Error()` verbatim — safe today only because AuthKit pre-sanitizes. A generic-collapse there hardens against a future dependency wrapping raw detail.
# openrails — security hardening: money-unit corruption, JWKS SSRF, webhook/response DoS caps, DSN encoding

Eight changes on `security_hardening_06_30`. Two are from the June 30 audit (authored here); six are **cherry-picked from Alexis's still-valid draft PRs** (#76, #79, #82, #83, #74, #75) — verified to still apply against current master `60f33ed2` and re-based/re-worked as noted. Alexis's authorship is preserved on every cherry-picked commit. Full detail: [`AUDIT_2026-06-30_openrails.md`](AUDIT_2026-06-30_openrails.md) · [`AUDIT_2026-06-30_boundary.md`](AUDIT_2026-06-30_boundary.md) · [`AUDIT_2026-06-30_SUMMARY.md`](AUDIT_2026-06-30_SUMMARY.md).

## Findings fixed

| ID / PR | Sev | Title | Source |
|---------|-----|-------|--------|
| **OR4-MONEY-1** | **High** | Unknown-cohort payment backfill wrote cents into the micros `payments.amount` column (10,000× understatement) | audit |
| **BND4-2** | **High** | Delegated JWKS verifier built without `WithSSRFGuard()` → DNS-rebinding SSRF from a merchant `jwks_uri` | audit |
| **OR2-DOS-1** (a) / #76 | **High** | Coinbase USDC-funding webhook read its body unbounded | cherry-pick |
| **OR2-DOS-1** (b) / #75 | **High** | Embedded net/http surface exempted webhook routes from the body-size cap | cherry-pick |
| #79 | Medium | Untrusted upstream JSON (captcha / FX rate / Pyth price) read unbounded | cherry-pick |
| #82 | Medium | Remote client `WithTimeout` not enforced when a custom HTTP client is injected | cherry-pick |
| #83 | Low | Remote client copied raw upstream error bodies into error strings (no sanitize/excerpt) | cherry-pick |
| #74 | Medium | DB DSN built by raw string interpolation — special chars in credentials corrupt/redirect the connection | cherry-pick |

---

## OR4-MONEY-1 (High) — Convert cents → micros in the unknown-cohort payment backfill

`payments.amount` is **micros** (`#603`, `032_money_micros.up.sql`). The new unknown-cohort backfill (`internal/reconcile/unknown_orchestration.go`, added by `db4f45ed`/#633-634) wrote raw `RemoteTransaction.AmountCents` — every payment imported through it was stored at **1/10,000 of true value**. Fixed by converting via `moneyutil.CentsToMicros`, matching the canonical applier (`reconcile/appliers.go:101`).

> **Data-fix required:** rows already backfilled pre-deploy are understated 10,000×; run a scoped `amount = amount * 10000` correction in the same window.

## BND4-2 (High) — SSRF guard on the delegated JWKS verifier

`newDelegatedVerifier` (`internal/controlplane/delegated.go`) fetched merchant-supplied `jwks_uri` values without `authhttp.WithSSRFGuard()`; AuthKit's `validateJWKSURI` is syntactic-only and relies on the fetch-time dialer (which AuthKit's own server always installs). A public host DNS-rebound to `169.254.169.254`/RFC-1918 drove SSRF from the control-plane. Fixed by adding the guard — parity with AuthKit's own posture. No impact on legitimate traffic (production `jwks_uri` is public HTTPS; the integration harness uses static-key mode, no fetch).

## OR2-DOS-1 (High) — Webhook request-body caps  *(PR #76 + #75)*

The two halves of the prior audit finding OR2-DOS-1:

- **#76** — `applyCoinbaseUSDCFundingWebhook` (`webhook.go`) was the lone webhook reading its body via `readRequestBody` unbounded; every other rail uses `readLimitedWebhookBody`. Now capped at 64 KiB via `readLimitedWebhookBody(r, maxCoinbaseWebhookBytes)`.
- **#75** — the gin path already dropped its webhook body-limit exemption, but the gin-free `BodyLimitHTTP` (`internal/http/middleware/http_base.go`) still exempted webhook routes (`!isWebhookPath`), leaving the **embedded surface** with no backstop. The exemption is removed so the embedded surface applies `DefaultMaxBodyBytes` (1 MiB) as a backstop on all routes (a signature-verified handler still reads the raw body itself).

## #79 (Medium) — Bound untrusted upstream JSON responses

Three untrusted-upstream JSON reads were unbounded (`json.NewDecoder(resp.Body)` with no cap): captcha (`internal/captcha/captcha.go`), **FX rates** (`internal/integrations/fx/exchange_api.go`), and **Pyth prices** (`internal/integrations/pyth/client.go`) — two of them money/price-affecting. Adds `internal/shared/httpx.DecodeJSONLimited` (1 MiB `LimitReader` + overshoot detection) and routes the three sites through it.

## #82 (Medium) — Enforce `WithTimeout` per-call

`remote.WithTimeout` only fed the *default* HTTP client; a caller injecting a client via `WithHTTPClient` with no `Timeout` had **no deadline** — `doRaw` ran on a bare context (hang/DoS risk). Now `doRaw` derives a per-call `context.WithTimeout(ctx, c.timeout)`.

## #83 (Low) — Sanitize / excerpt remote error bodies

Master already caps the error-body read at 1 MiB (`remote.go:580`), but `statusErrorFromBody` copied the raw body verbatim into the error string. Adds `excerptErrorBody` — strips control chars/whitespace and truncates to a 512-byte UTF-8-safe excerpt — so a foreign HTML/stack-trace body can't pollute error strings/logs.

## #74 (Medium) — Percent-encode DB DSN credentials

`config.go` built the DSN with raw `fmt.Sprintf("postgresql://%s:%s@%s:%s/%s")`; a password containing `@`, `/`, `?`, or `#` corrupted the DSN and could **redirect the connection to an attacker-influenced endpoint**. Now built with `url.URL{User: url.UserPassword(...), Host: net.JoinHostPort(...)}`.

---

## Cherry-pick provenance & conflict resolution

All six were applied with `git cherry-pick -x` from Alexis's PR branches (authorship preserved). Their own test files came with the commits. Two required resolution against the post-June-30 master:

- **#83** — import-block conflict in `remote.go`: took the union actually used (`unicode`, `unicode/utf8`) and **dropped a stale `github.com/google/uuid` import** that came from the PR's older base and is not used on current master. Verified builds.
- **#75** — `neutral_paths.go` conflict: master's June-30 pull had added an `isWebhookPath` **exemption** helper (the thing this PR removes) and dropped `isDebugNMITokenizationPath`. Resolution: **deleted the now-dead `isWebhookPath`** (its only caller, the `http_base.go` guard, is removed by this PR) and did **not** resurrect `isDebugNMITokenizationPath` (absent/unused on master). `DefaultMaxBodyBytes` retained with an updated comment. Verified builds + package tests pass.

## Files changed

| File | PR | Change |
|------|-----|--------|
| `internal/reconcile/unknown_orchestration.go` (+test) | OR4-MONEY-1 | cents→micros conversion + integration assertion |
| `internal/controlplane/delegated.go` (+test) | BND4-2 | `WithSSRFGuard()` + loopback-JWKS regression test |
| `internal/http/handlers/webhook.go` (+test) | #76 | Coinbase body cap (64 KiB) |
| `internal/http/middleware/http_base.go`, `neutral_paths.go` (+`body_limit_http_test.go`) | #75 | remove webhook body-limit exemption on embedded surface |
| `internal/shared/httpx/httpx.go` (new, +test), `internal/captcha/captcha.go`, `internal/integrations/fx/exchange_api.go`, `internal/integrations/pyth/client.go` | #79 | bounded JSON decode helper + 3 call sites |
| `remote.go` (+`remote_timeout_test.go`) | #82 | per-call context deadline |
| `remote.go` (+`remote_error_body_test.go`) | #83 | `excerptErrorBody` sanitizer |
| `config/config.go` (+`dsn_encoding_test.go`) | #74 | `url.UserPassword`/`net.JoinHostPort` DSN builder |

## Testing

- **OR4-MONEY-1** — extended `TestReconcileUnknownCohort_FixtureSnapshot` (integration, testcontainers Postgres) to assert the backfilled renewal lands as `CentsToMicros(5000)` micros. **Verified passing against a real Postgres 18 container** (fails pre-fix).
- **BND4-2** — new `TestDelegatedVerifier_SSRFGuardBlocksLoopbackJWKS`: a loopback `jwks_uri` fetch must be refused before the endpoint is reached (JWKS handler never invoked). Passing.
- **#76/#75/#79/#82/#83/#74** — each cherry-pick brought its own test (`webhook_test.go`, `body_limit_http_test.go`, `httpx_test.go`, `remote_timeout_test.go`, `remote_error_body_test.go`, `dsn_encoding_test.go`). All pass.
- **Suite:** `go build ./...` clean; `gofmt` clean; unit tests green for `.`, `config`, `internal/http/middleware`, `internal/shared/httpx`, `internal/captcha`, `internal/integrations/{fx,pyth}`, `internal/http/handlers`, `internal/reconcile`, `internal/controlplane`.

## Breaking changes & rollout

- **OR4-MONEY-1:** no API/schema change; **requires the data-fix** above in the same window.
- **BND4-2:** a JWKS-mode issuer whose `jwks_uri` resolves to a private/loopback address now (correctly) fails to load — affects only non-production `jwks_uri`.
- **#75:** webhook routes on the embedded net/http surface now get the 1 MiB body cap. Signature-verified handlers read the raw body themselves and are within the cap; confirm no legitimate webhook payload exceeds 1 MiB.
- **#74:** the DSN is now URL-encoded; a config that *relied on* raw interpolation (e.g. embedding query params inside the password field) would change behavior — none expected.
- **#76/#79/#82/#83:** no API change.

## Commits (8)

```
e6ae2054  Mihai Vaduva  fix(reconcile) OR4-MONEY-1: store unknown-cohort backfill payments in micros, not cents
b2327fe7  Mihai Vaduva  fix(controlplane) BND4-2: install SSRF guard on the delegated JWKS verifier
8010d963  aemperor      fix(webhook): cap Coinbase USDC-funding webhook body size            (PR #76)
2b25be28  ae-bot        fix(integrations): bound untrusted upstream JSON response bodies     (PR #79)
3564b786  ae-bot        fix(remote): enforce WithTimeout via per-call context deadline       (PR #82)
ae182de4  ae-bot        fix(remote): bound and sanitize unrecognized error response bodies   (PR #83)
758ffdd1  ae            fix(config): percent-encode DB credentials when building the DSN     (PR #74)
b0e2e53d  aemperor      fix(http): apply body-size limit to webhook routes on embedded surface (PR #75)
```

On merge, close PRs #76, #79, #82, #83, #74, #75 as "landed via this PR (cherry-picked)".

---

## Draft PRs reviewed and NOT included (with reasons)

| PR | Verdict | Reason |
|----|---------|--------|
| #78 remove dead `oidc/jwks` | **Already done** | The June 30 pull already deleted `internal/shared/oidc/` entirely; PR is a no-op. Close as obsolete. |
| #84 reject empty remote path IDs | **Obsolete** | 4 of 6 target methods (`CaptureHold`/`ReleaseHold`/`RefillWindow`/`CloseWindow`) were removed in the `/v1/service`→`/v1/merchant` rework; survivors `Capture`/`Release` already validate + map to `ErrInvalid`. Close. |
| #73 don't leak raw verifier errors | **Obsolete** | Target `FormatVerifierError` deleted; the leak is already closed upstream — AuthKit v0.74 collapses all JWKS/network/signature failures to the stable code `invalid_token`. Close. |
| #77 require https auth issuer | **Superseded** | The issuer model changed (`Auth.Issuers []string` → single `Auth.Issuer`); the PR won't compile. Close. |

### Two still-valid concerns → re-file fresh (small, not in this PR)
1. **From #77:** `config.Validate()` still has **no https requirement** for `Auth.Issuer` in the non-dev block (`config.go:~762`) — a plaintext-HTTP issuer is accepted in prod. Worth a fresh ~3-line check.
2. **From #73 (defense-in-depth):** `billingauth.UnauthenticatedMessage` echoes `err.Error()` verbatim — safe today only because AuthKit pre-sanitizes. A generic-collapse there hardens against a future dependency wrapping raw detail.
