### PR TITLE
fix #744/#746: live-resolve ConfiguredMerchant per request; add proxy-aware client-IP resolver

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -63,6 +63,13 @@ rate_limits:
   default:
     requests_per_minute: 300
 
+# CIDRs whose X-Forwarded-For is trusted (#746). Empty (default) trusts
+# NOTHING — rate limiting, abuse tracking, webhook IPAddress recording, and the
+# CCBill IP allowlist all use the raw socket peer. Set this to your load
+# balancer's/reverse proxy's address range when deploying behind one.
+# trusted_proxies:
+#   - 10.0.0.0/8
+
 captcha:
   provider: turnstile   # turnstile | recaptcha-v3 | hcaptcha
   site_key: ""

--- a/config/config.go
+++ b/config/config.go
@@ -184,6 +184,16 @@ type Config struct {
 	// defaults to 1h; "0" disables the loop; malformed values refuse to boot.
 	// Env: CATALOG_RECONCILIATION_INTERVAL.
 	CatalogReconciliationInterval string `koanf:"catalog_reconciliation_interval,omitempty"`
+
+	// TrustedProxies lists CIDRs (e.g. "10.0.0.0/8") whose X-Forwarded-For is
+	// trusted (#746: one proxy-aware client-IP resolver for rate limiting,
+	// abuse tracking, webhook IPAddress recording, and the CCBill IP
+	// allowlist). Empty (the default) trusts NOTHING — every client-IP
+	// resolution uses the raw socket peer, so a spoofed X-Forwarded-For has
+	// zero effect. Set this to your load balancer's/reverse proxy's address
+	// range when deploying behind one. Env: TRUSTED_PROXIES (YAML list or a
+	// JSON array string, e.g. TRUSTED_PROXIES='["10.0.0.0/8"]').
+	TrustedProxies []string `koanf:"trusted_proxies,omitempty"`
 }
 
 // CatalogReconciliationSchedule resolves the catalog reconciliation loop
@@ -1057,6 +1067,24 @@ func Validate(cfg *Config) error {
 		return fmt.Errorf("merchant_source config validation failed: %w", err)
 	}
 
+	if err := validateTrustedProxies(cfg.TrustedProxies); err != nil {
+		return fmt.Errorf("trusted_proxies config validation failed: %w", err)
+	}
+
+	return nil
+}
+
+// validateTrustedProxies rejects a malformed trusted_proxies CIDR at boot —
+// same posture as every other config typo in this file: a bad entry must
+// never silently no-op into a partially-trusting (or fully-untrusting)
+// resolver (#746). Self-contained: no other config region reads this list.
+func validateTrustedProxies(cidrs []string) error {
+	for _, raw := range cidrs {
+		trimmed := strings.TrimSpace(raw)
+		if _, _, err := net.ParseCIDR(trimmed); err != nil {
+			return fmt.Errorf("invalid CIDR %q (expected e.g. \"10.0.0.0/8\"): %w", raw, err)
+		}
+	}
 	return nil
 }
 

