### PR TITLE
vault auth re-auth supervisor + 403 resilience (#751)

### DIFF
--- a/internal/integrations/vault/auth.go
+++ b/internal/integrations/vault/auth.go
@@ -2,12 +2,19 @@ package vault
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"math/rand"
+	"net/http"
 	"os"
 	"strings"
+	"sync"
+	"time"
 
 	vaultapi "github.com/hashicorp/vault/api"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/open-rails/openrails/config"
 )
 
 // Config configures the Vault client + auth for a managed deployment. It is kept
@@ -20,9 +27,17 @@ type Config struct {
 	// "token" when a Token is supplied, otherwise it is an error.
 	AuthMethod string
 	// Token is a pre-issued Vault token (VAULT_TOKEN). Used directly when
-	// AuthMethod == "token" (dev / e2e). Not renewed by us — the operator owns it.
+	// AuthMethod == "token" (dev / e2e). Renewed on the same watcher machinery
+	// as approle/kubernetes when Vault reports it renewable (#751); otherwise
+	// see Login's token-mode doc for the (no-recovery) failure posture.
 	Token string
-	// AppRole credentials (AuthMethod == "approle").
+	// AppRole credentials (AuthMethod == "approle"). SecretID is re-resolved
+	// fresh on every login/re-login attempt (#751 — see resolveApproleSecretID):
+	// when it is delivered via the operator-mounted-secret-file convention
+	// (config/secret_files.go — a file named VAULT_SECRET_ID), the CURRENT
+	// file content is used every time, so a rotated secret_id is picked up
+	// the moment re-auth needs it; otherwise this static value is used
+	// unchanged.
 	RoleID   string
 	SecretID string
 	// Kubernetes auth (AuthMethod == "kubernetes").
@@ -35,22 +50,39 @@ type Config struct {
 
 const defaultK8sJWTPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
+// reauthSecretIDEnvVar is the operator-mounted-secret-file name (filename =
+// env-var name, config/secret_files.go's convention) resolveApproleSecretID
+// re-reads on every login/re-login attempt when the approle secret_id is
+// file-delivered.
+const reauthSecretIDEnvVar = "VAULT_SECRET_ID"
+
 // Login authenticates the OpenRails process to Vault (NOT per-merchant — merchant
 // isolation is enforced by the (tenant, name) addressing) and returns a client
-// whose token is kept fresh by a background renewer until ctx is cancelled.
-func Login(ctx context.Context, cfg Config) (*vaultapi.Client, error) {
+// whose token is kept fresh by a background Supervisor until ctx is cancelled.
+//
+// The returned Supervisor is the #751 "supervisor calling Login again" a stale
+// comment on the old renew() promised but never built: it renews the current
+// token/lease up to Vault's MAX TTL exactly as before, and now ALSO
+// re-authenticates automatically when that is no longer possible (see
+// Supervisor's doc). Callers that only need the client (tests standing up a
+// one-off root/dedicated-container connection, for instance) may discard it;
+// production callers should keep it to feed a readiness probe (AuthState) and
+// to wire KVv2Adapter.WithReauthTrigger for immediate 403-triggered re-auth.
+func Login(ctx context.Context, cfg Config) (*vaultapi.Client, *Supervisor, error) {
 	apiCfg := vaultapi.DefaultConfig()
 	if strings.TrimSpace(cfg.Address) != "" {
 		apiCfg.Address = cfg.Address
 	}
 	client, err := vaultapi.NewClient(apiCfg)
 	if err != nil {
-		return nil, fmt.Errorf("vault: new client: %w", err)
+		return nil, nil, fmt.Errorf("vault: new client: %w", err)
 	}
 
-	// Token auth short-circuits the login flow: the operator supplied a token
-	// directly (dev server, e2e, or a sidecar-managed token). We set it and do
-	// not run a renewer — its lifecycle is owned outside the process.
+	// Token auth short-circuits the credential-login flow: the operator
+	// supplied a token directly (dev server, e2e, or a sidecar-managed
+	// token). There is no login material to redo if it ever dies, so its
+	// Supervisor renews-if-renewable and otherwise only detects+alarms (#751
+	// task 3) — see startStaticTokenSupervisor.
 	method := strings.ToLower(strings.TrimSpace(cfg.AuthMethod))
 	if method == "" && strings.TrimSpace(cfg.Token) != "" {
 		method = "token"
@@ -60,36 +92,52 @@ func Login(ctx context.Context, cfg Config) (*vaultapi.Client, error) {
 		// boundary (config vault.token maps from VAULT_TOKEN); absence fails here.
 		token := strings.TrimSpace(cfg.Token)
 		if token == "" {
-			return nil, fmt.Errorf("vault: token auth selected but no token (set vault.token; env VAULT_TOKEN feeds it via config.Load)")
+			return nil, nil, fmt.Errorf("vault: token auth selected but no token (set vault.token; env VAULT_TOKEN feeds it via config.Load)")
 		}
 		client.SetToken(token)
-		return client, nil
+		sup, err := startStaticTokenSupervisor(ctx, client, token)
+		if err != nil {
+			return nil, nil, err
+		}
+		return client, sup, nil
 	}
 
 	secret, err := login(ctx, client, cfg)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if secret == nil || secret.Auth == nil || secret.Auth.ClientToken == "" {
-		return nil, fmt.Errorf("vault: login returned no token")
+		return nil, nil, fmt.Errorf("vault: login returned no token")
 	}
 	client.SetToken(secret.Auth.ClientToken)
 
-	if secret.Auth.Renewable {
-		go renew(ctx, client, secret)
-	}
-	return client, nil
+	sup := &Supervisor{client: client, cfg: cfg, reauthable: true, kick: make(chan struct{}, 1)}
+	// Supervise unconditionally, even when the initial secret is (unusually)
+	// non-renewable: the watcher still waits out its lease and signals done
+	// at expiry, which is exactly the re-auth trigger (#751) — previously a
+	// non-renewable initial secret meant NO watcher at all, and the token was
+	// never refreshed by any means.
+	go sup.superviseLoop(ctx, secret)
+	return client, sup, nil
 }
 
 func login(ctx context.Context, client *vaultapi.Client, cfg Config) (*vaultapi.Secret, error) {
 	switch strings.ToLower(strings.TrimSpace(cfg.AuthMethod)) {
 	case "approle":
 		mount := firstNonEmpty(cfg.AppRoleMount, "approle")
+		secretID, err := resolveApproleSecretID(cfg.SecretID)
+		if err != nil {
+			return nil, fmt.Errorf("vault: resolve approle secret_id: %w", err)
+		}
 		return client.Logical().WriteWithContext(ctx, "auth/"+mount+"/login", map[string]any{
 			"role_id":   cfg.RoleID,
-			"secret_id": cfg.SecretID,
+			"secret_id": secretID,
 		})
 	case "kubernetes":
+		// Re-read from disk on EVERY call (including every re-auth attempt):
+		// kubelet rotates this file in place, so re-reading is what lets
+		// re-login (#751) pick up a rotated service-account token instead of
+		// replaying whatever was on disk at process boot.
 		jwtPath := firstNonEmpty(cfg.K8sJWTPath, defaultK8sJWTPath)
 		jwt, err := os.ReadFile(jwtPath)
 		if err != nil {
@@ -105,10 +153,168 @@ func login(ctx context.Context, client *vaultapi.Client, cfg Config) (*vaultapi.
 	}
 }
 
-// renew keeps the auth token alive; on terminal failure it logs so the operator
-// (or a supervisor calling Login again) can react. It never panics.
-func renew(ctx context.Context, client *vaultapi.Client, secret *vaultapi.Secret) {
-	watcher, err := client.NewLifetimeWatcher(&vaultapi.LifetimeWatcherInput{Secret: secret})
+// resolveApproleSecretID resolves the CURRENT approle secret_id on every
+// login/re-login attempt (#751 task 2), mirroring config.Load's own
+// operator-mounted-secret-file convention (config/secret_files.go: a file
+// named after the env var, typically rendered by a Vault Agent template or a
+// CSI driver into /vault/secrets):
+//
+//   - a VAULT_SECRET_ID file under the mounted secrets dir: its CURRENT
+//     content, re-read fresh every call via config.SecretFiles() (the SAME
+//     accessor config.Load uses), so operator rotation is visible to the
+//     very next re-auth attempt;
+//   - otherwise: staticFallback, the value config.Load already resolved once
+//     at boot (an env var or a literal config value — either way frozen for
+//     the process lifetime, so there is nothing to re-read).
+//
+// This deliberately does NOT re-check the env var directly (#712: env is
+// read exactly once, at the binary boundary, by the config package — no
+// other package may call os.Getenv). Practically this never matters: the
+// file and env conventions are alternative delivery mechanisms for the same
+// slot, not meant to be set together. In the pathological case where an
+// operator sets both, config.Load's boot-time precedence (env wins) governs
+// the INITIAL login; a re-auth that finds the file still mounted will use
+// its content rather than the frozen env value — a documented, accepted
+// corner case, not a silent bug.
+func resolveApproleSecretID(staticFallback string) (string, error) {
+	files, err := config.SecretFiles()
+	if err != nil {
+		return "", fmt.Errorf("re-read mounted secret files: %w", err)
+	}
+	if v, ok := files[reauthSecretIDEnvVar]; ok {
+		return v, nil
+	}
+	return staticFallback, nil
+}
+
+// Supervisor is the "supervisor calling Login again" a stale comment on the
+// old renew() promised but never built (#751). It owns keeping ONE Login'd
+// Vault client authenticated for the life of the ctx Login was called with:
+//
+//   - it runs Vault's own LifetimeWatcher to renew the current token/lease up
+//     to its Vault-enforced MAX TTL — unchanged from before this issue;
+//   - when the watcher ends (MAX TTL reached, the secret was never
+//     renewable, or NotifyPermissionDenied confirms the token already died),
+//     it re-authenticates with the SAME credential method, re-resolving
+//     credential material fresh on every attempt (see resolveApproleSecretID
+//     and the kubernetes JWT re-read in login()), backing off exponentially
+//     with jitter between attempts and logging loudly on every failure;
+//   - on a successful re-auth it swaps the fresh token onto the SAME
+//     *vaultapi.Client every consumer already holds and starts a new
+//     watcher — see reauthWithBackoff's doc for why that swap is safe for
+//     concurrent readers;
+//   - a bare static token (VAULT_TOKEN) has no credential material to redo a
+//     login with, so its Supervisor only renews (when Vault reports the
+//     token renewable) or detects+alarms (when it does not) — see
+//     startStaticTokenSupervisor.
+//
+// AuthState is the #751 task-4 health probe: nil while currently
+// authenticated, the most recent failure otherwise. Exported so a readiness
+// probe (tracked separately in #748) can consume it without depending on any
+// of this package's internals beyond this one method.
+type Supervisor struct {
+	client *vaultapi.Client
+	cfg    Config
+
+	// reauthable is true only for AppRole/Kubernetes logins, which have
+	// credential material login() can redo. A bare token has none — see
+	// startStaticTokenSupervisor, which leaves this false (the zero value).
+	reauthable bool
+
+	mu  sync.Mutex
+	err error
+
+	// kick lets NotifyPermissionDenied end the CURRENT watch early — e.g. a
+	// runtime 403 whose self-lookup confirms the token is already dead —
+	// instead of waiting out its nominal remaining lease. Buffered(1):
+	// coalesces a burst of concurrent notifications into a single wakeup.
+	kick chan struct{}
+}
+
+// AuthState reports the Supervisor's current health: nil while Vault auth is
+// believed good, the most recent re-auth/detection failure otherwise. Safe to
+// call on a nil *Supervisor (reports healthy) so callers that discarded it
+// (one-off test clients) don't need a nil check.
+func (s *Supervisor) AuthState() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.err
+}
+
+func (s *Supervisor) setErr(err error) {
+	s.mu.Lock()
+	s.err = err
+	s.mu.Unlock()
+}
+
+// NotifyPermissionDenied lets a consumer (KVv2Adapter.WithReauthTrigger wires
+// this onto the KV adapter) report a Vault permission-denied response it just
+// observed, so a dead token is caught immediately instead of waiting out the
+// current lease/renewal window (#751 task 5) — turning the old 15-MINUTE-LATE,
+// cache-driven surprise into an immediate, correctly-attributed one.
+//
+// A 403 alone does not mean the TOKEN is dead: Vault returns the identical
+// permission-denied response for a live, healthy token reading a path its
+// policy simply doesn't grant. The distinguishing signal this error shape
+// allows: re-run a self-lookup with the SAME token. If the self-lookup ALSO
+// fails, the token itself is gone — trigger re-auth. If the self-lookup
+// succeeds, the token is alive and the original 403 was a legitimate policy
+// boundary on that one path; re-authenticating would reproduce the identical
+// policy and accomplish nothing, so this is a deliberate no-op (never treat a
+// scoped authorization denial as an auth-health problem).
+func (s *Supervisor) NotifyPermissionDenied(err error) {
+	if s == nil || s.client == nil || !IsPermissionDenied(err) {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, lookupErr := s.client.Auth().Token().LookupSelfWithContext(ctx); lookupErr != nil {
+		deadErr := fmt.Errorf("vault: auth token appears dead — a permission-denied read (%v) was followed by a failed self-lookup on the same token (%w)", err, lookupErr)
+		log.WithError(deadErr).Error("vault: detected auth-token death from a runtime read; triggering immediate re-auth")
+		s.setErr(deadErr)
+		select {
+		case s.kick <- struct{}{}:
+		default: // a kick is already pending/being handled
+		}
+		return
+	}
+	log.WithError(err).Debug("vault: permission-denied read, but the token itself still checks out (self-lookup ok) — treating as an in-policy denial, not a re-auth trigger")
+}
+
+// superviseLoop watches secret to the end of its life, then either
+// re-authenticates (credential-backed methods) or settles into the terminal
+// failed state (static tokens have nothing to redo a login with), repeating
+// for as long as ctx lives.
+func (s *Supervisor) superviseLoop(ctx context.Context, secret *vaultapi.Secret) {
+	for {
+		s.watchOnce(ctx, secret)
+		if ctx.Err() != nil {
+			return
+		}
+		if !s.reauthable {
+			s.setErr(fmt.Errorf("vault: static token auth has no re-authentication path and its lease/renewal has ended — Vault access WILL fail until the operator issues a fresh token (vault.token / VAULT_TOKEN) and restarts the process"))
+			log.Error("vault: static Vault token expired or was revoked with no automatic recovery possible — issue a new token and restart")
+			return
+		}
+		newSecret, ok := s.reauthWithBackoff(ctx)
+		if !ok {
+			return
+		}
+		s.setErr(nil)
+		secret = newSecret
+	}
+}
+
+// watchOnce runs a LifetimeWatcher for secret to completion: naturally (the
+// watcher's DoneCh, at Vault's MAX TTL or on a non-renewable lease), on ctx
+// cancellation, or on an external kick (NotifyPermissionDenied) proving the
+// token is already dead, in which case there is no point waiting out its
+// nominal remaining lease.
+func (s *Supervisor) watchOnce(ctx context.Context, secret *vaultapi.Secret) {
+	watcher, err := s.client.NewLifetimeWatcher(&vaultapi.LifetimeWatcherInput{Secret: secret})
 	if err != nil {
 		log.WithError(err).Warn("vault: could not start token renewer")
 		return
@@ -120,15 +326,127 @@ func renew(ctx context.Context, client *vaultapi.Client, secret *vaultapi.Secret
 		select {
 		case <-ctx.Done():
 			return
+		case <-s.kick:
+			return
 		case err := <-watcher.DoneCh():
 			if err != nil {
-				log.WithError(err).Warn("vault: token renewal stopped; re-auth required")
+				log.WithError(err).Info("vault: token renewal ended; re-authenticating")
 			}
 			return
 		case <-watcher.RenewCh():
-			// renewed; continue
+			// renewed; still healthy.
 		}
 	}
+}
+
+// reauthWithBackoff re-runs login with exponential backoff + jitter until it
+// succeeds or ctx is cancelled, logging loudly (repeated ERROR, not once) on
+// every failed attempt — the operator-facing signal #751 exists to create,
+// replacing 15-minutes-later cache-driven surprise with an immediate one.
+//
+// On success it swaps the fresh token onto the SAME *vaultapi.Client every
+// consumer already holds via client.SetToken. This is safe for concurrent
+// readers: vaultapi.Client guards SetToken/Token with its own internal
+// modifyLock (sync.RWMutex; hashicorp/vault/api client.go), so a swap can
+// never race a concurrent Token() read into a torn value. A request already
+// in flight read whatever token was current when IT built its request; any
+// request issued after the swap picks up the fresh token. No consumer (the KV
+// adapter, the Transit adapter, the capability prober) needs to be told the
+// token changed or hold a lock of its own.
+func (s *Supervisor) reauthWithBackoff(ctx context.Context) (*vaultapi.Secret, bool) {
+	const (
+		initialBackoff = 2 * time.Second
+		maxBackoff     = 2 * time.Minute
+	)
+	backoff := initialBackoff
+	for attempt := 1; ; attempt++ {
+		secret, err := login(ctx, s.client, s.cfg)
+		if err == nil && secret != nil && secret.Auth != nil && secret.Auth.ClientToken != "" {
+			s.client.SetToken(secret.Auth.ClientToken)
+			log.WithField("attempts", attempt).Info("vault: re-authentication succeeded")
+			return secret, true
+		}
+		if err == nil {
+			err = fmt.Errorf("vault: re-login returned no token")
+		}
+		s.setErr(fmt.Errorf("vault: re-authentication attempt %d failed: %w", attempt, err))
+		log.WithError(err).WithField("attempt", attempt).
+			Error("vault: RE-AUTHENTICATION FAILED — merchant secret / signing operations are degraded until this clears; retrying with backoff")
+
+		wait := backoff/2 + time.Duration(rand.Int63n(int64(backoff/2)+1))
+		select {
+		case <-ctx.Done():
+			return nil, false
+		case <-time.After(wait):
+		}
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+}
+
+// startStaticTokenSupervisor builds the Supervisor for token-mode auth (#751
+// task 3). A bare token has no login material to redo, so its Supervisor
+// never re-authenticates — it only renews (if Vault reports the token
+// renewable) or detects and loudly alarms (if not):
+//
+//   - renewable: the SAME watch loop as approle/kubernetes keeps it alive
+//     indefinitely on Vault's own renewal machinery. If renewal eventually
+//     exhausts (Vault enforces a max TTL on periodic tokens too), there is
+//     still nothing to re-authenticate WITH, so the terminal state is the
+//     loud failure below.
+//   - non-renewable with a real TTL: a prominent boot-time warning names the
+//     exact expiry deadline — no silent decay. A background watch flips
+//     AuthState() to a loud, permanent error right as the token's lease
+//     ends, so a runtime 403 is never the first signal.
+//   - non-renewable with TTL == 0 (Vault's shape for non-expiring root/dev
+//     tokens): nothing to watch — these keep working silently, as before.
+func startStaticTokenSupervisor(ctx context.Context, client *vaultapi.Client, token string) (*Supervisor, error) {
+	sup := &Supervisor{client: client, kick: make(chan struct{}, 1)}
+
+	lookup, err := client.Auth().Token().LookupSelfWithContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("vault: token auth: look up token self: %w", err)
+	}
+	renewable, err := lookup.TokenIsRenewable()
+	if err != nil {
+		return nil, fmt.Errorf("vault: token auth: parse renewable: %w", err)
+	}
+	ttl, err := lookup.TokenTTL()
+	if err != nil {
+		return nil, fmt.Errorf("vault: token auth: parse ttl: %w", err)
+	}
+
+	switch {
+	case renewable:
+		secret := &vaultapi.Secret{Auth: &vaultapi.SecretAuth{ClientToken: token, Renewable: true, LeaseDuration: int(ttl.Seconds())}}
+		go sup.superviseLoop(ctx, secret)
+	case ttl > 0:
+		deadline := time.Now().Add(ttl)
+		log.Warnf("vault: token auth uses a NON-RENEWABLE token expiring at %s (in %s) — Vault access WILL stop then with NO automatic recovery; rotate vault.token/VAULT_TOKEN and restart the process before that deadline", deadline.Format(time.RFC3339), ttl.Round(time.Second))
+		secret := &vaultapi.Secret{Auth: &vaultapi.SecretAuth{ClientToken: token, Renewable: false, LeaseDuration: int(ttl.Seconds())}}
+		go sup.superviseLoop(ctx, secret)
+	default:
+		// Non-expiring root/dev token: nothing to watch; keeps working
+		// silently forever, matching the documented contract.
+	}
+	return sup, nil
+}
+
+// IsPermissionDenied reports whether err is a Vault permission-denied
+// response (HTTP 403) — the shape NotifyPermissionDenied's distinguishing
+// check is built on. Exported so other callers wrapping Vault operations can
+// reuse the SAME classification instead of re-guessing at error text.
+func IsPermissionDenied(err error) bool {
+	if err == nil {
+		return false
+	}
+	var rerr *vaultapi.ResponseError
+	if errors.As(err, &rerr) {
+		return rerr.StatusCode == http.StatusForbidden
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "permission denied")
 }
 
 func firstNonEmpty(vals ...string) string {

--- a/internal/integrations/vault/auth_integration_test.go
+++ b/internal/integrations/vault/auth_integration_test.go
@@ -1,17 +1,21 @@
 //go:build integration
 
-// Real-Vault auth + token-lifecycle integration tests (#724). These replace the
-// former httptest Vault mock in auth_test.go: static-token and AppRole login are
-// asserted against the vaulttest container, and the LifetimeWatcher renewal path
-// (auth.go renew) is proven with a real short-period token.
+// Real-Vault auth + re-auth-lifecycle integration tests (#724, #751). These
+// replace the former httptest Vault mock in auth_test.go: static-token and
+// AppRole login, the LifetimeWatcher renewal path, and the #751 Supervisor's
+// automatic re-authentication (past max TTL, and on a revoked/dead token) are
+// all proven against the vaulttest container — never a mock.
 package vault
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"testing"
 	"time"
+
+	vaultapi "github.com/hashicorp/vault/api"
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 
 	"github.com/open-rails/openrails/internal/integrations/vault/vaulttest"
 )
@@ -23,12 +27,15 @@ func TestLogin_TokenAgainstRealVault(t *testing.T) {
 	ctx := context.Background()
 	addr, rootToken := vaulttest.Addr(t)
 
-	client, err := Login(ctx, Config{Address: addr, AuthMethod: "token", Token: rootToken})
+	client, sup, err := Login(ctx, Config{Address: addr, AuthMethod: "token", Token: rootToken})
 	if err != nil {
 		t.Fatalf("Login(token): %v", err)
 	}
 	if client.Token() != rootToken {
 		t.Fatalf("client token = %q, want the supplied token", client.Token())
+	}
+	if err := sup.AuthState(); err != nil {
+		t.Fatalf("AuthState() = %v, want nil for a healthy root token", err)
 	}
 
 	kv := NewKVv2Adapter(client, "secret")
@@ -51,7 +58,7 @@ func TestLogin_TokenAgainstRealVault(t *testing.T) {
 func TestLogin_TokenInferredFromTokenOnly(t *testing.T) {
 	ctx := context.Background()
 	addr, rootToken := vaulttest.Addr(t)
-	client, err := Login(ctx, Config{Address: addr, Token: rootToken})
+	client, _, err := Login(ctx, Config{Address: addr, Token: rootToken})
 	if err != nil {
 		t.Fatalf("Login(inferred token): %v", err)
 	}
@@ -68,7 +75,7 @@ func TestLogin_AppRole(t *testing.T) {
 	addr, _ := vaulttest.Addr(t)
 	roleID, secretID := vaulttest.EnsureAppRole(t, "openrails-it-kv", "openrails-approle-kv", vaulttest.PolicyKVReadWrite, nil)
 
-	client, err := Login(ctx, Config{Address: addr, AuthMethod: "approle", RoleID: roleID, SecretID: secretID})
+	client, _, err := Login(ctx, Config{Address: addr, AuthMethod: "approle", RoleID: roleID, SecretID: secretID})
 	if err != nil {
 		t.Fatalf("Login(approle): %v", err)
 	}
@@ -90,62 +97,222 @@ func TestLogin_AppRole(t *testing.T) {
 func TestLogin_AppRoleBadCredentialsFailsLoudly(t *testing.T) {
 	addr, _ := vaulttest.Addr(t)
 	roleID, _ := vaulttest.EnsureAppRole(t, "openrails-it-kv", "openrails-approle-kv", vaulttest.PolicyKVReadWrite, nil)
-	if _, err := Login(context.Background(), Config{Address: addr, AuthMethod: "approle", RoleID: roleID, SecretID: "wrong"}); err == nil {
+	if _, _, err := Login(context.Background(), Config{Address: addr, AuthMethod: "approle", RoleID: roleID, SecretID: "wrong"}); err == nil {
 		t.Fatal("approle login with a bad secret_id must fail loudly")
 	}
 }
 
-// TestTokenLifecycle_RenewalAndRevocation pins the #724 token-lifecycle
-// semantics with a REAL short-period token:
-//
-//  1. Login(approle) on a role with token_period=5s starts the LifetimeWatcher
-//     (auth.go renew); operations keep working well past the original TTL.
-//  2. Root revokes the token: operations fail LOUDLY (Vault 403), never silently.
-//  3. There is NO automatic re-login (pinned): the watcher logs and exits, and a
-//     supervisor calling Login again (or a process restart) is the recovery path.
-func TestTokenLifecycle_RenewalAndRevocation(t *testing.T) {
+// TestApproleSupervisor_ReauthsPastMaxTTL is the #751 task-(a) test: a role
+// bound to a SHORT max TTL (so the lease provably cannot be renewed past it)
+// keeps serving KV reads/writes well beyond that MAX TTL, because the
+// Supervisor re-authenticates automatically the moment the LifetimeWatcher
+// ends — the "supervisor calling Login again" that a stale comment on the old
+// renew() promised but never built.
+func TestApproleSupervisor_ReauthsPastMaxTTL(t *testing.T) {
 	if testing.Short() {
-		t.Skip("token-lifecycle test needs ~12s of wall clock")
+		t.Skip("re-auth test needs several seconds of wall clock")
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel() // stops the renewer goroutine
+	defer cancel() // stops the Supervisor's goroutine
 	addr, _ := vaulttest.Addr(t)
 
-	roleID, secretID := vaulttest.EnsureAppRole(t, "openrails-it-short", "openrails-approle-short", vaulttest.PolicyKVReadWrite,
-		map[string]any{"token_period": "5s"})
-	client, err := Login(ctx, Config{Address: addr, AuthMethod: "approle", RoleID: roleID, SecretID: secretID})
+	roleID, secretID := vaulttest.EnsureAppRole(t, "openrails-it-maxttl", "openrails-approle-maxttl", vaulttest.PolicyKVReadWrite,
+		map[string]any{"token_ttl": "2s", "token_max_ttl": "6s"})
+	client, sup, err := Login(ctx, Config{Address: addr, AuthMethod: "approle", RoleID: roleID, SecretID: secretID})
 	if err != nil {
-		t.Fatalf("Login(approle, 5s period): %v", err)
+		t.Fatalf("Login(approle, 2s/6s ttl): %v", err)
 	}
+	firstToken := client.Token()
 
+	// Deliberately NOT wired with WithReauthTrigger: recovery here must come
+	// from the LifetimeWatcher's own DoneCh firing at/near max TTL, proving
+	// the NATURAL (non-403-triggered) re-auth path, independent of #751 task
+	// 5's immediate-kick path (covered by TestApproleSupervisor_ReauthsOnRevocation).
 	kv := NewKVv2Adapter(client, "secret")
-	path := "secret/openrails/vaulttest/lifecycle/probe"
+	path := "secret/openrails/vaulttest/reauth-maxttl/probe"
 	t.Cleanup(func() { _ = kv.DeleteSecret(context.Background(), path) })
 
-	// Operate for ~11s (>2x the 5s period). Without renewal the token dies at 5s;
-	// every op succeeding proves the LifetimeWatcher kept it alive.
-	deadline := time.Now().Add(11 * time.Second)
-	for i := 0; time.Now().Before(deadline); i++ {
-		if _, err := kv.WriteSecret(ctx, path, map[string]string{"value": "alive"}); err != nil {
-			t.Fatalf("op at +%ds failed — LifetimeWatcher did not keep the token alive: %v", i, err)
+	// Poll past the 6s MAX TTL until the token rotates and writes succeed
+	// again. A momentary gap around the exact expiry instant (the watcher's
+	// grace/backoff math is wall-clock-approximate, not millisecond-exact
+	// against Vault's own revocation) is expected and tolerated — only
+	// failing to ever recover within the generous deadline is a bug.
+	deadline := time.Now().Add(20 * time.Second)
+	var rotated bool
+	for time.Now().Before(deadline) {
+		if _, err := kv.WriteSecret(ctx, path, map[string]string{"value": "alive"}); err == nil && client.Token() != firstToken {
+			rotated = true
+			break
 		}
-		time.Sleep(1 * time.Second)
+		time.Sleep(150 * time.Millisecond)
+	}
+	if !rotated {
+		t.Fatal("token never rotated / writes never recovered past max TTL — natural (DoneCh-triggered) re-auth did not happen")
+	}
+	if _, _, err := kv.ReadSecret(ctx, path); err != nil {
+		t.Fatalf("read after re-auth: %v", err)
+	}
+	if authErr := sup.AuthState(); authErr != nil {
+		t.Fatalf("AuthState() = %v, want nil after a successful re-auth", authErr)
+	}
+}
+
+// TestApproleSupervisor_ReauthsOnRevocation is the #751 task-(b) approle case:
+// revoking the CURRENT token out from under a live client makes the very next
+// KV read observe Vault's permission-denied response; NotifyPermissionDenied
+// (wired via WithReauthTrigger) confirms via self-lookup that the token is
+// dead and kicks the Supervisor immediately — no waiting out the ambient
+// lease/renewal window. A subsequent read succeeds without any restart.
+func TestApproleSupervisor_ReauthsOnRevocation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	addr, _ := vaulttest.Addr(t)
+
+	roleID, secretID := vaulttest.EnsureAppRole(t, "openrails-it-revoke", "openrails-approle-revoke", vaulttest.PolicyKVReadWrite, nil)
+	client, sup, err := Login(ctx, Config{Address: addr, AuthMethod: "approle", RoleID: roleID, SecretID: secretID})
+	if err != nil {
+		t.Fatalf("Login(approle): %v", err)
+	}
+	revokedToken := client.Token()
+
+	kv := NewKVv2Adapter(client, "secret").WithReauthTrigger(sup)
+	path := "secret/openrails/vaulttest/reauth-revoke/probe"
+	t.Cleanup(func() { _ = kv.DeleteSecret(context.Background(), path) })
+	if _, err := kv.WriteSecret(ctx, path, map[string]string{"value": "pre-revoke"}); err != nil {
+		t.Fatalf("seed write: %v", err)
 	}
 
-	// Revocation ⇒ loud failure (never a silent empty read).
-	vaulttest.RevokeToken(t, client.Token())
-	_, _, err = kv.ReadSecret(ctx, path)
-	if err == nil {
-		t.Fatal("read with a revoked token succeeded; want a loud Vault error")
+	vaulttest.RevokeToken(t, revokedToken)
+
+	deadline := time.Now().Add(10 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if _, _, err := kv.ReadSecret(ctx, path); err == nil {
+			lastErr = nil
+			break
+		} else {
+			lastErr = err
+		}
+		time.Sleep(200 * time.Millisecond)
 	}
-	if !strings.Contains(strings.ToLower(err.Error()), "permission denied") && !errors.Is(err, context.DeadlineExceeded) {
-		t.Logf("revoked-token error (pinned as loud, exact text may vary): %v", err)
+	if lastErr != nil {
+		t.Fatalf("read never recovered after revocation + 403-triggered re-auth: %v", lastErr)
+	}
+	if client.Token() == revokedToken {
+		t.Fatal("token never rotated after revocation — re-auth was not triggered")
+	}
+	if authErr := sup.AuthState(); authErr != nil {
+		t.Fatalf("AuthState() = %v, want nil after recovering from revocation", authErr)
+	}
+}
+
+// TestStaticTokenSupervisor_RenewsPeriodicToken proves the #751 task-3
+// renewable branch: a periodic (renewable) static token is kept alive by the
+// SAME watcher machinery as approle/kubernetes — this is renewal, not
+// re-authentication, so the token identity never changes.
+func TestStaticTokenSupervisor_RenewsPeriodicToken(t *testing.T) {
+	if testing.Short() {
+		t.Skip("renewal test needs several seconds of wall clock")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	addr, _ := vaulttest.Addr(t)
+	root := vaulttest.RootClient(t)
+
+	created, err := root.Auth().Token().Create(&vaultapi.TokenCreateRequest{
+		Policies: []string{"default"},
+		Period:   "3s",
+		NoParent: true,
+	})
+	if err != nil {
+		t.Fatalf("create periodic token: %v", err)
+	}
+	token := created.Auth.ClientToken
+
+	client, sup, err := Login(ctx, Config{Address: addr, AuthMethod: "token", Token: token})
+	if err != nil {
+		t.Fatalf("Login(token, periodic 3s): %v", err)
 	}
 
-	// Pinned: no self-healing re-login. The same client stays broken until a
-	// supervisor calls Login again / the process restarts.
-	time.Sleep(2 * time.Second)
-	if _, _, err := kv.ReadSecret(ctx, path); err == nil {
-		t.Fatal("client self-healed after revocation; re-login policy is supervisor/restart-owned and must not be emergent")
+	deadline := time.Now().Add(7 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := client.Auth().Token().LookupSelfWithContext(ctx); err != nil {
+			t.Fatalf("periodic token died — renewal did not keep it alive: %v", err)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if client.Token() != token {
+		t.Fatal("token identity changed — renewal must reuse the SAME token, not re-authenticate")
+	}
+	if authErr := sup.AuthState(); authErr != nil {
+		t.Fatalf("AuthState() = %v, want nil while renewal keeps succeeding", authErr)
+	}
+}
+
+// TestStaticTokenSupervisor_NonRenewableExpiryIsLoud is the #751 task-3
+// non-renewable branch and task-(b)'s static-token case: a non-renewable
+// token with a short TTL gets a prominent boot warning naming the deadline,
+// and AuthState() flips to a loud, PERMANENT error once the lease ends — no
+// silent decay, and (pinned) no self-healing, since a bare token has no
+// credential material to redo a login with.
+func TestStaticTokenSupervisor_NonRenewableExpiryIsLoud(t *testing.T) {
+	if testing.Short() {
+		t.Skip("expiry test needs several seconds of wall clock")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	addr, _ := vaulttest.Addr(t)
+	root := vaulttest.RootClient(t)
+
+	notRenewable := false
+	created, err := root.Auth().Token().Create(&vaultapi.TokenCreateRequest{
+		Policies:  []string{"default"},
+		TTL:       "2s",
+		Renewable: &notRenewable,
+		NoParent:  true,
+	})
+	if err != nil {
+		t.Fatalf("create non-renewable token: %v", err)
+	}
+	token := created.Auth.ClientToken
+
+	hook := logtest.NewGlobal()
+	defer hook.Reset()
+
+	_, sup, err := Login(ctx, Config{Address: addr, AuthMethod: "token", Token: token})
+	if err != nil {
+		t.Fatalf("Login(token, non-renewable, 2s ttl): %v", err)
+	}
+
+	var warned bool
+	for _, e := range hook.AllEntries() {
+		if e.Level == log.WarnLevel && strings.Contains(e.Message, "NON-RENEWABLE") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatal("expected a boot-time NON-RENEWABLE warning naming the expiry deadline")
+	}
+	if authErr := sup.AuthState(); authErr != nil {
+		t.Fatalf("AuthState() = %v, want nil immediately after boot", authErr)
+	}
+
+	deadline := time.Now().Add(6 * time.Second)
+	var sawErr bool
+	for time.Now().Before(deadline) {
+		if sup.AuthState() != nil {
+			sawErr = true
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if !sawErr {
+		t.Fatal("AuthState() never flipped to an error after the non-renewable token's TTL elapsed")
+	}
+
+	// Pinned: no self-healing. A bare static token has no login material.
+	time.Sleep(1 * time.Second)
+	if sup.AuthState() == nil {
+		t.Fatal("static non-renewable token self-healed — impossible, and must never happen")
 	}
 }

--- a/internal/integrations/vault/auth_test.go
+++ b/internal/integrations/vault/auth_test.go
@@ -2,7 +2,11 @@ package vault
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
+
+	vaultapi "github.com/hashicorp/vault/api"
 )
 
 // Pure-logic error paths only (no HTTP is attempted before these fail). The live
@@ -10,14 +14,120 @@ import (
 // auth_integration_test.go (#724) — never a httptest mock.
 
 func TestLogin_UnsupportedMethod(t *testing.T) {
-	if _, err := Login(context.Background(), Config{Address: "http://127.0.0.1:1", AuthMethod: "bogus"}); err == nil {
+	if _, _, err := Login(context.Background(), Config{Address: "http://127.0.0.1:1", AuthMethod: "bogus"}); err == nil {
 		t.Fatal("expected error for unsupported auth method")
 	}
 }
 
 // Token auth with no token fails loudly (#712: no ambient VAULT_TOKEN fallback).
 func TestLogin_TokenMethodRequiresToken(t *testing.T) {
-	if _, err := Login(context.Background(), Config{Address: "http://127.0.0.1:1", AuthMethod: "token"}); err == nil {
+	if _, _, err := Login(context.Background(), Config{Address: "http://127.0.0.1:1", AuthMethod: "token"}); err == nil {
 		t.Fatal("expected error for token auth without a token")
 	}
 }
+
+// --- resolveApproleSecretID (#751 task 2): the "re-read if file-delivered,
+// else static" accessor, pure logic (no Vault needed). ---
+
+func TestResolveApproleSecretID_StaticFallbackWhenNothingMounted(t *testing.T) {
+	t.Setenv("VAULT_SECRETS_PATH", t.TempDir()) // empty dir: no VAULT_SECRET_ID file
+	got, err := resolveApproleSecretID("static-value")
+	if err != nil {
+		t.Fatalf("resolveApproleSecretID: %v", err)
+	}
+	if got != "static-value" {
+		t.Fatalf("got %q, want the static fallback", got)
+	}
+}
+
+func TestResolveApproleSecretID_FileWinsOverStaticWhenNoEnv(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "VAULT_SECRET_ID"), []byte("from-file\n"), 0o600); err != nil {
+		t.Fatalf("seed secret file: %v", err)
+	}
+	t.Setenv("VAULT_SECRETS_PATH", dir)
+	got, err := resolveApproleSecretID("static-value")
+	if err != nil {
+		t.Fatalf("resolveApproleSecretID: %v", err)
+	}
+	if got != "from-file" {
+		t.Fatalf("got %q, want the mounted file's (trimmed) content", got)
+	}
+}
+
+// Re-reading picks up rotation between calls — the whole point of #751 task 2.
+func TestResolveApproleSecretID_FileReReadPicksUpRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "VAULT_SECRET_ID")
+	if err := os.WriteFile(path, []byte("v1"), 0o600); err != nil {
+		t.Fatalf("seed secret file: %v", err)
+	}
+	t.Setenv("VAULT_SECRETS_PATH", dir)
+	got, err := resolveApproleSecretID("static-value")
+	if err != nil || got != "v1" {
+		t.Fatalf("first read = (%q, %v), want v1", got, err)
+	}
+	if err := os.WriteFile(path, []byte("v2"), 0o600); err != nil {
+		t.Fatalf("rotate secret file: %v", err)
+	}
+	got, err = resolveApproleSecretID("static-value")
+	if err != nil || got != "v2" {
+		t.Fatalf("second read = (%q, %v), want v2 (rotation not picked up)", got, err)
+	}
+}
+
+// #712 boundary: resolveApproleSecretID must NOT read VAULT_SECRET_ID itself
+// (only config.SecretFiles, inside the config package, may read env) — so a
+// mounted file wins even when an env var of the same name is ALSO set. This
+// is the documented corner case on resolveApproleSecretID's doc comment: the
+// file and env conventions are alternative delivery mechanisms for the same
+// slot, not meant to be combined.
+func TestResolveApproleSecretID_FileWinsEvenWhenEnvVarAlsoSet(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "VAULT_SECRET_ID"), []byte("from-file"), 0o600); err != nil {
+		t.Fatalf("seed secret file: %v", err)
+	}
+	t.Setenv("VAULT_SECRETS_PATH", dir)
+	t.Setenv("VAULT_SECRET_ID", "from-env")
+	got, err := resolveApproleSecretID("static-value")
+	if err != nil {
+		t.Fatalf("resolveApproleSecretID: %v", err)
+	}
+	if got != "from-file" {
+		t.Fatalf("got %q, want the mounted file's content (this package never reads env directly, #712)", got)
+	}
+}
+
+// --- IsPermissionDenied (#751 task 5 classification), pure logic. ---
+
+func TestIsPermissionDenied(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"403 ResponseError", &vaultapi.ResponseError{StatusCode: 403, Errors: []string{"permission denied"}}, true},
+		{"404 ResponseError", &vaultapi.ResponseError{StatusCode: 404}, false},
+		{"wrapped 403", errWrap{&vaultapi.ResponseError{StatusCode: 403}}, true},
+		{"plain text fallback", plainErr("1 error occurred:\n\t* permission denied\n"), true},
+		{"unrelated error", plainErr("connection refused"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsPermissionDenied(tc.err); got != tc.want {
+				t.Errorf("IsPermissionDenied(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+type plainErr string
+
+func (e plainErr) Error() string { return string(e) }
+
+// errWrap mimics fmt.Errorf("...: %w", err)'s Unwrap shape without pulling in fmt.
+type errWrap struct{ err error }
+
+func (e errWrap) Error() string { return "wrapped: " + e.err.Error() }
+func (e errWrap) Unwrap() error { return e.err }

--- a/internal/integrations/vault/kv.go
+++ b/internal/integrations/vault/kv.go
@@ -13,8 +13,8 @@
 package vault
 
 import (
-	"encoding/json"
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -31,11 +31,38 @@ import (
 type KVv2Adapter struct {
 	client *vaultapi.Client
 	mount  string
+
+	// onPermissionDenied is called with every error a KV operation observes,
+	// letting a wired Supervisor decide (via NotifyPermissionDenied) whether
+	// it signals real token death (#751 task 5). Nil (the zero value / a bare
+	// NewKVv2Adapter) is a valid no-op — tests and one-off root/dedicated-
+	// container clients never need it.
+	onPermissionDenied func(error)
 }
 
 // NewKVv2Adapter builds a KV-v2 adapter for the given mount (e.g. "secret").
 func NewKVv2Adapter(client *vaultapi.Client, mount string) *KVv2Adapter {
 	return &KVv2Adapter{client: client, mount: strings.Trim(strings.TrimSpace(mount), "/")}
+}
+
+// WithReauthTrigger wires the adapter so every failed KV operation reports
+// its error to sup.NotifyPermissionDenied (#751 task 5): a permission-denied
+// response whose self-lookup confirms the token is dead triggers an
+// immediate re-auth instead of waiting out the current lease or the
+// merchant-secret cache TTL. Returns the adapter for chaining at
+// construction (e.g. merchantsecrets/store.go:
+// NewKVv2Adapter(client, mount).WithReauthTrigger(sup)). A nil sup is a no-op.
+func (a *KVv2Adapter) WithReauthTrigger(sup *Supervisor) *KVv2Adapter {
+	if sup != nil {
+		a.onPermissionDenied = sup.NotifyPermissionDenied
+	}
+	return a
+}
+
+func (a *KVv2Adapter) notifyErr(err error) {
+	if err != nil && a.onPermissionDenied != nil {
+		a.onPermissionDenied(err)
+	}
 }
 
 // rest strips the leading "<mount>/" the merchant store prepended.
@@ -58,6 +85,7 @@ func (a *KVv2Adapter) metadataPath(full string) string {
 func (a *KVv2Adapter) ReadSecret(ctx context.Context, path string) (map[string]string, int, error) {
 	sec, err := a.client.Logical().ReadWithContext(ctx, a.dataPath(path))
 	if err != nil {
+		a.notifyErr(err)
 		return nil, 0, fmt.Errorf("vault kv read: %w", err)
 	}
 	if sec == nil || sec.Data == nil {
@@ -98,6 +126,7 @@ func (a *KVv2Adapter) WriteSecret(ctx context.Context, path string, data map[str
 	}
 	sec, err := a.client.Logical().WriteWithContext(ctx, a.dataPath(path), map[string]any{"data": payload})
 	if err != nil {
+		a.notifyErr(err)
 		return 0, fmt.Errorf("vault kv write: %w", err)
 	}
 	if sec != nil {
@@ -109,6 +138,7 @@ func (a *KVv2Adapter) WriteSecret(ctx context.Context, path string, data map[str
 // DeleteSecret purges ALL versions via the metadata endpoint (idempotent).
 func (a *KVv2Adapter) DeleteSecret(ctx context.Context, path string) error {
 	if _, err := a.client.Logical().DeleteWithContext(ctx, a.metadataPath(path)); err != nil {
+		a.notifyErr(err)
 		return fmt.Errorf("vault kv delete: %w", err)
 	}
 	return nil
@@ -139,6 +169,7 @@ func (a *KVv2Adapter) listSecrets(ctx context.Context, root, rel string, depth i
 	}
 	sec, err := a.client.Logical().ListWithContext(ctx, a.metadataPath(full))
 	if err != nil {
+		a.notifyErr(err)
 		return nil, fmt.Errorf("vault kv list: %w", err)
 	}
 	if sec == nil || sec.Data == nil {

--- a/internal/merchantsecrets/store.go
+++ b/internal/merchantsecrets/store.go
@@ -33,6 +33,11 @@ type Store struct {
 	// key is supported. SecretWrite: provider-secret writes / config-push are possible.
 	SolanaCanSign bool
 	SecretWrite   bool
+	// VaultAuth is the #751 auth-health probe for the Vault client backing
+	// this store: nil when Vault isn't enabled, non-nil (call .AuthState())
+	// otherwise. NOT wired into any readiness surface by this package — #748
+	// is expected to consume it from a future Embedded.Ready.
+	VaultAuth *vault.Supervisor
 }
 
 // deriveRouteGates computes the advisory route-gating signals. localKeys: the
@@ -72,13 +77,14 @@ func Build(ctx context.Context, cfg *config.Config, pool *db.Pool) (*Store, erro
 	// token may actually do. The connection may serve KV, Transit, both, or (with a
 	// transit-only policy) only signing.
 	var (
-		vclient *vaultapi.Client
-		transit solanaint.TransitClient
-		caps    vault.Capabilities
+		vclient   *vaultapi.Client
+		transit   solanaint.TransitClient
+		caps      vault.Capabilities
+		vaultAuth *vault.Supervisor
 	)
 	if cfg != nil && cfg.Vault != nil && cfg.Vault.Enabled {
 		vc := cfg.Vault
-		client, err := vault.Login(ctx, vault.Config{
+		client, sup, err := vault.Login(ctx, vault.Config{
 			Address:    vc.Address,
 			AuthMethod: vc.AuthMethod,
 			Token:      vc.Token,
@@ -89,6 +95,7 @@ func Build(ctx context.Context, cfg *config.Config, pool *db.Pool) (*Store, erro
 		if err != nil {
 			return nil, fmt.Errorf("vault login: %w", err)
 		}
+		vaultAuth = sup
 		caps, err = vault.SelfCapabilities(ctx, client, vaultKVMount)
 		if err != nil {
 			// Only fatal when secrets are declared to live in Vault: the KV store
@@ -117,7 +124,7 @@ func Build(ctx context.Context, cfg *config.Config, pool *db.Pool) (*Store, erro
 		}
 		store := merchants.NewVaultSecretStore(
 			vaultKVMount,
-			vault.NewKVv2Adapter(vclient, vaultKVMount),
+			vault.NewKVv2Adapter(vclient, vaultKVMount).WithReauthTrigger(vaultAuth),
 			merchants.NewDBMerchantSlugResolver(pool),
 		)
 		return &Store{
@@ -126,6 +133,7 @@ func Build(ctx context.Context, cfg *config.Config, pool *db.Pool) (*Store, erro
 			Capabilities:  caps,
 			SolanaCanSign: solanaCanSign,
 			SecretWrite:   secretWrite,
+			VaultAuth:     vaultAuth,
 		}, nil
 	}
 
@@ -139,6 +147,7 @@ func Build(ctx context.Context, cfg *config.Config, pool *db.Pool) (*Store, erro
 		Capabilities:  caps,
 		SolanaCanSign: solanaCanSign,
 		SecretWrite:   secretWrite,
+		VaultAuth:     vaultAuth,
 	}, nil
 }
 
@@ -221,12 +230,20 @@ func BuildManifest(ctx context.Context, cfg *config.Config, store *merchants.Man
 // BuildTransit opens the Vault Transit signing client when Vault is enabled
 // (nil otherwise). Standalone of the KV store — MODE 1 uses it for Solana
 // vault_transit signers with no KV backend at all.
+//
+// The #751 re-auth Supervisor still runs in the background here (Login
+// starts it unconditionally) — the transit client's token stays fresh across
+// re-logins the same as the KV path's — but its AuthState() handle is
+// discarded because this exported function's signature is depended on
+// outside this package (internal/bootstrap, pkg/embedded); a future readiness
+// wiring (#748) that wants transit-only auth health will need a small
+// signature change here, noted in the tracker for that follow-up.
 func BuildTransit(ctx context.Context, cfg *config.Config) (solanaint.TransitClient, error) {
 	if cfg == nil || cfg.Vault == nil || !cfg.Vault.Enabled {
 		return nil, nil
 	}
 	vc := cfg.Vault
-	client, err := vault.Login(ctx, vault.Config{
+	client, _, err := vault.Login(ctx, vault.Config{
 		Address:    vc.Address,
 		AuthMethod: vc.AuthMethod,
 		Token:      vc.Token,

--- a/internal/merchantsecrets/vault_scenarios_integration_test.go
+++ b/internal/merchantsecrets/vault_scenarios_integration_test.go
@@ -308,13 +308,19 @@ func TestVaultOutage_FailClosedAtBootAndRead_RecoverWithoutRestart(t *testing.T)
 
 	cfg := vaultBackedConfig("production", d.Addr, d.RootToken)
 
-	// Unreachable at boot ⇒ Build fails loudly (vault declared means vault required).
+	// Unreachable at boot ⇒ Build fails loudly (vault declared means vault
+	// required). #751: token-mode Login itself now does a self-lookup (to
+	// learn renewability/TTL for the re-auth Supervisor), so an unreachable
+	// Vault can fail as early as "vault login" instead of the later
+	// capability probe — either is the same loud, no-degrade boot failure.
 	d.Pause(t)
 	bootCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	_, err := Build(bootCtx, cfg, pool)
 	cancel()
 	require.Error(t, err, "boot with unreachable Vault must fail loudly, never degrade")
-	require.Contains(t, err.Error(), "vault capability probe")
+	require.True(t,
+		strings.Contains(err.Error(), "vault capability probe") || strings.Contains(err.Error(), "vault login"),
+		"unexpected boot error shape: %v", err)
 	d.Unpause(t)
 
 	// Healthy boot; seed nameA through the store (it lands in the read cache too).


### PR DESCRIPTION
## Summary

Fixes #751: Vault auth (approle/kubernetes) renewed via LifetimeWatcher up to MAX TTL, then permanently died — the code comment promised "a supervisor calling Login again" that never existed. Token-mode (VAULT_TOKEN) was never renewed at all. Combined with the 15m merchant-secret cache, failures surfaced up to 15 minutes late, intermittently per (merchant, secret).

- `vault.Login` now returns `(*vaultapi.Client, *Supervisor, error)`. `Supervisor` runs the same LifetimeWatcher as before, and when it ends for any reason (max TTL, non-renewable, or a detected-dead token) re-runs `login()` with exponential backoff + jitter, swapping the fresh token onto the **same shared** `*vaultapi.Client` via `client.SetToken` — safe for concurrent readers because `vaultapi.Client` guards `SetToken`/`Token` with its own internal `modifyLock` (RWMutex); no consumer (KV adapter, transit adapter, capability prober) needs its own locking or notification.
- AppRole `secret_id` is re-resolved fresh on every login/re-login attempt via `resolveApproleSecretID`, which re-reads a mounted `VAULT_SECRET_ID` file (the `config/secret_files.go` convention) through `config.SecretFiles()` when file-delivered, else the static value — deliberately not a raw `os.Getenv` call, to respect the `#712` env-boundary rule (`config.TestNoLibraryEnvReads`). The kubernetes SA JWT was already re-read from disk on every `login()` call.
- Token-mode: renews on the same watcher machinery when Vault reports the token renewable; when non-renewable with a TTL, logs a prominent boot warning naming the expiry deadline and flips `AuthState()` to a permanent error the moment the lease ends (no silent decay, no self-heal — a bare token has no login material to redo). Non-expiring root/dev tokens keep working silently.
- 403 resilience: `KVv2Adapter.WithReauthTrigger(sup)` + `Supervisor.NotifyPermissionDenied` distinguish token death from a policy-scoped denial — a permission-denied KV response whose same-token self-lookup *also* fails means the token is dead (immediate re-auth kick, bypassing the current lease); a self-lookup that still succeeds is a legitimate ACL boundary (deliberate no-op).
- `Supervisor.AuthState() error` is the exported health accessor for #748's readiness wiring (not consumed here — left for that issue's merge, per instruction). `merchantsecrets.Store` gains a `VaultAuth *vault.Supervisor` field on the KV-backed path.

## Test plan

- [x] `gofmt` / `go vet` / `go build ./...` clean
- [x] `go test ./...` green (including the `#712` env-boundary test)
- [x] `go test -tags=integration -count=1 ./internal/integrations/vault/... ./internal/merchantsecrets/...` green — new tests against a real vaulttest Vault (never mocked):
  - `TestApproleSupervisor_ReauthsPastMaxTTL` — short TTL/max-TTL role, no 403-hook wired, proves the natural DoneCh→reauth path alone recovers past max TTL
  - `TestApproleSupervisor_ReauthsOnRevocation` — revoke the live token, proves the 403-triggered immediate-kick path
  - `TestStaticTokenSupervisor_RenewsPeriodicToken` — periodic token renewal keeps the same token identity
  - `TestStaticTokenSupervisor_NonRenewableExpiryIsLoud` — boot warning + permanent `AuthState()` error at expiry, no self-heal
  - Updated `TestVaultOutage_FailClosedAtBootAndRead_RecoverWithoutRestart` (pre-existing) for the new failure point (token-mode `Login` now does a self-lookup round-trip)

Tracker: `open-rails-tracker/openrails/progress.md` `#751` marked done, with a merge note for #748 on `Store.VaultAuth` vs the sibling's `Store.Ping`, and a known gap on `BuildTransit` (out of scope here) still discarding its `Supervisor` handle.