### PR TITLE
embedded hosts: default-protected rate limits + explicit credential posture (#742, #745)

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -68,7 +68,7 @@ jobs:
         run: |
           docker run --rm --network host \
             -e ENV=development \
-            -e TEST_MODE=true \
+            -e TEST_MODE=sandbox \
             -e DB_HOST=127.0.0.1 \
             -e DB_PORT=5434 \
             -e DB_DATABASE=openrails_db \
@@ -82,7 +82,7 @@ jobs:
         run: |
           cid="$(docker run -d --network host \
             -e ENV=development \
-            -e TEST_MODE=true \
+            -e TEST_MODE=sandbox \
             -e PORT=3053 \
             -e API_URL=http://127.0.0.1:3053 \
             -e AUTH_ISSUER=http://127.0.0.1:3053 \

--- a/.github/workflows/live-gated-integration.yml
+++ b/.github/workflows/live-gated-integration.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Live rail invoice collection tests
         env:
           OPENRAILS_LIVE_RAIL_TESTS: "1"
-          TEST_MODE: "true"
+          TEST_MODE: "sandbox"
           OPENRAILS_TEST_STRIPE_SECRET_KEY: ${{ secrets.OPENRAILS_TEST_STRIPE_SECRET_KEY }}
           NMI_SANDBOX_SECURITY_KEY: ${{ secrets.NMI_SANDBOX_SECURITY_KEY }}
         run: |

--- a/README.md
+++ b/README.md
@@ -327,29 +327,35 @@ The handler is framework-neutral `net/http` — OpenRails links no web framework
 Your frontend now calls these routes with its **normal session credential**.
 `Authenticator` protects checkout/user routes; `Gate` protects merchant routes.
 
-**Rate-limiting & captcha (built in).** The embedded surface runs OpenRails' own
-per-IP/per-user rate limiting + captcha **in-process** — you do not need to front it
-with your own gateway. It is on but **inert until you set `Config.RateLimits`** (a
-safe no-op otherwise). Set it on the config you pass to `embedded.New`/`embed.New`
-(Redis-backed when `Options.Redis` is set, in-memory per-process otherwise):
+**Rate-limiting & captcha (built in, on by default).** The embedded surface runs
+OpenRails' own per-IP/per-user rate limiting + captcha **in-process** — you do not
+need to front it with your own gateway. `embedded.New`/`embed.New` seed the same
+curated `Config.RateLimits` (Redis-backed when `Options.Redis` is set, in-memory
+per-process otherwise) standalone `config.Load` uses whenever you leave it nil (#742):
 
 ```go
-cfg.RateLimits = &config.RateLimitsConfig{
-    "default":   {RequestsPerMinute: 300},  // general API (SPA/NAT-friendly)
-    "checkout":  {RequestsPerMinute: 10},   // tight: deters card-testing
-    "subscribe": {RequestsPerMinute: 20},
-    "payment":   {RequestsPerMinute: 40},
-    "webhook":   {RequestsPerMinute: 1200}, // per source IP; absorbs rail bursts
-}
+config.GetDefaultBillingConfig().RateLimits // == what embedded.New seeds when Config.RateLimits is nil
+// {
+//   "default":   {RequestsPerMinute: 300},  // general API (SPA/NAT-friendly)
+//   "checkout":  {RequestsPerMinute: 10},   // tight: deters card-testing
+//   "subscribe": {RequestsPerMinute: 20},
+//   "payment":   {RequestsPerMinute: 40},
+//   "webhook":   {RequestsPerMinute: 1200}, // per source IP; absorbs rail bursts
+// }
+
+// Set your own to override the defaults instead of accepting them:
+cfg.RateLimits = &config.RateLimitsConfig{"checkout": {RequestsPerMinute: 5}}
 // Optional captcha escalation on extreme abuse (needs your Turnstile/reCAPTCHA keys):
 // cfg.Captcha = &config.CaptchaConfig{Provider: config.CaptchaProviderTurnstile,
 //     SiteKey: "...", SecretKey: "..."}
+
+// A host that truly fronts billing with its own gateway/limiter can opt all the
+// way out — RateLimitHTTP then runs as a pure passthrough:
+// cfg.RateLimitsDisabled = true
 ```
 
 Buckets key per-IP **and** per-authenticated-user (strictest wins), and apply to both
-the user surface and the delegated self/admin surface (`embgin.SelfHandler`). The
-values above mirror the standalone defaults. **Embedding hosts: do this when you wire
-the engine — it's easy to forget, and without it billing endpoints are unthrottled.**
+the user surface and the delegated self/admin surface (`embgin.SelfHandler`).
 
 ### 3. Call OpenRails in-process
 
@@ -426,10 +432,10 @@ or your own tooling instead — admin routes without a permission checker fail c
   non-authoritative metadata for things like checkout prefill.
 - **Admin authority:** live `merchant:*` permissions evaluated at request time in
   the caller's merchant group (see embedded guide §5). Never derived from role names.
-- **Sandbox vs live:** `TEST_MODE=true` routes every rail to its test/sandbox
+- **Sandbox vs live:** `TEST_MODE=sandbox` routes every rail to its test/sandbox
   environment and enforces sandbox credentials so you can't accidentally charge a real
-  card. It defaults on in development, must be explicit for live local runs, and is
-  rejected outside development (see Operating modes below).
+  card. It defaults to sandbox in development, must be explicit (`live`) for live local
+  runs, and is rejected outside development (see Operating modes below).
 
 ## Configuration
 
@@ -448,7 +454,9 @@ Two orthogonal settings:
   One of `full | limited | readonly`. The old `mode` / `MODE` / `--mode` alias is
   removed (#710) — a set key fails loudly at load.
 - **`test_mode`** (yaml) / `TEST_MODE` (env) / `--test-mode` (CLI flag) — the
-  **credential** axis: `true` enforces sandbox rail credentials. Default `false`.
+  **credential** axis: `sandbox | live`, no other values (and no bare boolean).
+  Embedded hosts must set it explicitly; unset has no default and construction
+  refuses to boot (#745).
 
 | `PROVIDER_WRITE_MODE=` | What runs |
 |---|---|
@@ -458,7 +466,7 @@ Two orthogonal settings:
 
 ### `test_mode` — sandbox credentials, orthogonal to provider write mode
 
-`TEST_MODE=true` is sandbox money with whatever behavior `provider_write_mode` selects
+`TEST_MODE=sandbox` is sandbox money with whatever behavior `provider_write_mode` selects
 (typically `full`): every rail routes to its test/sandbox environment, and the
 **credential guarantees** attach — a live Stripe key (`sk_live_`/`rk_live_`) refuses to boot; each
 configured NMI account is probed at boot with one auth on the non-issued test card —
@@ -469,12 +477,12 @@ verdicts are cached for 12h in `billing.probe_verdicts` keyed by sha256 of the k
 crash-looping supervisor pays one declined auth total, not one per restart — a fresh
 `simulated` verdict skips the probe, and a rotated key or stale verdict always
 re-probes (cache failures degrade to probing); CCBill uses
-`sandbox-api.ccbill.com`; Solana derives devnet structurally. `test_mode=true` is
+`sandbox-api.ccbill.com`; Solana derives devnet structurally. `test_mode=sandbox` is
 **rejected outside `env=development`** — sandbox money is dev-only. The old `mode=test`
-is exactly `TEST_MODE=true` + `PROVIDER_WRITE_MODE=full`.
+is exactly `TEST_MODE=sandbox` + `PROVIDER_WRITE_MODE=full`.
 
 At a glance — what each provider write mode permits (the `test_mode` axis applies orthogonally: with
-`TEST_MODE=true` the same matrix holds against sandbox rails, so no real money can
+`TEST_MODE=sandbox` the same matrix holds against sandbox rails, so no real money can
 move in any mode):
 
 | Operation | `full` | `limited` | `readonly` |
@@ -497,7 +505,9 @@ usable; `readonly` = reconciliation/forensics boots that must only observe.
 
 `provider_write_mode` is **required outside development** (the server refuses to boot
 without one); unset in dev defaults to `full`. `test_mode` defaults to sandbox in
-development and live outside development. Set `TEST_MODE=false` (or `--test-mode=false`)
+development and live outside development for standalone `config.Load` boots only —
+embedded hosts build `Config` programmatically and must set it explicitly, or
+construction refuses to boot (#745). Set `TEST_MODE=live` (or `--test-mode=live`)
 for a deliberate live local run. The old `mode=test` and `mode=production` values no
 longer exist.
 

--- a/cmd/openrails/main.go
+++ b/cmd/openrails/main.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -41,16 +40,10 @@ func main() {
 				}
 			}
 
-			// --test-mode mirrors --provider-write-mode: overwrite the TEST_MODE
-			// env var before Load so flag beats env beats yaml. Only applied when
-			// the flag was passed explicitly, so an unset flag never clobbers
-			// TEST_MODE.
-			if cmd.Flags().Changed("test-mode") {
-				testMode, err := cmd.Flags().GetBool("test-mode")
-				if err != nil {
-					return fmt.Errorf("failed to get test-mode flag: %w", err)
-				}
-				if err := os.Setenv("TEST_MODE", strconv.FormatBool(testMode)); err != nil {
+			// --test-mode rides the same koanf pipeline as --provider-write-mode:
+			// overwrite TEST_MODE before Load so flag beats env beats yaml.
+			if posture, err := cmd.Flags().GetString("test-mode"); err == nil && strings.TrimSpace(posture) != "" {
+				if err := os.Setenv("TEST_MODE", strings.TrimSpace(posture)); err != nil {
 					return fmt.Errorf("failed to apply --test-mode: %w", err)
 				}
 			}
@@ -71,7 +64,7 @@ func main() {
 	rootCmd.PersistentFlags().
 		String("provider-write-mode", "", "Payment-provider write policy: full | limited | readonly (overrides PROVIDER_WRITE_MODE env and config.yaml; required outside development)")
 	rootCmd.PersistentFlags().
-		Bool("test-mode", false, "Use sandbox rail credentials (Stripe test key, NMI sandbox probe, CCBill sandbox, Solana devnet); overrides TEST_MODE env and config.yaml; development only")
+		String("test-mode", "", "Credential posture: sandbox | live (sandbox uses Stripe test key, NMI sandbox probe, CCBill sandbox, Solana devnet); overrides TEST_MODE env and config.yaml; sandbox is development-only")
 
 	serverCmd := &cobra.Command{
 		Use:     "run-server",

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,7 +7,7 @@
 
 env: development
 provider_write_mode: full # full | limited | readonly; UNSET fail-closes to readonly (no provider writes) — set full/limited explicitly; required outside development
-test_mode: true           # sandbox credentials; development only
+test_mode: sandbox        # sandbox | live; sandbox is development-only
 
 host: 0.0.0.0
 port: 3053

--- a/config/config.go
+++ b/config/config.go
@@ -54,6 +54,30 @@ func (p *FlexiblePort) UnmarshalText(text []byte) error {
 
 const ConfigContextKey string = "config"
 
+// CredentialPosture is the sandbox-credential axis (#355/#745): "sandbox" or
+// "live", never a bare true/false. The Go zero value (empty string) means
+// UNSET — it can never be mistaken for "live" the way a bool's false zero
+// value could. UnmarshalText keeps config.yaml/TEST_MODE/--test-mode decoding
+// through koanf (the same encoding.TextUnmarshaler pattern FlexiblePort uses
+// above, #349).
+type CredentialPosture string
+
+const (
+	CredentialPostureSandbox CredentialPosture = "sandbox"
+	CredentialPostureLive    CredentialPosture = "live"
+)
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (p *CredentialPosture) UnmarshalText(text []byte) error {
+	switch s := CredentialPosture(strings.ToLower(strings.TrimSpace(string(text)))); s {
+	case "", CredentialPostureSandbox, CredentialPostureLive:
+		*p = s
+		return nil
+	default:
+		return fmt.Errorf("invalid test_mode %q: must be %q or %q", s, CredentialPostureSandbox, CredentialPostureLive)
+	}
+}
+
 type Config struct {
 	Env  string       `koanf:"env,omitempty"`
 	Port FlexiblePort `koanf:"port,omitempty"` // Standalone only: public HTTP port (default 3053)
@@ -71,18 +95,23 @@ type Config struct {
 	// still REQUIRED (Validate refuses to boot without one).
 	ProviderWriteMode string `koanf:"provider_write_mode,omitempty"`
 
-	// TestMode is the sandbox-credential axis (#355), orthogonal to Mode. When
-	// true, every rail routes to its sandbox environment AND the
+	// TestMode is the sandbox-credential axis (#355), orthogonal to Mode.
+	// "sandbox" routes every rail to its sandbox environment AND the
 	// credential guarantees attach: a live Stripe key (sk_live_/rk_live_)
 	// refuses to boot, configured NMI accounts are probed at boot (a decline
 	// of the non-issued test card proves production credentials and refuses
 	// the boot), CCBill uses the sandbox URL, and Solana derives devnet.
-	// When omitted, defaults to sandbox in development and live outside it
-	// (Load sets this fail-closed; see #355) — so a local boot is sandbox by
-	// default and a prod boot is live by default. test_mode=true is rejected
-	// outside env=development — sandbox money is dev-only. Set test_mode=false
-	// explicitly to run live credentials locally.
-	TestMode bool `koanf:"test_mode,omitempty"`
+	// "live" runs production credentials. Two explicit states ONLY (#745,
+	// replaces the bool whose zero value silently meant live money): the
+	// empty Go zero value is UNSET, tolerated only by standalone Load() —
+	// which defaults it to sandbox in development and live outside it (#355)
+	// — so a local boot is sandbox by default and a prod boot is live by
+	// default. embedded.New never runs Load's defaulting and refuses to
+	// construct with it unset — an embedded host must declare its posture,
+	// never guess (supersedes #711's warn-only). test_mode=sandbox is
+	// rejected outside env=development — sandbox money is dev-only. Set
+	// test_mode=live explicitly to run live credentials locally.
+	TestMode CredentialPosture `koanf:"test_mode,omitempty"`
 
 	// APIURL is the base URL where billing's versioned routes are mounted.
 	// Used for generating URLs (e.g., Solana Pay transaction_request URLs).
@@ -99,9 +128,19 @@ type Config struct {
 	Logger     *LoggerConfig     `koanf:"logger,omitempty"`
 	SendGrid   *SendGridConfig   `koanf:"sendgrid,omitempty"`
 	RateLimits *RateLimitsConfig `koanf:"rate_limits,omitempty"`
-	Captcha    *CaptchaConfig    `koanf:"captcha,omitempty"`
-	Encryption *EncryptionConfig `koanf:"encryption,omitempty"`
-	Vault      *VaultConfig      `koanf:"vault,omitempty"`
+	// RateLimitsDisabled explicitly opts OUT of OpenRails' built-in rate
+	// limiting/captcha enforcement (#742) — for a host that fronts billing
+	// with its own gateway/limiter and deliberately wants RateLimitHTTP to
+	// run as a passthrough. Zero value (false) keeps hosts PROTECTED:
+	// embedded.New seeds the same curated RateLimits/Captcha defaults
+	// config.Load applies whenever the host leaves them nil, unless this is
+	// explicitly set. Standalone Load() never needs it — GetDefaultBillingConfig
+	// always seeds RateLimits — but the knob is honored there too. Env:
+	// RATE_LIMITS_DISABLED.
+	RateLimitsDisabled bool              `koanf:"rate_limits_disabled,omitempty"`
+	Captcha            *CaptchaConfig    `koanf:"captcha,omitempty"`
+	Encryption         *EncryptionConfig `koanf:"encryption,omitempty"`
+	Vault              *VaultConfig      `koanf:"vault,omitempty"`
 
 	// AdminConsole gates the embedded merchant admin console SPA served at
 	// /admin/ (#740). Default OFF. Env: ADMIN_CONSOLE_ENABLED,
@@ -941,12 +980,22 @@ func Validate(cfg *Config) error {
 		return fmt.Errorf("invalid port %d: must be 1-65535", cfg.Port)
 	}
 
+	// A garbage TestMode value can only reach here via a direct Config{}
+	// literal (koanf's UnmarshalText already rejects it on the Load path) —
+	// defense in depth so a typo can never silently take an unrecognized
+	// branch (#745).
+	switch cfg.TestMode {
+	case "", CredentialPostureSandbox, CredentialPostureLive:
+	default:
+		return fmt.Errorf("invalid test_mode %q: must be %q or %q", cfg.TestMode, CredentialPostureSandbox, CredentialPostureLive)
+	}
+
 	isDev := cfg.Env == "development" || cfg.Env == "dev" || cfg.Env == ""
 	if !isDev {
 		// Sandbox credentials are dev-only (#355): a production deployment
 		// must never boot pointed at sandbox rails.
-		if cfg.TestMode {
-			return fmt.Errorf("test_mode=true is not allowed outside development")
+		if cfg.TestMode == CredentialPostureSandbox {
+			return fmt.Errorf("test_mode=sandbox is not allowed outside development")
 		}
 		// Outside development the operating mode must be declared explicitly —
 		// "I forgot to set it" must never silently pick a behavior. Checked on
@@ -969,6 +1018,16 @@ func Validate(cfg *Config) error {
 			if issuer := strings.TrimSpace(cfg.Auth.Issuer); issuer != "" && !strings.HasPrefix(strings.ToLower(issuer), "https://") {
 				return fmt.Errorf("auth issuer %q must use https outside development", issuer)
 			}
+		}
+		// #742: a nil RateLimits map is a passthrough in RateLimitHTTP — every
+		// endpoint runs unthrottled. embedded.New seeds the curated defaults
+		// whenever a host leaves this nil, so this only trips for a host that
+		// built its own Config directly (bypassing embedded.New) or a
+		// standalone config.yaml that explicitly nulled the map — either way,
+		// "forgot to configure rate limits" must never silently ship
+		// unprotected outside development.
+		if cfg.RateLimits == nil && !cfg.RateLimitsDisabled {
+			return fmt.Errorf("rate_limits is required outside development unless rate_limits_disabled is set (#742): set rate_limits, or rate_limits_disabled=true if this host fronts OpenRails with its own gateway/limiter")
 		}
 	}
 	if err := validateCaptcha(cfg.Captcha); err != nil {
@@ -1161,7 +1220,7 @@ func validateStripeKeyForTestMode(cfg *Config, rails RailMerchantAccountSet, isD
 				return fmt.Errorf("stripe rail %q: test key (sk_test_/rk_test_) is not allowed outside development when test_mode is disabled; use a live key or set test_mode=true", strings.ToLower(strings.TrimSpace(name)))
 			}
 			log.Warnf("⚠️  Stripe test key provided for rail %q but test_mode is disabled (live credentials) - disabling Stripe", strings.ToLower(strings.TrimSpace(name)))
-			log.Warn("   Use a live-mode key (sk_live_/rk_live_), or set test_mode=true for sandbox testing")
+			log.Warn("   Use a live-mode key (sk_live_/rk_live_), or set test_mode=sandbox for sandbox testing")
 			stripeProc.Stripe.SecretKey = ""
 		}
 	}
@@ -1460,11 +1519,14 @@ func (cfg *Config) GetProviderWriteMode() string {
 // IsTestMode returns true if payment rails should use sandbox/test
 // environments and the sandbox-credential guarantees apply (#355): Stripe
 // live-key refusal, NMI boot probe, CCBill sandbox URL, Solana devnet.
-// Orthogonal to ProviderWriteMode (pure behavior). When unset, Load defaults it
-// to sandbox in development and live outside it (#355); Validate rejects
-// test_mode=true outside development.
+// Orthogonal to ProviderWriteMode (pure behavior). Unset (empty) reads as
+// live, matching the historical bool zero value; standalone Load() always
+// resolves TestMode explicitly before this is read, and embedded.New refuses
+// to construct with it unset (#745), so "unset" in practice only reaches this
+// accessor via a direct Config{} literal in a test. Validate rejects
+// test_mode=sandbox outside development.
 func (cfg *Config) IsTestMode() bool {
-	return cfg.TestMode
+	return cfg.TestMode == CredentialPostureSandbox
 }
 
 // IsLimitedMode returns true if proactive payment-provider operations
@@ -1861,18 +1923,23 @@ func Load(configPath string) (*Config, error) {
 	// migration, but they no longer participate in runtime configuration. Keep
 	// Load permissive while ensuring the returned struct reflects the supported
 	// infrastructure-only config surface.
-	// Sandbox-by-default in development (#355): when test_mode is not explicitly
-	// provided, a dev-like boot defaults to sandbox credentials so a local run
-	// can never accidentally move real money against live rail credentials
-	// — the dangerous case is silent ("forgot to set it"), so the safe value is
-	// the one you get by omission. Outside development the default stays live
-	// (false), and an explicit test_mode=true is still rejected by Validate: prod
-	// opts into live only by omission and can never opt into sandbox. To run
-	// live locally, set test_mode=false explicitly (env TEST_MODE=false, flag
-	// --test-mode=false). This only governs standalone Load(); embedded hosts
-	// build the Config programmatically and supply their own value.
+	// Sandbox-by-default in development (#355/#745): when test_mode is not
+	// explicitly provided, a dev-like boot defaults to sandbox credentials so a
+	// local run can never accidentally move real money against live rail
+	// credentials — the dangerous case is silent ("forgot to set it"), so the
+	// safe value is the one you get by omission. Outside development the
+	// default stays live, and an explicit test_mode=sandbox is still rejected
+	// by Validate: prod opts into live only by omission and can never opt into
+	// sandbox. To run live locally, set test_mode=live explicitly (env
+	// TEST_MODE=live, flag --test-mode=live). This only governs standalone
+	// Load(); embedded hosts build the Config programmatically and MUST
+	// supply their own value — embedded.New refuses to construct otherwise.
 	if !k.Exists("test_mode") {
-		cfg.TestMode = cfg.IsDev()
+		if cfg.IsDev() {
+			cfg.TestMode = CredentialPostureSandbox
+		} else {
+			cfg.TestMode = CredentialPostureLive
+		}
 	}
 
 	// The control plane is mandatory in standalone mode (#469). In development
@@ -1953,10 +2020,10 @@ func logTestModeStatus(cfg *Config) {
 		log.Info("   Payment providers will use production environments")
 
 		// Warn if running real charges in dev environment. This only happens when
-		// TEST_MODE=false is set explicitly; omitted test_mode defaults to sandbox in dev.
+		// TEST_MODE=live is set explicitly; omitted test_mode defaults to sandbox in dev.
 		if cfg.IsDev() {
 			log.Warn("⚠️  Real payment processing enabled in dev environment")
-			log.Warn("   Set test_mode=true (env TEST_MODE=true, flag --test-mode) to use sandbox environments")
+			log.Warn("   Set test_mode=sandbox (env TEST_MODE=sandbox, flag --test-mode=sandbox) to use sandbox environments")
 		}
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -63,12 +63,12 @@ func TestLoad_EnvMapping(t *testing.T) {
 		}
 	})
 
-	t.Run("maps TEST_MODE to the top-level test_mode bool (#355)", func(t *testing.T) {
-		t.Setenv("TEST_MODE", "true")
+	t.Run("maps TEST_MODE to the top-level test_mode posture (#355/#745)", func(t *testing.T) {
+		t.Setenv("TEST_MODE", "sandbox")
 
 		cfg, err := Load("nonexistent-config.yaml")
 		assert.NoError(t, err)
-		assert.True(t, cfg.TestMode)
+		assert.Equal(t, CredentialPostureSandbox, cfg.TestMode)
 		assert.True(t, cfg.IsTestMode())
 	})
 
@@ -85,16 +85,16 @@ func TestLoad_EnvMapping(t *testing.T) {
 		cfg, err := Load("nonexistent-config.yaml")
 		assert.NoError(t, err)
 		assert.True(t, cfg.IsDev(), "default env is development")
-		assert.True(t, cfg.TestMode, "unset test_mode defaults to sandbox in dev — a local boot can never silently use live credentials")
+		assert.Equal(t, CredentialPostureSandbox, cfg.TestMode, "unset test_mode defaults to sandbox in dev — a local boot can never silently use live credentials")
 		assert.True(t, cfg.IsTestMode())
 	})
 
-	t.Run("explicit test_mode=false runs live in development (#355)", func(t *testing.T) {
-		t.Setenv("TEST_MODE", "false")
+	t.Run("explicit test_mode=live runs live in development (#355/#745)", func(t *testing.T) {
+		t.Setenv("TEST_MODE", "live")
 		cfg, err := Load("nonexistent-config.yaml")
 		assert.NoError(t, err)
 		assert.True(t, cfg.IsDev())
-		assert.False(t, cfg.TestMode, "explicit false is honored over the dev sandbox default")
+		assert.Equal(t, CredentialPostureLive, cfg.TestMode, "explicit live is honored over the dev sandbox default")
 		assert.False(t, cfg.IsTestMode())
 	})
 
@@ -297,16 +297,16 @@ func TestIsTestMode(t *testing.T) {
 		assert.False(t, (&Config{}).IsTestMode())
 	})
 
-	t.Run("test_mode=true is sandbox", func(t *testing.T) {
-		assert.True(t, (&Config{TestMode: true}).IsTestMode())
+	t.Run("test_mode=sandbox is sandbox", func(t *testing.T) {
+		assert.True(t, (&Config{TestMode: CredentialPostureSandbox}).IsTestMode())
 	})
 
 	t.Run("orthogonal to provider_write_mode", func(t *testing.T) {
 		assert.False(t, (&Config{ProviderWriteMode: ProviderWriteModeFull}).IsTestMode())
 		assert.False(t, (&Config{ProviderWriteMode: ProviderWriteModeLimited}).IsTestMode())
 		assert.False(t, (&Config{ProviderWriteMode: ProviderWriteModeReadOnly}).IsTestMode())
-		assert.True(t, (&Config{ProviderWriteMode: ProviderWriteModeFull, TestMode: true}).IsTestMode())
-		assert.True(t, (&Config{ProviderWriteMode: ProviderWriteModeReadOnly, TestMode: true}).IsTestMode())
+		assert.True(t, (&Config{ProviderWriteMode: ProviderWriteModeFull, TestMode: CredentialPostureSandbox}).IsTestMode())
+		assert.True(t, (&Config{ProviderWriteMode: ProviderWriteModeReadOnly, TestMode: CredentialPostureSandbox}).IsTestMode())
 	})
 }
 
@@ -364,14 +364,14 @@ func TestRequiresRLS(t *testing.T) {
 }
 
 func TestProductionTestModeValidation(t *testing.T) {
-	t.Run("prod env rejects test_mode=true", func(t *testing.T) {
+	t.Run("prod env rejects test_mode=sandbox", func(t *testing.T) {
 		cfg := GetDefaultBillingConfig()
 		cfg.Env = "prod"
 		cfg.ProviderWriteMode = ProviderWriteModeFull
-		cfg.TestMode = true
+		cfg.TestMode = CredentialPostureSandbox
 		assembleDBURL(cfg)
 		assert.False(t, cfg.IsDev(), "env=prod should not be dev")
-		assert.ErrorContains(t, Validate(cfg), "test_mode=true is not allowed outside development")
+		assert.ErrorContains(t, Validate(cfg), "test_mode=sandbox is not allowed outside development")
 	})
 
 	t.Run("prod env rejects a plaintext-http auth issuer", func(t *testing.T) {
@@ -398,22 +398,24 @@ func TestProductionTestModeValidation(t *testing.T) {
 	})
 
 	t.Run("a zero-value struct is live + readonly behavior (Load applies the dev sandbox default separately)", func(t *testing.T) {
-		// This builds the struct directly, bypassing Load(), so the zero-value
-		// TestMode is live. The dev sandbox-by-default behavior is applied by
-		// Load() and covered in TestLoad_EnvMapping (#355). Unset
-		// provider_write_mode FAIL-CLOSES to readonly (Paul 2026-07-02).
+		// This builds the struct directly, bypassing Load(), so TestMode is
+		// left unset (""), which IsTestMode() reads as live. The dev
+		// sandbox-by-default behavior is applied by Load() and covered in
+		// TestLoad_EnvMapping (#355/#745). Unset provider_write_mode
+		// FAIL-CLOSES to readonly (Paul 2026-07-02).
 		cfg := GetDefaultBillingConfig()
 		cfg.Env = "dev"
 		assembleDBURL(cfg)
-		assert.False(t, cfg.IsTestMode(), "zero-value test_mode is live; the dev sandbox default is a Load() concern")
+		assert.Equal(t, CredentialPosture(""), cfg.TestMode, "zero-value test_mode is unset; the dev sandbox default is a Load() concern")
+		assert.False(t, cfg.IsTestMode(), "unset test_mode reads as live")
 		assert.True(t, cfg.IsProviderReadOnly(), "unset provider_write_mode fail-closes to readonly")
 		assert.NoError(t, Validate(cfg))
 	})
 
-	t.Run("dev env accepts test_mode=true (sandbox)", func(t *testing.T) {
+	t.Run("dev env accepts test_mode=sandbox", func(t *testing.T) {
 		cfg := GetDefaultBillingConfig()
 		cfg.Env = "dev"
-		cfg.TestMode = true
+		cfg.TestMode = CredentialPostureSandbox
 		assembleDBURL(cfg)
 		assert.True(t, cfg.IsDev(), "env=dev should be dev")
 		assert.True(t, cfg.IsTestMode())
@@ -429,14 +431,61 @@ func TestProductionTestModeValidation(t *testing.T) {
 		assembleDBURL(cfg)
 		assert.NoError(t, Validate(cfg))
 	})
+
+	t.Run("garbage test_mode value is rejected regardless of env", func(t *testing.T) {
+		cfg := GetDefaultBillingConfig()
+		cfg.Env = "dev"
+		cfg.TestMode = CredentialPosture("yes")
+		assembleDBURL(cfg)
+		assert.ErrorContains(t, Validate(cfg), `invalid test_mode "yes"`)
+	})
+}
+
+// #742: RateLimitHTTP(nil, ...) is a full passthrough — Validate refuses a nil
+// rate_limits map outside development unless the host explicitly disabled it.
+func TestValidateRateLimitsRequiredOutsideDev(t *testing.T) {
+	t.Run("prod env rejects nil rate_limits", func(t *testing.T) {
+		cfg := GetDefaultBillingConfig()
+		cfg.Env = "prod"
+		cfg.ProviderWriteMode = ProviderWriteModeFull
+		cfg.DB.Username = "billing_app"
+		cfg.DB.Password = "production-db-password"
+		cfg.RateLimits = nil
+		assembleDBURL(cfg)
+		assert.ErrorContains(t, Validate(cfg), "rate_limits is required outside development")
+	})
+
+	t.Run("prod env accepts an explicit rate_limits_disabled opt-out", func(t *testing.T) {
+		cfg := GetDefaultBillingConfig()
+		cfg.Env = "prod"
+		cfg.ProviderWriteMode = ProviderWriteModeFull
+		cfg.DB.Username = "billing_app"
+		cfg.DB.Password = "production-db-password"
+		cfg.RateLimits = nil
+		cfg.RateLimitsDisabled = true
+		assembleDBURL(cfg)
+		assert.NoError(t, Validate(cfg))
+	})
+
+	t.Run("dev env tolerates nil rate_limits", func(t *testing.T) {
+		cfg := GetDefaultBillingConfig()
+		cfg.Env = "dev"
+		cfg.RateLimits = nil
+		assembleDBURL(cfg)
+		assert.NoError(t, Validate(cfg))
+	})
 }
 
 // stripeTestModeConfig builds a minimal Config plus in-memory RailMerchantAccountSet with a
 // single Stripe rail carrying the given secret key and test_mode setting.
 func stripeTestModeConfig(secretKey string, testMode bool) (*Config, RailMerchantAccountSet) {
+	posture := CredentialPostureLive
+	if testMode {
+		posture = CredentialPostureSandbox
+	}
 	return &Config{
 			ProviderWriteMode: ProviderWriteModeFull,
-			TestMode:          testMode,
+			TestMode:          posture,
 		}, RailMerchantAccountSet{
 			"stripe": {
 				Rail:   models.RailStripe,
@@ -508,7 +557,7 @@ func TestValidateStripeKeyForTestMode(t *testing.T) {
 	})
 
 	t.Run("validates every stripe rail", func(t *testing.T) {
-		cfg := &Config{ProviderWriteMode: ProviderWriteModeFull, TestMode: false}
+		cfg := &Config{ProviderWriteMode: ProviderWriteModeFull, TestMode: CredentialPostureLive}
 		rails := RailMerchantAccountSet{
 			"stripe_primary":  {Rail: models.RailStripe, Stripe: &StripeRailConfig{SecretKey: "sk_live_primary"}},
 			"stripe_archived": {Rail: models.RailStripe, Archived: true, Stripe: &StripeRailConfig{SecretKey: "sk_test_legacy"}},
@@ -578,14 +627,14 @@ func TestCatalogTargetSelectors(t *testing.T) {
 // guard: an account whose declared environment contradicts test_mode is rejected;
 // a matching or unset (derived) environment passes.
 func TestRailEnvironmentMustMatchTestMode(t *testing.T) {
-	// test_mode=true (sandbox) rejects a live-declared account.
-	err := ValidateRailSet(&Config{ProviderWriteMode: ProviderWriteModeFull, TestMode: true}, RailMerchantAccountSet{
+	// test_mode=sandbox rejects a live-declared account.
+	err := ValidateRailSet(&Config{ProviderWriteMode: ProviderWriteModeFull, TestMode: CredentialPostureSandbox}, RailMerchantAccountSet{
 		"stripe": {Rail: models.RailStripe, Environment: "live", Stripe: &StripeRailConfig{SecretKey: "sk_test_x"}},
 	})
 	require.ErrorContains(t, err, "requires environment=test")
 
-	// test_mode=false (production) rejects a test-declared account.
-	cfgLive := &Config{ProviderWriteMode: ProviderWriteModeFull, TestMode: false}
+	// test_mode=live (production) rejects a test-declared account.
+	cfgLive := &Config{ProviderWriteMode: ProviderWriteModeFull, TestMode: CredentialPostureLive}
 	require.ErrorContains(t, ValidateRailSet(cfgLive, RailMerchantAccountSet{
 		"stripe": {Rail: models.RailStripe, Environment: "test", Stripe: &StripeRailConfig{SecretKey: "sk_live_x"}},
 	}), "requires environment=live")
@@ -607,7 +656,7 @@ func TestRailEnvironmentMustMatchTestMode(t *testing.T) {
 func TestStripeLiveKeyRejectedInTestMode(t *testing.T) {
 	cfg := GetDefaultBillingConfig()
 	cfg.DB.URL = "postgres://admin:admin_password@localhost:5432/openrails_db?sslmode=disable"
-	cfg.TestMode = true
+	cfg.TestMode = CredentialPostureSandbox
 	rails := RailMerchantAccountSet{
 		"stripe": {Rail: "stripe", Stripe: &StripeRailConfig{SecretKey: "sk_live_abc123"}},
 	}
@@ -859,7 +908,7 @@ func TestOperatingModes(t *testing.T) {
 	require.True(t, ro.IsProviderReadOnly())
 
 	// mode is pure behavior: test_mode does not change the behavior gates
-	roSandbox := &Config{ProviderWriteMode: ProviderWriteModeReadOnly, TestMode: true}
+	roSandbox := &Config{ProviderWriteMode: ProviderWriteModeReadOnly, TestMode: CredentialPostureSandbox}
 	require.True(t, roSandbox.IsLimitedMode())
 	require.True(t, roSandbox.IsProviderReadOnly())
 

--- a/config/merchant_source_test.go
+++ b/config/merchant_source_test.go
@@ -14,6 +14,10 @@ func validAPIBase(env string) *Config {
 		MerchantSource:    MerchantSourceAPI,
 		ProviderWriteMode: ProviderWriteModeReadOnly,
 		DB:                &DBConfig{URL: "postgres://u:p@localhost:5432/x"},
+		// #742: Validate refuses nil rate_limits outside development —
+		// orthogonal to what this test exercises (merchant_source), so give it
+		// a posture rather than tripping that gate incidentally.
+		RateLimits: GetDefaultBillingConfig().RateLimits,
 	}
 }
 
@@ -85,6 +89,7 @@ func TestMerchantSourceManifestIgnoresEncryptionPosture(t *testing.T) {
 		MerchantSource:    MerchantSourceManifest,
 		ProviderWriteMode: ProviderWriteModeReadOnly,
 		DB:                &DBConfig{URL: "postgres://u:p@localhost:5432/x"},
+		RateLimits:        GetDefaultBillingConfig().RateLimits,
 	}
 	if err := Validate(cfg); err != nil {
 		t.Fatalf("manifest mode must not require an encryption/secret backend: %v", err)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -109,7 +109,7 @@ services:
     environment:
       # Service runtime mode
       ENV: "${ENV:-development}"
-      TEST_MODE: "${TEST_MODE:-true}"
+      TEST_MODE: "${TEST_MODE:-sandbox}"
       PORT: "3053"
       API_URL: "${API_URL:-http://localhost:3053}"
       AUTH_ISSUER: "${AUTH_ISSUER:-http://localhost:3053}"

--- a/docs/e2e-mobius-sandbox.md
+++ b/docs/e2e-mobius-sandbox.md
@@ -74,7 +74,7 @@ Minimum set (fill in real values):
 
 ```bash
 # sandbox mode
-TEST_MODE=true
+TEST_MODE=sandbox
 
 # NMI sandbox values used by the bootstrap manifest and helper scripts.
 NMI_SANDBOX_SECURITY_KEY=...
@@ -92,7 +92,7 @@ E2E_NMI_PLAN_ID=openrails_e2e_nmi_daily_999
 
 Notes:
 - Billing uses fixed NMI gateway endpoints for direct-post and query calls. Use
-  sandbox/test credentials when `TEST_MODE=true`.
+  sandbox/test credentials when `TEST_MODE=sandbox`.
 - OpenRails does not read RAILS_* from `.env`. Seed merchant-scoped
   provider credentials through `openrails push-merchant-config`:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -398,7 +398,7 @@ what backfills those missed provider events from the durable watermark.
   system-initiated touches a provider; everything user/admin-asked works.
   `readonly`: zero provider writes, wire-enforced on all three rails (NMI
   direct-post, Stripe transport, Solana transaction submission).
-- `test_mode = true|false` — credential sandbox enforcement, orthogonal to
+- `test_mode = sandbox|live` — credential sandbox enforcement, orthogonal to
   provider_write_mode: sandbox routing + Stripe live-key refusal + the NMI boot probe (one
   auth on the non-issued test card; a decline proves production credentials
   and refuses the boot) + Solana devnet. Probe verdicts cache for 12h in

--- a/embed/inprocess_transport_integration_test.go
+++ b/embed/inprocess_transport_integration_test.go
@@ -34,7 +34,7 @@ func TestInProcessTransportAuthTraversal(t *testing.T) {
 	t.Cleanup(pool.Close)
 	dbtest.EnsureTestMerchant(ctx, t, pool)
 
-	cfg := &config.Config{Env: "dev", DB: &config.DBConfig{URL: dsn}}
+	cfg := &config.Config{Env: "dev", TestMode: config.CredentialPostureLive, DB: &config.DBConfig{URL: dsn}}
 	rt, err := New(ctx, Options{Options: embedded.Options{Config: cfg}})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })

--- a/embed/manifest_mode_integration_test.go
+++ b/embed/manifest_mode_integration_test.go
@@ -40,7 +40,8 @@ import (
 
 func manifestModeConfig(dsn string) *config.Config {
 	return &config.Config{
-		Env: "dev",
+		Env:      "dev",
+		TestMode: config.CredentialPostureLive,
 		// Explicit default (#723): manifest-is-truth.
 		MerchantSource: config.MerchantSourceManifest,
 		// full: the loop test executes a (fake-provider) charge.
@@ -361,6 +362,7 @@ func TestAPIMode_MutationRoutesWork(t *testing.T) {
 	slug := fmt.Sprintf("mapi%d", nano)
 	cfg := &config.Config{
 		Env:               "dev",
+		TestMode:          config.CredentialPostureLive,
 		MerchantSource:    config.MerchantSourceAPI,
 		ProviderWriteMode: config.ProviderWriteModeFull,
 		DB:                &config.DBConfig{URL: dsn},
@@ -414,6 +416,7 @@ func TestManifestMode_APIModeRefusesManifestTruth(t *testing.T) {
 	slug := fmt.Sprintf("mrefuse%d", nano)
 	cfg := &config.Config{
 		Env:            "dev",
+		TestMode:       config.CredentialPostureLive,
 		MerchantSource: config.MerchantSourceAPI,
 		DB:             &config.DBConfig{URL: dsn},
 	}

--- a/embed/provision_integration_test.go
+++ b/embed/provision_integration_test.go
@@ -28,7 +28,7 @@ func TestUpsertMerchantConfig_SeedsRailMerchantAccounts(t *testing.T) {
 	pool := appDB.Pool()
 
 	slug := fmt.Sprintf("embed-provision-%d", time.Now().UnixNano())
-	cfg := &config.Config{Env: "dev", DB: &config.DBConfig{URL: dsn}}
+	cfg := &config.Config{Env: "dev", TestMode: config.CredentialPostureLive, DB: &config.DBConfig{URL: dsn}}
 	rt, err := embed.New(ctx, embed.Options{
 		Options: embedded.Options{Config: cfg},
 	})

--- a/embed/pull_arming_integration_test.go
+++ b/embed/pull_arming_integration_test.go
@@ -42,7 +42,7 @@ func TestEmbeddedPullArming_ManifestSecretsNoPaymentProviders(t *testing.T) {
 	ccbillAccount := fmt.Sprintf("91%04d-0000", nano%10_000)
 	securityKey := fmt.Sprintf("sec-key-%d", nano)
 
-	cfg := &config.Config{Env: "dev", DB: &config.DBConfig{URL: dsn}}
+	cfg := &config.Config{Env: "dev", TestMode: config.CredentialPostureLive, DB: &config.DBConfig{URL: dsn}}
 	rt, err := embed.New(ctx, embed.Options{
 		Options: embedded.Options{Config: cfg}, // deliberately NO PaymentProviders
 	})
@@ -179,7 +179,7 @@ func (f *pullFakeNMI) sawKey(key string) bool {
 func pullCLIManifestMerchant(t *testing.T, ctx context.Context, dsn, slug string, m embed.MerchantConfig) merchant.ID {
 	t.Helper()
 	appDB := dbtest.OpenAppDB(t, dsn)
-	cfg := &config.Config{Env: "dev", DB: &config.DBConfig{URL: dsn}}
+	cfg := &config.Config{Env: "dev", TestMode: config.CredentialPostureLive, DB: &config.DBConfig{URL: dsn}}
 	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg}})
 	require.NoError(t, err)
 	id, err := rt.UpsertMerchantConfig(ctx, slug, m)
@@ -233,7 +233,7 @@ func TestPullProviderCLI_ManifestModeArmsFromManifestPlane(t *testing.T) {
 	fake := newPullFakeNMI(t)
 	var out bytes.Buffer
 	require.NoError(t, embedded.PullProvider(ctx, embedded.PullProviderOptions{
-		Config:           &config.Config{Env: "dev", DB: &config.DBConfig{URL: dsn}},
+		Config:           &config.Config{Env: "dev", TestMode: config.CredentialPostureLive, DB: &config.DBConfig{URL: dsn}},
 		MerchantSlug:     slug,
 		Providers:        []string{"nmi"},
 		LogDir:           t.TempDir(),
@@ -277,7 +277,7 @@ func TestPullProviderCLI_ManifestModeMissingSecretRailNotArmed(t *testing.T) {
 	hook := logrustest.NewGlobal()
 	defer hook.Reset()
 	err := embedded.PullProvider(ctx, embedded.PullProviderOptions{
-		Config:           &config.Config{Env: "dev", DB: &config.DBConfig{URL: dsn}},
+		Config:           &config.Config{Env: "dev", TestMode: config.CredentialPostureLive, DB: &config.DBConfig{URL: dsn}},
 		MerchantSlug:     slug,
 		Providers:        []string{"nmi"},
 		LogDir:           t.TempDir(),

--- a/embed/spend_delegations_integration_test.go
+++ b/embed/spend_delegations_integration_test.go
@@ -28,7 +28,7 @@ func TestEmbeddedClientSetCustomerSpendDelegations(t *testing.T) {
 	t.Cleanup(pool.Close)
 	customerID := dbtest.EnsureCustomerIDPgx(ctx, t, pool, "b6b6b6b6-0000-4000-8000-000000000042")
 
-	cfg := &config.Config{Env: "dev", DB: &config.DBConfig{URL: dsn}}
+	cfg := &config.Config{Env: "dev", TestMode: config.CredentialPostureLive, DB: &config.DBConfig{URL: dsn}}
 	rt, err := New(ctx, Options{Options: embedded.Options{Config: cfg}})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })

--- a/internal/app/build_runtime_test.go
+++ b/internal/app/build_runtime_test.go
@@ -15,7 +15,7 @@ func TestCreateCCBillDataLinkClientPropagatesTestMode(t *testing.T) {
 
 	cfg := config.GetDefaultBillingConfig()
 	cfg.ProviderWriteMode = config.ProviderWriteModeFull
-	cfg.TestMode = true
+	cfg.TestMode = config.CredentialPostureSandbox
 	rails := config.RailMerchantAccountSet{
 		"ccbill": {
 			Rail: models.RailCCBill,
@@ -70,7 +70,11 @@ func solanaCfg(t *testing.T, testMode bool, tokens map[string]config.TokenConfig
 	t.Helper()
 	cfg := config.GetDefaultBillingConfig()
 	cfg.ProviderWriteMode = config.ProviderWriteModeFull
-	cfg.TestMode = testMode
+	posture := config.CredentialPostureLive
+	if testMode {
+		posture = config.CredentialPostureSandbox
+	}
+	cfg.TestMode = posture
 	rails := config.RailMerchantAccountSet{
 		"solana": {Rail: models.RailSolana, Solana: &config.SolanaRailConfig{Tokens: tokens}},
 	}

--- a/internal/http/embedhttp/embedhttp.go
+++ b/internal/http/embedhttp/embedhttp.go
@@ -121,12 +121,15 @@ func FromApp(a *app.App) *Assembler {
 // CORS, body limit, merchant resolution) — the gin-free analogue of the global
 // engine middleware. The returned handler imports zero gin on the request path.
 //
-// Rate-limiting + the captcha challenge flow ARE enforced here: the embedded
-// surface runs OpenRails' own per-IP/per-user rate limits and captcha via the
-// gin-free middleware.RateLimitHTTP, so an embedded host does not need to front
-// billing with its own gateway. billingauth.Optional runs ahead of the limiter so
-// an authenticated caller is keyed per-user, not only per-IP (mirroring the
-// standalone engine's authProvider.Optional() → RateLimit order).
+// Rate-limiting + the captcha challenge flow ARE enforced here BY DEFAULT
+// (#742): embedded.New seeds config.Config.RateLimits/Captcha with the same
+// curated defaults config.Load applies whenever the host leaves them nil, so
+// an embedded host does not need to front billing with its own gateway unless
+// it explicitly opts out (config.Config.RateLimitsDisabled) — RateLimitHTTP
+// runs as a passthrough only then. billingauth.Optional runs ahead of the
+// limiter so an authenticated caller is keyed per-user, not only per-IP
+// (mirroring the standalone engine's authProvider.Optional() → RateLimit
+// order).
 func (s *Assembler) NewHTTPHandler(opts Options) http.Handler {
 	routeSets := routeSetMap(opts.RouteSets)
 	if err := s.validateAuthBoundary(routeSets); err != nil {

--- a/internal/http/handlers/webhook_ccbill_test.go
+++ b/internal/http/handlers/webhook_ccbill_test.go
@@ -17,6 +17,15 @@ import (
 	"github.com/open-rails/openrails/pkg/merchant"
 )
 
+// credentialPostureFromBool maps the test helpers' legacy bool parameter onto
+// the explicit posture enum (#745).
+func credentialPostureFromBool(sandbox bool) config.CredentialPosture {
+	if sandbox {
+		return config.CredentialPostureSandbox
+	}
+	return config.CredentialPostureLive
+}
+
 // stubCCBillLiveProbe swaps the catalog probe for the duration of a test.
 func stubCCBillLiveProbe(t *testing.T, hasLive bool, err error) {
 	t.Helper()
@@ -33,7 +42,7 @@ func newCCBillWebhookRequest(t *testing.T, testMode bool, remoteAddr string) (*h
 	req.RemoteAddr = remoteAddr
 	req.SetPathValue("provider", "ccbill")
 	req = req.WithContext(merchant.WithID(req.Context(), merchant.ID(uuid.New())))
-	rt := &app.Runtime{Config: &config.Config{TestMode: testMode}}
+	rt := &app.Runtime{Config: &config.Config{TestMode: credentialPostureFromBool(testMode)}}
 	return httprequest.NewHTTP(w, req, rt), w
 }
 
@@ -67,7 +76,7 @@ func TestCCBillWebhookSandboxPostureKeepsDevBypass(t *testing.T) {
 func TestCCBillWebhookIPAllowedMatrix(t *testing.T) {
 	newReq := func(testMode bool) *httprequest.Request {
 		req := httptest.NewRequest(http.MethodPost, "/v1/webhooks/ccbill", nil)
-		return httprequest.NewHTTP(httptest.NewRecorder(), req, &app.Runtime{Config: &config.Config{TestMode: testMode}})
+		return httprequest.NewHTTP(httptest.NewRecorder(), req, &app.Runtime{Config: &config.Config{TestMode: credentialPostureFromBool(testMode)}})
 	}
 
 	// Allowlisted CCBill source IP always passes, regardless of posture.

--- a/internal/http/routes_merchant_webhook_integration_test.go
+++ b/internal/http/routes_merchant_webhook_integration_test.go
@@ -65,8 +65,8 @@ func TestMerchantWebhookRouteHTTPResolvesMerchantBeforeVerifyingStripe(t *testin
 	putProviderSecretEnv(t, ctx, secrets, acme.ID, "stripe", "test", "acct_acme_test", "webhook_signing_secret", "whsec_acme_test")
 	putProviderSecretEnv(t, ctx, secrets, acme.ID, "nmi", "test", "nmi_acme_test", "webhook_signing_secret", "nmi_acme_test")
 
-	rt := &app.Runtime{Config: &config.Config{TestMode: true}, Merchants: svc}
-	globalRT := &app.Runtime{Config: &config.Config{TestMode: true}, Merchants: svc}
+	rt := &app.Runtime{Config: &config.Config{TestMode: config.CredentialPostureSandbox}, Merchants: svc}
+	globalRT := &app.Runtime{Config: &config.Config{TestMode: config.CredentialPostureSandbox}, Merchants: svc}
 	mux := http.NewServeMux()
 	httproutes.RegisterWebhookRoutes(router.NewMux(mux, "/global", globalRT), globalRT)
 	httproutes.RegisterMerchantWebhookRoutes(router.NewMux(mux, "/v1", rt), rt)

--- a/internal/integrationharness/embedded_mount_handler_integration_test.go
+++ b/internal/integrationharness/embedded_mount_handler_integration_test.go
@@ -45,8 +45,9 @@ func TestEmbeddedMountHandlerEndToEnd(t *testing.T) {
 	rt, err := embed.New(ctx, embed.Options{
 		Options: embedded.Options{
 			Config: &config.Config{
-				Env: "dev",
-				DB:  &config.DBConfig{URL: h.DSN},
+				Env:      "dev",
+				TestMode: config.CredentialPostureSandbox,
+				DB:       &config.DBConfig{URL: h.DSN},
 			},
 			Redis: h.Redis,
 		},

--- a/internal/integrationharness/harness.go
+++ b/internal/integrationharness/harness.go
@@ -242,7 +242,7 @@ func (h *Harness) StartEmbeddedHost(currency string) *Surface {
 
 	dbtest.EnsureTestMerchant(h.ctx, h.t, h.sharedPool())
 
-	cfg := &config.Config{Env: "dev", DB: &config.DBConfig{URL: h.DSN}}
+	cfg := &config.Config{Env: "dev", TestMode: config.CredentialPostureSandbox, DB: &config.DBConfig{URL: h.DSN}}
 	rt, err := embed.New(h.ctx, embed.Options{
 		Options: embedded.Options{Config: cfg, Redis: h.Redis},
 	})
@@ -377,7 +377,7 @@ func (h *Harness) startStandalone(currency, appDSN, name string, opts ...Standal
 
 	cfg := &config.Config{
 		Env:      "dev",
-		TestMode: true,
+		TestMode: config.CredentialPostureSandbox,
 		// MODE 2 (#723): the standalone harness IS the API-driven SaaS shape —
 		// merchants/secrets/catalog mutate over the HTTP surface it exercises.
 		// Manifest-mode standalone behavior is tested per-case, not here.

--- a/internal/integrationharness/mount_route_selection_integration_test.go
+++ b/internal/integrationharness/mount_route_selection_integration_test.go
@@ -51,8 +51,9 @@ func TestMountHandlerRouteSelection(t *testing.T) {
 	rt, err := embed.New(ctx, embed.Options{
 		Options: embedded.Options{
 			Config: &config.Config{
-				Env: "dev",
-				DB:  &config.DBConfig{URL: h.DSN},
+				Env:      "dev",
+				TestMode: config.CredentialPostureSandbox,
+				DB:       &config.DBConfig{URL: h.DSN},
 			},
 			Redis: h.Redis,
 		},

--- a/internal/integrationharness/route_surface_test.go
+++ b/internal/integrationharness/route_surface_test.go
@@ -33,7 +33,7 @@ func TestStandaloneRouteSurface(t *testing.T) {
 
 	cfg := &config.Config{
 		Env:      "dev",
-		TestMode: true,
+		TestMode: config.CredentialPostureSandbox,
 		Host:     "127.0.0.1",
 		Port:     0,
 		DB:       &config.DBConfig{URL: appDSN},

--- a/internal/integrations/stripeapi/stripeapi_test.go
+++ b/internal/integrations/stripeapi/stripeapi_test.go
@@ -66,7 +66,7 @@ func TestNonReadOnlyAllowsWrites(t *testing.T) {
 	srv, hits := newCountingServer(t)
 	for _, cfg := range []*config.Config{
 		nil, // nil = tests/full (documented Client contract)
-		{ProviderWriteMode: config.ProviderWriteModeFull, TestMode: true}, // sandbox creds, full behavior
+		{ProviderWriteMode: config.ProviderWriteModeFull, TestMode: config.CredentialPostureSandbox}, // sandbox creds, full behavior
 		{ProviderWriteMode: config.ProviderWriteModeFull},
 		{ProviderWriteMode: config.ProviderWriteModeLimited}, // limited gates live at the dispatcher/worker layer, not the wire
 	} {

--- a/internal/intents/manual_rebill_store_arming_integration_test.go
+++ b/internal/intents/manual_rebill_store_arming_integration_test.go
@@ -27,8 +27,8 @@ import (
 // only the external NMI gateway is a fake HTTP server.
 
 func storeRebillConfig() *config.Config {
-	// TestMode=true → provider environment "test", matching the seeding below.
-	return &config.Config{Env: "dev", TestMode: true, ProviderWriteMode: config.ProviderWriteModeFull}
+	// TestMode=sandbox → provider environment "test", matching the seeding below.
+	return &config.Config{Env: "dev", TestMode: config.CredentialPostureSandbox, ProviderWriteMode: config.ProviderWriteModeFull}
 }
 
 func rebillMerchantsService(t *testing.T, dbi *db.DB) *merchants.Service {
@@ -161,7 +161,7 @@ func TestManualRebillNoStoreRow_FallsBackToBootClients(t *testing.T) {
 	// only ever declare test-environment accounts, so the pull scope is
 	// deterministically empty here even when other packages concurrently seed
 	// NMI rows for the shared test merchant.
-	liveCfg := &config.Config{Env: "dev", TestMode: false, ProviderWriteMode: config.ProviderWriteModeFull}
+	liveCfg := &config.Config{Env: "dev", TestMode: config.CredentialPostureLive, ProviderWriteMode: config.ProviderWriteModeFull}
 
 	cfg := storeRebillConfig()
 	boot := map[string]*nmi.NMIClient{"mobius": bootClient}

--- a/internal/modules/checkout/merchant_rail_secrets_test.go
+++ b/internal/modules/checkout/merchant_rail_secrets_test.go
@@ -235,9 +235,13 @@ func TestCheckoutCCBillSubscriptionUsesMerchantSecret(t *testing.T) {
 }
 
 func checkoutRailConfig(testMode bool) *config.Config {
+	posture := config.CredentialPostureLive
+	if testMode {
+		posture = config.CredentialPostureSandbox
+	}
 	return &config.Config{
 		ProviderWriteMode: config.ProviderWriteModeFull,
-		TestMode:          testMode,
+		TestMode:          posture,
 	}
 }
 

--- a/internal/modules/checkout/sandbox_rail_credentials_integration_test.go
+++ b/internal/modules/checkout/sandbox_rail_credentials_integration_test.go
@@ -56,7 +56,7 @@ func TestSandboxPostureCheckoutResolvesNMIAndCCBillFromTestRows(t *testing.T) {
 	seed("ccbill", ccbillAccount)
 	putSecret("ccbill", ccbillAccount, "salt", "ccbill-sandbox-salt-681")
 
-	svc := &CheckoutService{Config: &config.Config{ProviderWriteMode: config.ProviderWriteModeFull, TestMode: true}}
+	svc := &CheckoutService{Config: &config.Config{ProviderWriteMode: config.ProviderWriteModeFull, TestMode: config.CredentialPostureSandbox}}
 	svc.SetMerchantSecretStore(store)
 	svc.SetRailMerchantAccountSecretResolver(msvc)
 

--- a/internal/modules/checkout/session_service_solana_security_test.go
+++ b/internal/modules/checkout/session_service_solana_security_test.go
@@ -300,7 +300,7 @@ const (
 
 func testSolanaCheckoutConfig() *config.Config {
 	return &config.Config{
-		TestMode: true,
+		TestMode: config.CredentialPostureSandbox,
 	}
 }
 

--- a/internal/modules/money/live_rail_invoice_integration_test.go
+++ b/internal/modules/money/live_rail_invoice_integration_test.go
@@ -84,7 +84,7 @@ func TestLiveStripeInvoiceCollectionAgainstTestAccount(t *testing.T) {
 	// declared full: unset now fails CLOSED to readonly, and this test's whole
 	// point is a real test-mode invoice write.
 	stripeSvc := &subscriptions.StripeService{
-		Config: &config.Config{Env: "dev", TestMode: true, ProviderWriteMode: config.ProviderWriteModeFull},
+		Config: &config.Config{Env: "dev", TestMode: config.CredentialPostureSandbox, ProviderWriteMode: config.ProviderWriteModeFull},
 		Rails: config.RailMerchantAccountSet{
 			"stripe": {Rail: models.RailStripe, AccountID: stripeAccountID, Stripe: &config.StripeRailConfig{SecretKey: storeCreds.SecretKey}},
 		},
@@ -185,7 +185,7 @@ func requireLiveRailTest(t *testing.T) {
 		t.Skipf("%s=1 is required for live rail invoice tests", liveRailOptIn)
 	}
 	if !isTruthy(os.Getenv("TEST_MODE")) && !isTruthy(os.Getenv("OPENRAILS_TEST_MODE")) {
-		t.Fatalf("TEST_MODE=true is required for live rail invoice tests")
+		t.Fatalf("TEST_MODE=sandbox is required for live rail invoice tests")
 	}
 }
 
@@ -201,7 +201,7 @@ func cleanupInvoiceRows(t *testing.T, pool *pgxpool.Pool, ctx context.Context, p
 
 func isTruthy(v string) bool {
 	switch strings.ToLower(strings.TrimSpace(v)) {
-	case "1", "true", "yes", "on":
+	case "1", "true", "yes", "on", "sandbox":
 		return true
 	default:
 		return false

--- a/internal/modules/money/merchant_store_arming_integration_test.go
+++ b/internal/modules/money/merchant_store_arming_integration_test.go
@@ -28,7 +28,7 @@ import (
 // merchantsServiceForTest builds the production merchants.Service over the
 // shared test DB with the production DB-backed secret store (real
 // openrails.merchant_secrets rows), in the test-environment posture the live
-// tests run under (TEST_MODE=true).
+// tests run under (TEST_MODE=sandbox).
 func merchantsServiceForTest(t *testing.T, dbi *db.DB) *merchants.Service {
 	t.Helper()
 	store, err := merchants.NewDBSecretStore(dbi.DataPool())
@@ -97,7 +97,7 @@ func TestRailCredentialStoreArming_ProductionResolutionPath(t *testing.T) {
 	require.Equal(t, stripeKey, creds.SecretKey, "LoadStripeCredentials must resolve the seeded scoped secret")
 
 	stripeSvc := &subscriptions.StripeService{
-		Config: &config.Config{Env: "dev", TestMode: true},
+		Config: &config.Config{Env: "dev", TestMode: config.CredentialPostureSandbox},
 		Rails: config.RailMerchantAccountSet{
 			"stripe": {Rail: models.RailStripe, AccountID: stripeAccount, Stripe: &config.StripeRailConfig{SecretKey: creds.SecretKey}},
 		},

--- a/internal/modules/money/merchant_store_collection_integration_test.go
+++ b/internal/modules/money/merchant_store_collection_integration_test.go
@@ -29,9 +29,9 @@ import (
 // fallback and the fail-closed (declared-but-secretless) contract.
 
 func storeCollectionTestConfig() *config.Config {
-	// TestMode=true → provider environment "test", matching
+	// TestMode=sandbox → provider environment "test", matching
 	// merchantsServiceForTest / seedRailMerchantAccountSecrets.
-	return &config.Config{Env: "dev", TestMode: true, ProviderWriteMode: config.ProviderWriteModeFull}
+	return &config.Config{Env: "dev", TestMode: config.CredentialPostureSandbox, ProviderWriteMode: config.ProviderWriteModeFull}
 }
 
 func storeArmedCharger(dbi *db.DB, msvc *merchants.Service, boot map[string]money.CollectionAdapter, endpoints money.CollectionEndpoints) *money.ScopedCharger {

--- a/internal/modules/money/nmi_collection_sandbox_integration_test.go
+++ b/internal/modules/money/nmi_collection_sandbox_integration_test.go
@@ -48,7 +48,8 @@ func TestChargeOutstanding_NMISandbox_CollectsRealCharge(t *testing.T) {
 	cleanupInvoiceRows(t, pool, ctx, payer)
 
 	// The REAL NMI client, pointed at the REAL sandbox Direct Post endpoint (no URL
-	// override). test_mode=true mirrors the TEST_MODE=true sandbox configuration.
+	// override). The nmi.NewClient testMode=true mirrors the TEST_MODE=sandbox
+	// configuration.
 	client, err := nmi.NewClient(string(models.RailNMI), &config.NMIProviderSettings{
 		SecurityKey:   securityKey,
 		WebhookSecret: strings.TrimSpace(os.Getenv("NMI_WEBHOOK_SIGNING_SECRET")),

--- a/internal/modules/paymentmethods/vault_service_test.go
+++ b/internal/modules/paymentmethods/vault_service_test.go
@@ -288,9 +288,13 @@ func (r vaultPerMerchantProviderSecretResolver) ActiveRailMerchantAccountScope(_
 }
 
 func vaultTestConfig(testMode bool) *config.Config {
+	posture := config.CredentialPostureLive
+	if testMode {
+		posture = config.CredentialPostureSandbox
+	}
 	return &config.Config{
 		ProviderWriteMode: config.ProviderWriteModeFull,
-		TestMode:          testMode,
+		TestMode:          posture,
 	}
 }
 

--- a/pkg/embedded/controlplane/provision_integration_test.go
+++ b/pkg/embedded/controlplane/provision_integration_test.go
@@ -73,7 +73,7 @@ func (s *captureEmailSender) resetLink(email string) string {
 func hostedTestConfig(dsn, issuer string) *config.Config {
 	return &config.Config{
 		Env:      "dev",
-		TestMode: true,
+		TestMode: config.CredentialPostureSandbox,
 		// MODE 2 (#723): the hosted-embedder shape — merchants are created over
 		// code paths (ProvisionMerchant), not a manifest.
 		MerchantSource: config.MerchantSourceAPI,

--- a/pkg/embedded/embedded.go
+++ b/pkg/embedded/embedded.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/open-rails/openrails/config"
 	"github.com/open-rails/openrails/internal/app"
@@ -37,10 +37,15 @@ var (
 
 type Options struct {
 	// Config is built programmatically by the host — embedded mode never runs
-	// config.Load, so none of Load's defaulting applies. In particular set
-	// Config.TestMode EXPLICITLY: the zero value means LIVE credential posture
-	// (standalone dev boots default to sandbox; embedded ones do not). New()
-	// warns when TestMode is left false in a dev-like Env (#711).
+	// config.Load, so none of Load's defaulting applies. New() refuses to
+	// construct unless the host has declared its posture explicitly (#745):
+	//   - Config.Env must be non-empty (no implicit dev-like "" posture).
+	//   - Config.TestMode must be config.CredentialPostureSandbox or
+	//     config.CredentialPostureLive (the zero value is UNSET, never "live"
+	//     by default — supersedes #711's warn-only).
+	// New() also seeds Config.RateLimits/Config.Captcha with the same curated
+	// defaults config.Load applies whenever the host leaves them nil (#742),
+	// unless Config.RateLimitsDisabled opts out.
 	Config *config.Config
 	// PGXPool is the host-supplied database handle (pgx/v5). The bun-era
 	// *sql.DB option was removed with the ORM (#334).
@@ -72,18 +77,12 @@ func New(opts Options) (*Embedded, error) {
 	if opts.Config == nil {
 		return nil, fmt.Errorf("config is required")
 	}
+	if err := applyEmbeddedDefaults(opts.Config); err != nil {
+		return nil, err
+	}
 	rails, err := ApplyPaymentProviders(opts.PaymentProviders)
 	if err != nil {
 		return nil, err
-	}
-
-	// #711: warn on the embedded test_mode zero-value fail-open. Standalone
-	// Load() defaults a dev-like boot to sandbox; embedded hosts build Config
-	// programmatically, so a forgotten TestMode silently means LIVE credentials.
-	// Warn-only (an explicit TestMode=false is indistinguishable from omission).
-	if opts.Config.IsDev() && !opts.Config.TestMode {
-		log.Warn("openrails embedded: Config.TestMode is false in a dev-like env — LIVE credential posture. " +
-			"Standalone defaults dev boots to sandbox; set TestMode explicitly (true for sandbox, false if live is intended).")
 	}
 
 	// Build the application graph only; HTTP surfaces (StandaloneHandler /
@@ -101,6 +100,50 @@ func New(opts Options) (*Embedded, error) {
 	}
 
 	return &Embedded{app: application}, nil
+}
+
+// applyEmbeddedDefaults enforces the posture embedded construction must
+// declare explicitly (#745) and seeds the protective defaults config.Load
+// applies (#742) — both because embedded hosts build Config programmatically
+// and never run Load's defaulting/validation pipeline. Mutates cfg in place;
+// called once, early, before the application graph is built.
+func applyEmbeddedDefaults(cfg *config.Config) error {
+	// #745: an empty Env reads as "development" throughout this package
+	// (IsDev/RequiresRLS/RequiresSecretEncryption/Validate's isDev gate),
+	// disabling every hard-gate check below. Standalone Load() defaults dev
+	// boots to sandbox-safe behavior on top of that; embedded construction has
+	// no such safety net, so it must never inherit the dev-like default by
+	// omission — the host must say which environment this is.
+	if strings.TrimSpace(cfg.Env) == "" {
+		return fmt.Errorf("embedded: config.Env is required (#745) — embedded construction never runs config.Load's dev-like empty-Env default; set it explicitly (e.g. \"development\", \"staging\", \"production\")")
+	}
+	// #745: the zero value of the old bool TestMode field silently meant LIVE
+	// credentials; CredentialPosture keeps that trap from recurring by making
+	// "unset" a third, rejected state instead of overlapping with "live"
+	// (supersedes #711's warn-only). Standalone Load() resolves this
+	// explicitly (dev defaults to sandbox, everything else to live) before
+	// Validate ever runs; embedded construction has no such step.
+	switch cfg.TestMode {
+	case config.CredentialPostureSandbox, config.CredentialPostureLive:
+	default:
+		return fmt.Errorf("embedded: config.TestMode is required (#745) — set config.CredentialPostureSandbox or config.CredentialPostureLive explicitly; embedded construction never runs config.Load's dev-defaults-to-sandbox fallback, so an unset value must never be assumed")
+	}
+
+	// #742: RateLimitHTTP(nil, ...) is a full passthrough — a host that never
+	// set RateLimits ships completely unthrottled. Seed the same curated
+	// defaults config.Load applies, unless the host explicitly opted out (a
+	// host that fronts billing with its own gateway/rate limiter). A host that
+	// already set its own RateLimits/Captcha is left alone either way.
+	if !cfg.RateLimitsDisabled {
+		defaults := config.GetDefaultBillingConfig()
+		if cfg.RateLimits == nil {
+			cfg.RateLimits = defaults.RateLimits
+		}
+		if cfg.Captcha == nil {
+			cfg.Captcha = defaults.Captcha
+		}
+	}
+	return nil
 }
 
 // App returns the application graph, the bridge the HTTP surface constructors

--- a/pkg/embedded/embedded_test.go
+++ b/pkg/embedded/embedded_test.go
@@ -1,0 +1,89 @@
+package embedded
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+)
+
+// #745: embedded construction must declare Env and TestMode explicitly — no
+// implicit dev-like defaulting the way standalone config.Load applies.
+
+func TestApplyEmbeddedDefaultsRequiresExplicitEnv(t *testing.T) {
+	cfg := &config.Config{TestMode: config.CredentialPostureLive}
+	err := applyEmbeddedDefaults(cfg)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "config.Env is required")
+
+	cfg = &config.Config{Env: "   ", TestMode: config.CredentialPostureLive}
+	require.ErrorContains(t, applyEmbeddedDefaults(cfg), "config.Env is required")
+}
+
+func TestApplyEmbeddedDefaultsRequiresExplicitTestMode(t *testing.T) {
+	cfg := &config.Config{Env: "development"}
+	err := applyEmbeddedDefaults(cfg)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "config.TestMode is required")
+
+	// Neither a dev-like Env nor a prod-like one may silently pick a posture.
+	cfg = &config.Config{Env: "production"}
+	require.ErrorContains(t, applyEmbeddedDefaults(cfg), "config.TestMode is required")
+}
+
+func TestApplyEmbeddedDefaultsAcceptsExplicitPosture(t *testing.T) {
+	cfg := &config.Config{Env: "development", TestMode: config.CredentialPostureSandbox}
+	require.NoError(t, applyEmbeddedDefaults(cfg))
+
+	cfg = &config.Config{Env: "production", TestMode: config.CredentialPostureLive}
+	require.NoError(t, applyEmbeddedDefaults(cfg))
+}
+
+// #742: a host that never set RateLimits/Captcha gets the same curated
+// defaults config.Load applies — the embedded HTTP surface must not silently
+// ship unthrottled.
+func TestApplyEmbeddedDefaultsSeedsRateLimitsWhenNil(t *testing.T) {
+	cfg := &config.Config{Env: "development", TestMode: config.CredentialPostureSandbox}
+	require.NoError(t, applyEmbeddedDefaults(cfg))
+
+	require.NotNil(t, cfg.RateLimits, "embedded construction must seed curated rate-limit defaults")
+	require.Equal(t, config.GetDefaultBillingConfig().RateLimits, cfg.RateLimits)
+	require.NotNil(t, cfg.Captcha, "embedded construction must seed the default captcha posture")
+	require.Equal(t, config.CaptchaProviderTurnstile, cfg.Captcha.EffectiveProvider())
+}
+
+func TestApplyEmbeddedDefaultsLeavesHostRateLimitsAlone(t *testing.T) {
+	custom := &config.RateLimitsConfig{"checkout": {RequestsPerMinute: 1}}
+	cfg := &config.Config{Env: "development", TestMode: config.CredentialPostureSandbox, RateLimits: custom}
+	require.NoError(t, applyEmbeddedDefaults(cfg))
+	require.Same(t, custom, cfg.RateLimits, "a host-supplied RateLimits must not be overwritten")
+}
+
+func TestApplyEmbeddedDefaultsExplicitDisableYieldsPassthrough(t *testing.T) {
+	cfg := &config.Config{
+		Env:                "development",
+		TestMode:           config.CredentialPostureSandbox,
+		RateLimitsDisabled: true,
+	}
+	require.NoError(t, applyEmbeddedDefaults(cfg))
+	require.Nil(t, cfg.RateLimits, "an explicit opt-out must leave RateLimitHTTP as a passthrough")
+	require.Nil(t, cfg.Captcha)
+}
+
+// New() surfaces the same errors — asserted without a real DB, since the
+// posture/defaults checks run before anything DB-dependent.
+func TestNewRejectsMissingConfig(t *testing.T) {
+	_, err := New(Options{})
+	require.ErrorContains(t, err, "config is required")
+}
+
+func TestNewRejectsUnsetPostureBeforeTouchingTheDatabase(t *testing.T) {
+	cfg := &config.Config{} // no Env, no TestMode, no DB
+	_, err := New(Options{Config: cfg})
+	require.ErrorContains(t, err, "config.Env is required")
+
+	cfg = &config.Config{Env: "development"}
+	_, err = New(Options{Config: cfg})
+	require.ErrorContains(t, err, "config.TestMode is required")
+}

--- a/pkg/service/catalog_provider_stripe_live_test.go
+++ b/pkg/service/catalog_provider_stripe_live_test.go
@@ -32,13 +32,13 @@ func TestLiveStripeCatalogAutoCreateReusesContentKeys(t *testing.T) {
 	defer cancel()
 
 	stripeSvc := &catalog.StripeCatalogService{
-		Config: &config.Config{Env: "dev", TestMode: true},
+		Config: &config.Config{Env: "dev", TestMode: config.CredentialPostureSandbox},
 		Rails: config.RailMerchantAccountSet{
 			"stripe": {Rail: models.RailStripe, Stripe: &config.StripeRailConfig{SecretKey: key}},
 		},
 	}
 	svc := &Service{rt: &app.Runtime{
-		Config: &config.Config{Env: "dev", TestMode: true},
+		Config: &config.Config{Env: "dev", TestMode: config.CredentialPostureSandbox},
 		Rails: config.RailMerchantAccountSet{
 			"stripe": {Rail: models.RailStripe, Stripe: &config.StripeRailConfig{SecretKey: key}},
 		},

--- a/pkg/service/catalog_provider_stripe_test.go
+++ b/pkg/service/catalog_provider_stripe_test.go
@@ -21,7 +21,7 @@ import (
 
 func newStripeAdapterWithServer(serverURL string) *stripeAdapter {
 	svc := &Service{rt: &app.Runtime{
-		Config: &config.Config{Env: "dev", TestMode: true, ProviderWriteMode: config.ProviderWriteModeFull},
+		Config: &config.Config{Env: "dev", TestMode: config.CredentialPostureSandbox, ProviderWriteMode: config.ProviderWriteModeFull},
 		Rails: config.RailMerchantAccountSet{
 			"stripe": {Rail: models.RailStripe, Stripe: &config.StripeRailConfig{SecretKey: "sk_test_wirepin"}},
 		},


### PR DESCRIPTION
## Summary

- **#742** — `embedded.New` seeds `Config.RateLimits`/`Config.Captcha` from `GetDefaultBillingConfig()` whenever the host leaves them nil, closing the `RateLimitHTTP(nil, ...)` passthrough that let embedded hosts ship completely unthrottled while embedhttp.go's doc comment promised the opposite. New `Config.RateLimitsDisabled bool` (zero value = false = protected) lets a host that truly fronts the engine with its own gateway opt out explicitly. `config.Validate` now refuses a nil `RateLimits` map outside development unless that opt-out is set.
- **#745** — `Config.TestMode` moves from `bool` to a new `CredentialPosture` enum (`sandbox`/`live`; wire names `test_mode`/`TEST_MODE`/`--test-mode` unchanged, only the accepted values change) so the Go zero value is UNSET rather than an implicit LIVE-money posture. `embedded.New` now hard-rejects both an unset `TestMode` and an empty `Env` — embedded construction never runs `config.Load`'s dev-like defaulting, so it can no longer silently compose `Env=""→dev` with `TestMode zero→live` the way #711's warn-only left open. Standalone `config.Load`'s own dev-defaulting behavior (empty `Env`→development, unset `test_mode`→sandbox-in-dev/live-otherwise) is unchanged.
- Swept `config.go` for other zero-value-is-dangerous fields; findings (fixed / already-safe / flagged-for-later) are recorded in the tracker.

Pre-launch, no back-compat aliases: `TEST_MODE=true|false` is no longer accepted — hosts set `TEST_MODE=sandbox|live`. doujins/openrails-saas need to update on their next version bump (their hand-copied `RateLimits` workaround, saas commit b1e5020, can also be deleted then).

## Test plan

- [x] `gofmt`, `go vet ./...`, `go vet -tags=integration ./...`, `go build ./...` all clean
- [x] `go test ./...` (full repo, no docker) green
- [x] `go test -tags=integration ./pkg/embedded/... ./embed/... ./internal/integrationharness/... ./internal/modules/checkout/... ./internal/modules/money/... ./internal/intents/... ./internal/http/...` green (docker-backed)
- [x] New unit tests: `pkg/embedded/embedded_test.go` (Env/TestMode-required, RateLimits/Captcha default-seeding, explicit opt-out passthrough), `config.TestValidateRateLimitsRequiredOutsideDev`, extended `config.TestProductionTestModeValidation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)