--- a/config/trusted_proxies_test.go
+++ b/config/trusted_proxies_test.go
@@ -1,0 +1,41 @@
+package config
+
+import "testing"
+
+func TestValidateTrustedProxies(t *testing.T) {
+	cases := []struct {
+		name    string
+		cidrs   []string
+		wantErr bool
+	}{
+		{"nil is fine (trust nothing)", nil, false},
+		{"empty slice is fine", []string{}, false},
+		{"single valid CIDR", []string{"10.0.0.0/8"}, false},
+		{"multiple valid CIDRs", []string{"10.0.0.0/8", "192.168.0.0/16"}, false},
+		{"malformed CIDR rejected", []string{"not-a-cidr"}, true},
+		{"bare IP without prefix rejected", []string{"10.0.0.5"}, true},
+		{"one good one bad rejected", []string{"10.0.0.0/8", "garbage"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateTrustedProxies(tc.cidrs)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("validateTrustedProxies(%v) err=%v, wantErr=%v", tc.cidrs, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidateRejectsMalformedTrustedProxy pins that the top-level Validate
+// entry point actually calls the trusted_proxies check (#746) — a typo'd CIDR
+// must fail boot, never silently no-op into an unintended trust posture.
+func TestValidateRejectsMalformedTrustedProxy(t *testing.T) {
+	cfg := &Config{
+		Env:               "development",
+		ProviderWriteMode: ProviderWriteModeFull,
+		TrustedProxies:    []string{"definitely-not-a-cidr"},
+	}
+	if err := Validate(cfg); err == nil {
+		t.Fatal("Validate() should reject a malformed trusted_proxies entry")
+	}
+}

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -5,7 +5,7 @@ per *bucket* (endpoint category) and across multiple *subjects* (dimensions)
 simultaneously — a request is throttled if **any** applicable subject is over its
 limit. Counters live in Redis when configured, with an in-memory fallback.
 
-Implementation: [`internal/http/middleware/ratelimit.go`](../internal/http/middleware/ratelimit.go).
+Implementation: [`internal/http/middleware/ratelimit_neutral.go`](../internal/http/middleware/ratelimit_neutral.go).
 
 ## Subjects (dimensions)
 
@@ -16,11 +16,31 @@ Every request is counted against each subject that applies to it:
 | IP       | `ip:<addr>`          | All requests              | Bucket limit |
 | User     | `user:<user_id>`     | Authenticated requests    | Bucket limit |
 
-- **IP** uses the socket peer address (`RemoteAddr`), not `X-Forwarded-For`, so it
-  cannot be spoofed by a client header. Run behind a trusted proxy that sets the
-  real peer address if terminating TLS upstream.
+- **IP** is the resolved client IP (see "Trusted proxies" below) — by default
+  the socket peer address (`RemoteAddr`), not `X-Forwarded-For`, so it cannot be
+  spoofed by a client header. Behind a load balancer, configure `trusted_proxies`
+  so the IP subject keys on the real client instead of the LB's own address.
 - **User** keys on the authenticated JWT `user_id`, so a single account is limited
   even as it rotates IPs.
+
+## Trusted proxies
+
+`trusted_proxies` (env `TRUSTED_PROXIES`) is a list of CIDRs (e.g. `10.0.0.0/8`)
+whose `X-Forwarded-For` is trusted. It is the ONE client-IP resolver shared by
+rate limiting, abuse tracking, webhook `IPAddress` recording, and the CCBill
+webhook IP allowlist (`internal/shared/iputil.TrustedProxies`).
+
+- **Empty (default): trust nothing.** Every resolution uses the raw socket
+  peer — a spoofed `X-Forwarded-For` has zero effect.
+- **Configured:** when the direct socket peer falls inside a trusted CIDR,
+  `X-Forwarded-For` is walked right-to-left, skipping trusted hops, to the
+  first untrusted address — that's the resolved client IP. A peer outside the
+  trusted ranges never gets to inject a forwarded address at all.
+
+Set this to your load balancer's/reverse proxy's address range whenever
+OpenRails sits behind one — otherwise every request appears to come from the
+proxy, collapsing rate limits onto one shared bucket and, for CCBill, 403ing
+every live webhook (the LB's address is never in CCBill's own IP ranges).
 
 ## Buckets (endpoint categories)
 

--- a/embed/client.go
+++ b/embed/client.go
@@ -58,7 +58,7 @@ type localClient struct {
 // merchant-owned DB access. Without this every store call fails
 // merchant.Require in embedded mode.
 func (c *localClient) merchantCtx(ctx context.Context) context.Context {
-	mid := c.rt.ConfiguredMerchant
+	mid := c.rt.ConfiguredMerchant()
 	if mid.IsZero() {
 		if v, ok := merchant.FromContext(ctx); ok {
 			mid = v

--- a/embed/inprocess_transport_integration_test.go
+++ b/embed/inprocess_transport_integration_test.go
@@ -38,7 +38,7 @@ func TestInProcessTransportAuthTraversal(t *testing.T) {
 	rt, err := New(ctx, Options{Options: embedded.Options{Config: cfg}})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })
-	rt.emb.App().Runtime.ConfiguredMerchant = dbtest.TestMerchantID
+	rt.emb.App().Runtime.SetConfiguredMerchant(dbtest.TestMerchantID)
 
 	handler := newServiceHandler(rt.emb.App().Runtime)
 

--- a/embed/manifest_mode_integration_test.go
+++ b/embed/manifest_mode_integration_test.go
@@ -521,5 +521,5 @@ func TestManifestMode_ReadSideBindKeepsWorking(t *testing.T) {
 	boundID, err := reader.UpsertMerchantConfig(ctx, slug, embed.MerchantConfig{})
 	require.NoError(t, err)
 	require.Equal(t, id, boundID, "the empty upsert binds to the same merchant")
-	require.Equal(t, boundID, reader.Embedded().App().Runtime.ConfiguredMerchant)
+	require.Equal(t, boundID, reader.Embedded().App().Runtime.ConfiguredMerchant())
 }

--- a/embed/mount_order_integration_test.go
+++ b/embed/mount_order_integration_test.go
@@ -1,0 +1,72 @@
+//go:build integration
+
+package embed_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/embed"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/pkg/billingauth"
+	"github.com/open-rails/openrails/pkg/embedded"
+)
+
+// TestMountedHandlerResolvesMerchantBoundAfterMount pins the #744 fix: the
+// embedded HTTP surface (pkg/embedded.MountHandler -> embedhttp.NewHTTPHandler)
+// resolves Runtime.ConfiguredMerchant() PER REQUEST rather than baking a
+// snapshot into the middleware chain at mount time. Before the fix, mounting
+// the handler BEFORE UpsertMerchantConfig bound the merchant pinned the
+// surface to the zero merchant FOREVER (mount-time bake), even though the SDK
+// (embed/transport.go's live read) worked fine — an order-sensitive,
+// unenforced split brain. This test drives that exact order: mount, THEN
+// bind, THEN request.
+func TestMountedHandlerResolvesMerchantBoundAfterMount(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+
+	slug := fmt.Sprintf("mount-order-%d", time.Now().UnixNano())
+	cfg := &config.Config{Env: "dev", DB: &config.DBConfig{URL: dsn}}
+	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg}})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rt.Close(context.Background()) })
+
+	// Mount BEFORE any merchant is bound: Runtime.ConfiguredMerchant() is zero
+	// at this instant. RouteSetCheckout requires an Authenticator (unused by
+	// the public GET /products route below; billingauth.Optional tolerates
+	// its failure and proceeds unauthenticated).
+	noAuth := billingauth.AuthenticatorFunc(func(context.Context, *http.Request) (billingauth.UserContext, error) {
+		return billingauth.UserContext{}, billingauth.ErrUnauthenticated
+	})
+	handler, err := embedded.MountHandler(rt.Embedded(), embedded.MountOptions{
+		RouteSets:     []embedded.RouteSet{embedded.RouteSetCheckout},
+		Authenticator: noAuth,
+	})
+	require.NoError(t, err)
+
+	// Bind the merchant AFTER the handler is already mounted and could be
+	// serving traffic — the exact order the #744 bug broke.
+	_, err = rt.UpsertMerchantConfig(ctx, slug, embed.MerchantConfig{DisplayName: slug})
+	require.NoError(t, err)
+
+	// Empty MountOptions.MountPrefix means incoming paths already arrive
+	// canonical ("/v1/..."); combinedMount adds the "/billing" segment the
+	// mux registered under before dispatching.
+	req := httptest.NewRequest(http.MethodGet, "/v1/products", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	// Before the fix this 500s: ResolveMerchantHTTP pinned the zero merchant
+	// into the middleware chain at mount time, so MerchantDBConnMW's
+	// merchant.Require fails on every request forever, regardless of any
+	// later bind. After the fix, ConfiguredMerchant() is resolved live on
+	// every request and reflects the bind — an ordinary (empty) product list.
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}

--- a/embed/provision.go
+++ b/embed/provision.go
@@ -90,8 +90,8 @@ func (rt *Runtime) UpsertMerchantConfig(ctx context.Context, slug string, m Merc
 	if err != nil {
 		return merchant.ID{}, fmt.Errorf("openrails embed: upsert merchant config: %w", err)
 	}
-	if a.Runtime.ConfiguredMerchant.IsZero() {
-		a.Runtime.ConfiguredMerchant = tn.ID
+	if a.Runtime.ConfiguredMerchant().IsZero() {
+		a.Runtime.SetConfiguredMerchant(tn.ID)
 	}
 	// MODE 1: arm the runtime consumers (checkout/vault/webhooks/pulls) over the
 	// freshly seeded in-memory plane right away — no standalone server or worker

--- a/embed/spend_delegations_integration_test.go
+++ b/embed/spend_delegations_integration_test.go
@@ -32,7 +32,7 @@ func TestEmbeddedClientSetCustomerSpendDelegations(t *testing.T) {
 	rt, err := New(ctx, Options{Options: embedded.Options{Config: cfg}})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })
-	rt.emb.App().Runtime.ConfiguredMerchant = dbtest.TestMerchantID
+	rt.emb.App().Runtime.SetConfiguredMerchant(dbtest.TestMerchantID)
 
 	client := rt.Client()
 	err = client.SetCustomerSpendDelegations(ctx, customerID.String(), []openrails.SpendDelegationInput{{

--- a/embed/transport.go
+++ b/embed/transport.go
@@ -57,7 +57,7 @@ type inprocessTransport struct {
 func (t *inprocessTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
 	// Live read: EnsureMerchant/provisioning may bind the merchant after New.
-	mid := t.rt.ConfiguredMerchant
+	mid := t.rt.ConfiguredMerchant()
 	if mid.IsZero() {
 		if v, ok := merchant.FromContext(ctx); ok {
 			mid = v // host pinned it per call via openrails.WithMerchant

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -125,7 +125,7 @@ func BootstrapWithOptions(cfg *config.Config, opts *BootstrapOptions) (*App, err
 		return nil, fmt.Errorf("initialise runtime: %w", err)
 	}
 	if opts != nil {
-		runtime.ConfiguredMerchant = opts.ConfiguredMerchant
+		runtime.SetConfiguredMerchant(opts.ConfiguredMerchant)
 	}
 
 	var appCache cache.Cache

--- a/internal/app/build_runtime.go
+++ b/internal/app/build_runtime.go
@@ -51,6 +51,7 @@ import (
 	"github.com/open-rails/openrails/internal/modules/subscriptions"
 	"github.com/open-rails/openrails/internal/modules/webhooks"
 	riverjobs "github.com/open-rails/openrails/internal/river"
+	"github.com/open-rails/openrails/internal/shared/iputil"
 	postgresmigrations "github.com/open-rails/openrails/migrations/postgres"
 )
 
@@ -316,11 +317,14 @@ func buildRuntimeWithOverrides(cfg *config.Config, overrides *runtimeOverrides) 
 	}())
 
 	runtime := &Runtime{
-		DB:                   database,
-		RedisClient:          redisClient,
-		Config:               cfg,
-		Rails:                railSet,
-		Clock:                clock,
+		DB:          database,
+		RedisClient: redisClient,
+		Config:      cfg,
+		Rails:       railSet,
+		Clock:       clock,
+		// #746: one proxy-aware client-IP resolver, built once from config;
+		// empty cfg.TrustedProxies yields a resolver that trusts nothing.
+		TrustedProxies:       iputil.ParseTrustedProxies(cfg.TrustedProxies),
 		AdmissionPolicyCache: admission.NewPolicyCache(0), // #513: default long TTL (config)
 		CCBillClient:         ccbillClient,
 		CCBillRESTClient:     ccbillRESTClient,

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -41,6 +42,7 @@ import (
 	"github.com/open-rails/openrails/internal/modules/subscriptions"
 	"github.com/open-rails/openrails/internal/modules/webhooks"
 	riverjobs "github.com/open-rails/openrails/internal/river"
+	"github.com/open-rails/openrails/internal/shared/iputil"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
 
@@ -50,10 +52,26 @@ type Runtime struct {
 	RedisClient *redis.Client
 	Config      *config.Config
 
-	// ConfiguredMerchant scopes this engine instance to one merchant — set by embedded
-	// hosts that run one engine per merchant. Zero in standalone, where the merchant is
-	// resolved per-credential. OpenRails is multi-merchant either way.
-	ConfiguredMerchant merchant.ID
+	// configuredMerchant scopes this engine instance to one merchant — set by
+	// embedded hosts that run one engine per merchant (zero in standalone,
+	// where the merchant is resolved per-credential). It is an atomic because
+	// UpsertMerchantConfig may bind it AFTER New (embed/provision.go) while an
+	// HTTP handler built from this Runtime may already be mounted and serving
+	// requests (#744): every reader MUST go through ConfiguredMerchant() and
+	// re-resolve live (mirroring embed/transport.go's in-process live read) —
+	// never cache the value at handler-construction time, or mount order
+	// relative to the bind silently determines which merchant a request lands
+	// on. Use SetConfiguredMerchant to write it.
+	configuredMerchant atomic.Pointer[merchant.ID]
+
+	// TrustedProxies is the boot-configured proxy-aware client-IP resolver
+	// (#746), built once from config.Config.TrustedProxies. A nil/empty
+	// resolver trusts nothing (raw socket peer only). Every consumer that
+	// needs "the request's real client IP" — rate-limit subject keys, abuse
+	// tracking, webhook IPAddress recording, the CCBill IP allowlist —
+	// resolves through this ONE instance instead of reading
+	// RemoteAddr/X-Forwarded-For itself.
+	TrustedProxies *iputil.TrustedProxies
 
 	// Rails is the temporary in-memory provider credential bridge for
 	// embedded/private construction. It is not loaded from config.yaml/.env.
@@ -188,6 +206,32 @@ type Runtime struct {
 	// mechanism (no inline deletes). User-asked cancellations use a separate
 	// user-origin instance wired into UserSubscriptionService.
 	DeferredDeletes subscriptions.DeferredDeleteScheduler
+}
+
+// ConfiguredMerchant returns the merchant this engine instance is scoped to,
+// resolved fresh on every call — NEVER cache this at handler-construction
+// time (#744: UpsertMerchantConfig can bind it after New, after a handler
+// built from this Runtime is already mounted and serving requests). Zero in
+// standalone, or before any bind.
+func (r *Runtime) ConfiguredMerchant() merchant.ID {
+	if r == nil {
+		return merchant.ID{}
+	}
+	if id := r.configuredMerchant.Load(); id != nil {
+		return *id
+	}
+	return merchant.ID{}
+}
+
+// SetConfiguredMerchant binds this engine instance to a merchant. Safe to
+// call post-boot (embed.UpsertMerchantConfig) concurrently with in-flight
+// requests calling ConfiguredMerchant() — that concurrency safety is the
+// entire point of #744's fix.
+func (r *Runtime) SetConfiguredMerchant(id merchant.ID) {
+	if r == nil {
+		return
+	}
+	r.configuredMerchant.Store(&id)
 }
 
 func (r *Runtime) FXRateHealth() (time.Time, bool) {

--- a/internal/bootstrap/serverboot/serverboot.go
+++ b/internal/bootstrap/serverboot/serverboot.go
@@ -115,7 +115,6 @@ func NewServer(cfg *config.Config, opts *Options) (*Result, error) {
 		Redis:                  application.RedisClient,
 		Authenticator:          authenticator,
 		DelegatedAuthenticator: optsValue(opts, func(o *Options) billingauth.DelegatedAuthenticator { return o.DelegatedAuthenticator }),
-		ConfiguredMerchant:     application.Runtime.ConfiguredMerchant,
 		ControlPlane:           embcp.Get(application),
 	})
 	if err != nil {

--- a/internal/http/embedhttp/embedhttp.go
+++ b/internal/http/embedhttp/embedhttp.go
@@ -27,8 +27,8 @@ import (
 	"github.com/open-rails/openrails/internal/http/router"
 	httproutes "github.com/open-rails/openrails/internal/http/routes"
 	"github.com/open-rails/openrails/internal/http/routesurface"
+	"github.com/open-rails/openrails/internal/shared/iputil"
 	"github.com/open-rails/openrails/pkg/billingauth"
-	"github.com/open-rails/openrails/pkg/merchant"
 )
 
 // EmbeddedV1Prefix is the canonical API prefix for embedded mode handlers.
@@ -74,7 +74,6 @@ type Assembler struct {
 	// gate on its permissions — the gin-free counterpart of the self surface's
 	// DelegatedPrincipalRequired. nil for standalone (control-plane resolvers).
 	DelegatedAuthenticator billingauth.DelegatedAuthenticator
-	ConfiguredMerchant     merchant.ID
 }
 
 // FromApp builds an Assembler from the gin-free application graph (the same
@@ -107,9 +106,6 @@ func FromApp(a *app.App) *Assembler {
 			AdminPermissionChecker:    checker,
 			ServiceCredentialResolver: resolver,
 		})
-	}
-	if a.Runtime != nil {
-		asm.ConfiguredMerchant = a.Runtime.ConfiguredMerchant
 	}
 	return asm
 }
@@ -191,25 +187,33 @@ func (s *Assembler) NewHTTPHandler(opts Options) http.Handler {
 		httproutes.RegisterMerchantWebhookRoutes(router.NewMux(mux, EmbeddedV1Prefix, s.Runtime), s.Runtime)
 	}
 
-	// Resolve the configured merchant SLUG → internal merchant.ID once at
-	// bootstrap (#336): the resolver pins it per request. A non-empty-but-
-	// unknown slug is a configuration error. EMBEDDED boot (embed.New) ensures
-	// the bound merchant row before this runs, so it never trips here; a
+	// Merchant resolution (#223/#336) pins Runtime.ConfiguredMerchant() onto
+	// the request context before any merchant-owned DB access. It is resolved
+	// PER REQUEST, not cached here at handler-construction time (#744): an
+	// embedded host's UpsertMerchantConfig call can bind the merchant AFTER
+	// this handler is already mounted and serving traffic, and
+	// Runtime.ConfiguredMerchant() always reflects the latest bind. Zero
+	// (unbound) is a legal boot state — merchant-owned operations then hard-fail
+	// downstream instead of silently defaulting.
 	var rateLimits *config.RateLimitsConfig
 	var captchaCfg *config.CaptchaConfig
+	var resolver *iputil.TrustedProxies
 	if s.Cfg != nil {
 		rateLimits = s.Cfg.RateLimits
 		captchaCfg = s.Cfg.Captcha
+	}
+	if s.Runtime != nil {
+		resolver = s.Runtime.TrustedProxies
 	}
 	return middleware.ChainHTTP(mux,
 		middleware.SecurityHeadersHTTP(),
 		middleware.CORSHTTP(nil),
 		middleware.BodyLimitHTTP(middleware.DefaultMaxBodyBytes),
-		middleware.ResolveMerchantHTTP(s.ConfiguredMerchant),
+		middleware.ResolveMerchantHTTP(s.Runtime.ConfiguredMerchant),
 		// Best-effort auth so the rate limiter can key by user, not only IP.
 		middleware.HTTPMiddleware(billingauth.Optional(s.Authenticator)),
 		// OpenRails-native rate-limiting + captcha for embedded hosts.
-		middleware.RateLimitHTTP(rateLimits, captchaCfg, s.RDB, s.CaptchaStore),
+		middleware.RateLimitHTTP(rateLimits, captchaCfg, s.RDB, s.CaptchaStore, resolver),
 	)
 }
 
@@ -250,10 +254,14 @@ func (s *Assembler) captchaStatusHandler(w http.ResponseWriter, r *http.Request)
 		cfg = s.Cfg.Captcha
 	}
 	var store *captcha.ChallengeStore
+	var resolver *iputil.TrustedProxies
 	if s != nil {
 		store = s.CaptchaStore
+		if s.Runtime != nil {
+			resolver = s.Runtime.TrustedProxies
+		}
 	}
-	CaptchaStatusHandler(cfg, store)(w, r)
+	CaptchaStatusHandler(cfg, store, resolver)(w, r)
 }
 
 // captchaClientScriptHandler is the gin-free captcha client-script endpoint.
@@ -266,8 +274,11 @@ func (s *Assembler) captchaClientScriptHandler(w http.ResponseWriter, r *http.Re
 }
 
 // CaptchaStatusHandler is the captcha discovery endpoint shared by the embedded
-// and standalone surfaces (#670: one implementation, two mounts).
-func CaptchaStatusHandler(cfg *config.CaptchaConfig, store *captcha.ChallengeStore) http.HandlerFunc {
+// and standalone surfaces (#670: one implementation, two mounts). resolver
+// must be the SAME trusted-proxy resolver RateLimitHTTP enforces with (#746),
+// or the subject key checked here can diverge from the one actually
+// challenged.
+func CaptchaStatusHandler(cfg *config.CaptchaConfig, store *captcha.ChallengeStore, resolver *iputil.TrustedProxies) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		resp := map[string]any{
 			"enabled":           cfg.IsEnabled(),
@@ -279,7 +290,7 @@ func CaptchaStatusHandler(cfg *config.CaptchaConfig, store *captcha.ChallengeSto
 			resp["provider"] = cfg.EffectiveProvider()
 		}
 		if cfg.IsEnabled() && store != nil {
-			for _, subjectKey := range middleware.RateLimitSubjectKeysHTTP(r) {
+			for _, subjectKey := range middleware.RateLimitSubjectKeysHTTP(r, resolver) {
 				challenged, err := store.IsChallenged(r.Context(), subjectKey)
 				if err != nil {
 					continue

--- a/internal/http/embedhttp/self.go
+++ b/internal/http/embedhttp/self.go
@@ -12,8 +12,8 @@ import (
 	"github.com/open-rails/openrails/internal/http/router"
 	httproutes "github.com/open-rails/openrails/internal/http/routes"
 	"github.com/open-rails/openrails/internal/http/routesurface"
+	"github.com/open-rails/openrails/internal/shared/iputil"
 	"github.com/open-rails/openrails/pkg/billingauth"
-	"github.com/open-rails/openrails/pkg/merchant"
 )
 
 // NewSelfHandler assembles the embedded browser-direct SELF-SERVICE surface
@@ -27,7 +27,7 @@ import (
 // CORS, body limit, merchant resolution, rate-limit + captcha), keeping it
 // behaviorally consistent with the base embedded handler. Host-supplied
 // delegated authenticators own their own browser-origin policy.
-func NewSelfHandler(rt *app.Runtime, authn billingauth.DelegatedAuthenticator, configured merchant.ID, providerRouteOverride *routesurface.ProviderRoutes) http.Handler {
+func NewSelfHandler(rt *app.Runtime, authn billingauth.DelegatedAuthenticator, providerRouteOverride *routesurface.ProviderRoutes) http.Handler {
 	mux := http.NewServeMux()
 	delegatedMW := middleware.DelegatedPrincipalRequired(authn)
 	providerRoutes := ProviderRoutesForRuntime(rt, providerRouteOverride)
@@ -40,8 +40,10 @@ func NewSelfHandler(rt *app.Runtime, authn billingauth.DelegatedAuthenticator, c
 	var rateLimits *config.RateLimitsConfig
 	var captchaCfg *config.CaptchaConfig
 	var rdb *redis.Client
+	var resolver *iputil.TrustedProxies
 	if rt != nil {
 		rdb = rt.RedisClient
+		resolver = rt.TrustedProxies
 		if rt.Config != nil {
 			rateLimits = rt.Config.RateLimits
 			captchaCfg = rt.Config.Captcha
@@ -52,8 +54,11 @@ func NewSelfHandler(rt *app.Runtime, authn billingauth.DelegatedAuthenticator, c
 		middleware.SecurityHeadersHTTP(),
 		middleware.CORSHTTP(nil),
 		middleware.BodyLimitHTTP(middleware.DefaultMaxBodyBytes),
-		middleware.ResolveMerchantHTTP(configured),
-		middleware.RateLimitHTTP(rateLimits, captchaCfg, rdb, captcha.NewChallengeStore(rdb)),
+		// Resolved PER REQUEST off the Runtime (#744) — never a value snapshotted
+		// here at construction time, so a mount that races UpsertMerchantConfig's
+		// post-boot bind still resolves correctly on every request.
+		middleware.ResolveMerchantHTTP(rt.ConfiguredMerchant),
+		middleware.RateLimitHTTP(rateLimits, captchaCfg, rdb, captcha.NewChallengeStore(rdb), resolver),
 	)
 }
 
@@ -65,7 +70,7 @@ func ProviderRoutesForRuntime(rt *app.Runtime, override *routesurface.ProviderRo
 		return *override
 	}
 	if rt != nil {
-		if len(rt.Rails) > 0 || !rt.ConfiguredMerchant.IsZero() {
+		if len(rt.Rails) > 0 || !rt.ConfiguredMerchant().IsZero() {
 			if caps := rt.RouteCapabilities; caps != nil {
 				return routesurface.ProviderRoutesFromRailsWithCapabilities(rt.Rails, *caps)
 			}

--- a/internal/http/handlers/webhook.go
+++ b/internal/http/handlers/webhook.go
@@ -66,7 +66,7 @@ func readLimitedWebhookBody(r *httprequest.Request, maxBytes int64) ([]byte, boo
 
 func Webhook(r *httprequest.Request) {
 	provider := webhookutil.CanonicalRail(r.Param("provider"))
-	clientIP := r.GetRemoteIP()
+	clientIP := r.ClientIP()
 	log.WithFields(log.Fields{"provider": provider, "client_ip": clientIP}).Debug("Received webhook")
 	if r.State == nil || r.State.Config == nil {
 		r.ErrorJSON(http.StatusServiceUnavailable, "Webhook processing is not configured")
@@ -148,7 +148,7 @@ func processResolvedMerchantWebhook(r *httprequest.Request, provider string, mer
 		return
 	}
 	if provider == subscriptions.RailCCBill {
-		clientIP := r.GetRemoteIP()
+		clientIP := r.ClientIP()
 		if !ccbillWebhookIPAllowed(r, clientIP) {
 			r.ErrorJSON(http.StatusForbidden, "Unauthorized webhook source")
 			return
@@ -228,7 +228,7 @@ func processResolvedMerchantWebhook(r *httprequest.Request, provider string, mer
 		EventID:        prepared.EventID,
 		EventType:      prepared.EventType,
 		Payload:        prepared.Body,
-		IPAddress:      r.GetRemoteIP(),
+		IPAddress:      r.ClientIP(),
 		Signature:      prepared.Signature,
 		SignatureValid: &signatureVerified,
 		ReceivedAt:     time.Now(),
@@ -421,7 +421,7 @@ func processMerchantNMIWebhookBody(r *httprequest.Request, provider string, merc
 		EventID:               prepared.EventID,
 		EventType:             prepared.EventType,
 		Payload:               prepared.Body,
-		IPAddress:             r.GetRemoteIP(),
+		IPAddress:             r.ClientIP(),
 		Signature:             prepared.Signature,
 		SigningSecret:         signingKey,
 		SignatureValid:        &signatureVerified,

--- a/internal/http/handlers/webhook_ccbill_test.go
+++ b/internal/http/handlers/webhook_ccbill_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/open-rails/openrails/config"
 	"github.com/open-rails/openrails/internal/app"
 	httprequest "github.com/open-rails/openrails/internal/http/request"
+	"github.com/open-rails/openrails/internal/shared/iputil"
 	"github.com/open-rails/openrails/internal/shared/webhookutil"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
@@ -131,4 +132,72 @@ func TestCCBillWebhookMessageNeverClaimsSignatureValid(t *testing.T) {
 
 	// River path: an unverified Prepared must enqueue with SignatureValid nil.
 	require.Nil(t, prepared.QueueArgs("64.38.212.5").SignatureValid)
+}
+
+// newCCBillWebhookRequestBehindProxy builds a webhook request that physically
+// arrived through remoteAddr (the direct socket peer — e.g. a load balancer),
+// carrying forwardedFor as the X-Forwarded-For header. trustedProxies configures
+// the #746 resolver Runtime.TrustedProxies uses to decide whether to honor it.
+func newCCBillWebhookRequestBehindProxy(t *testing.T, remoteAddr, forwardedFor string, trustedProxies []string) (*httprequest.Request, *httptest.ResponseRecorder) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	body := `{"eventType":"NewSaleSuccess","clientAccnum":"900000","clientSubacc":"0000","transactionId":"1"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/webhooks/ccbill?eventType=NewSaleSuccess", strings.NewReader(body))
+	req.RemoteAddr = remoteAddr
+	if forwardedFor != "" {
+		req.Header.Set("X-Forwarded-For", forwardedFor)
+	}
+	req.SetPathValue("provider", "ccbill")
+	req = req.WithContext(merchant.WithID(req.Context(), merchant.ID(uuid.New())))
+	rt := &app.Runtime{
+		Config:         &config.Config{TestMode: false, TrustedProxies: trustedProxies},
+		TrustedProxies: iputil.ParseTrustedProxies(trustedProxies),
+	}
+	return httprequest.NewHTTP(w, req, rt), w
+}
+
+// #746: a CCBill webhook that physically arrives through a configured trusted
+// reverse proxy (RemoteAddr = the proxy/load balancer, X-Forwarded-For =
+// CCBill's real source IP) passes the IP allowlist — the resolved client IP,
+// not the proxy's own socket address, is what's evaluated. Exercises the full
+// Webhook() dispatch path, not just the allowlist helper in isolation.
+func TestCCBillWebhookAllowsRequestBehindTrustedProxy(t *testing.T) {
+	stubCCBillLiveProbe(t, false, nil)
+
+	r, w := newCCBillWebhookRequestBehindProxy(t, "10.0.0.5:443", "64.38.212.5", []string{"10.0.0.0/8"})
+
+	Webhook(r)
+
+	// Reaches enqueue (which 500s here only because no River producer is
+	// wired in this test runtime) instead of 403ing at the IP allowlist —
+	// proof the resolved client IP (from XFF, since the proxy is trusted) was
+	// evaluated, not the load balancer's own address.
+	require.Equal(t, http.StatusInternalServerError, w.Code, w.Body.String())
+}
+
+// #746: without trusted_proxies configured, a spoofed X-Forwarded-For
+// claiming to be a CCBill IP has ZERO effect — the socket peer (the actual
+// sender) is what's evaluated, and an off-allowlist sender correctly 403s.
+func TestCCBillWebhookRejectsSpoofedForwardedForWithoutTrustedProxies(t *testing.T) {
+	stubCCBillLiveProbe(t, false, nil)
+
+	r, w := newCCBillWebhookRequestBehindProxy(t, "203.0.113.9:443", "64.38.212.5", nil)
+
+	Webhook(r)
+
+	require.Equal(t, http.StatusForbidden, w.Code, w.Body.String())
+}
+
+// #746: the same spoof attempt against a proxy that IS in trusted_proxies but
+// where the attacker IS the direct peer (no proxy involved at all) still
+// 403s — trusting a CIDR range never means trusting an arbitrary claimed
+// X-Forwarded-For from an untrusted direct connection outside that range.
+func TestCCBillWebhookIPAllowedIgnoresForwardedForFromUntrustedPeer(t *testing.T) {
+	stubCCBillLiveProbe(t, false, nil)
+
+	r, w := newCCBillWebhookRequestBehindProxy(t, "203.0.113.9:443", "64.38.212.5", []string{"10.0.0.0/8"})
+
+	Webhook(r)
+
+	require.Equal(t, http.StatusForbidden, w.Code, w.Body.String())
 }

--- a/internal/http/middleware/http_base.go
+++ b/internal/http/middleware/http_base.go
@@ -217,16 +217,30 @@ func OriginAllowed(origin string, allowedOrigins []string) bool {
 }
 
 // ResolveMerchantHTTP is the net/http analogue of ResolveMerchant. It pins the
-// engine's CONSTRUCTION-TIME merchant (`configured`) onto the request context
-// BEFORE any merchant-owned DB access, so MerchantDBConnMW pins the connection to
-// the correct merchant (issue #223/#227). An OpenRails engine is bound to a single
-// merchant at construction — there is NO default merchant (#336).
+// engine's configured merchant onto the request context BEFORE any
+// merchant-owned DB access, so MerchantDBConnMW pins the connection to the
+// correct merchant (issue #223/#227). An OpenRails engine is bound to a
+// single merchant — there is NO default merchant (#336).
 //
-// If `configured` is zero, NOTHING is pinned: downstream merchant.Require fails,
-// so a missing merchant is a hard error rather than a silent default.
-func ResolveMerchantHTTP(configured merchant.ID) HTTPMiddleware {
+// resolve is called ON EVERY REQUEST, never once at construction time
+// (#744): an embedded engine's bound merchant is set post-boot
+// (UpsertMerchantConfig binds after New — embed/provision.go), and an HTTP
+// handler built from the same Runtime may already be mounted and serving
+// requests before that bind happens. Pass a live accessor — typically the
+// Runtime's own method value, e.g. `middleware.ResolveMerchantHTTP(rt.ConfiguredMerchant)`
+// — never a value snapshotted at handler-construction time, or mounting
+// before the bind pins every request to the zero merchant forever.
+//
+// If resolve is nil or returns zero, NOTHING is pinned: downstream
+// merchant.Require fails, so a missing merchant is a hard error rather than a
+// silent default.
+func ResolveMerchantHTTP(resolve func() merchant.ID) HTTPMiddleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var configured merchant.ID
+			if resolve != nil {
+				configured = resolve()
+			}
 			if configured.IsZero() {
 				next.ServeHTTP(w, r)
 				return
@@ -235,4 +249,12 @@ func ResolveMerchantHTTP(configured merchant.ID) HTTPMiddleware {
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+// StaticMerchant adapts a fixed merchant.ID into the resolver ResolveMerchantHTTP
+// expects. Production code should prefer a live accessor (Runtime.ConfiguredMerchant);
+// this exists for callers with a genuinely fixed id — chiefly tests that pin one
+// merchant for the lifetime of a test server.
+func StaticMerchant(id merchant.ID) func() merchant.ID {
+	return func() merchant.ID { return id }
 }

--- a/internal/http/middleware/ratelimit_http_test.go
+++ b/internal/http/middleware/ratelimit_http_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/open-rails/openrails/config"
 	"github.com/open-rails/openrails/internal/captcha"
+	"github.com/open-rails/openrails/internal/shared/iputil"
 	"github.com/open-rails/openrails/pkg/billingauth"
 )
 
@@ -52,7 +53,7 @@ func doHTTPPost(h http.Handler, path, ip, token string) *httptest.ResponseRecord
 // stub verifier can be supplied), the same way RateLimitHTTP wires it internally.
 func rlHTTPHandlerWithDeps(deps RateLimitDeps, captchaCfg *config.CaptchaConfig, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		subjects := rateLimitSubjectsHTTP(r)
+		subjects := rateLimitSubjectsHTTP(r, nil)
 		decision := EvaluateRateLimit(w, r, subjects, deps)
 		applyRateLimitDecisionHTTP(w, r, next, decision, captchaCfg)
 	})
@@ -61,7 +62,7 @@ func rlHTTPHandlerWithDeps(deps RateLimitDeps, captchaCfg *config.CaptchaConfig,
 func TestRateLimitHTTPBlocksOverLimit(t *testing.T) {
 	t.Parallel()
 	limits := config.RateLimitsConfig{"checkout": {RequestsPerMinute: 1}, "default": {RequestsPerMinute: 60}}
-	h := RateLimitHTTP(&limits, nil, nil, captcha.NewChallengeStore(nil))(okHTTPHandler())
+	h := RateLimitHTTP(&limits, nil, nil, captcha.NewChallengeStore(nil), nil)(okHTTPHandler())
 
 	require.Equal(t, http.StatusOK, doHTTPPost(h, "/v1/checkout", "203.0.113.70", "").Code)
 	blocked := doHTTPPost(h, "/v1/checkout", "203.0.113.70", "")
@@ -70,10 +71,62 @@ func TestRateLimitHTTPBlocksOverLimit(t *testing.T) {
 	require.Equal(t, "1", blocked.Header().Get("X-RateLimit-Limit"))
 }
 
+// #746: behind a configured trusted proxy, the rate-limit subject key is the
+// resolved client IP (from X-Forwarded-For), not the proxy's own socket
+// address — two distinct clients arriving through the SAME load balancer are
+// limited INDEPENDENTLY instead of collapsing onto one shared bucket.
+func TestRateLimitHTTPKeysByResolvedClientIPBehindTrustedProxy(t *testing.T) {
+	t.Parallel()
+	limits := config.RateLimitsConfig{"checkout": {RequestsPerMinute: 1}, "default": {RequestsPerMinute: 60}}
+	resolver := iputil.ParseTrustedProxies([]string{"10.0.0.0/8"})
+	h := RateLimitHTTP(&limits, nil, nil, captcha.NewChallengeStore(nil), resolver)(okHTTPHandler())
+
+	doThroughProxy := func(forwardedFor string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/v1/checkout", nil)
+		req.RemoteAddr = "10.0.0.5:1234" // the trusted load balancer
+		req.Header.Set("X-Forwarded-For", forwardedFor)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		return w
+	}
+
+	// Client A's first request is allowed; its second trips the 1/min limit.
+	require.Equal(t, http.StatusOK, doThroughProxy("203.0.113.10").Code)
+	require.Equal(t, http.StatusTooManyRequests, doThroughProxy("203.0.113.10").Code)
+
+	// Client B, behind the SAME proxy, gets its OWN bucket — proof the key is
+	// the resolved client IP, not the shared load-balancer address.
+	require.Equal(t, http.StatusOK, doThroughProxy("203.0.113.11").Code)
+}
+
+// Without a resolver (no trusted_proxies configured), the load balancer's own
+// address is what's keyed — X-Forwarded-For has zero effect, so distinct
+// "clients" behind the same untrusted proxy collapse onto ONE bucket. This
+// pins the pre-#746 / no-config baseline so the trusted-proxy test above is a
+// meaningful contrast, not a tautology.
+func TestRateLimitHTTPCollapsesToSocketIPWithoutResolver(t *testing.T) {
+	t.Parallel()
+	limits := config.RateLimitsConfig{"checkout": {RequestsPerMinute: 1}, "default": {RequestsPerMinute: 60}}
+	h := RateLimitHTTP(&limits, nil, nil, captcha.NewChallengeStore(nil), nil)(okHTTPHandler())
+
+	doThroughProxy := func(forwardedFor string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/v1/checkout", nil)
+		req.RemoteAddr = "10.0.0.5:1234"
+		req.Header.Set("X-Forwarded-For", forwardedFor)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		return w
+	}
+
+	require.Equal(t, http.StatusOK, doThroughProxy("203.0.113.10").Code)
+	// A "different" forwarded client still 429s: same socket peer, same bucket.
+	require.Equal(t, http.StatusTooManyRequests, doThroughProxy("203.0.113.11").Code)
+}
+
 func TestRateLimitHTTPRejectsOversizedContentLength(t *testing.T) {
 	t.Parallel()
 	limits := config.RateLimitsConfig{"checkout": {RequestsPerMinute: 10}}
-	h := RateLimitHTTP(&limits, nil, nil, captcha.NewChallengeStore(nil))(okHTTPHandler())
+	h := RateLimitHTTP(&limits, nil, nil, captcha.NewChallengeStore(nil), nil)(okHTTPHandler())
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/checkout", nil)
 	req.RemoteAddr = "203.0.113.71:1234"
@@ -87,7 +140,7 @@ func TestRateLimitHTTPRejectsOversizedContentLength(t *testing.T) {
 func TestRateLimitHTTPNormalizesEmbeddedPrefix(t *testing.T) {
 	t.Parallel()
 	limits := config.RateLimitsConfig{"checkout": {RequestsPerMinute: 1}, "default": {RequestsPerMinute: 60}}
-	h := RateLimitHTTP(&limits, nil, nil, captcha.NewChallengeStore(nil))(okHTTPHandler())
+	h := RateLimitHTTP(&limits, nil, nil, captcha.NewChallengeStore(nil), nil)(okHTTPHandler())
 
 	// The embedded surface serves under /billing/v1/*; the bucket classifier must
 	// strip the /billing prefix so the checkout limit still applies.
@@ -141,7 +194,7 @@ func TestRateLimitHTTPLimitsByUserAcrossIPs(t *testing.T) {
 	// request from a DIFFERENT IP but the same user is still blocked.
 	chain := ChainHTTP(okHTTPHandler(),
 		HTTPMiddleware(billingauth.Optional(auth)),
-		RateLimitHTTP(&limits, nil, nil, captcha.NewChallengeStore(nil)),
+		RateLimitHTTP(&limits, nil, nil, captcha.NewChallengeStore(nil), nil),
 	)
 
 	require.Equal(t, http.StatusOK, doHTTPPost(chain, "/v1/checkout", "203.0.113.80", "").Code)
@@ -251,7 +304,7 @@ func TestRateLimitHTTPDoesNotLimitCaptchaStatusOrClientScript(t *testing.T) {
 	t.Parallel()
 	limits := config.RateLimitsConfig{"default": {RequestsPerMinute: 1}}
 	captchaCfg := &config.CaptchaConfig{Provider: config.CaptchaProviderTurnstile, SiteKey: "site-key", SecretKey: "secret-key"}
-	h := RateLimitHTTP(&limits, captchaCfg, nil, captcha.NewChallengeStore(nil))(okHTTPHandler())
+	h := RateLimitHTTP(&limits, captchaCfg, nil, captcha.NewChallengeStore(nil), nil)(okHTTPHandler())
 
 	for _, path := range []string{"/v1/captcha/status", "/v1/captcha/client.js"} {
 		for i := 0; i < 3; i++ {
@@ -317,7 +370,7 @@ func TestRateLimitHTTPRejectsOversizedChunkedBody(t *testing.T) {
 		require.Error(t, err)
 		w.WriteHeader(http.StatusRequestEntityTooLarge)
 	})
-	h := RateLimitHTTP(&limits, nil, nil, captcha.NewChallengeStore(nil))(next)
+	h := RateLimitHTTP(&limits, nil, nil, captcha.NewChallengeStore(nil), nil)(next)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/checkout", strings.NewReader(strings.Repeat("a", int(BucketMaxContentLength["checkout"]+1))))
 	req.RemoteAddr = "203.0.113.61:1234"

--- a/internal/http/middleware/ratelimit_neutral.go
+++ b/internal/http/middleware/ratelimit_neutral.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -23,6 +22,7 @@ import (
 
 	"github.com/open-rails/openrails/config"
 	"github.com/open-rails/openrails/internal/captcha"
+	"github.com/open-rails/openrails/internal/shared/iputil"
 	"github.com/open-rails/openrails/pkg/api"
 	"github.com/open-rails/openrails/pkg/billingauth"
 )
@@ -313,7 +313,13 @@ func evaluateCaptchaVerify(r *http.Request, deps RateLimitDeps, bucket, clientIP
 // Identity for the user-scoped subject is read from the request context
 // (billingauth.FromContext), so mount billingauth.Optional BEFORE this so an
 // authenticated caller is limited per-user, not only per-IP.
-func RateLimitHTTP(limits *config.RateLimitsConfig, captchaCfg *config.CaptchaConfig, rdb *redis.Client, challengeStore *captcha.ChallengeStore) HTTPMiddleware {
+//
+// resolver is the #746 proxy-aware client-IP resolver: the IP-scoped subject
+// key is the resolved client, not the raw socket peer, so a deployment behind
+// a configured trusted proxy still limits per real client instead of
+// collapsing every request onto the load balancer's one address. A nil/empty
+// resolver falls back to the socket peer (equivalent to no proxy trust).
+func RateLimitHTTP(limits *config.RateLimitsConfig, captchaCfg *config.CaptchaConfig, rdb *redis.Client, challengeStore *captcha.ChallengeStore, resolver *iputil.TrustedProxies) HTTPMiddleware {
 	if limits == nil {
 		return func(next http.Handler) http.Handler { return next }
 	}
@@ -330,7 +336,7 @@ func RateLimitHTTP(limits *config.RateLimitsConfig, captchaCfg *config.CaptchaCo
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			subjects := rateLimitSubjectsHTTP(r)
+			subjects := rateLimitSubjectsHTTP(r, resolver)
 			decision := EvaluateRateLimit(w, r, subjects, deps)
 			applyRateLimitDecisionHTTP(w, r, next, decision, captchaCfg)
 		})
@@ -390,13 +396,15 @@ func captchaSiteKey(cfg *config.CaptchaConfig) string {
 }
 
 // rateLimitSubjectsHTTP derives the ip:/user: subjects from a plain request,
-// reading identity from the request context (billingauth).
-func rateLimitSubjectsHTTP(r *http.Request) []RateLimitSubject {
+// reading identity from the request context (billingauth) and the client IP
+// via resolver (#746: a nil/empty resolver trusts nothing, i.e. the socket peer).
+func rateLimitSubjectsHTTP(r *http.Request, resolver *iputil.TrustedProxies) []RateLimitSubject {
 	if r == nil {
 		return nil
 	}
 	subjects := make([]RateLimitSubject, 0, 2)
-	if clientIP := strings.TrimSpace(httpClientIP(r)); clientIP != "" {
+	resolved := resolver.ResolveClientIP(r.RemoteAddr, r.Header.Get("X-Forwarded-For"))
+	if clientIP := strings.TrimSpace(resolved); clientIP != "" {
 		subjects = append(subjects, RateLimitSubject{Scope: RateLimitScopeIP, Value: clientIP, Key: RateLimitScopeIP + ":" + clientIP})
 	}
 	if uc, ok := billingauth.FromContext(r.Context()); ok {
@@ -410,18 +418,10 @@ func rateLimitSubjectsHTTP(r *http.Request) []RateLimitSubject {
 // RateLimitSubjectKeysHTTP is the gin-free analogue of RateLimitSubjectKeys (issue
 // #282): it derives the same ip:/user: subject keys from a plain *http.Request. The
 // embedded captcha-status handler uses it to report whether a subject is currently
-// challenged.
-func RateLimitSubjectKeysHTTP(r *http.Request) []string {
-	return SubjectKeys(rateLimitSubjectsHTTP(r))
-}
-
-// httpClientIP extracts the socket peer IP from a plain request (no forwarded
-// header trust), matching the gin ClientIP used by rate-limit subjects.
-func httpClientIP(r *http.Request) string {
-	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
-		return host
-	}
-	return r.RemoteAddr
+// challenged; resolver MUST be the same one RateLimitHTTP was built with, or the
+// keys diverge.
+func RateLimitSubjectKeysHTTP(r *http.Request, resolver *iputil.TrustedProxies) []string {
+	return SubjectKeys(rateLimitSubjectsHTTP(r, resolver))
 }
 
 // SubjectKeys returns the non-empty Key of each subject.

--- a/internal/http/request/request.go
+++ b/internal/http/request/request.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/open-rails/openrails/internal/app"
 	"github.com/open-rails/openrails/internal/modules/checkout"
+	"github.com/open-rails/openrails/internal/shared/iputil"
 	"github.com/open-rails/openrails/pkg/api"
 	"github.com/open-rails/openrails/pkg/billingauth"
 )
@@ -278,19 +279,23 @@ func (r *Request) GetUser() *checkout.UserIdentity {
 	return nil
 }
 
-func (r *Request) GetClientIP() string {
-	if forwarded := r.t.Header("X-Forwarded-For"); forwarded != "" {
-		ips := strings.Split(forwarded, ",")
-		if len(ips) > 0 {
-			return strings.TrimSpace(ips[0])
-		}
+// ClientIP returns the resolved client IP for this request (#746): the raw
+// socket peer, or — when that peer is inside a configured trusted_proxies
+// CIDR — the first untrusted address found walking X-Forwarded-For
+// right-to-left. Every consumer that needs "the client's IP" (rate limiting,
+// abuse tracking, webhook IPAddress recording, the CCBill IP allowlist) MUST
+// resolve through this (or the same Runtime.TrustedProxies resolver) so proxy
+// trust is enforced identically everywhere. With no trusted_proxies
+// configured this is exactly GetRemoteIP.
+func (r *Request) ClientIP() string {
+	if r.Request == nil {
+		return ""
 	}
-
-	if realIP := r.t.Header("X-Real-IP"); realIP != "" {
-		return strings.TrimSpace(realIP)
+	var resolver *iputil.TrustedProxies
+	if r.State != nil {
+		resolver = r.State.TrustedProxies
 	}
-
-	return r.GetRemoteIP()
+	return resolver.ResolveClientIP(r.Request.RemoteAddr, r.t.Header("X-Forwarded-For"))
 }
 
 func (r *Request) GetRemoteIP() string {

--- a/internal/http/routes/bearer_repro_test.go
+++ b/internal/http/routes/bearer_repro_test.go
@@ -45,7 +45,7 @@ func TestRequiredMWPinsUserContextForHandler(t *testing.T) {
 		middleware.SecurityHeadersHTTP(),
 		middleware.CORSHTTP(nil),
 		middleware.BodyLimitHTTP(middleware.DefaultMaxBodyBytes),
-		middleware.ResolveMerchantHTTP(dbtest.TestMerchantID),
+		middleware.ResolveMerchantHTTP(middleware.StaticMerchant(dbtest.TestMerchantID)),
 	)
 
 	req := httptest.NewRequest(http.MethodGet, "/billing/v1/me/balance", nil)

--- a/internal/http/routes_public.go
+++ b/internal/http/routes_public.go
@@ -15,7 +15,7 @@ import (
 
 func (s *Server) registerUserRoutesAt(mux *http.ServeMux, apiPrefix string) {
 	s.handle(mux, http.MethodGet+" "+apiPrefix+"/captcha/status",
-		embedhttp.CaptchaStatusHandler(s.cfg.Captcha, s.captchaStore))
+		embedhttp.CaptchaStatusHandler(s.cfg.Captcha, s.captchaStore, s.trustedProxies()))
 	s.handle(mux, http.MethodGet+" "+apiPrefix+"/captcha/client.js",
 		embedhttp.CaptchaClientScriptHandler(s.cfg.Captcha))
 	httproutes.RegisterUserRoutes(router.NewMuxRecorded(mux, apiPrefix, s.runtime, s.recordRoute), s.runtime, httproutes.Options{

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -18,9 +18,9 @@ import (
 	"github.com/open-rails/openrails/internal/merchantsecrets"
 	"github.com/open-rails/openrails/internal/modules/solana/recurring"
 	"github.com/open-rails/openrails/internal/modules/solana/solanasubs"
+	"github.com/open-rails/openrails/internal/shared/iputil"
 	"github.com/open-rails/openrails/pkg/billingauth"
 	"github.com/open-rails/openrails/pkg/cache"
-	"github.com/open-rails/openrails/pkg/merchant"
 )
 
 type Dependencies struct {
@@ -42,7 +42,6 @@ type Dependencies struct {
 	// explicitly mapped principal for /v1/me/* + /v1/merchant/*, OVERRIDING the
 	// control plane's default delegated-token verifier.
 	DelegatedAuthenticator billingauth.DelegatedAuthenticator
-	ConfiguredMerchant     merchant.ID
 }
 
 type Server struct {
@@ -65,10 +64,6 @@ type Server struct {
 	// control-plane DB) and permission-group provisioner, and is always built
 	// (#469: the control plane is mandatory on this surface).
 	merchants *merchants.Service
-
-	// configuredMerchant scopes legacy single-merchant installs. Zero in standalone,
-	// where the merchant is resolved per-credential.
-	configuredMerchant merchant.ID
 
 	// browserCORSOriginSource is the standalone browser CORS origin source.
 	// Production leaves this nil and reads AuthKit remote_application state via
@@ -175,7 +170,6 @@ func New(deps Dependencies) (*Server, error) {
 		rdb:                    deps.Redis,
 		authenticator:          deps.Authenticator,
 		delegatedAuthenticator: deps.DelegatedAuthenticator,
-		configuredMerchant:     deps.ConfiguredMerchant,
 		controlPlane:           deps.ControlPlane,
 		captchaStore:           captcha.NewChallengeStore(deps.Redis),
 	}
@@ -386,6 +380,15 @@ func New(deps Dependencies) (*Server, error) {
 	return s, nil
 }
 
+// trustedProxies returns the #746 client-IP resolver, nil-safe against a
+// Server built without New() (some unit tests construct &Server{} directly).
+func (s *Server) trustedProxies() *iputil.TrustedProxies {
+	if s == nil || s.runtime == nil {
+		return nil
+	}
+	return s.runtime.TrustedProxies
+}
+
 // wrapPublicHandler applies the global middleware chain — the neutral analogue
 // (and successor, #670) of the old gin engine's global middleware, same order.
 func (s *Server) wrapPublicHandler(mux *http.ServeMux) http.Handler {
@@ -400,13 +403,14 @@ func (s *Server) wrapPublicHandler(mux *http.ServeMux) http.Handler {
 		middleware.CORSFromSourceHTTP(s.browserCORSOrigins),
 		middleware.BodyLimitHTTP(middleware.DefaultMaxBodyBytes),
 		// Resolve the merchant / billing namespace before authorization and before any
-		// merchant-owned DB access (issue #223). Pins the construction-time configured
-		// merchant resolved once at boot (#336); zero when none is configured, in
-		// which case merchant-owned operations hard-fail (there is no default merchant).
-		middleware.ResolveMerchantHTTP(s.configuredMerchant),
+		// merchant-owned DB access (issue #223). Resolved PER REQUEST off the Runtime
+		// (#744), never a value snapshotted here at construction time; zero when none
+		// is configured, in which case merchant-owned operations hard-fail (there is
+		// no default merchant).
+		middleware.ResolveMerchantHTTP(s.runtime.ConfiguredMerchant),
 		// Best-effort auth so the rate limiter can key by user, not only IP.
 		middleware.HTTPMiddleware(billingauth.Optional(s.authenticator)),
-		middleware.RateLimitHTTP(s.cfg.RateLimits, s.cfg.Captcha, s.rdb, s.captchaStore),
+		middleware.RateLimitHTTP(s.cfg.RateLimits, s.cfg.Captcha, s.rdb, s.captchaStore, s.trustedProxies()),
 	)
 }
 

--- a/internal/integrationharness/harness.go
+++ b/internal/integrationharness/harness.go
@@ -251,7 +251,7 @@ func (h *Harness) StartEmbeddedHost(currency string) *Surface {
 	// Bind the engine to the test merchant — what embed provisioning
 	// (EnsureMerchant/UpsertMerchantConfig) does on a real host. The in-process
 	// transport (#685) pins this merchant per request.
-	rt.Embedded().App().Runtime.ConfiguredMerchant = dbtest.TestMerchantID
+	rt.Embedded().App().Runtime.SetConfiguredMerchant(dbtest.TestMerchantID)
 
 	mux := http.NewServeMux()
 	runtime := rt.Embedded().App().Runtime
@@ -265,7 +265,7 @@ func (h *Harness) StartEmbeddedHost(currency string) *Surface {
 			}}),
 		},
 	)
-	srv := httptest.NewServer(middleware.ChainHTTP(mux, middleware.ResolveMerchantHTTP(dbtest.TestMerchantID)))
+	srv := httptest.NewServer(middleware.ChainHTTP(mux, middleware.ResolveMerchantHTTP(runtime.ConfiguredMerchant)))
 	h.cleanup(srv.Close)
 
 	return &Surface{

--- a/internal/integrationharness/standalone_no_default_merchant_test.go
+++ b/internal/integrationharness/standalone_no_default_merchant_test.go
@@ -28,7 +28,7 @@ func TestStandaloneNoDefaultMerchantResolvesRequestScopedMerchant(t *testing.T) 
 	h := New(t, ctx)
 	surface := h.StartStandalone("usd")
 
-	require.True(t, surface.app.Runtime.ConfiguredMerchant.IsZero(), "standalone must not carry a default merchant")
+	require.True(t, surface.app.Runtime.ConfiguredMerchant().IsZero(), "standalone must not carry a default merchant")
 
 	payerID := uuid.NewString()
 	status, body := requestJSON(t, http.MethodGet, surface.BaseURL+"/v1/merchant/credits/balance?currency=usd&customer_id="+payerID, surface.Token, nil)

--- a/internal/modules/abuse/card_abuse.go
+++ b/internal/modules/abuse/card_abuse.go
@@ -117,10 +117,11 @@ func (g *CardAbuseGuard) countFailure(ctx context.Context, key, unit string, win
 }
 
 // RecordChargeFailure records one failed/declined card attempt for the given
-// captcha subjects (use middleware.RateLimitSubjectKeysHTTP(r): ["ip:x","user:y"]) and
-// escalates each subject's captcha/block state, then advances the site-wide
-// attack-mode counter. Best-effort: errors are logged, never propagated, so
-// abuse tracking can't break the (already failed) charge response.
+// captcha subjects (use middleware.SubjectKeysFromContext(ctx): ["ip:x","user:y"],
+// the SAME resolved-client-IP subjects RateLimitHTTP pinned for this request —
+// #746) and escalates each subject's captcha/block state, then advances the
+// site-wide attack-mode counter. Best-effort: errors are logged, never
+// propagated, so abuse tracking can't break the (already failed) charge response.
 func (g *CardAbuseGuard) RecordChargeFailure(ctx context.Context, subjectKeys []string) {
 	if !g.enabled() {
 		return

--- a/internal/shared/iputil/clientip.go
+++ b/internal/shared/iputil/clientip.go
@@ -1,0 +1,101 @@
+package iputil
+
+import (
+	"net"
+	"strings"
+)
+
+// TrustedProxies is the ONE proxy-aware client-IP resolver (#746). Every
+// consumer that needs "the request's real client IP" — rate-limit subject
+// keys, abuse tracking, webhook IPAddress recording, the CCBill webhook IP
+// allowlist — resolves through an instance of this built from the SAME
+// config.Config.TrustedProxies list, so proxy trust is enforced identically
+// everywhere instead of each call site trusting (or not trusting)
+// X-Forwarded-For on its own.
+//
+// Semantics: a nil/empty TrustedProxies trusts NOTHING — every resolution
+// returns the raw socket peer, so a spoofed X-Forwarded-For has zero effect.
+// When the immediate socket peer falls inside a trusted CIDR,
+// ResolveClientIP walks X-Forwarded-For right-to-left, skipping trusted
+// hops, to the first untrusted address — the standard reverse-proxy
+// algorithm: everything to the right of that address was appended by a
+// proxy we trust, so it is the closest honest claim of "who is the client".
+type TrustedProxies struct {
+	nets []*net.IPNet
+}
+
+// ParseTrustedProxies builds a resolver from configured CIDR strings.
+// Malformed entries are silently skipped here — config.Validate is
+// responsible for rejecting them at boot (a typo must never boot into a
+// partially-trusting state); this constructor stays permissive so a resolver
+// built from an already-validated config is always usable.
+func ParseTrustedProxies(cidrs []string) *TrustedProxies {
+	tp := &TrustedProxies{}
+	for _, raw := range cidrs {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		if _, ipNet, err := net.ParseCIDR(raw); err == nil {
+			tp.nets = append(tp.nets, ipNet)
+		}
+	}
+	return tp
+}
+
+func (t *TrustedProxies) trusts(ip net.IP) bool {
+	if t == nil || ip == nil {
+		return false
+	}
+	for _, n := range t.nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// ResolveClientIP returns the real client IP for one request. remoteAddr is
+// the transport-level peer (http.Request.RemoteAddr — "host:port" or a bare
+// host); forwardedFor is the raw X-Forwarded-For header value (possibly
+// empty, possibly several comma-separated hops). Nil-safe: a nil
+// *TrustedProxies always returns the socket peer, matching "empty = trust
+// nothing".
+func (t *TrustedProxies) ResolveClientIP(remoteAddr, forwardedFor string) string {
+	peer := hostOnly(remoteAddr)
+	if !t.trusts(net.ParseIP(peer)) {
+		return peer
+	}
+	hops := splitForwardedFor(forwardedFor)
+	for i := len(hops) - 1; i >= 0; i-- {
+		if !t.trusts(net.ParseIP(hops[i])) {
+			return hops[i]
+		}
+	}
+	// Every hop (including the direct peer) is a trusted proxy — no
+	// untrusted address was ever observed on the wire; the direct peer is
+	// the best available answer.
+	return peer
+}
+
+func hostOnly(remoteAddr string) string {
+	if host, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		return host
+	}
+	return remoteAddr
+}
+
+func splitForwardedFor(header string) []string {
+	if strings.TrimSpace(header) == "" {
+		return nil
+	}
+	parts := strings.Split(header, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/shared/iputil/clientip_test.go
+++ b/internal/shared/iputil/clientip_test.go
@@ -1,0 +1,83 @@
+package iputil
+
+import "testing"
+
+func TestTrustedProxiesResolveClientIP(t *testing.T) {
+	cases := []struct {
+		name       string
+		cidrs      []string
+		remoteAddr string
+		xff        string
+		want       string
+	}{
+		{
+			name:       "no trusted proxies configured trusts nothing",
+			cidrs:      nil,
+			remoteAddr: "10.0.0.5:443",
+			xff:        "203.0.113.9",
+			want:       "10.0.0.5",
+		},
+		{
+			name:       "untrusted peer ignores forwarded header entirely (spoof attempt)",
+			cidrs:      []string{"10.0.0.0/8"},
+			remoteAddr: "203.0.113.9:443", // attacker, not in the trusted range
+			xff:        "64.38.212.5",     // forged claim of a trusted-looking IP
+			want:       "203.0.113.9",
+		},
+		{
+			name:       "trusted peer: single-hop XFF resolves to the forwarded client",
+			cidrs:      []string{"10.0.0.0/8"},
+			remoteAddr: "10.0.0.5:443",
+			xff:        "64.38.212.5",
+			want:       "64.38.212.5",
+		},
+		{
+			name:       "trusted peer: multi-hop XFF walks right-to-left past trusted hops",
+			cidrs:      []string{"10.0.0.0/8"},
+			remoteAddr: "10.0.0.5:443",
+			// Rightmost (10.0.0.6) is the trusted internal LB hop; the real
+			// client is the leftmost, untrusted entry.
+			xff:  "64.38.212.5, 10.0.0.6",
+			want: "64.38.212.5",
+		},
+		{
+			name:       "trusted peer: every hop trusted falls back to the direct peer",
+			cidrs:      []string{"10.0.0.0/8"},
+			remoteAddr: "10.0.0.5:443",
+			xff:        "10.0.0.6, 10.0.0.7",
+			want:       "10.0.0.5",
+		},
+		{
+			name:       "remoteAddr without a port is used as-is",
+			cidrs:      nil,
+			remoteAddr: "203.0.113.9",
+			xff:        "",
+			want:       "203.0.113.9",
+		},
+		{
+			name:       "malformed CIDR is silently skipped, trusting nothing",
+			cidrs:      []string{"not-a-cidr"},
+			remoteAddr: "10.0.0.5:443",
+			xff:        "64.38.212.5",
+			want:       "10.0.0.5",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resolver := ParseTrustedProxies(tc.cidrs)
+			got := resolver.ResolveClientIP(tc.remoteAddr, tc.xff)
+			if got != tc.want {
+				t.Errorf("ResolveClientIP(%q, %q) = %q, want %q", tc.remoteAddr, tc.xff, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNilTrustedProxiesTrustsNothing(t *testing.T) {
+	var resolver *TrustedProxies
+	got := resolver.ResolveClientIP("10.0.0.5:443", "64.38.212.5")
+	if got != "10.0.0.5" {
+		t.Errorf("nil resolver: got %q, want socket peer 10.0.0.5", got)
+	}
+}

--- a/pkg/embedded/mount.go
+++ b/pkg/embedded/mount.go
@@ -9,7 +9,6 @@ import (
 	"github.com/open-rails/openrails/internal/http/embedhttp"
 	"github.com/open-rails/openrails/internal/http/routesurface"
 	"github.com/open-rails/openrails/pkg/billingauth"
-	"github.com/open-rails/openrails/pkg/merchant"
 )
 
 // MountOptions configures the combined embedded surface (MountHandler).
@@ -51,9 +50,6 @@ func MountHandler(e *Embedded, opts MountOptions) (http.Handler, error) {
 	asm := embedhttp.FromApp(e.App())
 	asm.Authenticator = opts.Authenticator
 	asm.Gate = opts.Gate
-	if a := e.App(); a != nil && a.Runtime != nil {
-		asm.ConfiguredMerchant = a.Runtime.ConfiguredMerchant
-	}
 	userRouteSets := routeSetsWithoutCustomer(active)
 	user := http.NotFoundHandler()
 	if len(userRouteSets) > 0 {
@@ -100,17 +96,13 @@ func selfHandler(e *Embedded, authn billingauth.DelegatedAuthenticator, provider
 	if authn == nil {
 		return nil, fmt.Errorf("embedded billing: self surface requires MountOptions.DelegatedAuthenticator")
 	}
-	var configured merchant.ID
-	if a.Runtime != nil {
-		configured = a.Runtime.ConfiguredMerchant
-	}
-	return newSelfHandler(a.Runtime, authn, configured, providerRouteOverride), nil
+	return newSelfHandler(a.Runtime, authn, providerRouteOverride), nil
 }
 
 // newSelfHandler delegates to the neutral assembly; kept as the unit-testable
 // seam (no live app graph required).
-func newSelfHandler(rt *app.Runtime, authn billingauth.DelegatedAuthenticator, configured merchant.ID, providerRouteOverride *routesurface.ProviderRoutes) http.Handler {
-	return embedhttp.NewSelfHandler(rt, authn, configured, providerRouteOverride)
+func newSelfHandler(rt *app.Runtime, authn billingauth.DelegatedAuthenticator, providerRouteOverride *routesurface.ProviderRoutes) http.Handler {
+	return embedhttp.NewSelfHandler(rt, authn, providerRouteOverride)
 }
 
 func providerRoutesFromMountOptions(opt *ProviderRoutes) *routesurface.ProviderRoutes {

--- a/pkg/embedded/self_test.go
+++ b/pkg/embedded/self_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/open-rails/openrails/internal/dbtest"
 	"github.com/open-rails/openrails/pkg/billingauth"
-	"github.com/open-rails/openrails/pkg/merchant"
 )
 
 // These tests pin the EMBEDDED mount of the host-pluggable self surface
@@ -56,7 +55,7 @@ func doSelf(h http.Handler, method, path string) *httptest.ResponseRecorder {
 func TestSelfHandler_EmbeddedPathsMountedWithoutSelfPermissions(t *testing.T) {
 	self := newSelfHandler(nil, stubSelfAuthenticator{
 		principal: selfPrincipal(),
-	}, merchant.ID{}, nil)
+	}, nil)
 
 	w := doSelf(self, http.MethodGet, "/billing/v1/me/balance")
 	require.NotEqual(t, http.StatusNotFound, w.Code, w.Body.String())
@@ -80,7 +79,7 @@ func TestSelfHandler_EmbeddedPathsMountedWithoutSelfPermissions(t *testing.T) {
 // Host authenticator rejection and invalid principals map to 401 (fail closed),
 // exactly like the standalone host-pluggable mode.
 func TestSelfHandler_FailClosed(t *testing.T) {
-	h := newSelfHandler(nil, stubSelfAuthenticator{err: billingauth.ErrUnauthenticated}, merchant.ID{}, nil)
+	h := newSelfHandler(nil, stubSelfAuthenticator{err: billingauth.ErrUnauthenticated}, nil)
 	w := doSelf(h, http.MethodGet, "/billing/v1/me/balance?currency=usd")
 	require.Equal(t, http.StatusUnauthorized, w.Code, w.Body.String())
 
@@ -89,7 +88,7 @@ func TestSelfHandler_FailClosed(t *testing.T) {
 		principal: &billingauth.DelegatedPrincipal{
 			SubjectID: "user-1",
 		},
-	}, merchant.ID{}, nil)
+	}, nil)
 	w = doSelf(h, http.MethodGet, "/billing/v1/me/balance?currency=usd")
 	require.Equal(t, http.StatusUnauthorized, w.Code, w.Body.String())
 	require.Contains(t, w.Body.String(), "delegated_principal_invalid")
@@ -97,7 +96,7 @@ func TestSelfHandler_FailClosed(t *testing.T) {
 	// Merchant-admin routes live on the base embedded handler, not SelfHandler.
 	h = newSelfHandler(nil, stubSelfAuthenticator{
 		principal: selfPrincipal("platform:metrics:read"),
-	}, merchant.ID{}, nil)
+	}, nil)
 	w = doSelf(h, http.MethodGet, "/billing/v1/merchant/metrics")
 	require.Equal(t, http.StatusNotFound, w.Code, w.Body.String())
 }

--- a/pkg/embedded/standalone.go
+++ b/pkg/embedded/standalone.go
@@ -47,12 +47,11 @@ func StandaloneServer(e *Embedded) (*server.Server, error) {
 		return nil, fmt.Errorf("control plane verifier unavailable")
 	}
 	return server.New(server.Dependencies{
-		Config:             a.Config,
-		Cache:              a.Cache,
-		Runtime:            a.Runtime,
-		Redis:              a.RedisClient,
-		Authenticator:      authenticator,
-		ConfiguredMerchant: a.Runtime.ConfiguredMerchant,
-		ControlPlane:       embcp.Get(a),
+		Config:        a.Config,
+		Cache:         a.Cache,
+		Runtime:       a.Runtime,
+		Redis:         a.RedisClient,
+		Authenticator: authenticator,
+		ControlPlane:  embcp.Get(a),
 	})
 }

--- a/tests/customer_delegation_spend_http_integration_test.go
+++ b/tests/customer_delegation_spend_http_integration_test.go
@@ -104,7 +104,7 @@ func TestCustomerDelegationSpend_HTTP_EndToEnd(t *testing.T) {
 	}
 	httproutes.RegisterServiceRoutes(httprouter.NewMux(admitMux, "/v1/merchant", suite.App.Runtime), suite.App.Runtime,
 		httproutes.Options{Gate: httproutes.NewGate(httproutes.GateOptions{ServiceCredentialResolver: resolver})})
-	admitSrv := httptest.NewServer(middleware.ChainHTTP(admitMux, middleware.ResolveMerchantHTTP(dbtest.TestMerchantID)))
+	admitSrv := httptest.NewServer(middleware.ChainHTTP(admitMux, middleware.ResolveMerchantHTTP(middleware.StaticMerchant(dbtest.TestMerchantID))))
 	t.Cleanup(admitSrv.Close)
 
 	type admitResp struct {

--- a/tests/service_admit_http_integration_test.go
+++ b/tests/service_admit_http_integration_test.go
@@ -52,7 +52,7 @@ func TestServiceAdmit_HTTP_EndToEnd(t *testing.T) {
 		permissions: []string{controlplane.PermMerchantCustomerSettingsRead, controlplane.PermMerchantCustomerSettingsUpdate, controlplane.PermMerchantAdmissionsCreate},
 	}
 	httproutes.RegisterServiceRoutes(httprouter.NewMux(mux, "/v1/merchant", suite.App.Runtime), suite.App.Runtime, httproutes.Options{Gate: httproutes.NewGate(httproutes.GateOptions{ServiceCredentialResolver: resolver})})
-	router := middleware.ChainHTTP(mux, middleware.ResolveMerchantHTTP(dbtest.TestMerchantID))
+	router := middleware.ChainHTTP(mux, middleware.ResolveMerchantHTTP(middleware.StaticMerchant(dbtest.TestMerchantID)))
 
 	post := func(path string, body any) *httptest.ResponseRecorder {
 		var rdr *bytes.Reader

--- a/tests/service_facade_parity_test.go
+++ b/tests/service_facade_parity_test.go
@@ -135,7 +135,7 @@ func TestServiceFacade_CreditsAndEntitlements_ParityWithServiceHTTP(t *testing.T
 		},
 	}
 	httproutes.RegisterServiceRoutes(httprouter.NewMux(mux, "/v1/merchant", suite.App.Runtime), suite.App.Runtime, httproutes.Options{Gate: httproutes.NewGate(httproutes.GateOptions{ServiceCredentialResolver: resolver})})
-	router := middleware.ChainHTTP(mux, middleware.ResolveMerchantHTTP(dbtest.TestMerchantID))
+	router := middleware.ChainHTTP(mux, middleware.ResolveMerchantHTTP(middleware.StaticMerchant(dbtest.TestMerchantID)))
 
 	withServiceCredential := func(req *http.Request) {
 		req.Header.Set("Authorization", "Bearer openrails_st_testkeyid_testsecret")
@@ -178,7 +178,7 @@ func TestServiceFacade_CreditsAndEntitlements_ParityWithServiceHTTP(t *testing.T
 	jwtResolver := resolver
 	jwtResolver.serviceJWT = true
 	httproutes.RegisterServiceRoutes(httprouter.NewMux(jwtMux, "/v1/merchant", suite.App.Runtime), suite.App.Runtime, httproutes.Options{Gate: httproutes.NewGate(httproutes.GateOptions{ServiceCredentialResolver: jwtResolver})})
-	jwtRouter := middleware.ChainHTTP(jwtMux, middleware.ResolveMerchantHTTP(dbtest.TestMerchantID))
+	jwtRouter := middleware.ChainHTTP(jwtMux, middleware.ResolveMerchantHTTP(middleware.StaticMerchant(dbtest.TestMerchantID)))
 	withServiceJWT := func(req *http.Request) {
 		req.Header.Set("Authorization", "Bearer eyJ.service.jwt")
 	}

--- a/tests/unified_billing_e2e_test.go
+++ b/tests/unified_billing_e2e_test.go
@@ -86,7 +86,7 @@ func newBillingE2EHarness(t *testing.T, suite *TestContainerSuite) *billingE2EHa
 		controlplane.PermMerchantAdmissionsCreate,
 	}}
 	httproutes.RegisterServiceRoutes(httprouter.NewMux(mux, "/v1/merchant", suite.App.Runtime), suite.App.Runtime, httproutes.Options{Gate: httproutes.NewGate(httproutes.GateOptions{ServiceCredentialResolver: resolver})})
-	router := middleware.ChainHTTP(mux, middleware.ResolveMerchantHTTP(dbtest.TestMerchantID))
+	router := middleware.ChainHTTP(mux, middleware.ResolveMerchantHTTP(middleware.StaticMerchant(dbtest.TestMerchantID)))
 
 	return &billingE2EHarness{
 		t:          t,


### PR DESCRIPTION
## Summary

**#744 — `ConfiguredMerchant` split brain.** `Runtime.ConfiguredMerchant` is now an `atomic.Pointer[merchant.ID]` behind `ConfiguredMerchant()` / `SetConfiguredMerchant()`. `middleware.ResolveMerchantHTTP` takes a `func() merchant.ID` resolver instead of a value baked at construction time. Every HTTP mount path now closes over the Runtime and resolves the merchant fresh per request (matching `embed/transport.go`'s existing live read), instead of snapshotting it once when the handler is built:

- `internal/http/embedhttp/embedhttp.go` — deleted the baked `Assembler.ConfiguredMerchant` field; rewrote the truncated/false doc comment.
- `internal/http/embedhttp/self.go` — `NewSelfHandler` dropped its baked `configured merchant.ID` param.
- `pkg/embedded/mount.go` — deleted the `asm.ConfiguredMerchant = ...` bake.
- `internal/http/server.go` (standalone) — same anti-pattern, same fix, for consistency (not explicitly named in the issue but identical bug shape).

**#746 — one proxy-aware client-IP resolver.** New `internal/shared/iputil.TrustedProxies` (stdlib-only leaf package), configured by `config.Config.TrustedProxies` (`trusted_proxies` / env `TRUSTED_PROXIES`). Empty trusts nothing (raw socket peer); when the direct peer is inside a trusted CIDR, walks `X-Forwarded-For` right-to-left past trusted hops to the first untrusted address. Wired through:

- Rate-limit subject keys (`internal/http/middleware/ratelimit_neutral.go`)
- Abuse tracking — free, since it reads the same rate-limit subject keys
- Webhook `IPAddress` recording + the CCBill IP allowlist (`internal/http/handlers/webhook.go`, via the new `Request.ClientIP()`)
- The captcha-status endpoint (kept in sync with the rate limiter's subject keys)

`GetClientIP()` (unconditionally trusting XFF, zero callers) is deleted.

**Sibling note (#743):** the shared knob is `config.Config.TrustedProxies []string` + `internal/shared/iputil.TrustedProxies`. #743 already landed its own `AttachOptions.TrustedProxies []string` forwarding into AuthKit's `authhttp.WithTrustedProxies` for the control-plane surface — same CIDR shape, separate config path today. A future pass could unify the two operator-facing knobs; this PR keeps its half cleanly reusable (`iputil.ParseTrustedProxies` / `(*TrustedProxies).ResolveClientIP`) for that merge.

## Test plan

- [x] `gofmt -l`, `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` clean
- [x] `go test ./...` green
- [x] `go test -tags=integration -count=1 ./embed/... ./pkg/embedded/... ./internal/http/... ./internal/integrationharness/...` green (one pre-existing, unrelated failure in `internal/http/handlers` reproduced identically on `origin/master`, not touched by this PR)
- [x] New `embed/mount_order_integration_test.go`: mounts the embedded HTTP handler *before* `UpsertMerchantConfig` binds the merchant, binds after, then hits a merchant-scoped route and requires success — the exact order that broke before the fix (verified by temporarily reintroducing the old bake and confirming the test fails)
- [x] New `internal/shared/iputil/clientip_test.go`: resolver algorithm (no-config, spoofed untrusted peer, single/multi-hop trusted XFF, all-hops-trusted fallback, malformed CIDR, nil receiver)
- [x] New `config/trusted_proxies_test.go`: validation + wired into `config.Validate`
- [x] New CCBill webhook tests: trusted-proxy XFF passes the allowlist; no-config spoofed XFF is ignored (403s on the real socket address); untrusted peer can't inject XFF either
- [x] New rate-limit tests: resolved client IP behind a trusted proxy keys two distinct clients independently; without a resolver they collapse onto one bucket (contrast baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)