### PR TITLE
in-process user authenticator seam (#739): ControlPlane.UserAuthenticator for embedding hosts

### DIFF
--- a/internal/bootstrap/serverboot/serverboot.go
+++ b/internal/bootstrap/serverboot/serverboot.go
@@ -16,7 +16,6 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/open-rails/openrails/config"
 	"github.com/open-rails/openrails/internal/app"
-	internalauth "github.com/open-rails/openrails/internal/auth"
 	"github.com/open-rails/openrails/internal/bootstrap"
 	server "github.com/open-rails/openrails/internal/http"
 	"github.com/open-rails/openrails/pkg/billingauth"
@@ -93,11 +92,10 @@ func NewServer(cfg *config.Config, opts *Options) (*Result, error) {
 	}
 	authenticator := optsValue(opts, func(o *Options) billingauth.Authenticator { return o.Authenticator })
 	if authenticator == nil {
-		cp := embcp.Get(application)
-		if cp == nil || cp.AuthService() == nil || cp.AuthService().Verifier() == nil {
+		authenticator = embcp.Get(application).UserAuthenticator()
+		if authenticator == nil {
 			return nil, fmt.Errorf("control plane verifier unavailable")
 		}
-		authenticator = internalauth.NewAuthenticator(cp.AuthService().Verifier())
 	}
 
 	// MODE 1 (#723): the standalone server loads the merchant manifest at boot —

--- a/internal/controlplane/service.go
+++ b/internal/controlplane/service.go
@@ -17,7 +17,9 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/auth"
 	"github.com/open-rails/openrails/internal/db"
+	"github.com/open-rails/openrails/pkg/billingauth"
 )
 
 // ControlPlane is OpenRails' in-process AuthKit control plane (issue #224). It
@@ -339,6 +341,25 @@ func (c *ControlPlane) AuthService() *authhttp.Service {
 		return nil
 	}
 	return c.authSvc
+}
+
+// UserAuthenticator returns the in-process billingauth.Authenticator for a host
+// embedding this control plane (#739): the host's own HTTP routes authenticate
+// bearer tokens against the SAME verifier state the control plane mints and
+// verifies with (issuer, audiences, API-key prefix, in-memory signing keys,
+// core-service enrichment) — no JWKS HTTP fetch, so mint and verify cannot
+// drift. It is exactly the authenticator the standalone server wires for its
+// user routes.
+//
+// Scope: hosts embedding the control plane use THIS for their own routes.
+// pkg/embedded/authkit.NewVerifierAuthenticator remains for verifying REMOTE
+// issuers over JWKS; a JWKS HTTP route exists purely for external verifiers.
+// Returns nil when the control plane or its verifier is absent.
+func (c *ControlPlane) UserAuthenticator() billingauth.Authenticator {
+	if c == nil || c.authSvc == nil || c.authSvc.Verifier() == nil {
+		return nil
+	}
+	return auth.NewAuthenticator(c.authSvc.Verifier())
 }
 
 // Pool returns the control plane's schema-aware pgx pool (the pool holding the

