### PR TITLE
control plane: AttachOptions Frontend/TrustedProxies forwarding + RunBootstrap fix (#743, #747)

### DIFF
--- a/internal/controlplane/bootstrap.go
+++ b/internal/controlplane/bootstrap.go
@@ -50,8 +50,20 @@ type BootstrapOptions struct {
 	// alone and add an admin user later.
 	InitialAdminUserID string
 
-	// MintInitialAPIKey controls whether a deployment admin API key is
-	// minted when none exists. Defaults to true.
+	// MintInitialAPIKey requests minting the merchant's first deployment admin
+	// API key. Defaults to false (the zero value) — Bootstrap never mints
+	// unless a caller explicitly asks (#747).
+	//
+	// Even when true, a key is minted ONLY if this merchant group has NEVER
+	// had one: eligibility is checked against the FULL key history (live AND
+	// revoked), not just the currently-live count. A merchant group with zero
+	// LIVE keys because an operator revoked all of them (e.g. after a
+	// suspected compromise) is NOT a first-run state, and is never
+	// auto-healed with a silently-minted replacement — including by a
+	// standalone caller that passes true on every boot as a routine "ensure a
+	// key exists" idiom. That idiom now gets exactly one mint, ever, per
+	// merchant group. A deliberate replacement key after a revocation is a
+	// separate, explicit operator action, not a Bootstrap side effect.
 	MintInitialAPIKey bool
 }
 
@@ -134,15 +146,18 @@ func (c *ControlPlane) Bootstrap(ctx context.Context, opts BootstrapOptions) (*B
 		return nil, err
 	}
 
-	// 3. Mint an initial deployment admin API key only when the merchant group has
-	//    none yet. The key is minted under the merchant group against the `owner`
-	//    role (resolves to `merchant:*`) and scoped to the merchant resource.
+	// 3. Mint an initial deployment admin API key only when explicitly
+	//    requested AND this merchant group has NEVER had one before (#747).
+	//    "Never had one" is the FULL key history (live and revoked) — a
+	//    merchant with zero LIVE keys because an operator revoked all of them
+	//    is not a first-run state, and a routine re-Bootstrap must not
+	//    auto-heal that revocation with a fresh, silently-minted replacement.
 	if opts.MintInitialAPIKey {
 		existing, lerr := core.ListAPIKeys(ctx, MerchantType, slug)
 		if lerr != nil {
 			return nil, fmt.Errorf("controlplane: list admin API keys: %w", lerr)
 		}
-		if !anyLiveAPIKey(existing) {
+		if len(existing) == 0 {
 			createdBy := strings.TrimSpace(opts.InitialAdminUserID)
 			if createdBy == "" {
 				createdBy, err = c.ensureBootstrapAPIKeyActor(ctx)
@@ -209,17 +224,6 @@ func (c *ControlPlane) EnsureMerchantAPIKeyActor(ctx context.Context, merchantSl
 		return "", fmt.Errorf("controlplane: assign api-key actor merchant owner: %w", err)
 	}
 	return createdBy, nil
-}
-
-// anyLiveAPIKey reports whether the merchant group already has at least one
-// non-revoked API key, so bootstrap does not mint a duplicate on re-run.
-func anyLiveAPIKey(toks []authkit.APIKey) bool {
-	for _, t := range toks {
-		if t.RevokedAt == nil {
-			return true
-		}
-	}
-	return false
 }
 
 // recordMerchantGroupBySlug writes the merchant permission-group's internal id onto

--- a/internal/controlplane/bootstrap_integration_test.go
+++ b/internal/controlplane/bootstrap_integration_test.go
@@ -165,6 +165,76 @@ func TestBootstrap_Idempotent(t *testing.T) {
 	require.Equal(t, dbtest.TestMerchantID, resolved.MerchantID)
 }
 
+// TestBootstrap_RevokedKeysNeverAutoRemint is #747's core regression guard: an
+// operator who revokes every API key for a merchant group (e.g. after a
+// suspected compromise) must never have a fresh one silently minted by a later
+// Bootstrap call — not even one that explicitly requests minting. Eligibility
+// is the merchant group's FULL key history, not just its current live count.
+func TestBootstrap_RevokedKeysNeverAutoRemint(t *testing.T) {
+	ctx := context.Background()
+	pool := newBootstrapTestPool(t)
+	cp := newTestControlPlane(t, pool)
+
+	// Genuine first run: no key history yet, explicit request mints.
+	res1, err := cp.Bootstrap(ctx, BootstrapOptions{BootstrapMerchantSlug: dbtest.TestMerchantSlug, MintInitialAPIKey: true})
+	require.NoError(t, err)
+	require.True(t, res1.APIKeyMinted, "genuine first run should mint")
+	require.NotEmpty(t, res1.APIKeySecret)
+
+	// Operator revokes the key.
+	keys, err := cp.Core().ListAPIKeys(ctx, MerchantType, dbtest.TestMerchantSlug)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	revoked, err := cp.Core().RevokeAPIKey(ctx, MerchantType, dbtest.TestMerchantSlug, keys[0].ID)
+	require.NoError(t, err)
+	require.True(t, revoked)
+
+	// Sanity: zero LIVE keys now, but the key HISTORY is non-empty.
+	afterRevoke, err := cp.Core().ListAPIKeys(ctx, MerchantType, dbtest.TestMerchantSlug)
+	require.NoError(t, err)
+	require.Len(t, afterRevoke, 1)
+	require.NotNil(t, afterRevoke[0].RevokedAt)
+
+	// A routine re-Bootstrap WITHOUT a mint request must not mint (trivially).
+	res2, err := cp.Bootstrap(ctx, BootstrapOptions{BootstrapMerchantSlug: dbtest.TestMerchantSlug, MintInitialAPIKey: false})
+	require.NoError(t, err)
+	require.False(t, res2.APIKeyMinted)
+
+	// #747's actual fix: an EXPLICIT mint request must ALSO not auto-heal the
+	// revocation — this merchant group has had a key before, so it is not a
+	// first-run state, regardless of what the caller asks for.
+	res3, err := cp.Bootstrap(ctx, BootstrapOptions{BootstrapMerchantSlug: dbtest.TestMerchantSlug, MintInitialAPIKey: true})
+	require.NoError(t, err)
+	require.False(t, res3.APIKeyMinted, "an explicit mint request must never auto-heal a merchant that previously had a key")
+	require.Empty(t, res3.APIKeySecret)
+
+	// Exactly one API key exists ever (the original, revoked) — no replacement minted.
+	finalKeys, err := cp.Core().ListAPIKeys(ctx, MerchantType, dbtest.TestMerchantSlug)
+	require.NoError(t, err)
+	require.Len(t, finalKeys, 1, "no replacement key should have been minted after revocation")
+}
+
+// TestBootstrap_FreshMerchantMintsOnlyOnExplicitRequest proves the OTHER half
+// of #747's fix still works for a merchant that never had a key: the zero
+// value (MintInitialAPIKey: false) never mints, and an explicit true does.
+func TestBootstrap_FreshMerchantMintsOnlyOnExplicitRequest(t *testing.T) {
+	ctx := context.Background()
+	pool := newBootstrapTestPool(t)
+	cp := newTestControlPlane(t, pool)
+
+	res1, err := cp.Bootstrap(ctx, BootstrapOptions{BootstrapMerchantSlug: dbtest.TestMerchantSlug, MintInitialAPIKey: false})
+	require.NoError(t, err)
+	require.False(t, res1.APIKeyMinted, "the zero value must never mint")
+	keys, err := cp.Core().ListAPIKeys(ctx, MerchantType, dbtest.TestMerchantSlug)
+	require.NoError(t, err)
+	require.Empty(t, keys)
+
+	res2, err := cp.Bootstrap(ctx, BootstrapOptions{BootstrapMerchantSlug: dbtest.TestMerchantSlug, MintInitialAPIKey: true})
+	require.NoError(t, err)
+	require.True(t, res2.APIKeyMinted, "a genuinely first-run merchant mints on explicit request")
+	require.NotEmpty(t, res2.APIKeySecret)
+}
+
 func TestBootstrap_SeedsPermissionCatalog(t *testing.T) {
 	ctx := context.Background()
 	pool := newBootstrapTestPool(t)

--- a/internal/controlplane/catalog_test.go
+++ b/internal/controlplane/catalog_test.go
@@ -2,9 +2,6 @@ package controlplane
 
 import (
 	"testing"
-	"time"
-
-	"github.com/open-rails/authkit"
 )
 
 func TestGroups_CustomerExposesRemoteApplications(t *testing.T) {
@@ -17,23 +14,6 @@ func TestGroups_CustomerExposesRemoteApplications(t *testing.T) {
 		}
 	}
 	t.Fatal("customer group persona missing")
-}
-
-func TestAnyLiveAPIKey(t *testing.T) {
-	now := time.Now()
-	revoked := &now
-	if anyLiveAPIKey(nil) {
-		t.Error("nil API keys should not be live")
-	}
-	if anyLiveAPIKey([]authkit.APIKey{{RevokedAt: revoked}}) {
-		t.Error("only-revoked API keys should not count as live")
-	}
-	if !anyLiveAPIKey([]authkit.APIKey{{RevokedAt: nil}}) {
-		t.Error("a non-revoked API key should count as live")
-	}
-	if !anyLiveAPIKey([]authkit.APIKey{{RevokedAt: revoked}, {RevokedAt: nil}}) {
-		t.Error("a mix with one live API key should count as live")
-	}
 }
 
 // TestAdmissionCreatePermission_GateSemantics proves the admission hot-path gate:

--- a/internal/controlplane/service.go
+++ b/internal/controlplane/service.go
@@ -63,9 +63,11 @@ type ControlPlane struct {
 }
 
 type options struct {
-	hosted bool
-	email  authcore.EmailSender
-	sms    authcore.SMSSender
+	hosted         bool
+	email          authcore.EmailSender
+	sms            authcore.SMSSender
+	frontend       authcore.FrontendConfig
+	trustedProxies []string
 }
 
 // Option configures the control plane for embedding hosts.
@@ -99,6 +101,34 @@ func WithSMSSender(sender authcore.SMSSender) Option {
 	}
 }
 
+// WithFrontend overrides authcore.Config.Frontend — the host-owned frontend
+// routes AuthKit uses to build absolute emailed links (verification, password
+// reset, ...). #743: without this, Frontend.BaseURL pins to the control
+// plane's own token issuer, which for a hosted product is an API host that
+// serves no pages — emailed verify/reset links 404. Hosted products MUST set
+// this to their product frontend's origin. Absent (zero value), New keeps the
+// pre-#743 default (BaseURL: issuer); every path left blank on a supplied
+// override still falls back to authcore's own per-field defaults
+// (VerifyPath->"/verify", PasswordResetPath->"/reset", etc).
+func WithFrontend(fc authcore.FrontendConfig) Option {
+	return func(o *options) {
+		o.frontend = fc
+	}
+}
+
+// WithTrustedProxies configures the reverse-proxy/LB CIDRs AuthKit's HTTP
+// server trusts when deriving the client IP (CF-Connecting-IP / X-Forwarded-For)
+// for its per-client registration/login rate limiter (#743). Without this,
+// authhttp keys the limiter off the immediate TCP peer — behind any load
+// balancer that is the LB's own address, so the whole product shares ONE
+// registration bucket. Empty (the default) keeps authhttp's safe
+// direct-RemoteAddr behavior.
+func WithTrustedProxies(cidrs []string) Option {
+	return func(o *options) {
+		o.trustedProxies = cidrs
+	}
+}
+
 func newOptions(opts []Option) options {
 	var out options
 	for _, opt := range opts {
@@ -129,6 +159,20 @@ func registrationVerification(locked bool) authcore.RegistrationVerificationPoli
 		return authcore.RegistrationVerificationNone
 	}
 	return authcore.RegistrationVerificationRequired
+}
+
+// resolveFrontendConfig resolves authcore.Config.Frontend (#743): an explicit
+// host override (WithFrontend) wins outright — a host that supplies ANY
+// FrontendConfig owns the whole struct, and authcore itself defaults every
+// field the host leaves blank (BaseURL->issuer, VerifyPath->"/verify",
+// PasswordResetPath->"/reset", ...). Absent an override, New keeps the
+// pre-#743 default of pinning BaseURL at the control-plane issuer, made
+// explicit here rather than relying on authcore's own BaseURL-empty fallback.
+func resolveFrontendConfig(issuer string, override authcore.FrontendConfig) authcore.FrontendConfig {
+	if override != (authcore.FrontendConfig{}) {
+		return override
+	}
+	return authcore.FrontendConfig{BaseURL: issuer}
 }
 
 // resolveControlPlaneKeySource builds the JWT signing KeySource for the
@@ -221,7 +265,7 @@ func New(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, opts ...Op
 			IssuedAudiences:   []string{"openrails"},
 			ExpectedAudiences: []string{"openrails"},
 		},
-		Frontend:    authcore.FrontendConfig{BaseURL: issuer},
+		Frontend:    resolveFrontendConfig(issuer, options.frontend),
 		APIKeys:     authcore.APIKeysConfig{Prefix: APIKeyPrefix},
 		Environment: strings.TrimSpace(cfg.Env),
 		// HARD CUT (#567): OpenRails declares two FLAT top-level permission-group
@@ -263,7 +307,14 @@ func New(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, opts ...Op
 	if err != nil {
 		return nil, fmt.Errorf("controlplane: build authkit client: %w", err)
 	}
-	authSvc, err := authhttp.NewServer(authClient)
+	// HTTP-layer options (#743): trusted-proxy CIDRs so the per-client
+	// registration/login rate limiter keys on the real client behind a load
+	// balancer instead of the LB's own peer address.
+	var authHTTPOpts []authhttp.Option
+	if len(options.trustedProxies) > 0 {
+		authHTTPOpts = append(authHTTPOpts, authhttp.WithTrustedProxies(options.trustedProxies...))
+	}
+	authSvc, err := authhttp.NewServer(authClient, authHTTPOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("controlplane: build authkit service: %w", err)
 	}

--- a/internal/integrationharness/harness.go
+++ b/internal/integrationharness/harness.go
@@ -417,7 +417,7 @@ func (h *Harness) startStandalone(currency, appDSN, name string, opts ...Standal
 	// scoped to the merchant — the production provisioning path (cmd/openrails
 	// run-server does the same at boot). MintInitialAPIKey returns the
 	// one-time secret we hand to the client.
-	res, err := embcp.RunBootstrap(h.ctx, app, controlplane.BootstrapOptions{
+	res, err := embcp.RunBootstrap(h.ctx, app, embcp.BootstrapOptions{
 		BootstrapMerchantSlug: dbtest.TestMerchantSlug,
 		MintInitialAPIKey:     true,
 	})

--- a/pkg/embedded/controlplane/attachoptions_forwarding_integration_test.go
+++ b/pkg/embedded/controlplane/attachoptions_forwarding_integration_test.go
@@ -1,0 +1,175 @@
+//go:build integration
+
+package controlplane_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	authcore "github.com/open-rails/authkit/embedded"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/dbtest"
+	embcp "github.com/open-rails/openrails/pkg/embedded/controlplane"
+)
+
+// postJSONWithHeaders is postJSON (provision_integration_test.go) plus
+// caller-supplied headers (needed here to set X-Forwarded-For).
+func postJSONWithHeaders(t *testing.T, url, body string, headers map[string]string) int {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// TestFrontendOverride_PasswordResetLinkUsesProductFrontend proves #743's
+// headline finding is fixed: with no override, AuthKit pins Frontend.BaseURL
+// at the control plane's own token issuer — an API host that serves no pages
+// — so an emailed password-reset link 404s. AttachOptions.Frontend lets a
+// hosted product point the link at its OWN frontend instead.
+func TestFrontendOverride_PasswordResetLinkUsesProductFrontend(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+	issuer := "https://controlplane.openrails.test"
+	cfg := hostedTestConfig(dsn, issuer)
+	e := newHostApp(t, cfg)
+
+	sender := &captureEmailSender{}
+	const frontendBase = "https://app.example.test"
+	require.NoError(t, embcp.AttachWithOptions(ctx, e.App(), cfg, nil, embcp.AttachOptions{
+		EmailSender: sender,
+		Frontend: authcore.FrontendConfig{
+			BaseURL:           frontendBase,
+			PasswordResetPath: "/account/reset",
+		},
+	}))
+	srv := mountAuthRoutes(t, e)
+
+	cp := embcp.Get(e.App())
+	require.NotNil(t, cp)
+	email := "reset-target@example.test"
+	_, err := cp.Core().CreateUser(ctx, email, "resettarget")
+	require.NoError(t, err)
+
+	status, body := postJSON(t, srv.URL+"/email/password/reset/request", `{"email":"`+email+`"}`)
+	require.Equal(t, http.StatusAccepted, status, "%v", body)
+
+	link := sender.resetLink(email)
+	require.NotEmpty(t, link, "reset link delivered to the host sender")
+	require.True(t, strings.HasPrefix(link, frontendBase+"/account/reset"),
+		"reset link must use the overridden product frontend + path, not the issuer: %s", link)
+	require.NotContains(t, link, issuer, "reset link must not point at the control-plane issuer")
+}
+
+// TestFrontendAbsent_KeepsPreviousIssuerBasedDefault pins the "absent -> current
+// behavior" contract: with no Frontend override, BaseURL still pins at the
+// issuer exactly as before #743 (so existing self-hosted deployments, which
+// never set this, see no behavior change).
+func TestFrontendAbsent_KeepsPreviousIssuerBasedDefault(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+	issuer := "https://controlplane2.openrails.test"
+	cfg := hostedTestConfig(dsn, issuer)
+	e := newHostApp(t, cfg)
+
+	sender := &captureEmailSender{}
+	require.NoError(t, embcp.AttachWithOptions(ctx, e.App(), cfg, nil, embcp.AttachOptions{
+		EmailSender: sender,
+	}))
+	srv := mountAuthRoutes(t, e)
+
+	cp := embcp.Get(e.App())
+	email := "reset-default@example.test"
+	_, err := cp.Core().CreateUser(ctx, email, "resetdefault")
+	require.NoError(t, err)
+
+	status, body := postJSON(t, srv.URL+"/email/password/reset/request", `{"email":"`+email+`"}`)
+	require.Equal(t, http.StatusAccepted, status, "%v", body)
+
+	link := sender.resetLink(email)
+	require.NotEmpty(t, link)
+	require.True(t, strings.HasPrefix(link, issuer+"/reset"),
+		"with no override, the link must still use the issuer + authcore's default reset path: %s", link)
+}
+
+// TestTrustedProxies_ClientIPBucketsByForwardedHeader proves #743's second
+// finding is fixed: AttachOptions.TrustedProxies reaches authhttp's per-client
+// rate limiter. Without it, every request collapses onto the loopback peer
+// address (as seen by any test/prod reverse proxy or LB) and shares ONE
+// bucket; with the peer declared trusted, distinct X-Forwarded-For clients
+// get independent buckets.
+func TestTrustedProxies_ClientIPBucketsByForwardedHeader(t *testing.T) {
+	ctx := context.Background()
+	// RLPasswordResetRequest defaults to Limit:6/hour (authhttp.DefaultRateLimits) —
+	// one more request than that must 429 when every request shares one bucket.
+	const requests = 7
+
+	run := func(t *testing.T, trustedProxies []string) []int {
+		dsn := dbtest.SharedPostgresDSN(t)
+		cfg := hostedTestConfig(dsn, "https://controlplane.openrails.test")
+		e := newHostApp(t, cfg)
+		require.NoError(t, embcp.AttachWithOptions(ctx, e.App(), cfg, nil, embcp.AttachOptions{
+			EmailSender:    &captureEmailSender{},
+			TrustedProxies: trustedProxies,
+		}))
+		srv := mountAuthRoutes(t, e)
+
+		codes := make([]int, 0, requests)
+		for i := 0; i < requests; i++ {
+			email := fmt.Sprintf("reset-%d-%s@example.test", i, strings.ToLower(strings.ReplaceAll(t.Name(), "/", "-")))
+			status := postJSONWithHeaders(t, srv.URL+"/email/password/reset/request",
+				`{"email":"`+email+`"}`,
+				map[string]string{"X-Forwarded-For": fmt.Sprintf("203.0.113.%d", i+1)})
+			codes = append(codes, status)
+		}
+		return codes
+	}
+
+	t.Run("untrusted_proxy_shares_one_bucket", func(t *testing.T) {
+		codes := run(t, nil)
+		sawRateLimited := false
+		for _, c := range codes {
+			if c == http.StatusTooManyRequests {
+				sawRateLimited = true
+			}
+		}
+		require.True(t, sawRateLimited,
+			"with no TrustedProxies, every request shares the loopback peer's bucket and must eventually 429: %v", codes)
+	})
+
+	t.Run("trusted_proxy_keys_on_forwarded_ip", func(t *testing.T) {
+		codes := run(t, []string{"127.0.0.1/32", "::1/128"})
+		for i, c := range codes {
+			require.Equalf(t, http.StatusAccepted, c,
+				"request %d must not be rate limited once TrustedProxies keys the limiter on its own forwarded IP: %v", i, codes)
+		}
+	})
+}
+
+// TestTrustedProxies_InvalidCIDRFailsAttach proves the option actually reaches
+// authhttp.WithTrustedProxies (an invalid CIDR is authhttp's own construction
+// error, not something OpenRails could produce by accident) rather than being
+// silently dropped.
+func TestTrustedProxies_InvalidCIDRFailsAttach(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+	cfg := hostedTestConfig(dsn, "https://controlplane.openrails.test")
+	e := newHostApp(t, cfg)
+
+	err := embcp.AttachWithOptions(ctx, e.App(), cfg, nil, embcp.AttachOptions{
+		EmailSender:    &captureEmailSender{},
+		TrustedProxies: []string{"not-a-cidr"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid trusted proxy CIDR")
+}

--- a/pkg/embedded/controlplane/bootstrap_integration_test.go
+++ b/pkg/embedded/controlplane/bootstrap_integration_test.go
@@ -1,0 +1,87 @@
+//go:build integration
+
+package controlplane_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/dbtest"
+	embcp "github.com/open-rails/openrails/pkg/embedded/controlplane"
+)
+
+// TestRunBootstrap_ExternalShapeAndExplicitMintOnly is #747's regression
+// guard, exercised entirely through the exported pkg/embedded/controlplane
+// surface (this file cannot import internal/controlplane, proving the shape
+// really is external-host-constructible):
+//
+//   - embcp.BootstrapOptions{...} compiles and round-trips through
+//     embcp.RunBootstrap (the alias pattern actually works, not just typechecks).
+//   - RunBootstrap forwards MintInitialAPIKey VERBATIM: a false request never
+//     mints, even on a merchant's very first Bootstrap call (pre-#747 this was
+//     force-overridden to true regardless of what the caller passed).
+//   - An explicit true mints once, normally.
+//   - After an operator revokes that key, a later explicit true request does
+//     NOT auto-heal it with a fresh mint.
+func TestRunBootstrap_ExternalShapeAndExplicitMintOnly(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+	cfg := hostedTestConfig(dsn, "https://controlplane.openrails.test")
+	e := newHostApp(t, cfg)
+	require.NoError(t, embcp.Attach(ctx, e.App(), cfg, nil))
+
+	// Provision the merchant through the #738 public seam (no raw SQL): this is
+	// also the realistic API-mode shape, where a merchant row/group can exist
+	// before Bootstrap ever runs for it.
+	slug := "bootstrap-747-" + strings.ToLower(uuid.NewString()[:8])
+	_, err := embcp.ProvisionMerchant(ctx, e.App(), embcp.ProvisionMerchantRequest{Slug: slug})
+	require.NoError(t, err)
+
+	cp := embcp.Get(e.App())
+	require.NotNil(t, cp)
+
+	// A false request must never mint — not even on the merchant's very first
+	// RunBootstrap call. Pre-#747 this was force-overridden to true.
+	res1, err := embcp.RunBootstrap(ctx, e.App(), embcp.BootstrapOptions{
+		BootstrapMerchantSlug: slug,
+		MintInitialAPIKey:     false,
+	})
+	require.NoError(t, err)
+	require.False(t, res1.APIKeyMinted, "MintInitialAPIKey:false must be honored verbatim")
+	keys, err := cp.Core().ListAPIKeys(ctx, "merchant", slug)
+	require.NoError(t, err)
+	require.Empty(t, keys)
+
+	// An explicit true request on this genuinely-first-run merchant mints.
+	res2, err := embcp.RunBootstrap(ctx, e.App(), embcp.BootstrapOptions{
+		BootstrapMerchantSlug: slug,
+		MintInitialAPIKey:     true,
+	})
+	require.NoError(t, err)
+	require.True(t, res2.APIKeyMinted)
+	require.NotEmpty(t, res2.APIKeySecret)
+
+	// Operator revokes it (e.g. suspected compromise).
+	keys, err = cp.Core().ListAPIKeys(ctx, "merchant", slug)
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	revoked, err := cp.Core().RevokeAPIKey(ctx, "merchant", slug, keys[0].ID)
+	require.NoError(t, err)
+	require.True(t, revoked)
+
+	// A later explicit mint request must NOT auto-heal the revocation.
+	res3, err := embcp.RunBootstrap(ctx, e.App(), embcp.BootstrapOptions{
+		BootstrapMerchantSlug: slug,
+		MintInitialAPIKey:     true,
+	})
+	require.NoError(t, err)
+	require.False(t, res3.APIKeyMinted, "RunBootstrap must never re-mint after an operator revokes all keys")
+
+	finalKeys, err := cp.Core().ListAPIKeys(ctx, "merchant", slug)
+	require.NoError(t, err)
+	require.Len(t, finalKeys, 1, "no replacement key should exist after revocation")
+}

--- a/pkg/embedded/controlplane/controlplane.go
+++ b/pkg/embedded/controlplane/controlplane.go
@@ -25,6 +25,77 @@ import (
 )
 
 // AttachOptions configures the embedded AuthKit control-plane seam.
+//
+// # Field-by-field forwarding audit (#743)
+//
+// AttachOptions is the ONLY seam an embedding host has onto the AuthKit dials
+// OpenRails' control plane wires (authcore.Config + authhttp.NewServer's
+// functional options). Below is every dial on both surfaces and whether
+// AttachOptions forwards it, so the next missing forward is a deliberate
+// decision recorded here, not a silent gap rediscovered by a 404 in
+// production (#743's Frontend-links finding was exactly that).
+//
+// authcore.Config (the AuthKit engine):
+//   - Token (Issuer/Audiences/durations/SessionMaxPerUser): NOT forwarded.
+//     Issuer comes from cfg.Auth.Issuer (already host-configurable at the
+//     config layer); the "openrails" audience is an OpenRails product
+//     constant, not a per-host dial (#750 tracks exporting it as a named
+//     constant instead of a literal). Token durations/session caps have no
+//     AttachOptions knob yet — an open gap, not yet requested by a host.
+//   - Frontend: FORWARDED (this issue) via AttachOptions.Frontend.
+//   - Registration: NOT a raw forward. OpenRails computes it from
+//     HostedPosture (open+required vs closed+none) — this is product policy
+//     (#738), not a pass-through dial; a host cannot pick a THIRD policy.
+//   - Keys: NOT forwarded. Signing-key resolution is OpenRails' own
+//     responsibility (resolveControlPlaneKeySource: cfg.Auth.* inline
+//     material, else vault keys.json, else dev-ephemeral) — a host has no
+//     business injecting a KeySource or flipping VerifyOnly.
+//   - Identity (OAuth/OIDC providers): NOT forwarded. No AttachOptions
+//     provider list exists; hosted external-login is a future issue, not a
+//     silently-defaulted feature.
+//   - APIKeys.Prefix: NOT forwarded — the "openrails" API-key brand prefix
+//     (APIKeyPrefix) is an OpenRails product decision, not host-configurable.
+//   - APIKeys.MaxTTL: NOT forwarded — no cap today; open gap, not a decision.
+//   - TwoFactor / Passkeys: NOT forwarded — neither feature area is wired
+//     into the control plane's mounted routes for embedded hosts yet.
+//   - RBAC: NOT forwarded — OpenRails' own Groups() permission-group catalog
+//     IS the product's authorization schema (#567); a host cannot override
+//     its own persona/permission model.
+//   - Environment: forwarded, but via cfg.Env at the config layer (already a
+//     top-level host-set value), not a separate AttachOptions field.
+//   - Schema / SolanaNetwork: NOT AttachOptions concerns — Schema follows
+//     cfg.DB.SchemaName() at the DB-wiring layer; SolanaNetwork derives from
+//     Environment (authcore's own default), never overridden today.
+//
+// authcore.Option (engine-construction functional options):
+//   - WithEmailSender / WithSMSSender: FORWARDED via AttachOptions.EmailSender
+//     / SMSSender (#738).
+//   - WithEphemeralStore / embedded.WithRedis: NOT forwarded — DISCOVERED GAP,
+//     not fixed here (out of #743's scope): the control-plane engine built by
+//     internal/controlplane.New never wires Redis/an ephemeral store at all.
+//     authhttp's own construction-time validate() hard-fails when
+//     Environment is not dev-like and no Redis was supplied — so today ANY
+//     hosted attach with a production-like Environment string and no Redis
+//     wired some other way will fail to boot. Flagged for a follow-up issue,
+//     not silently absorbed into this one.
+//   - WithEntitlements / WithClickHouse: NOT forwarded — unrelated feature
+//     areas OpenRails' control plane does not use.
+//
+// authhttp.Option (HTTP-layer construction options, authhttp.NewServer):
+//   - WithTrustedProxies: FORWARDED (this issue) via AttachOptions.TrustedProxies.
+//   - WithClientIPFunc: NOT forwarded — superseded by WithTrustedProxies (the
+//     "normal knob", per its own doc); exposing a raw ClientIPFunc would let a
+//     host inject arbitrary, unaudited client-IP logic. Advanced/test-only by
+//     authhttp's own doc.
+//   - WithRateLimiter / WithoutRateLimiter: NOT forwarded — BLOCKED on authkit
+//     #242 (a merge-style per-bucket override API). The raw options are a
+//     full-policy-replacement footgun ("ADVANCED/TEST ONLY" per authhttp's own
+//     doc); forwarding them today would let a host disable rate limiting
+//     entirely instead of tuning one bucket. Tracked, not implemented.
+//   - WithRedis: NOT forwarded — see the WithEphemeralStore gap above; the
+//     HTTP layer reuses whatever the engine wired (nothing, today).
+//   - WithLanguageConfig: NOT forwarded — i18n is not wired into
+//     AttachOptions; no host has asked for it yet.
 type AttachOptions struct {
 	// HostedPosture opens AuthKit registration and mounts the full AuthKit API.
 	// Leave false for private standalone-compatible embedded hosts.
@@ -42,6 +113,29 @@ type AttachOptions struct {
 	// the mounted self-service verify/reset routes.
 	EmailSender authcore.EmailSender
 	SMSSender   authcore.SMSSender
+
+	// Frontend overrides AuthKit's Frontend config — the host-owned frontend
+	// routes used to build absolute emailed links (verification, password
+	// reset, ...). #743: left zero, BaseURL pins at the control-plane's own
+	// issuer, which for a hosted product is an API host that serves no pages
+	// — emailed verify/reset links 404 (the reported bug). Hosted products
+	// MUST set at least Frontend.BaseURL to their product frontend's origin;
+	// VerifyPath/PasswordResetPath/etc default per authcore's own rules
+	// (VerifyPath->"/verify", PasswordResetPath->"/reset", ...) when left
+	// blank. The type is authkit/embedded's own exported FrontendConfig — no
+	// OpenRails-owned wrapper needed, matching EmailSender/SMSSender above.
+	Frontend authcore.FrontendConfig
+
+	// TrustedProxies lists the CIDRs of reverse proxies/load balancers in
+	// front of this deployment. When set, AuthKit's HTTP server derives the
+	// client IP for its per-client registration/login rate limiter from
+	// forwarded headers ONLY when the immediate peer is one of these CIDRs
+	// (#743); otherwise (the default, empty) it uses the direct TCP peer,
+	// which behind any LB collapses every client into one shared bucket.
+	// Coordinate with #746's engine-wide trusted-proxy resolver: this is
+	// deliberately a standalone AttachOptions field, not a shared config key,
+	// until that unification lands.
+	TrustedProxies []string
 }
 
 // Get recovers the concrete *controlplane.ControlPlane attached to the app, or
@@ -94,6 +188,12 @@ func AttachWithOptions(ctx context.Context, a *app.App, cfg *config.Config, inje
 	if opts.SMSSender != nil {
 		cpOpts = append(cpOpts, controlplane.WithSMSSender(opts.SMSSender))
 	}
+	if opts.Frontend != (authcore.FrontendConfig{}) {
+		cpOpts = append(cpOpts, controlplane.WithFrontend(opts.Frontend))
+	}
+	if len(opts.TrustedProxies) > 0 {
+		cpOpts = append(cpOpts, controlplane.WithTrustedProxies(opts.TrustedProxies))
+	}
 	cp, err := controlplane.New(ctx, cfg, pool, cpOpts...)
 	if err != nil {
 		if ownedPool {
@@ -110,25 +210,38 @@ func AttachWithOptions(ctx context.Context, a *app.App, cfg *config.Config, inje
 	return nil
 }
 
+// BootstrapOptions is the nameable, externally-constructible alias for
+// controlplane.BootstrapOptions (#747, the embed/provision.go alias pattern):
+// internal/controlplane cannot be imported outside this module, so before this
+// alias existed RunBootstrap took a parameter no external host could construct
+// — the ONLY caller was this repo's own test harness.
+type BootstrapOptions = controlplane.BootstrapOptions
+
+// BootstrapResult is the nameable alias for controlplane.BootstrapResult; see
+// BootstrapOptions.
+type BootstrapResult = controlplane.BootstrapResult
+
 // RunBootstrap idempotently bootstraps the OpenRails-owned AuthKit control plane
 // (#224): ensures the bootstrap authority, OpenRails operator role, the
-// openrails.* permission catalog, and an initial operator API key.
-// Calling it without an attached control plane is a wiring error (#469: the
-// standalone always attaches one first).
+// openrails.* permission catalog, and — only when opts.MintInitialAPIKey is
+// true — an initial operator API key. Calling it without an attached control
+// plane is a wiring error (#469: the standalone always attaches one first).
+//
+// #747: opts is forwarded VERBATIM — RunBootstrap used to force
+// MintInitialAPIKey to true regardless of what the caller passed, so "defaults
+// to true" actually meant "always true". A caller that wants a key must now
+// ask for one explicitly, every time, and even then Bootstrap mints only when
+// this merchant group has never had a key before (see BootstrapOptions'
+// MintInitialAPIKey doc) — an operator who revokes every key after a
+// suspected compromise is never silently re-issued a fresh one on the next
+// routine boot.
 //
 // Call it AFTER migrations have run (so openrails.merchants and profiles.* exist) and
 // at startup. Safe to re-run. This was App.RunControlPlaneBootstrap before #284.
-func RunBootstrap(ctx context.Context, a *app.App, opts controlplane.BootstrapOptions) (*controlplane.BootstrapResult, error) {
+func RunBootstrap(ctx context.Context, a *app.App, opts BootstrapOptions) (*BootstrapResult, error) {
 	cp := Get(a)
 	if cp == nil {
 		return nil, fmt.Errorf("control plane bootstrap: no control plane attached (call Attach first)")
 	}
-	if !opts.MintInitialAPIKey {
-		opts.MintInitialAPIKey = true
-	}
-	res, err := cp.Bootstrap(ctx, opts)
-	if err != nil {
-		return res, err
-	}
-	return res, nil
+	return cp.Bootstrap(ctx, opts)
 }

--- a/pkg/embedded/controlplane/provision_integration_test.go
+++ b/pkg/embedded/controlplane/provision_integration_test.go
@@ -26,10 +26,12 @@ import (
 func TestMain(m *testing.M) { dbtest.RunMain(m) }
 
 // captureEmailSender implements the authkit/embedded EmailSender alias the way
-// an external host would: it records the verification code instead of sending.
+// an external host would: it records the verification code / reset link
+// instead of sending.
 type captureEmailSender struct {
-	mu    sync.Mutex
-	codes map[string]string // normalized email -> last verification code
+	mu         sync.Mutex
+	codes      map[string]string // normalized email -> last verification code
+	resetLinks map[string]string // normalized email -> last password reset link URL
 }
 
 func (s *captureEmailSender) SendVerification(_ context.Context, email, _ string, msg authcore.VerificationMessage) error {
@@ -41,7 +43,13 @@ func (s *captureEmailSender) SendVerification(_ context.Context, email, _ string
 	s.codes[email] = msg.Code
 	return nil
 }
-func (s *captureEmailSender) SendPasswordResetLink(context.Context, string, string, string) error {
+func (s *captureEmailSender) SendPasswordResetLink(_ context.Context, email, _, resetURL string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.resetLinks == nil {
+		s.resetLinks = map[string]string{}
+	}
+	s.resetLinks[email] = resetURL
 	return nil
 }
 func (s *captureEmailSender) SendAccountRegistrationInvite(context.Context, string, string) error {
@@ -54,6 +62,12 @@ func (s *captureEmailSender) code(email string) string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.codes[email]
+}
+
+func (s *captureEmailSender) resetLink(email string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.resetLinks[email]
 }
 
 func hostedTestConfig(dsn, issuer string) *config.Config {

--- a/pkg/embedded/embedded.go
+++ b/pkg/embedded/embedded.go
@@ -197,7 +197,11 @@ func (e *Embedded) Service() (*service.Service, error) {
 // Control-plane bootstrap + accessor moved to the OPT-IN pkg/embedded/controlplane
 // helper (#284): the embedded CORE no longer imports internal/controlplane (or,
 // through it, AuthKit). Standalone/AuthKit hosts call
-// controlplane.RunBootstrap(ctx, e.App(), opts) and controlplane.Get(e.App()).
+// controlplane.RunBootstrap(ctx, e.App(), controlplane.BootstrapOptions{...}) and
+// controlplane.Get(e.App()) — BootstrapOptions/BootstrapResult are that
+// package's own nameable, externally-constructible aliases (#747) for the
+// internal/controlplane types of the same name, so an external host builds
+// opts without reaching into (or being able to import) internal/controlplane.
 
 func (e *Embedded) RunWorkers(ctx context.Context) error {
 	if e == nil || e.app == nil || e.app.Runtime == nil {


### PR DESCRIPTION
## Summary

**#743 — AttachOptions forwarding audit**
- `AttachOptions.Frontend` (type `authcore.FrontendConfig`, the authkit/embedded alias — same pattern as `EmailSender`/`SMSSender`) threads through a new `controlplane.WithFrontend` option into `authcore.Config.Frontend`. Fixes hosted verification/password-reset emails linking to `<issuer>/verify`|`/reset` (an API host that serves no pages, a hard 404) instead of the product's own frontend. Absent (zero value) keeps the pre-existing `BaseURL: issuer` default.
- `AttachOptions.TrustedProxies []string` (CIDRs) threads through `controlplane.WithTrustedProxies` into `authhttp.WithTrustedProxies` (authkit already ships this option; `authhttp.NewServer` already takes variadic `Option`s). Without it, AuthKit's per-client registration/login rate limiter keys on the immediate TCP peer, which behind any load balancer collapses every client onto one shared bucket.
- Full field-by-field audit of `AttachOptions` vs `authcore.Config` + `authhttp` options is now a doc comment on `AttachOptions` itself, so every deliberate non-forward has a one-line reason. Flags one gap discovered but intentionally NOT fixed here (out of scope): the control-plane engine never wires Redis/an ephemeral store, so `authhttp.NewServer`'s own construction-time check will hard-fail any hosted attach with a production-like `Environment` string and no Redis wired some other way.
- Rate-limit bucket overrides stay blocked on authkit #242 (tracker task left unchecked).

**#747 — RunBootstrap uncallable / force-overriding / auto-re-minting**
- `pkg/embedded/controlplane.BootstrapOptions` / `BootstrapResult` are now nameable aliases (`= controlplane.BootstrapOptions` / `BootstrapResult`, the `embed/provision.go` pattern) instead of the unnameable internal type — `RunBootstrap` is now genuinely callable from outside this module.
- `RunBootstrap` no longer force-overrides `MintInitialAPIKey` to `true`; the caller's value is forwarded verbatim.
- `ControlPlane.Bootstrap`'s mint-eligibility check now looks at the merchant group's **full** API-key history (live + revoked via `core.ListAPIKeys`), not just the live count. A merchant with zero *live* keys because an operator revoked all of them (e.g. after a suspected compromise) is no longer treated as a first-run state — a routine re-Bootstrap call (even one that explicitly asks to mint) will never silently re-mint a replacement key. A genuinely first-run merchant (zero keys ever) still mints normally on explicit request.
- Fixed `pkg/embedded/embedded.go`'s doc, which pointed hosts at the previously-uncallable seam.
- `internal/integrationharness/harness.go` updated to construct `embcp.BootstrapOptions{}` (the alias) instead of reaching into `internal/controlplane` directly.
- Checked `cmd/openrails` and `internal/bootstrap/serverboot` for existing `RunBootstrap`/`Bootstrap` call sites — there are none today, so nothing to update there.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean on all touched files
- [x] `go build -tags integration ./...`, `go vet -tags integration ./...` clean
- [x] `go test ./...` green
- [x] `go test -tags=integration ./internal/controlplane/...` green, including new `TestBootstrap_RevokedKeysNeverAutoRemint` and `TestBootstrap_FreshMerchantMintsOnlyOnExplicitRequest`
- [x] `go test -tags=integration ./pkg/embedded/controlplane/...` green, including new `TestFrontendOverride_PasswordResetLinkUsesProductFrontend`, `TestFrontendAbsent_KeepsPreviousIssuerBasedDefault`, `TestTrustedProxies_ClientIPBucketsByForwardedHeader`, `TestTrustedProxies_InvalidCIDRFailsAttach`, `TestRunBootstrap_ExternalShapeAndExplicitMintOnly`

Tracker: open-rails-tracker `openrails/progress.md` #743/#747 checked off in a separate commit.