### PR TITLE
Readiness + boot-posture truth (#748): real Ready(), fail-loud arming, declared verify-only, symmetric test-key gate

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -785,6 +785,13 @@ type AuthConfig struct {
 	// is set (env AUTHKIT_KEYS_PATH; special-cased below). Empty uses
 	// jwtkit.DefaultAuthKeysPath ("/vault/auth").
 	KeysPath string `koanf:"keys_path,omitempty"`
+	// MintDisabled DECLARES the control plane verify-only (#748): token
+	// minting is intentionally off, so internal/controlplane.New never even
+	// attempts signing-key discovery. Without this flag, a signing-key
+	// discovery failure is a construction (boot) failure outside development
+	// — verify-only must be a declared posture, never a silent downgrade from
+	// an outage indistinguishable from intent.
+	MintDisabled bool `koanf:"mint_disabled,omitempty"`
 }
 
 // TokenConfig defines configuration for a specific Solana token.
@@ -1111,10 +1118,17 @@ func ValidateRailSet(cfg *Config, rails RailMerchantAccountSet) error {
 	if err := validateRails(cfg, rails, isDev); err != nil {
 		return fmt.Errorf("rails validation failed: %w", err)
 	}
-	return validateStripeKeyForTestMode(cfg, rails)
+	return validateStripeKeyForTestMode(cfg, rails, isDev)
 }
 
-func validateStripeKeyForTestMode(cfg *Config, rails RailMerchantAccountSet) error {
+// validateStripeKeyForTestMode enforces the two credential/test_mode
+// mismatches SYMMETRICALLY (#748): a live key can never run under
+// test_mode=true, and — outside development — a test key can never run under
+// test_mode=false. Both used to diverge: the first hard-failed, the second
+// only warned and silently cleared the key, leaving the rail off behind a
+// "healthy" boot. Development keeps the warn-and-clear for the second case so
+// a local .env with a leftover test key doesn't need to be hand-edited.
+func validateStripeKeyForTestMode(cfg *Config, rails RailMerchantAccountSet, isDev bool) error {
 	if cfg == nil {
 		cfg = &Config{}
 	}
@@ -1140,6 +1154,12 @@ func validateStripeKeyForTestMode(cfg *Config, rails RailMerchantAccountSet) err
 			return fmt.Errorf("stripe rail %q: live key (sk_live_/rk_live_) is not allowed when test_mode is enabled; use a test key or unset test_mode", strings.ToLower(strings.TrimSpace(name)))
 		}
 		if !cfg.IsTestMode() && isTestKey {
+			if !isDev {
+				// #748: mirror the live-key-under-test_mode hard guarantee above —
+				// a live deployment must never boot "healthy" with the rail silently
+				// disabled because a test key snuck into a live-mode config.
+				return fmt.Errorf("stripe rail %q: test key (sk_test_/rk_test_) is not allowed outside development when test_mode is disabled; use a live key or set test_mode=true", strings.ToLower(strings.TrimSpace(name)))
+			}
 			log.Warnf("⚠️  Stripe test key provided for rail %q but test_mode is disabled (live credentials) - disabling Stripe", strings.ToLower(strings.TrimSpace(name)))
 			log.Warn("   Use a live-mode key (sk_live_/rk_live_), or set test_mode=true for sandbox testing")
 			stripeProc.Stripe.SecretKey = ""

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -449,48 +449,61 @@ func TestValidateStripeKeyForTestMode(t *testing.T) {
 	// Standard secret keys (sk_*)
 	t.Run("sk_live_ + test_mode=true is a hard error (#347)", func(t *testing.T) {
 		cfg, rails := stripeTestModeConfig("sk_live_abc123", true)
-		assert.Error(t, validateStripeKeyForTestMode(cfg, rails), "live key in test env must refuse to boot")
+		assert.Error(t, validateStripeKeyForTestMode(cfg, rails, cfg.IsDev()), "live key in test env must refuse to boot")
 	})
 
 	t.Run("sk_test_ + test_mode=true allowed", func(t *testing.T) {
 		cfg, rails := stripeTestModeConfig("sk_test_abc123", true)
-		assert.NoError(t, validateStripeKeyForTestMode(cfg, rails))
+		assert.NoError(t, validateStripeKeyForTestMode(cfg, rails, cfg.IsDev()))
 		assert.Equal(t, "sk_test_abc123", rails["stripe"].Stripe.SecretKey, "test key in test env should be kept")
 	})
 
-	t.Run("sk_test_ + test_mode=false disables Stripe", func(t *testing.T) {
+	t.Run("sk_test_ + test_mode=false disables Stripe in development", func(t *testing.T) {
 		cfg, rails := stripeTestModeConfig("sk_test_abc123", false)
-		assert.NoError(t, validateStripeKeyForTestMode(cfg, rails))
-		assert.Empty(t, rails["stripe"].Stripe.SecretKey, "test key in live env should be disabled")
+		assert.NoError(t, validateStripeKeyForTestMode(cfg, rails, cfg.IsDev()))
+		assert.Empty(t, rails["stripe"].Stripe.SecretKey, "test key in live env should be disabled in dev")
+	})
+
+	t.Run("sk_test_ + test_mode=false outside development is a hard error (#748)", func(t *testing.T) {
+		cfg, rails := stripeTestModeConfig("sk_test_abc123", false)
+		cfg.Env = "production"
+		assert.Error(t, validateStripeKeyForTestMode(cfg, rails, cfg.IsDev()), "test key under live mode must refuse to boot outside development")
+		assert.Equal(t, "sk_test_abc123", rails["stripe"].Stripe.SecretKey, "a hard-failed validation must not silently mutate the config")
 	})
 
 	t.Run("sk_live_ + test_mode=false allowed", func(t *testing.T) {
 		cfg, rails := stripeTestModeConfig("sk_live_abc123", false)
-		assert.NoError(t, validateStripeKeyForTestMode(cfg, rails))
+		assert.NoError(t, validateStripeKeyForTestMode(cfg, rails, cfg.IsDev()))
 		assert.Equal(t, "sk_live_abc123", rails["stripe"].Stripe.SecretKey, "live key in live env should be kept")
 	})
 
 	// Restricted keys (rk_*) — these must be classified the same as sk_* keys.
 	t.Run("rk_live_ + test_mode=true is a hard error (#347)", func(t *testing.T) {
 		cfg, rails := stripeTestModeConfig("rk_live_abc123", true)
-		assert.Error(t, validateStripeKeyForTestMode(cfg, rails), "restricted live key in test env must refuse to boot")
+		assert.Error(t, validateStripeKeyForTestMode(cfg, rails, cfg.IsDev()), "restricted live key in test env must refuse to boot")
 	})
 
 	t.Run("rk_test_ + test_mode=true allowed", func(t *testing.T) {
 		cfg, rails := stripeTestModeConfig("rk_test_abc123", true)
-		assert.NoError(t, validateStripeKeyForTestMode(cfg, rails))
+		assert.NoError(t, validateStripeKeyForTestMode(cfg, rails, cfg.IsDev()))
 		assert.Equal(t, "rk_test_abc123", rails["stripe"].Stripe.SecretKey, "restricted test key in test env should be kept")
 	})
 
-	t.Run("rk_test_ + test_mode=false disables Stripe", func(t *testing.T) {
+	t.Run("rk_test_ + test_mode=false disables Stripe in development", func(t *testing.T) {
 		cfg, rails := stripeTestModeConfig("rk_test_abc123", false)
-		assert.NoError(t, validateStripeKeyForTestMode(cfg, rails))
-		assert.Empty(t, rails["stripe"].Stripe.SecretKey, "restricted test key in live env should be disabled")
+		assert.NoError(t, validateStripeKeyForTestMode(cfg, rails, cfg.IsDev()))
+		assert.Empty(t, rails["stripe"].Stripe.SecretKey, "restricted test key in live env should be disabled in dev")
+	})
+
+	t.Run("rk_test_ + test_mode=false outside development is a hard error (#748)", func(t *testing.T) {
+		cfg, rails := stripeTestModeConfig("rk_test_abc123", false)
+		cfg.Env = "production"
+		assert.Error(t, validateStripeKeyForTestMode(cfg, rails, cfg.IsDev()), "restricted test key under live mode must refuse to boot outside development")
 	})
 
 	t.Run("rk_live_ + test_mode=false allowed", func(t *testing.T) {
 		cfg, rails := stripeTestModeConfig("rk_live_abc123", false)
-		assert.NoError(t, validateStripeKeyForTestMode(cfg, rails))
+		assert.NoError(t, validateStripeKeyForTestMode(cfg, rails, cfg.IsDev()))
 		assert.Equal(t, "rk_live_abc123", rails["stripe"].Stripe.SecretKey, "restricted live key in live env should be kept")
 	})
 
@@ -500,7 +513,7 @@ func TestValidateStripeKeyForTestMode(t *testing.T) {
 			"stripe_primary":  {Rail: models.RailStripe, Stripe: &StripeRailConfig{SecretKey: "sk_live_primary"}},
 			"stripe_archived": {Rail: models.RailStripe, Archived: true, Stripe: &StripeRailConfig{SecretKey: "sk_test_legacy"}},
 		}
-		require.NoError(t, validateStripeKeyForTestMode(cfg, rails))
+		require.NoError(t, validateStripeKeyForTestMode(cfg, rails, cfg.IsDev()))
 		require.Equal(t, "sk_live_primary", rails["stripe_primary"].Stripe.SecretKey)
 		require.Empty(t, rails["stripe_archived"].Stripe.SecretKey)
 	})

--- a/internal/app/merchants_wiring.go
+++ b/internal/app/merchants_wiring.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 
 	log "github.com/sirupsen/logrus"
 
@@ -20,34 +21,51 @@ import (
 // MODE 1 (#723, merchant_source=manifest): the store is the runtime's
 // in-memory manifest plane — no DB/Vault store is ever constructed.
 //
-// Failure is a loud degradation, not a boot error: the pull plane falls back
-// to the boot-config rails plane only. Hosts that provision secrets still hit
-// the hard #667 encryption-posture gate on their provisioning path.
-func (r *Runtime) EnsureMerchantsService(ctx context.Context) {
+// Failure posture (#748, mirrors #667's encryption-posture gate): outside
+// development a failure to arm is a boot ERROR, not a loud degradation —
+// silently falling back to boot-config-only rails means webhooks 503 forever
+// behind a green /readyz, exactly the "degraded state that boots healthy"
+// #748 closes. Development keeps the original warn-and-continue so a
+// from-scratch dev boot with no Vault/master key still runs. Either way, the
+// armed/unarmed state (and, once armed, live backend reachability) is
+// surfaced by Runtime.Ready (#748) — never invisible after this returns.
+func (r *Runtime) EnsureMerchantsService(ctx context.Context) error {
 	if r == nil || r.Merchants != nil || r.DB == nil || r.Config == nil {
-		return
+		return nil
 	}
 	var store merchants.MerchantSecretStore
+	var ping func(context.Context) error
 	if r.Config.IsManifestMerchantSource() {
 		if r.ManifestSecrets == nil {
-			log.Warn("merchant_source=manifest but the manifest secret plane is missing; provider pulls arm from boot-config rails only (#723)")
-			return
+			return r.armingFailure(fmt.Errorf("merchant_source=manifest but the manifest secret plane is missing (#723)"))
 		}
 		store = r.ManifestSecrets
 	} else {
 		backend, err := merchantsecrets.Build(ctx, r.Config, r.DB.DataPool())
 		if err != nil {
-			log.WithError(err).Warn("merchant secret store unavailable; provider pulls arm from boot-config rails only (#699)")
-			return
+			return r.armingFailure(fmt.Errorf("merchant secret store unavailable (#699): %w", err))
 		}
 		store = backend.Secrets
+		ping = backend.Ping
 	}
 	svc, err := merchants.NewService(r.DB.DataPool(), store, config.ExpectedProviderEnvironment(r.Config.IsTestMode()))
 	if err != nil {
-		log.WithError(err).Warn("merchants service unavailable; provider pulls arm from boot-config rails only (#699)")
-		return
+		return r.armingFailure(fmt.Errorf("merchants service unavailable (#699): %w", err))
 	}
 	r.ArmMerchantsService(svc, store)
+	r.MerchantSecretPing = ping
+	return nil
+}
+
+// armingFailure applies the #667-style environment gate to a merchants-arming
+// failure: a boot error everywhere except development, where it warns and lets
+// the pull plane fall back to the boot-config rails plane only.
+func (r *Runtime) armingFailure(err error) error {
+	if r.Config.IsDev() {
+		log.WithError(err).Warn("merchants service failed to arm; provider pulls fall back to boot-config rails only (#699) — development only, refuses boot outside development (#748)")
+		return nil
+	}
+	return fmt.Errorf("merchants service failed to arm outside development (#748): %w", err)
 }
 
 // ArmMerchantsService installs the merchants service AND wires its store into

--- a/internal/app/probe_cache_integration_test.go
+++ b/internal/app/probe_cache_integration_test.go
@@ -4,6 +4,7 @@ package app
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -13,9 +14,19 @@ import (
 
 	"github.com/open-rails/openrails/internal/db"
 	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/internal/integrations/vault/vaulttest"
 )
 
-func TestMain(m *testing.M) { dbtest.RunMain(m) }
+// TestMain composes dbtest's and vaulttest's shared-container teardowns (both
+// RunMain variants os.Exit, so they cannot nest) — this package's #748
+// readiness tests need a real Vault alongside the shared Postgres.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	vaulttest.TerminateShared()
+	dbtest.TerminateShared()
+	dbtest.TerminateSharedRedis()
+	os.Exit(code)
+}
 
 // TestProbeVerdictCacheRoundtrip exercises the #348 probe-cooldown persistence
 // exactly as the boot path uses it: the unprivileged openrails_app role on a

--- a/internal/app/ready.go
+++ b/internal/app/ready.go
@@ -1,0 +1,93 @@
+package app
+
+import (
+	"context"
+	"fmt"
+)
+
+// ReadinessDependency is one boot-dependency probed by Runtime.Ready (#748).
+type ReadinessDependency struct {
+	// Name identifies the dependency (e.g. "postgres", "garnet", "merchant_secrets", "river").
+	Name string
+	// Available is true when the dependency is configured (where relevant) and reachable.
+	Available bool
+	// Err is nil when Available; otherwise the reason (missing config or a live probe failure).
+	Err error
+}
+
+// Ready runs the #748 canonical dependency probes shared by EVERY host
+// surface — standalone (/readyz, internal/http/routes_public.go) and embedded
+// (pkg/embedded.Embedded.Ready) both call this so neither can report healthy
+// while the other reports degraded.
+//
+// Checks: Postgres (always required), Redis (probed ONLY when configured —
+// Redis is optional everywhere else in OpenRails, so its absence must not
+// fail readiness; when configured, an unreachable Redis DOES fail it), the
+// merchant-secret backend (armed at boot, AND live-reachable when armed with
+// a Vault-backed store — a paused/unreachable Vault fails this even though
+// arming succeeded earlier), and River producer presence.
+//
+// Returns every dependency's status (for verbose diagnostics) plus a single
+// wrapped error naming the FIRST failing one; nil when everything the running
+// configuration actually depends on is healthy.
+func (r *Runtime) Ready(ctx context.Context) ([]ReadinessDependency, error) {
+	if r == nil {
+		dep := ReadinessDependency{Name: "runtime", Err: fmt.Errorf("not initialized")}
+		return []ReadinessDependency{dep}, fmt.Errorf("readiness: %s: %w", dep.Name, dep.Err)
+	}
+
+	var deps []ReadinessDependency
+	probe := func(name string, err error) {
+		deps = append(deps, ReadinessDependency{Name: name, Available: err == nil, Err: err})
+	}
+
+	var pgErr error
+	if r.DB == nil || r.DB.Pool() == nil {
+		pgErr = fmt.Errorf("not configured")
+	} else {
+		pgErr = r.DB.Pool().Ping(ctx)
+	}
+	probe("postgres", pgErr)
+
+	// Redis (garnet) is optional everywhere else in OpenRails — only probe it,
+	// and only fail readiness on it, when the runtime actually holds a client.
+	if r.RedisClient != nil {
+		probe("garnet", r.RedisClient.Ping(ctx).Err())
+	}
+
+	probe("merchant_secrets", r.merchantSecretsReady(ctx))
+
+	var riverErr error
+	if r.RiverProducer == nil {
+		riverErr = fmt.Errorf("river producer not initialized")
+	}
+	probe("river", riverErr)
+
+	for _, d := range deps {
+		if !d.Available {
+			return deps, fmt.Errorf("readiness: %s: %w", d.Name, d.Err)
+		}
+	}
+	return deps, nil
+}
+
+// merchantSecretsReady checks the #699/#723/#748 arming contract: the
+// merchants service (or, in MODE 1, the manifest plane) must be armed, and —
+// when arming built a live backend (Vault) — that backend must still answer.
+func (r *Runtime) merchantSecretsReady(ctx context.Context) error {
+	if r.Config != nil && r.Config.IsManifestMerchantSource() {
+		if r.ManifestSecrets == nil {
+			return fmt.Errorf("manifest secret plane not armed (#723)")
+		}
+		return nil
+	}
+	if r.Merchants == nil {
+		return fmt.Errorf("merchants service not armed (secret-store build failed at boot, #699/#748)")
+	}
+	if r.MerchantSecretPing != nil {
+		if err := r.MerchantSecretPing(ctx); err != nil {
+			return fmt.Errorf("backend unreachable: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/app/ready_integration_test.go
+++ b/internal/app/ready_integration_test.go
@@ -1,0 +1,123 @@
+//go:build integration
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/db"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/internal/integrations/vault/vaulttest"
+)
+
+// testRuntimeDB opens a *db.DB over the shared migrated test Postgres.
+func testRuntimeDB(t *testing.T) (*db.DB, string) {
+	t.Helper()
+	dsn := dbtest.SharedPostgresDSN(t)
+	pool, err := pgxpool.New(context.Background(), dsn)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	appDB, err := db.NewWithPGXPool(pool, config.DefaultSchema)
+	require.NoError(t, err)
+	return appDB, dsn
+}
+
+// TestEnsureMerchantsService_ArmingFailureOutsideDev proves the #748 posture:
+// a merchant-secret-store build failure is a boot ERROR outside development
+// (Merchants stays nil AND the caller gets a non-nil error to propagate,
+// exactly as river_register.go's addBillingWorkersToRegistry now does), while
+// development keeps the original warn-and-continue.
+func TestEnsureMerchantsService_ArmingFailureOutsideDev(t *testing.T) {
+	appDB, _ := testRuntimeDB(t)
+	ctx := context.Background()
+
+	// A Vault login failure (bad address, nothing listening) fails
+	// merchantsecrets.Build unconditionally, in every environment — unlike the
+	// #667 encryption posture (which dev is deliberately ALLOWED to run
+	// without), this isolates the dev-vs-non-dev ARMING gate itself.
+	failingConfig := func(env string) *config.Config {
+		return &config.Config{
+			Env:            env,
+			MerchantSource: config.MerchantSourceAPI,
+			SecretBackend:  config.SecretBackendVault,
+			Vault:          &config.VaultConfig{Enabled: true, Address: "http://127.0.0.1:1", AuthMethod: "token", Token: "irrelevant"},
+		}
+	}
+
+	t.Run("outside development: fails boot, Merchants stays unarmed", func(t *testing.T) {
+		rt := &Runtime{DB: appDB, Config: failingConfig("production")}
+		err := rt.EnsureMerchantsService(ctx)
+		require.Error(t, err, "arming failure outside development must fail boot (#748)")
+		require.Contains(t, err.Error(), "outside development")
+		require.Nil(t, rt.Merchants)
+	})
+
+	t.Run("development: warns and continues, Merchants stays unarmed but boot succeeds", func(t *testing.T) {
+		rt := &Runtime{DB: appDB, Config: failingConfig("development")}
+		err := rt.EnsureMerchantsService(ctx)
+		require.NoError(t, err, "development keeps the original warn-and-continue")
+		require.Nil(t, rt.Merchants)
+	})
+}
+
+// TestReady_FullStackGreenAndNamesVaultOutage proves Runtime.Ready end to end
+// (#748): green when Postgres, a Vault-backed armed merchants service, and
+// River are all healthy and Redis is simply unconfigured (optional — must
+// never fail readiness); it then names "merchant_secrets" when that SAME
+// armed backend goes unreachable, proving a successful arm at boot is never
+// mistaken for staying healthy.
+func TestReady_FullStackGreenAndNamesVaultOutage(t *testing.T) {
+	appDB, dsn := testRuntimeDB(t)
+	ctx := context.Background()
+	addr, token := vaulttest.Addr(t)
+
+	cfg := &config.Config{
+		Env:            "production",
+		MerchantSource: config.MerchantSourceAPI,
+		SecretBackend:  config.SecretBackendVault,
+		DB:             &config.DBConfig{URL: dsn},
+		Vault:          &config.VaultConfig{Enabled: true, Address: addr, AuthMethod: "token", Token: token},
+	}
+
+	rt := &Runtime{DB: appDB, Config: cfg}
+	require.NoError(t, rt.EnsureMerchantsService(ctx), "arming against a healthy Vault must succeed")
+	require.NotNil(t, rt.Merchants)
+	require.NotNil(t, rt.MerchantSecretPing, "a Vault-backed arm must wire a live-reachability probe")
+
+	producer, producerPool, err := buildRiverProducer(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { producerPool.Close() })
+	rt.RiverProducer = producer
+
+	deps, err := rt.Ready(ctx)
+	require.NoError(t, err, "full stack green, got deps=%+v", deps)
+	for _, d := range deps {
+		require.Truef(t, d.Available, "%s should be available: %v", d.Name, d.Err)
+		require.NotEqual(t, "garnet", d.Name, "unconfigured Redis must not even be probed (#748: required only when configured)")
+	}
+
+	// Simulate the SAME armed backend going unreachable after boot (paused
+	// Vault / network partition): Ready must now name it, not report stale
+	// health from arming time.
+	rt.MerchantSecretPing = func(context.Context) error {
+		return fmt.Errorf("vault unreachable: dial tcp: connection refused")
+	}
+	deps, err = rt.Ready(ctx)
+	require.Error(t, err, "an unreachable Vault-backed merchant-secret store must fail Ready")
+	require.Contains(t, err.Error(), "merchant_secrets")
+	var found bool
+	for _, d := range deps {
+		if d.Name == "merchant_secrets" {
+			found = true
+			require.False(t, d.Available)
+			require.Error(t, d.Err)
+		}
+	}
+	require.True(t, found, "merchant_secrets must appear in the dependency detail")
+}

--- a/internal/app/river_register.go
+++ b/internal/app/river_register.go
@@ -35,8 +35,12 @@ func (r *Runtime) addBillingWorkersToRegistry(ctx context.Context, workers *rive
 	}
 	// #699: workers that resolve per-merchant secrets (provider refresh, Stripe
 	// webhook reconcile) need the merchants service even on embedded hosts that
-	// never build the standalone HTTP server. No-op when already set.
-	r.EnsureMerchantsService(ctx)
+	// never build the standalone HTTP server. No-op when already set. Outside
+	// development a failure to arm is now a boot error (#748) that propagates
+	// through InitRiver -> RunWorkers, which main.go already treats as fatal.
+	if err := r.EnsureMerchantsService(ctx); err != nil {
+		return fmt.Errorf("arm merchants service: %w", err)
+	}
 
 	clock := r.Clock
 	if clock == nil {

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -112,6 +112,13 @@ type Runtime struct {
 	// consumers read it through Merchants like any other store. The DB/Vault
 	// store is never constructed in this mode.
 	ManifestSecrets *merchants.ManifestSecretStore
+	// MerchantSecretPing, when set, live-probes whether the merchant-secret
+	// backend built for Merchants is reachable RIGHT NOW (#748 Ready()) — the
+	// counterpart to Merchants' boot-time arming. Nil when arming hasn't run
+	// (see Ready's armed/unarmed check) or the backend needs no separate
+	// liveness probe (e.g. MODE 1's in-memory manifest plane). Set by
+	// EnsureMerchantsService / the standalone server alongside Merchants.
+	MerchantSecretPing func(ctx context.Context) error
 	// CollectionResolver is the ONE #725 store-armed per-merchant credential
 	// builder (arrears/top-up adapters + #730 manual-rebill NMI clients).
 	CollectionResolver *money.MerchantCollectionAdapterBuilder

--- a/internal/bootstrap/merchant_manifest_integration_test.go
+++ b/internal/bootstrap/merchant_manifest_integration_test.go
@@ -789,8 +789,11 @@ func apiModeReconcileConfig() *config.Config {
 func newMerchantManifestControlPlane(t *testing.T, pool *pgxpool.Pool) *controlplane.ControlPlane {
 	t.Helper()
 	cfg := &config.Config{
-		Env:  "test",
-		Auth: &config.AuthConfig{Issuer: "https://openrails.test"},
+		Env: "test",
+		// MintDisabled: "test" is not a dev-like env (#748: verify-only must be
+		// declared outside development), and this control plane is never asked
+		// to mint in these manifest-reconcile tests.
+		Auth: &config.AuthConfig{Issuer: "https://openrails.test", MintDisabled: true},
 	}
 	cp, err := controlplane.New(context.Background(), cfg, pool)
 	require.NoError(t, err)

--- a/internal/bootstrap/remote_application_integration_test.go
+++ b/internal/bootstrap/remote_application_integration_test.go
@@ -27,9 +27,12 @@ func TestMerchantRemoteApplicationTrustSourcesIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	cfg := &config.Config{
-		Env:  "test",
-		DB:   &config.DBConfig{},
-		Auth: &config.AuthConfig{Issuer: "https://openrails.test"},
+		Env: "test",
+		DB:  &config.DBConfig{},
+		// MintDisabled: this test only exercises cp.Core() directly (never
+		// mints), and "test" is not a dev-like env (#748: verify-only must be
+		// declared outside development, not stumbled into from a missing key).
+		Auth: &config.AuthConfig{Issuer: "https://openrails.test", MintDisabled: true},
 	}
 	cp, err := controlplane.New(ctx, cfg, pool)
 	require.NoError(t, err)

--- a/internal/controlplane/mint_posture_integration_test.go
+++ b/internal/controlplane/mint_posture_integration_test.go
@@ -1,0 +1,60 @@
+//go:build integration
+
+package controlplane
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+)
+
+// TestNew_VerifyOnlyMustBeDeclared proves the #748 posture: verify-only is a
+// DECLARED config choice (auth.mint_disabled=true), never a silent downgrade
+// from a signing-key discovery error. Outside development, a discovery
+// failure without the flag is now a construction (boot) failure — previously
+// it just warned and ran verify-only regardless of environment, making an
+// outage indistinguishable from an intentional posture.
+//
+// Env "test" is used for the non-dev cases (matching the sibling
+// bootstrap-package control-plane tests): it is NOT dev-like per OpenRails'
+// own config.IsDev (so the #748 gate under test treats it as non-development),
+// but IS dev-like per authkit's separate embedded.IsDevEnvironment classifier
+// (so construction doesn't also need a Redis-backed ephemeral store to get
+// past an unrelated authkit environment gate).
+func TestNew_VerifyOnlyMustBeDeclared(t *testing.T) {
+	pool := newBootstrapTestPool(t)
+	ctx := context.Background()
+
+	t.Run("non-dev + no key + mint_disabled unset refuses to boot", func(t *testing.T) {
+		cfg := &config.Config{
+			Env:  "test",
+			Auth: &config.AuthConfig{Issuer: "https://openrails.test"},
+		}
+		_, err := New(ctx, cfg, pool)
+		require.Error(t, err, "an undeclared verify-only posture outside development must refuse to boot")
+		require.Contains(t, err.Error(), "mint_disabled")
+	})
+
+	t.Run("non-dev + no key + mint_disabled=true boots verify-only", func(t *testing.T) {
+		cfg := &config.Config{
+			Env:  "test",
+			Auth: &config.AuthConfig{Issuer: "https://openrails.test", MintDisabled: true},
+		}
+		cp, err := New(ctx, cfg, pool)
+		require.NoError(t, err, "a DECLARED verify-only posture must boot even outside development")
+		require.NotNil(t, cp)
+	})
+
+	t.Run("dev + no key + mint_disabled unset still boots on the ephemeral dev key path", func(t *testing.T) {
+		cfg := &config.Config{
+			Env:  "dev",
+			Auth: &config.AuthConfig{Issuer: "https://openrails.test"},
+		}
+		cp, err := New(ctx, cfg, pool)
+		require.NoError(t, err, "development must keep booting without a declared posture (#748 scopes the hard failure to non-development)")
+		require.NotNil(t, cp)
+	})
+}

--- a/internal/controlplane/service.go
+++ b/internal/controlplane/service.go
@@ -236,20 +236,36 @@ func New(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, opts ...Op
 	// ACTIVE_KEY_ID/ACTIVE_PRIVATE_KEY_PEM) wins; else /vault/auth/keys.json;
 	// else (dev only) an ephemeral dev key.
 	//
-	// The signing key is OPTIONAL (#527/#87): when no key is discoverable (the
-	// prod no-key case — dev always gets an ephemeral one), the control plane runs
-	// as a pure VERIFIER instead of failing the boot. It verifies inbound host-app
-	// delegated tokens and serves RBAC, but cannot MINT tokens (mint paths return
-	// authkit ErrMissingSigner). This is the expected posture for a standalone
-	// deployment with no login-capable users; mounting a key (env/keys.json/vault)
-	// re-enables minting automatically. Key presence is the enablement signal — no
-	// separate knob.
-	keySource, keyErr := resolveControlPlaneKeySource(cfg)
+	// The signing key is OPTIONAL (#527/#87): a control plane with no key runs
+	// as a pure VERIFIER instead of failing the boot — it verifies inbound
+	// host-app delegated tokens and serves RBAC, but cannot MINT tokens (mint
+	// paths return authkit ErrMissingSigner). But verify-only must be a
+	// DECLARED posture, not stumbled into (#748): auth.mint_disabled=true
+	// says so explicitly and skips key discovery entirely (there is nothing to
+	// discover — minting is off by intent). Without that flag, a signing-key
+	// discovery error used to silently downgrade to verify-only with a warn,
+	// indistinguishable from an outage, with mint failures only surfacing at
+	// request time. Now a discovery error is a construction (boot) failure
+	// outside development (mirrors the #667 encryption-posture gate);
+	// development keeps the original warn-and-continue so a from-scratch dev
+	// boot with no keys.json still runs on its ephemeral dev key path (which
+	// itself never errors — see jwtkit.ResolveKeySource).
+	var keySource jwtkit.KeySource
 	verifyOnly := false
-	if keyErr != nil {
-		log.WithError(keyErr).Warn("controlplane: no signing key discovered; running VERIFY-ONLY (token minting disabled)")
-		keySource = nil
+	if cfg.Auth.MintDisabled {
 		verifyOnly = true
+		log.Info("controlplane: auth.mint_disabled=true; running VERIFY-ONLY by declared posture (token minting disabled)")
+	} else {
+		ks, keyErr := resolveControlPlaneKeySource(cfg)
+		switch {
+		case keyErr == nil:
+			keySource = ks
+		case cfg.IsDev():
+			log.WithError(keyErr).Warn("controlplane: no signing key discovered; running VERIFY-ONLY (token minting disabled) — development only; declare auth.mint_disabled=true to make this posture explicit outside development (#748)")
+			verifyOnly = true
+		default:
+			return nil, fmt.Errorf("controlplane: signing key discovery failed outside development (declare auth.mint_disabled=true if verify-only is intentional, #748): %w", keyErr)
+		}
 	}
 
 	options := newOptions(opts)

--- a/internal/http/routes_public.go
+++ b/internal/http/routes_public.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/open-rails/openrails/internal/app"
 	"github.com/open-rails/openrails/internal/http/embedhttp"
 	"github.com/open-rails/openrails/internal/http/router"
 	httproutes "github.com/open-rails/openrails/internal/http/routes"
@@ -64,18 +65,29 @@ func (s *Server) registerStandaloneMetaRoutes(mux *http.ServeMux) {
 	s.handle(mux, http.MethodGet+" /readyz", http.HandlerFunc(s.readyHandler))
 }
 
+// readyHandler serves /health/ready and /readyz. Dependency checks are the
+// SAME ones pkg/embedded.Embedded.Ready runs (#748, internal/app.Runtime.Ready)
+// — standalone and embedded report one shared posture, never two.
 func (s *Server) readyHandler(w http.ResponseWriter, r *http.Request) {
-	services, servicesReady := s.requiredServiceHealth(r.Context())
-	authReady := s.authenticator != nil
+	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+	defer cancel()
+
+	var runtime *app.Runtime
+	if s != nil {
+		runtime = s.runtime
+	}
+	deps, err := runtime.Ready(ctx)
+	authReady := s != nil && s.authenticator != nil
 	verbose := r.URL.Query().Get("verbose") == "1" || strings.EqualFold(r.URL.Query().Get("verbose"), "true")
-	if !servicesReady || !authReady {
+
+	if err != nil || !authReady {
 		resp := map[string]any{
 			"status":  "not_ready",
 			"service": "billing",
 			"auth":    map[string]any{"available": authReady},
 		}
 		if verbose {
-			resp["dependencies"] = services
+			resp["dependencies"] = dependencyStatus(deps)
 		}
 		writeJSON(w, http.StatusServiceUnavailable, resp)
 		return
@@ -87,50 +99,27 @@ func (s *Server) readyHandler(w http.ResponseWriter, r *http.Request) {
 		"auth":    map[string]any{"available": true},
 	}
 	if verbose {
-		resp["dependencies"] = services
+		resp["dependencies"] = dependencyStatus(deps)
 	}
 	writeJSON(w, http.StatusOK, resp)
 }
 
-// requiredServiceHealth pings the required dependencies (postgres, garnet) on
-// demand. /ready is the only consumer of dependency health, so these direct
-// pings replaced the background circuit-breaker manager (#666).
-func (s *Server) requiredServiceHealth(ctx context.Context) (map[string]any, bool) {
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-
-	var pgPing, redisPing func(context.Context) error
-	if s != nil && s.runtime != nil {
-		if s.runtime.DB != nil {
-			if pool := s.runtime.DB.Pool(); pool != nil {
-				pgPing = pool.Ping
-			}
+// dependencyStatus renders Runtime.Ready's per-dependency detail for the
+// verbose /readyz payload (#748).
+func dependencyStatus(deps []app.ReadinessDependency) map[string]any {
+	out := make(map[string]any, len(deps))
+	for _, d := range deps {
+		if d.Available {
+			out[d.Name] = map[string]any{"available": true}
+			continue
 		}
-		if rdb := s.runtime.RedisClient; rdb != nil {
-			redisPing = func(c context.Context) error { return rdb.Ping(c).Err() }
+		entry := map[string]any{"available": false}
+		if d.Err != nil {
+			entry["last_error"] = d.Err.Error()
 		}
+		out[d.Name] = entry
 	}
-
-	services := map[string]any{}
-	allReady := true
-	for _, dep := range []struct {
-		name string
-		ping func(context.Context) error
-	}{{"postgres", pgPing}, {"garnet", redisPing}} {
-		switch {
-		case dep.ping == nil:
-			services[dep.name] = map[string]any{"available": false, "reason": "not_configured"}
-			allReady = false
-		default:
-			if err := dep.ping(ctx); err != nil {
-				services[dep.name] = map[string]any{"available": false, "last_error": err.Error()}
-				allReady = false
-			} else {
-				services[dep.name] = map[string]any{"available": true}
-			}
-		}
-	}
-	return services, allReady
+	return out
 }
 
 func writeJSON(w http.ResponseWriter, code int, body any) {

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -214,6 +214,9 @@ func New(deps Dependencies) (*Server, error) {
 		s.merchants = tsvc
 		if deps.Runtime != nil {
 			deps.Runtime.Merchants = tsvc
+			// #748: live-reachability probe for /readyz (nil-safe no-op for the
+			// manifest plane / DB-backed store — only a Vault-backed store checks).
+			deps.Runtime.MerchantSecretPing = secretBackend.Ping
 			// #661: gate the provider route surface on what OpenRails can actually do.
 			deps.Runtime.RouteCapabilities = &routesurface.RuntimeCapabilities{
 				SolanaCanSign: secretBackend.SolanaCanSign,

--- a/internal/merchantsecrets/ready_integration_test.go
+++ b/internal/merchantsecrets/ready_integration_test.go
@@ -1,0 +1,69 @@
+//go:build integration
+
+package merchantsecrets
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/integrations/vault/vaulttest"
+)
+
+// unreachableVaultClient points at an address nothing listens on, so any
+// logical call fails fast (connection refused) instead of hanging.
+func unreachableVaultClient(t *testing.T) *vaultapi.Client {
+	t.Helper()
+	apiCfg := vaultapi.DefaultConfig()
+	apiCfg.Address = "http://127.0.0.1:1"
+	apiCfg.HttpClient.Timeout = 2 * time.Second
+	client, err := vaultapi.NewClient(apiCfg)
+	require.NoError(t, err)
+	client.SetToken("irrelevant")
+	return client
+}
+
+// TestStorePing proves the #748 live-reachability probe backing
+// Runtime.Ready's merchant-secret check: a DB-backed store's Ping is always a
+// no-op (arming and liveness collapse to the same DB ping), a reachable
+// Vault-backed store's Ping succeeds, and — critically — a Vault that goes
+// unreachable AFTER a successful Build (paused, network partition) fails
+// Ping. Arming succeeding at boot must not be mistaken for staying healthy.
+func TestStorePing(t *testing.T) {
+	pool, ctx := startSecretsPostgres(t)
+
+	t.Run("DB-backed store: Ping is always a no-op", func(t *testing.T) {
+		store, err := Build(ctx, &config.Config{Env: "dev", MerchantSource: config.MerchantSourceAPI, SecretBackend: config.SecretBackendDB}, pool)
+		require.NoError(t, err)
+		require.NoError(t, store.Ping(ctx))
+	})
+
+	t.Run("Vault-backed store: reachable Vault pings clean", func(t *testing.T) {
+		addr, token := vaulttest.Addr(t)
+		store, err := Build(ctx, vaultBackedConfig("production", addr, token), pool)
+		require.NoError(t, err)
+		require.NoError(t, store.Ping(ctx))
+	})
+
+	t.Run("Vault-backed store: unreachable Vault fails Ping naming the dependency", func(t *testing.T) {
+		addr, token := vaulttest.Addr(t)
+		store, err := Build(ctx, vaultBackedConfig("production", addr, token), pool)
+		require.NoError(t, err, "Build succeeds against a healthy Vault")
+		require.NoError(t, store.Ping(ctx), "sanity: healthy before we simulate an outage")
+
+		// Simulate Vault going unreachable AFTER boot (paused / network
+		// partition) on the SAME Store, without disturbing the shared
+		// vaulttest container other tests reuse.
+		store.vclient = unreachableVaultClient(t)
+
+		pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		err = store.Ping(pingCtx)
+		require.Error(t, err, "an unreachable Vault must fail Ping, not just Build")
+		require.Contains(t, err.Error(), "vault unreachable")
+	})
+}

--- a/internal/merchantsecrets/store.go
+++ b/internal/merchantsecrets/store.go
@@ -35,9 +35,38 @@ type Store struct {
 	SecretWrite   bool
 	// VaultAuth is the #751 auth-health probe for the Vault client backing
 	// this store: nil when Vault isn't enabled, non-nil (call .AuthState())
-	// otherwise. NOT wired into any readiness surface by this package — #748
-	// is expected to consume it from a future Embedded.Ready.
+	// otherwise. Ping folds it in so readiness sees auth death too.
 	VaultAuth *vault.Supervisor
+	// vclient is the authenticated Vault client Build logged in with, kept ONLY
+	// when Vault actually serves the merchant-secret KV store (secret_backend=vault).
+	// nil for the DB-backed store and for BuildManifest — Ping is then a no-op,
+	// since those backends have no separate liveness signal beyond the runtime DB
+	// ping / in-memory plane (#748 Ready()).
+	vclient *vaultapi.Client
+}
+
+// Ping reports whether the merchant-secret backend is usable RIGHT NOW — the
+// live counterpart to Build's construction-time capability probe (#748).
+// DB-backed stores need no separate check (nil receiver client -> always nil,
+// the runtime DB ping already covers them). Vault-backed stores first check
+// the #751 auth supervisor (a dead/unrecoverable token is a readiness failure
+// even while the server is reachable), then re-run the same
+// sys/capabilities-self probe Build used, on the SAME authenticated client, so
+// a Vault that goes unreachable/sealed/paused AFTER boot is caught by
+// readiness instead of only surfacing at request time.
+func (s *Store) Ping(ctx context.Context) error {
+	if s == nil || s.vclient == nil {
+		return nil
+	}
+	if s.VaultAuth != nil {
+		if err := s.VaultAuth.AuthState(); err != nil {
+			return fmt.Errorf("vault auth: %w", err)
+		}
+	}
+	if _, err := vault.SelfCapabilities(ctx, s.vclient, vaultKVMount); err != nil {
+		return fmt.Errorf("vault unreachable: %w", err)
+	}
+	return nil
 }
 
 // deriveRouteGates computes the advisory route-gating signals. localKeys: the
@@ -134,6 +163,7 @@ func Build(ctx context.Context, cfg *config.Config, pool *db.Pool) (*Store, erro
 			SolanaCanSign: solanaCanSign,
 			SecretWrite:   secretWrite,
 			VaultAuth:     vaultAuth,
+			vclient:       vclient,
 		}, nil
 	}
 

--- a/pkg/embedded/embedded.go
+++ b/pkg/embedded/embedded.go
@@ -117,7 +117,7 @@ func (e *Embedded) App() *app.App {
 // A zero RouteSets slice uses EmbeddedDefaultRouteSets.
 //
 // Note: billing health endpoints are not exposed in embedded mode.
-// If a host wants billing readiness, call IsBillingReady and include it in the host's /readyz.
+// If a host wants billing readiness, call (*Embedded).Ready (#748) and include it in the host's /readyz.
 type HTTPHandlerOptions struct {
 	RouteSets      []RouteSet
 	ProviderRoutes *ProviderRoutes

--- a/pkg/embedded/ready.go
+++ b/pkg/embedded/ready.go
@@ -1,0 +1,25 @@
+package embedded
+
+import (
+	"context"
+	"fmt"
+)
+
+// Ready is the embedded engine's REAL, supported readiness probe (#748) —
+// what the HTTPHandlerOptions doc above used to point hosts at under the name
+// IsBillingReady, which never existed. Call this from the host's own
+// /readyz/health-check handler.
+//
+// It delegates to the internal/app.Runtime checks shared with the standalone
+// surface's /readyz, so both report the SAME posture: Postgres, Redis (only
+// when configured), the merchant-secret backend (armed + live-reachable), and
+// River producer presence. Returns a wrapped error naming the first failing
+// dependency; nil when every dependency the running configuration actually
+// depends on is healthy.
+func (e *Embedded) Ready(ctx context.Context) error {
+	if e == nil || e.app == nil || e.app.Runtime == nil {
+		return fmt.Errorf("embedded: not initialized")
+	}
+	_, err := e.app.Runtime.Ready(ctx)
+	return err
+}


### PR DESCRIPTION
## Summary

Closes four "degraded states that boot healthy" (issue #748):

- **`Embedded.Ready(ctx) error`** (new `pkg/embedded/ready.go`) is the real, supported readiness probe — `embedded.go`'s doc used to point hosts at a nonexistent `IsBillingReady`; it now points here. The actual dependency checks live in a new `internal/app.Runtime.Ready` (new `internal/app/ready.go`), shared by standalone's `/readyz`/`/health/ready` (`internal/http/routes_public.go` rewired; `requiredServiceHealth` deleted) so both surfaces report **one** posture: Postgres, Redis (**only when configured** — it was previously required unconditionally even though Redis is optional everywhere else in OpenRails), the merchant-secret backend (armed + live-reachable), and River producer presence. Returns per-dependency detail plus a wrapped error naming the first failure.
- **Merchants-service arming is fail-loud outside development** (`internal/app/merchants_wiring.go`): `EnsureMerchantsService` now returns an error; outside `cfg.IsDev()` a secret-store build failure is a boot error (mirrors #667's encryption-posture gate) instead of warn-and-continue with webhooks silently 503ing behind a green `/readyz`. The error propagates through `river_register.go` → `InitRiver` → `RunWorkers`, which `cmd/openrails` already treats as fatal. Development keeps the original warn. A Vault-backed arm also wires `Runtime.MerchantSecretPing` (new `merchantsecrets.Store.Ping`) so `Ready()` catches a Vault that goes unreachable **after** a successful boot-time arm — arming succeeding once is not mistaken for staying healthy.
- **Verify-only must be declared** (`internal/controlplane/service.go`): new `auth.mint_disabled` config field (`config.AuthConfig.MintDisabled`). Declared → skips signing-key discovery entirely (nothing to discover, minting is off by intent). Undeclared → a signing-key discovery error is now a construction (boot) failure outside development — previously it silently downgraded to verify-only with a warn in every environment, indistinguishable from an outage. Development keeps the ephemeral-dev-key path (which itself never errors).
- **Symmetric credential-mode failure** (`config.go` `validateStripeKeyForTestMode`): a live key under `test_mode=true` already hard-failed; a test key under `test_mode=false` now also hard-fails outside development (previously: warn + silently clear the key, rail off). Development keeps the warn-and-clear.

## Config keys added
- `auth.mint_disabled` (bool, env `AUTH_MINT_DISABLED`) — declares the control plane verify-only.

## Test plan
- [x] `gofmt -l`, `go vet ./...` and `-tags integration`, `go build ./...` and `-tags integration` — all clean.
- [x] `go test ./...` — green.
- [x] `go test -tags integration ./internal/controlplane/...` (new `mint_posture_integration_test.go`: undeclared verify-only refuses to boot outside dev / `mint_disabled=true` boots verify-only outside dev / dev still boots on the ephemeral-key path).
- [x] `go test -tags integration ./internal/merchantsecrets/...` (new `ready_integration_test.go`: `Store.Ping` no-op for DB-backed, clean against a real vaulttest Vault, fails once that same Vault is made unreachable post-boot).
- [x] `go test -tags integration ./internal/app/...` (new `ready_integration_test.go`: arming failure outside dev fails boot / dev warns and continues; full-stack green with a real Vault-backed arm, River producer, and no Redis configured — then names `merchant_secrets` once the armed Vault goes unreachable).
- [x] `go test -tags integration ./internal/bootstrap/... ./embed/... ./internal/integrationharness/... ./internal/http/... ./pkg/embedded/... ./tests/...` (`-run TestHealthEndpoints`) — all green.
- Confirmed one pre-existing, unrelated integration failure (`TestFindingsQueueApproveCCBillCancelAndRefund` in `internal/http/handlers`) reproduces identically on `origin/master` with zero diff in that code path — not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)