--- a/pkg/embedded/authkit/authkit.go
+++ b/pkg/embedded/authkit/authkit.go
@@ -18,9 +18,14 @@ import (
 // issuers, optionally constraining the token audience. Pass the returned value
 // as gin.MountOptions.Authenticator or a host Gate input.
 //
-// This is an explicit embedded-host bridge. Standalone OpenRails does not read
-// issuers from config; it authenticates with its own control-plane/AuthKit
-// tokens and merchant remote applications.
+// This is an explicit embedded-host bridge for REMOTE issuers: keys are
+// HTTP-fetched from each issuer's /.well-known/jwks.json. A host embedding the
+// control plane in-process should NOT verify its own tokens this way — use
+// ControlPlane.UserAuthenticator (#739), which shares the control plane's
+// in-memory verifier state; the JWKS HTTP route exists purely for external
+// verifiers. Standalone OpenRails does not read issuers from config; it
+// authenticates with its own control-plane/AuthKit tokens and merchant remote
+// applications.
 func NewVerifierAuthenticator(issuers []string, expectedAud string) (billingauth.Authenticator, error) {
 	v, err := auth.NewIssuerVerifier(issuers, expectedAud)
 	if err != nil {

--- a/pkg/embedded/controlplane/user_authenticator_integration_test.go
+++ b/pkg/embedded/controlplane/user_authenticator_integration_test.go
@@ -1,0 +1,79 @@
+//go:build integration
+
+package controlplane_test
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/dbtest"
+	embcp "github.com/open-rails/openrails/pkg/embedded/controlplane"
+)
+
+// TestUserAuthenticator_InProcess drives the #739 seam through the exported
+// surface only: a hosted embedder registers + verifies a user over the mounted
+// AuthKit routes, then authenticates its OWN wrapper-style *http.Request with
+// ControlPlane.UserAuthenticator. The token issuer is a URL nothing listens on,
+// so a passing verify proves the keys came from process memory — no JWKS HTTP
+// fetch.
+func TestUserAuthenticator_InProcess(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+	// Nothing serves this issuer: a JWKS fetch would fail, an in-process verify
+	// must not care.
+	cfg := hostedTestConfig(dsn, "https://unreachable-issuer.openrails.test")
+	e := newHostApp(t, cfg)
+
+	sender := &captureEmailSender{}
+	require.NoError(t, embcp.AttachWithOptions(ctx, e.App(), cfg, nil, embcp.AttachOptions{
+		HostedPosture: true,
+		EmailSender:   sender,
+	}))
+	srv := mountAuthRoutes(t, e)
+
+	// Register -> verify; the confirm response establishes a session and returns
+	// the user's access token.
+	sfx := strings.ToLower(uuid.NewString()[:8])
+	email := "authee-" + sfx + "@example.test"
+	status, body := postJSON(t, srv.URL+"/register",
+		`{"identifier":"`+email+`","username":"authee`+sfx+`","password":"str0ng-horse-battery!"}`)
+	require.Equal(t, http.StatusAccepted, status, "register: %v", body)
+	code := sender.code(email)
+	require.NotEmpty(t, code)
+	status, body = postJSON(t, srv.URL+"/email/verify/confirm",
+		`{"email":"`+email+`","code":"`+code+`"}`)
+	require.Equal(t, http.StatusOK, status, "verify confirm: %v", body)
+	token, _ := body["access_token"].(string)
+	require.NotEmpty(t, token, "verify confirm returns an access token")
+
+	cp := embcp.Get(e.App())
+	user, err := cp.Core().GetUserByEmail(ctx, email)
+	require.NoError(t, err)
+
+	authn := cp.UserAuthenticator()
+	require.NotNil(t, authn, "attached control plane vends a user authenticator")
+
+	// A host route request carrying the bearer token resolves to the minted user.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://saas.internal/api/v1/me", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	uc, err := authn.Authenticate(ctx, req)
+	require.NoError(t, err, "in-process verify of our own token")
+	require.Equal(t, user.ID, uc.UserID)
+	require.NoError(t, uc.ValidateSubject())
+
+	// Garbage credentials are rejected.
+	bad, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://saas.internal/api/v1/me", nil)
+	require.NoError(t, err)
+	bad.Header.Set("Authorization", "Bearer not-a-token")
+	_, err = authn.Authenticate(ctx, bad)
+	require.Error(t, err, "garbage token must not authenticate")
+
+	// No control plane -> no authenticator (nil, not a panic).
+	require.Nil(t, embcp.Get(nil).UserAuthenticator())
+}

--- a/pkg/embedded/standalone.go
+++ b/pkg/embedded/standalone.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	internalauth "github.com/open-rails/openrails/internal/auth"
 	server "github.com/open-rails/openrails/internal/http"
-	"github.com/open-rails/openrails/pkg/billingauth"
 	embcp "github.com/open-rails/openrails/pkg/embedded/controlplane"
 )
 
@@ -44,13 +42,7 @@ func StandaloneServer(e *Embedded) (*server.Server, error) {
 			return nil, fmt.Errorf("attach control plane: %w", err)
 		}
 	}
-	authenticator := func() billingauth.Authenticator {
-		cp := embcp.Get(a)
-		if cp == nil || cp.AuthService() == nil || cp.AuthService().Verifier() == nil {
-			return nil
-		}
-		return internalauth.NewAuthenticator(cp.AuthService().Verifier())
-	}()
+	authenticator := embcp.Get(a).UserAuthenticator()
 	if authenticator == nil {
 		return nil, fmt.Errorf("control plane verifier unavailable")
 	}


### PR DESCRIPTION
Implements #739 (follow-up to #738).

Hosts embedding the control plane in-process had only `pkg/embedded/authkit.NewVerifierAuthenticator` — a JWKS HTTP fetch of their own in-memory keys over loopback. This exports the wiring the standalone server already uses for its user routes:

- `(*ControlPlane).UserAuthenticator() billingauth.Authenticator` — built from the control plane's own AuthKit verifier (same issuer/audiences/API-key prefix, in-memory RawKeys, IsLocal, core-service enrichment), so mint and verify cannot drift. Callable on the unnamed value externals hold via `embcp.Get(app)`.
- standalone/serverboot authenticator wiring deduped through the new method (no second verifier construction).
- `NewVerifierAuthenticator` doc scoped to REMOTE issuers; the JWKS HTTP route remains purely for external verifiers.
- Integration test: hosted posture, register→verify→access token, authenticate an `*http.Request` through the seam with nothing listening at the issuer URL (proves no JWKS fetch); garbage token rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)