### PR TITLE
hosted-embedding seams (#738): exported ProvisionMerchant + hosted-posture verification senders

### DIFF
--- a/internal/controlplane/service.go
+++ b/internal/controlplane/service.go
@@ -62,6 +62,8 @@ type ControlPlane struct {
 
 type options struct {
 	hosted bool
+	email  authcore.EmailSender
+	sms    authcore.SMSSender
 }
 
 // Option configures the control plane for embedding hosts.
@@ -73,6 +75,25 @@ type Option func(*options)
 func WithHostedPosture() Option {
 	return func(o *options) {
 		o.hosted = true
+	}
+}
+
+// WithEmailSender wires a host-owned verification email sender into the AuthKit
+// engine (#738). Hosted posture keeps registration verification Required, and
+// authkit refuses construction when that policy has no configured sender — so a
+// hosted host must supply at least one of email/SMS. Self-hosted posture never
+// needs one (closed registration verifies nothing).
+func WithEmailSender(sender authcore.EmailSender) Option {
+	return func(o *options) {
+		o.email = sender
+	}
+}
+
+// WithSMSSender wires a host-owned verification SMS sender (#738); see
+// WithEmailSender.
+func WithSMSSender(sender authcore.SMSSender) Option {
+	return func(o *options) {
+		o.sms = sender
 	}
 }
 
@@ -215,16 +236,28 @@ func New(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, opts ...Op
 		// Verification set EXPLICITLY: authkit v0.76.0 defaults unset to
 		// "required" (its doc says "none" — code wins), which refuses boot with
 		// no sender. Locked registration has nothing to verify → none; hosted
-		// keeps required and must configure an email/SMS sender.
+		// keeps required and must configure an email/SMS sender
+		// (WithEmailSender/WithSMSSender, #738).
 		Registration: authcore.RegistrationConfig{
 			NativeUserMode: registrationMode(lockedRegistration),
 			Verification:   registrationVerification(lockedRegistration),
 		},
 	}
 
+	// Host-owned verification senders (#738) are engine dependencies, wired as
+	// authkit functional options. authkit enforces the required-policy/sender
+	// pairing itself at HTTP-server construction below — no downgrade here.
+	var coreOpts []authcore.Option
+	if options.email != nil {
+		coreOpts = append(coreOpts, authcore.WithEmailSender(options.email))
+	}
+	if options.sms != nil {
+		coreOpts = append(coreOpts, authcore.WithSMSSender(options.sms))
+	}
+
 	// Client-first construction (#142): build the AuthKit engine, then adapt it
 	// with the HTTP server. Core() / the delegated verifier hold this client.
-	authClient, err := authcore.New(coreCfg, pool)
+	authClient, err := authcore.New(coreCfg, pool, coreOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("controlplane: build authkit client: %w", err)
 	}

--- a/internal/merchants/lifecycle.go
+++ b/internal/merchants/lifecycle.go
@@ -77,6 +77,17 @@ func NewService(pool *db.Pool, secrets MerchantSecretStore, providerEnvironment 
 	return &Service{pool: pool, secrets: secrets, providerEnvironment: env}, nil
 }
 
+// NewDirectoryService builds a directory-only Service: merchant provisioning +
+// lookup over openrails.merchants, with no secret store and no provider-account
+// environment (scoped credential lookups are unavailable). It is the lifecycle
+// slice the control-plane provisioning seam needs (#738).
+func NewDirectoryService(pool *db.Pool) (*Service, error) {
+	if pool == nil {
+		return nil, errors.New("merchants: pgx pool is required")
+	}
+	return &Service{pool: pool}, nil
+}
+
 // NewSecretManagementService builds a secret-management-only Service. It is for
 // runtimes/tests that only need credential list/write/delete/validate behavior;
 // lifecycle methods such as Provision still require NewService with a DB pool.

--- a/pkg/embedded/controlplane/controlplane.go
+++ b/pkg/embedded/controlplane/controlplane.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	authcore "github.com/open-rails/authkit/embedded"
 
 	"github.com/open-rails/openrails/config"
 	"github.com/open-rails/openrails/internal/app"
@@ -28,6 +29,19 @@ type AttachOptions struct {
 	// HostedPosture opens AuthKit registration and mounts the full AuthKit API.
 	// Leave false for private standalone-compatible embedded hosts.
 	HostedPosture bool
+
+	// EmailSender / SMSSender are host-owned verification senders threaded into
+	// the AuthKit engine (#738). The types (and the VerificationMessage payload a
+	// sender receives) are the github.com/open-rails/authkit/embedded aliases, so
+	// an external host implements them without reaching into authkit internals.
+	//
+	// Hosted posture keeps registration verification Required, and authkit fails
+	// construction loudly when that policy has no sender — so HostedPosture
+	// requires at least one of these. Self-hosted posture ignores them for
+	// registration (closed, nothing to verify); a supplied sender still powers
+	// the mounted self-service verify/reset routes.
+	EmailSender authcore.EmailSender
+	SMSSender   authcore.SMSSender
 }
 
 // Get recovers the concrete *controlplane.ControlPlane attached to the app, or
@@ -73,6 +87,12 @@ func AttachWithOptions(ctx context.Context, a *app.App, cfg *config.Config, inje
 	var cpOpts []controlplane.Option
 	if opts.HostedPosture {
 		cpOpts = append(cpOpts, controlplane.WithHostedPosture())
+	}
+	if opts.EmailSender != nil {
+		cpOpts = append(cpOpts, controlplane.WithEmailSender(opts.EmailSender))
+	}
+	if opts.SMSSender != nil {
+		cpOpts = append(cpOpts, controlplane.WithSMSSender(opts.SMSSender))
 	}
 	cp, err := controlplane.New(ctx, cfg, pool, cpOpts...)
 	if err != nil {

--- a/pkg/embedded/controlplane/provision.go
+++ b/pkg/embedded/controlplane/provision.go
@@ -20,8 +20,13 @@ type ProvisionMerchantRequest struct {
 	// Slug is the merchant slug (merchant.ValidateSlug rules). Required.
 	Slug string
 	// OwnerUserID is an optional AuthKit user uuid seeded as the merchant
-	// permission-group's owner (auto-holds `merchant:*`, #567). When the
-	// merchant already exists, the owner role is (re)assigned idempotently.
+	// permission-group's owner (auto-holds `merchant:*`, #567) — ONLY when this
+	// call creates the group. A pre-existing merchant's roles are never touched
+	// (a registration wrapper can safely pass any authenticated user with a
+	// user-chosen slug and branch on Created; a slug squatter cannot be granted
+	// ownership of someone else's merchant). Re-runs stay idempotent: the
+	// creating call already seeded the owner. Later owner changes go through
+	// Core().AssignGroupRole explicitly.
 	OwnerUserID string
 }
 
@@ -88,11 +93,6 @@ func ProvisionMerchant(ctx context.Context, a *app.App, req ProvisionMerchantReq
 		groupCreated = true
 	case err != nil:
 		return nil, fmt.Errorf("control plane provision: resolve merchant group %q: %w", slug, err)
-	case owner != "":
-		// Group pre-existed: ensure the owner holds the owner role (idempotent).
-		if aerr := core.AssignGroupRole(ctx, controlplane.MerchantType, slug, owner, authcore.SubjectKindUser, controlplane.MerchantRoleOwner); aerr != nil {
-			return nil, fmt.Errorf("control plane provision: assign merchant owner: %w", aerr)
-		}
 	}
 
 	// Create/link the directory row (permission_group_id) via the merchants

--- a/pkg/embedded/controlplane/provision.go
+++ b/pkg/embedded/controlplane/provision.go
@@ -1,0 +1,121 @@
+package controlplane
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/open-rails/authkit"
+	authcore "github.com/open-rails/authkit/embedded"
+
+	"github.com/open-rails/openrails/internal/app"
+	"github.com/open-rails/openrails/internal/controlplane"
+	"github.com/open-rails/openrails/internal/merchants"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// ProvisionMerchantRequest parameterizes runtime merchant provisioning (#738).
+type ProvisionMerchantRequest struct {
+	// Slug is the merchant slug (merchant.ValidateSlug rules). Required.
+	Slug string
+	// OwnerUserID is an optional AuthKit user uuid seeded as the merchant
+	// permission-group's owner (auto-holds `merchant:*`, #567). When the
+	// merchant already exists, the owner role is (re)assigned idempotently.
+	OwnerUserID string
+}
+
+// ProvisionMerchantResult reports what ProvisionMerchant ensured.
+type ProvisionMerchantResult struct {
+	// MerchantID is the openrails.merchants directory row id.
+	MerchantID merchant.ID
+	// GroupID is the merchant permission-group's internal AuthKit id (#567).
+	GroupID string
+	// Created is false when the merchant already existed (both the permission
+	// group and the directory row); true when this call created either.
+	Created bool
+}
+
+// ProvisionMerchant idempotently provisions a merchant at runtime through the
+// attached control plane (#738): ensures root-group containment, resolves or
+// creates the merchant permission-group (persona=merchant, parent=root, owner =
+// req.OwnerUserID), and creates/links the openrails.merchants directory row
+// with the group's id. Safe to re-run.
+//
+// This is the engine mechanism behind a hosted wrapper's "registration is
+// provisioning" flow (openrails-saas #2/#3): it works in both merchant_source
+// modes but exists for merchant_source=api, where merchants are created over
+// code paths instead of a manifest. Calling it without an attached control
+// plane is a wiring error (call Attach/AttachWithOptions first).
+func ProvisionMerchant(ctx context.Context, a *app.App, req ProvisionMerchantRequest) (*ProvisionMerchantResult, error) {
+	cp := Get(a)
+	if cp == nil {
+		return nil, fmt.Errorf("control plane provision: no control plane attached (call Attach first)")
+	}
+	core := cp.Core()
+	if core == nil {
+		return nil, fmt.Errorf("control plane provision: core service unavailable")
+	}
+	slug := merchant.NormalizeSlug(req.Slug)
+	if err := merchant.ValidateSlug(slug); err != nil {
+		return nil, err
+	}
+	owner := strings.TrimSpace(req.OwnerUserID)
+
+	// Root group + declared containment first (idempotent), as bootstrap does.
+	if _, err := core.EnsureRootGroup(ctx); err != nil {
+		return nil, fmt.Errorf("control plane provision: ensure root group: %w", err)
+	}
+	if err := core.SeedPermissionGroupContainment(ctx); err != nil {
+		return nil, fmt.Errorf("control plane provision: seed permission-group containment: %w", err)
+	}
+
+	// Resolve-or-create the merchant permission-group — the merchant IS the
+	// group (#567): type=merchant, resourceRef=slug, parent=root.
+	groupCreated := false
+	groupID, err := core.ResolveGroupIDForSlug(ctx, controlplane.MerchantType, slug)
+	switch {
+	case errors.Is(err, authkit.ErrGroupNotFound):
+		groupID, err = core.CreatePermissionGroup(ctx, authkit.CreatePermissionGroupRequest{
+			Persona:        controlplane.MerchantType,
+			InstanceSlug:   slug,
+			ParentPersona:  authcore.RootPersona,
+			OwnerSubjectID: owner,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("control plane provision: create merchant group %q: %w", slug, err)
+		}
+		groupCreated = true
+	case err != nil:
+		return nil, fmt.Errorf("control plane provision: resolve merchant group %q: %w", slug, err)
+	case owner != "":
+		// Group pre-existed: ensure the owner holds the owner role (idempotent).
+		if aerr := core.AssignGroupRole(ctx, controlplane.MerchantType, slug, owner, authcore.SubjectKindUser, controlplane.MerchantRoleOwner); aerr != nil {
+			return nil, fmt.Errorf("control plane provision: assign merchant owner: %w", aerr)
+		}
+	}
+
+	// Create/link the directory row (permission_group_id) via the merchants
+	// lifecycle slice — the same row bootstrap requires to pre-exist (#480);
+	// runtime provisioning creates it.
+	dir, err := merchants.NewDirectoryService(cp.Pool())
+	if err != nil {
+		return nil, fmt.Errorf("control plane provision: build merchant directory service: %w", err)
+	}
+	rowExisted := true
+	if _, gerr := dir.GetBySlug(ctx, slug); errors.Is(gerr, merchants.ErrMerchantNotFound) {
+		rowExisted = false
+	} else if gerr != nil {
+		return nil, fmt.Errorf("control plane provision: resolve merchant directory row %q: %w", slug, gerr)
+	}
+	m, err := dir.Provision(ctx, merchants.ProvisionRequest{Slug: slug, PermissionGroupID: groupID})
+	if err != nil {
+		return nil, fmt.Errorf("control plane provision: provision merchant directory row %q: %w", slug, err)
+	}
+
+	return &ProvisionMerchantResult{
+		MerchantID: m.ID,
+		GroupID:    groupID,
+		Created:    groupCreated || !rowExisted,
+	}, nil
+}

--- a/pkg/embedded/controlplane/provision_integration_test.go
+++ b/pkg/embedded/controlplane/provision_integration_test.go
@@ -1,0 +1,212 @@
+//go:build integration
+
+package controlplane_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	authcore "github.com/open-rails/authkit/embedded"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/permissions"
+	"github.com/open-rails/openrails/pkg/embedded"
+	embcp "github.com/open-rails/openrails/pkg/embedded/controlplane"
+)
+
+func TestMain(m *testing.M) { dbtest.RunMain(m) }
+
+// captureEmailSender implements the authkit/embedded EmailSender alias the way
+// an external host would: it records the verification code instead of sending.
+type captureEmailSender struct {
+	mu    sync.Mutex
+	codes map[string]string // normalized email -> last verification code
+}
+
+func (s *captureEmailSender) SendVerification(_ context.Context, email, _ string, msg authcore.VerificationMessage) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.codes == nil {
+		s.codes = map[string]string{}
+	}
+	s.codes[email] = msg.Code
+	return nil
+}
+func (s *captureEmailSender) SendPasswordResetLink(context.Context, string, string, string) error {
+	return nil
+}
+func (s *captureEmailSender) SendAccountRegistrationInvite(context.Context, string, string) error {
+	return nil
+}
+func (s *captureEmailSender) SendLoginCode(context.Context, string, string, string) error { return nil }
+func (s *captureEmailSender) SendWelcome(context.Context, string, string) error           { return nil }
+
+func (s *captureEmailSender) code(email string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.codes[email]
+}
+
+func hostedTestConfig(dsn, issuer string) *config.Config {
+	return &config.Config{
+		Env:      "dev",
+		TestMode: true,
+		// MODE 2 (#723): the hosted-embedder shape — merchants are created over
+		// code paths (ProvisionMerchant), not a manifest.
+		MerchantSource: config.MerchantSourceAPI,
+		DB:             &config.DBConfig{URL: dsn},
+		Auth:           &config.AuthConfig{Issuer: issuer},
+	}
+}
+
+func newHostApp(t *testing.T, cfg *config.Config) *embedded.Embedded {
+	t.Helper()
+	e, err := embedded.New(embedded.Options{Config: cfg})
+	require.NoError(t, err, "embedded.New")
+	t.Cleanup(func() { _ = e.Close(context.Background()) })
+	return e
+}
+
+// mountAuthRoutes serves the attached control plane's AuthKit route surface the
+// way an external host mounts it (RouteSpecs are native ServeMux patterns).
+func mountAuthRoutes(t *testing.T, e *embedded.Embedded) *httptest.Server {
+	t.Helper()
+	cp := embcp.Get(e.App())
+	require.NotNil(t, cp, "control plane attached")
+	mux := http.NewServeMux()
+	for _, spec := range cp.RouteSpecs() {
+		mux.Handle(spec.Method+" "+spec.Path, spec.Handler)
+	}
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func postJSON(t *testing.T, url, body string) (int, map[string]any) {
+	t.Helper()
+	resp, err := http.Post(url, "application/json", strings.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	var decoded map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&decoded)
+	return resp.StatusCode, decoded
+}
+
+// TestHostedPosture_RegisterVerifyProvision drives the full #738 hosted-embedder
+// journey through the exported surface only: hosted attach with a host-supplied
+// email sender boots, a user registers and email-verifies over the AuthKit HTTP
+// surface, and ProvisionMerchant makes that user the owner of a fresh merchant
+// (permission group + linked openrails.merchants directory row), idempotently.
+func TestHostedPosture_RegisterVerifyProvision(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+	cfg := hostedTestConfig(dsn, "https://hosted.openrails.test")
+	e := newHostApp(t, cfg)
+
+	// Hosted posture with NO sender must fail loudly at construction (#536 gap:
+	// registration verification is Required and nothing could deliver it).
+	err := embcp.AttachWithOptions(ctx, e.App(), cfg, nil, embcp.AttachOptions{HostedPosture: true})
+	require.Error(t, err, "hosted posture without a sender must refuse to boot")
+	require.Contains(t, err.Error(), "no email or SMS sender")
+
+	// With a host-owned sender, hosted posture boots.
+	sender := &captureEmailSender{}
+	require.NoError(t, embcp.AttachWithOptions(ctx, e.App(), cfg, nil, embcp.AttachOptions{
+		HostedPosture: true,
+		EmailSender:   sender,
+	}))
+	srv := mountAuthRoutes(t, e)
+
+	// Register -> pending registration + verification email to the capture sender.
+	sfx := strings.ToLower(uuid.NewString()[:8])
+	email := "owner-" + sfx + "@example.test"
+	username := "owner" + sfx
+	status, body := postJSON(t, srv.URL+"/register",
+		`{"identifier":"`+email+`","username":"`+username+`","password":"str0ng-horse-battery!"}`)
+	require.Equal(t, http.StatusAccepted, status, "register: %v", body)
+	code := sender.code(email)
+	require.NotEmpty(t, code, "verification code delivered to host sender")
+
+	// Confirm -> the pending registration becomes a real, verified user.
+	status, body = postJSON(t, srv.URL+"/email/verify/confirm",
+		`{"email":"`+email+`","code":"`+code+`"}`)
+	require.Equal(t, http.StatusOK, status, "verify confirm: %v", body)
+
+	cp := embcp.Get(e.App())
+	user, err := cp.Core().GetUserByEmail(ctx, email)
+	require.NoError(t, err)
+
+	// Registration is provisioning (openrails-saas #2/#3): the verified user
+	// becomes the owner of a freshly provisioned merchant.
+	slug := "saas-" + sfx
+	res1, err := embcp.ProvisionMerchant(ctx, e.App(), embcp.ProvisionMerchantRequest{
+		Slug:        slug,
+		OwnerUserID: user.ID,
+	})
+	require.NoError(t, err)
+	require.True(t, res1.Created, "first provision creates the merchant")
+	require.NotEmpty(t, res1.GroupID)
+	require.False(t, res1.MerchantID.IsZero())
+
+	// Directory row exists and records the merchant group's id (#567).
+	pool, err := pgxpool.New(ctx, dsn)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	var rowID, rowGroupID string
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT id::text, permission_group_id FROM openrails.merchants WHERE slug = $1 AND deleted_at IS NULL`,
+		slug).Scan(&rowID, &rowGroupID))
+	require.Equal(t, res1.MerchantID.String(), rowID)
+	require.Equal(t, res1.GroupID, rowGroupID)
+
+	// The owner holds the merchant owner role (= merchant:*), never platform authority.
+	canRead, err := cp.Core().Can(ctx, user.ID, authcore.SubjectKindUser, "merchant", slug, permissions.MerchantSettingsRead)
+	require.NoError(t, err)
+	require.True(t, canRead, "provisioned owner should hold merchant permissions")
+
+	// Second call is idempotent: same ids, nothing recreated, owner role stable.
+	res2, err := embcp.ProvisionMerchant(ctx, e.App(), embcp.ProvisionMerchantRequest{
+		Slug:        slug,
+		OwnerUserID: user.ID,
+	})
+	require.NoError(t, err)
+	require.False(t, res2.Created, "re-run must not recreate the merchant")
+	require.Equal(t, res1.MerchantID, res2.MerchantID)
+	require.Equal(t, res1.GroupID, res2.GroupID)
+	stillOwner, err := cp.Core().Can(ctx, user.ID, authcore.SubjectKindUser, "merchant", slug, permissions.MerchantSettingsRead)
+	require.NoError(t, err)
+	require.True(t, stillOwner)
+
+	// Provisioning without an attached control plane is a wiring error.
+	bare := newHostApp(t, hostedTestConfig(dsn, "https://bare.openrails.test"))
+	_, err = embcp.ProvisionMerchant(ctx, bare.App(), embcp.ProvisionMerchantRequest{Slug: "never-" + sfx})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no control plane attached")
+}
+
+// TestSelfHostedPosture_RegistrationStaysClosed guards the default posture: a
+// plain Attach (no options, no sender) still boots, and the public registration
+// surface is not mounted.
+func TestSelfHostedPosture_RegistrationStaysClosed(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+	cfg := hostedTestConfig(dsn, "https://selfhosted.openrails.test")
+	e := newHostApp(t, cfg)
+
+	require.NoError(t, embcp.Attach(ctx, e.App(), cfg, nil))
+	require.True(t, embcp.Get(e.App()).SelfHostedPosture())
+	srv := mountAuthRoutes(t, e)
+
+	status, _ := postJSON(t, srv.URL+"/register",
+		`{"identifier":"nobody@example.test","username":"nobody","password":"str0ng-horse-battery!"}`)
+	require.Equal(t, http.StatusNotFound, status, "self-hosted posture must not mount /register")
+}


### PR DESCRIPTION
Implements #738 — the two seams an external hosted embedder (openrails-saas) needs but could not reach from outside the module.

## ProvisionMerchant (pkg/embedded/controlplane)

`ProvisionMerchant(ctx, app, {Slug, OwnerUserID})` provisions a merchant at runtime through the attached control plane: root-group containment, resolve-or-create the merchant permission-group (persona=merchant, parent=root, owner seeded/idempotently re-assigned), and create/link the `openrails.merchants` directory row with `permission_group_id` (#567) via a new directory-only merchants lifecycle slice (`merchants.NewDirectoryService`). Idempotent; returns `{MerchantID, GroupID, Created}`; wiring error without an attached control plane. This is the engine mechanism behind the wrapper's "registration is provisioning" (openrails-saas #2/#3).

## Hosted-posture verification senders

`AttachOptions` grows `EmailSender`/`SMSSender` (the `authkit/embedded` aliases, incl. `VerificationMessage`), threaded through new `internal/controlplane.WithEmailSender/WithSMSSender` options into the authkit engine construction — so `WithHostedPosture` (#536) can actually boot. Hosted posture with no sender still fails loudly (authkit's construction-time check is the single enforcement point). Self-hosted posture unchanged.

## Tests

Integration (`pkg/embedded/controlplane`, exported surface only): hosted attach with a capture sender boots; register → email-verify-confirm → ProvisionMerchant(owner=verified user); asserts directory row + group link, merchant owner role via `Can`, idempotent re-run (`Created=false`, same IDs), no-sender hosted attach fails loudly, self-hosted posture mounts no `/register`. Unit suite, `internal/controlplane`, `internal/merchants`, `pkg/embedded`, `embed` integration suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)