### PR TITLE
bump authkit v0.78.0 -> v0.79.0: genesis client, rate-limit overrides, Redis wiring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/knadh/koanf/v2 v2.2.2
 	github.com/moby/moby/api v1.54.3-0.20260603163940-285b47192d4b
 	github.com/moby/moby/client v0.4.2-0.20260603163940-285b47192d4b
-	github.com/open-rails/authkit v0.78.0
+	github.com/open-rails/authkit v0.79.0
 	github.com/open-rails/migratekit v1.3.0
 	github.com/redis/go-redis/v9 v9.12.1
 	github.com/riverqueue/river v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -263,8 +263,8 @@ github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729 h1:yf
 github.com/oasisprotocol/curve25519-voi v0.0.0-20251114093237-2ab5a27a1729/go.mod h1:hVoHR2EVESiICEMbg137etN/Lx+lSrHPTD39Z/uE+2s=
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
-github.com/open-rails/authkit v0.78.0 h1:QCLi0CgsVxhZZlbeWXa3p0CICsjSu8hGsQnFDIF0NIg=
-github.com/open-rails/authkit v0.78.0/go.mod h1:gfpqg5Dk7aKmepkypI8nFcN8XI3Gn5OVVMNAIMZDT+Y=
+github.com/open-rails/authkit v0.79.0 h1:TsEH04eT00+Qcd4djBexyGyMs4aKx4GexYTElC1m/iM=
+github.com/open-rails/authkit v0.79.0/go.mod h1:18SNsP83yBeu6/XozQsvstZsi2f9zU39VHZ9xkF3WeA=
 github.com/open-rails/migratekit v1.3.0 h1:Gf24VrBsayPESjF1gWBgVvkPhVMziQJ86LhNT/GJWus=
 github.com/open-rails/migratekit v1.3.0/go.mod h1:FmXhq5556xhvcDHx1wP3rNH1UBv408GHrxLw9gWXn6k=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/internal/bootstrap/merchant_manifest.go
+++ b/internal/bootstrap/merchant_manifest.go
@@ -1426,7 +1426,7 @@ func provisionMerchantGroup(ctx context.Context, cp *controlplane.ControlPlane, 
 		if err != nil {
 			return "", fmt.Errorf("merchant bootstrap: register remote_application for %q: %w", slug, err)
 		}
-		if err := core.AssignGroupRole(ctx, controlplane.MerchantType, slug, stored.ID, authcore.SubjectKindRemoteApp, controlplane.MerchantRoleOwner); err != nil {
+		if err := core.Genesis().AssignGroupRole(ctx, controlplane.MerchantType, slug, stored.ID, authcore.SubjectKindRemoteApp, controlplane.MerchantRoleOwner); err != nil {
 			return "", fmt.Errorf("merchant bootstrap: grant remote_application owner role for %q: %w", slug, err)
 		}
 	}

--- a/internal/controlplane/bootstrap.go
+++ b/internal/controlplane/bootstrap.go
@@ -75,7 +75,7 @@ type BootstrapOptions struct {
 // optionally minted under the merchant group when none exists.
 //
 // It runs AFTER migrations / at startup, exclusively through in-process AuthKit
-// CORE calls (EnsureRootGroup / CreatePermissionGroup / AssignGroupRole /
+// CORE calls (EnsureRootGroup / CreatePermissionGroup / Genesis().AssignGroupRole /
 // MintAPIKeyWithOptions) — never raw AuthKit SQL or a private HTTP route.
 // Re-running it is safe: group creation and owner assignment are idempotent; the
 // API key is minted only when none already exists.
@@ -125,7 +125,7 @@ func (c *ControlPlane) Bootstrap(ctx context.Context, opts BootstrapOptions) (*B
 		return nil, fmt.Errorf("controlplane: resolve merchant group %q: %w", slug, err)
 	} else if adminID := strings.TrimSpace(opts.InitialAdminUserID); adminID != "" {
 		// Group already existed: ensure the admin holds the owner role (idempotent).
-		if aerr := core.AssignGroupRole(ctx, MerchantType, slug, adminID, authcore.SubjectKindUser, MerchantRoleOwner); aerr != nil {
+		if aerr := core.Genesis().AssignGroupRole(ctx, MerchantType, slug, adminID, authcore.SubjectKindUser, MerchantRoleOwner); aerr != nil {
 			return nil, fmt.Errorf("controlplane: assign merchant owner to initial admin: %w", aerr)
 		}
 		log.WithFields(log.Fields{"merchant": slug, "user_id": adminID}).
@@ -164,7 +164,7 @@ func (c *ControlPlane) Bootstrap(ctx context.Context, opts BootstrapOptions) (*B
 				if err != nil {
 					return nil, err
 				}
-				if aerr := core.AssignGroupRole(ctx, MerchantType, slug, createdBy, authcore.SubjectKindUser, MerchantRoleOwner); aerr != nil {
+				if aerr := core.Genesis().AssignGroupRole(ctx, MerchantType, slug, createdBy, authcore.SubjectKindUser, MerchantRoleOwner); aerr != nil {
 					return nil, fmt.Errorf("controlplane: assign bootstrap api-key actor owner: %w", aerr)
 				}
 			}
@@ -220,7 +220,7 @@ func (c *ControlPlane) EnsureMerchantAPIKeyActor(ctx context.Context, merchantSl
 	if err != nil {
 		return "", err
 	}
-	if err := c.Core().AssignGroupRole(ctx, MerchantType, merchantSlug, createdBy, authcore.SubjectKindUser, MerchantRoleOwner); err != nil {
+	if err := c.Core().Genesis().AssignGroupRole(ctx, MerchantType, merchantSlug, createdBy, authcore.SubjectKindUser, MerchantRoleOwner); err != nil {
 		return "", fmt.Errorf("controlplane: assign api-key actor merchant owner: %w", err)
 	}
 	return createdBy, nil

--- a/internal/controlplane/bootstrap_integration_test.go
+++ b/internal/controlplane/bootstrap_integration_test.go
@@ -364,7 +364,7 @@ func TestRootOperatorBoundary_ReachNotMerchantCapability(t *testing.T) {
 
 	rootOperator, err := cp.Core().CreateUser(ctx, "root-operator@example.test", "rootoperator")
 	require.NoError(t, err)
-	require.NoError(t, cp.Core().AssignGroupRole(ctx, authcore.RootPersona, "", rootOperator.ID, authcore.SubjectKindUser, authcore.OwnerRoleName))
+	require.NoError(t, cp.Core().Genesis().AssignGroupRole(ctx, authcore.RootPersona, "", rootOperator.ID, authcore.SubjectKindUser, authcore.OwnerRoleName))
 
 	canModerateMerchant, err := cp.Core().Can(ctx, rootOperator.ID, authcore.SubjectKindUser, authcore.RootPersona, "", "root:merchants:delete")
 	require.NoError(t, err)

--- a/internal/controlplane/catalog.go
+++ b/internal/controlplane/catalog.go
@@ -10,7 +10,7 @@
 //   - bootstraps the merchant permission-group, the OpenRails permission catalog
 //     (`merchant:*` / `customer:*`), and an initial deployment admin API key
 //     through in-process AuthKit CORE calls (CreatePermissionGroup /
-//     AssignGroupRole / MintAPIKey) — never raw SQL or a private HTTP route.
+//     Genesis().AssignGroupRole / MintAPIKey) — never raw SQL or a private HTTP route.
 //
 // HARDCUT (#567): merchant-local authority is evaluated in the caller's merchant
 // permission-group using OpenRails' app permissions (`merchant:*` seller,

--- a/internal/controlplane/customer_group.go
+++ b/internal/controlplane/customer_group.go
@@ -52,7 +52,7 @@ func (c *ControlPlane) EnsureCustomerPermissionGroup(ctx context.Context, custom
 	} else if err != nil {
 		return "", fmt.Errorf("controlplane: resolve customer group %q: %w", customerID, err)
 	} else if ownerSubject != "" {
-		if err := core.AssignGroupRole(ctx, CustomerType, customerID, ownerSubject, authcore.SubjectKindUser, CustomerRoleOwner); err != nil {
+		if err := core.Genesis().AssignGroupRole(ctx, CustomerType, customerID, ownerSubject, authcore.SubjectKindUser, CustomerRoleOwner); err != nil {
 			return "", fmt.Errorf("controlplane: assign customer owner: %w", err)
 		}
 	}

--- a/internal/controlplane/redis_requirement_integration_test.go
+++ b/internal/controlplane/redis_requirement_integration_test.go
@@ -1,0 +1,92 @@
+//go:build integration
+
+package controlplane
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	authcore "github.com/open-rails/authkit/embedded"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/dbtest"
+)
+
+// noopEmailSender satisfies authcore.EmailSender without sending anything —
+// enough to let hosted posture's Registration.Verification=Required
+// construction check pass; this file's tests never exercise a route.
+type noopEmailSender struct{}
+
+func (noopEmailSender) SendVerification(context.Context, string, string, authcore.VerificationMessage) error {
+	return nil
+}
+func (noopEmailSender) SendPasswordResetLink(context.Context, string, string, string) error {
+	return nil
+}
+func (noopEmailSender) SendAccountRegistrationInvite(context.Context, string, string) error {
+	return nil
+}
+func (noopEmailSender) SendLoginCode(context.Context, string, string, string) error { return nil }
+func (noopEmailSender) SendWelcome(context.Context, string, string) error           { return nil }
+
+// stagingControlPlaneConfig is newTestControlPlane's cfg with a non-development
+// Environment (#753): authhttp.NewServer's own construction-time validate()
+// requires a Redis-backed ephemeral store whenever Environment is not dev-like
+// (embedded.IsDevEnvironment) — "staging" here is what actually exercises that
+// gate ("dev", used everywhere else in this file, never does).
+// Auth.MintDisabled=true sidesteps signing-key discovery (no keys.json exists
+// in this test environment, which outside development would otherwise be a
+// separate, unrelated construction failure — irrelevant to the Redis gate
+// under test here).
+func stagingControlPlaneConfig() *config.Config {
+	return &config.Config{
+		Env: "staging",
+		Auth: &config.AuthConfig{
+			Issuer:       "https://openrails-staging.test",
+			MintDisabled: true,
+		},
+	}
+}
+
+// TestNew_HostedStagingWithRedis_Succeeds proves #753's fix: New now accepts
+// WithRedis, wiring the caller's Redis client into AuthKit's engine as its
+// ephemeral store (authcore.WithRedis) — which authhttp.NewServer (authkit
+// v0.79.0, #210) also reuses for its own HTTP-layer rate limiter/state caches.
+// A hosted control plane in a non-development environment must boot when
+// Redis is supplied.
+func TestNew_HostedStagingWithRedis_Succeeds(t *testing.T) {
+	ctx := context.Background()
+	pool := newBootstrapTestPool(t)
+	rdb, _ := dbtest.SharedRedisClient(t)
+
+	cp, err := New(ctx, stagingControlPlaneConfig(), pool,
+		WithHostedPosture(),
+		WithEmailSender(noopEmailSender{}),
+		WithRedis(rdb),
+	)
+	require.NoError(t, err, "hosted control plane in a non-development environment must boot when Redis is wired")
+	require.NotNil(t, cp)
+}
+
+// TestNew_HostedStagingWithoutRedis_FailsNamingRedis is the mirror: before
+// #753, internal/controlplane.New never wired Redis/an ephemeral store into
+// authhttp.NewServer at all, so ANY hosted construction with a
+// production-like Environment string hard-failed unconditionally. With no
+// WithRedis option supplied, New must still fail — but the error must clearly
+// name the Redis/ephemeral-store requirement so an operator can act on it.
+func TestNew_HostedStagingWithoutRedis_FailsNamingRedis(t *testing.T) {
+	ctx := context.Background()
+	pool := newBootstrapTestPool(t)
+
+	cp, err := New(ctx, stagingControlPlaneConfig(), pool,
+		WithHostedPosture(),
+		WithEmailSender(noopEmailSender{}),
+	)
+	require.Error(t, err, "a non-development control plane with no Redis wired must fail, not silently boot unprotected")
+	require.Nil(t, cp)
+	require.Contains(t, strings.ToLower(err.Error()), "redis",
+		"the failure must name the Redis/ephemeral-store requirement: %v", err)
+}

--- a/internal/controlplane/service.go
+++ b/internal/controlplane/service.go
@@ -9,11 +9,12 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/open-rails/authkit"
 	authhttp "github.com/open-rails/authkit/authhttp"
 	authcore "github.com/open-rails/authkit/embedded"
 	jwtkit "github.com/open-rails/authkit/jwtkit"
+	"github.com/open-rails/authkit/ratelimit"
 	"github.com/open-rails/authkit/verify"
+	"github.com/redis/go-redis/v9"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/open-rails/openrails/config"
@@ -63,11 +64,13 @@ type ControlPlane struct {
 }
 
 type options struct {
-	hosted         bool
-	email          authcore.EmailSender
-	sms            authcore.SMSSender
-	frontend       authcore.FrontendConfig
-	trustedProxies []string
+	hosted             bool
+	email              authcore.EmailSender
+	sms                authcore.SMSSender
+	frontend           authcore.FrontendConfig
+	trustedProxies     []string
+	rateLimitOverrides map[string]ratelimit.Limit
+	redis              *redis.Client
 }
 
 // Option configures the control plane for embedding hosts.
@@ -126,6 +129,32 @@ func WithFrontend(fc authcore.FrontendConfig) Option {
 func WithTrustedProxies(cidrs []string) Option {
 	return func(o *options) {
 		o.trustedProxies = cidrs
+	}
+}
+
+// WithRateLimitOverrides overlays bucket-specific limits onto AuthKit's
+// built-in rate-limit defaults (authhttp.WithRateLimitOverrides; #743 task 3,
+// unblocked by authkit v0.79.0's authkit#242 merge-style override API). Keys
+// are AuthKit's exported bucket names (authhttp.RLPasswordLogin, etc.);
+// unset buckets keep AuthKit's default. Never replaces the whole policy —
+// authhttp.WithRateLimiter/WithoutRateLimiter remain the (unforwarded,
+// advanced-only) full-replacement seam.
+func WithRateLimitOverrides(overrides map[string]ratelimit.Limit) Option {
+	return func(o *options) {
+		o.rateLimitOverrides = overrides
+	}
+}
+
+// WithRedis wires a Redis client into the AuthKit engine's ephemeral store
+// (authcore.WithRedis) — #753. authhttp.NewServer (authkit v0.79.0, #210)
+// automatically reuses this SAME client for its own OIDC/SIWS state caches
+// and rate limiter, so this one call satisfies both layers' Redis needs.
+// Required outside development: authhttp.NewServer hard-fails construction
+// when Environment is non-development and no Redis-backed ephemeral store
+// was wired.
+func WithRedis(rd *redis.Client) Option {
+	return func(o *options) {
+		o.redis = rd
 	}
 }
 
@@ -292,7 +321,7 @@ func New(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, opts ...Op
 		// its own namespace directly; the flat case needs no cross-namespace grant).
 		RBAC: Groups(),
 		// Private standalone posture: no public user self-registration. Embedded
-		// bootstrap/core calls (CreatePermissionGroup/AssignGroupRole/MintAPIKey)
+		// bootstrap/core calls (CreatePermissionGroup/Genesis().AssignGroupRole/MintAPIKey)
 		// are unaffected. Hosted products opt in with WithHostedPosture; no
 		// config/env knob opens this in standalone.
 		// Verification set EXPLICITLY: authkit v0.76.0 defaults unset to
@@ -316,6 +345,14 @@ func New(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, opts ...Op
 	if options.sms != nil {
 		coreOpts = append(coreOpts, authcore.WithSMSSender(options.sms))
 	}
+	// #753: wire the engine's Redis client as AuthKit's ephemeral store.
+	// authhttp.NewServer below (authkit v0.79.0, #210) automatically reuses
+	// THIS SAME client for its own OIDC/SIWS caches and rate limiter — one
+	// wire satisfies both layers, and is REQUIRED outside development (see
+	// authhttp.NewServer's validate()).
+	if options.redis != nil {
+		coreOpts = append(coreOpts, authcore.WithRedis(options.redis))
+	}
 
 	// Client-first construction (#142): build the AuthKit engine, then adapt it
 	// with the HTTP server. Core() / the delegated verifier hold this client.
@@ -325,10 +362,14 @@ func New(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, opts ...Op
 	}
 	// HTTP-layer options (#743): trusted-proxy CIDRs so the per-client
 	// registration/login rate limiter keys on the real client behind a load
-	// balancer instead of the LB's own peer address.
+	// balancer instead of the LB's own peer address; per-bucket rate-limit
+	// overrides layered onto AuthKit's defaults.
 	var authHTTPOpts []authhttp.Option
 	if len(options.trustedProxies) > 0 {
 		authHTTPOpts = append(authHTTPOpts, authhttp.WithTrustedProxies(options.trustedProxies...))
+	}
+	if len(options.rateLimitOverrides) > 0 {
+		authHTTPOpts = append(authHTTPOpts, authhttp.WithRateLimitOverrides(options.rateLimitOverrides))
 	}
 	authSvc, err := authhttp.NewServer(authClient, authHTTPOpts...)
 	if err != nil {
@@ -394,8 +435,19 @@ func New(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, opts ...Op
 }
 
 // Core returns the underlying AuthKit core service used for in-process
-// group/role/API key operations.
-func (c *ControlPlane) Core() authkit.Client {
+// group/role/API key operations. The return type is the concrete
+// *authcore.Client (not the authkit.Client interface): it satisfies
+// authkit.Client in full (every existing Core()-based call site keeps
+// compiling unchanged) AND additionally exposes .Genesis() (authkit v0.79.0,
+// #241) — the unchecked bootstrap/migration mutators (AssignGroupRole,
+// AssignRoleBySlug, RemoveRoleBySlug, RemoveGroupSubject) that authkit
+// deliberately dropped from the swappable Client interface. Bootstrap/seed/
+// lazy-materialization code (internal/controlplane/bootstrap.go,
+// customer_group.go, internal/bootstrap/merchant_manifest.go, the integration
+// harness) calls Core().Genesis().AssignGroupRole(...) etc.; runtime request
+// handlers must use the actor-checked *As methods on the Client interface
+// instead (never Genesis()).
+func (c *ControlPlane) Core() *authcore.Client {
 	if c == nil {
 		return nil
 	}

--- a/internal/integrationharness/cross_merchant_isolation_test.go
+++ b/internal/integrationharness/cross_merchant_isolation_test.go
@@ -266,7 +266,7 @@ func TestStandaloneMerchantAdmitAcceptsUserSessionByPermissionHTTP(t *testing.T)
 		email := username + "@example.com"
 		user, err := core.CreateUser(ctx, email, username)
 		require.NoError(t, err, "create user")
-		require.NoError(t, core.AssignGroupRole(ctx, controlplane.MerchantType, dbtest.TestMerchantSlug, user.ID, authcore.SubjectKindUser, roleForPerms(perms)), "assign merchant role")
+		require.NoError(t, core.Genesis().AssignGroupRole(ctx, controlplane.MerchantType, dbtest.TestMerchantSlug, user.ID, authcore.SubjectKindUser, roleForPerms(perms)), "assign merchant role")
 		token, _, err := core.IssueAccessToken(ctx, user.ID, nil)
 		require.NoError(t, err, "issue access token")
 		return token
@@ -398,7 +398,7 @@ func TestCoreDoesNotMountPlatformAdminRoutesHTTP(t *testing.T) {
 	require.NoError(t, err, "create merchant admin user")
 	// #567: assign the merchant `owner` role directly in the merchant group (no
 	// separate group membership step).
-	require.NoError(t, core.AssignGroupRole(ctx, controlplane.MerchantType, dbtest.TestMerchantSlug, user.ID, authcore.SubjectKindUser, controlplane.MerchantRoleOwner), "assign merchant admin role")
+	require.NoError(t, core.Genesis().AssignGroupRole(ctx, controlplane.MerchantType, dbtest.TestMerchantSlug, user.ID, authcore.SubjectKindUser, controlplane.MerchantRoleOwner), "assign merchant admin role")
 	token, _, err := core.IssueAccessToken(ctx, user.ID, nil)
 	require.NoError(t, err, "issue merchant admin user access token")
 

--- a/internal/integrationharness/harness.go
+++ b/internal/integrationharness/harness.go
@@ -651,7 +651,7 @@ func (s *Surface) registerRemoteApplication(slug, ownerMerchantSlug, role string
 	require.NoError(h.t, err, "register remote_application")
 
 	if role != "" {
-		require.NoError(h.t, core.AssignGroupRole(h.ctx, controlplane.MerchantType, ownerMerchantSlug, ra.ID, authcore.SubjectKindRemoteApp, role),
+		require.NoError(h.t, core.Genesis().AssignGroupRole(h.ctx, controlplane.MerchantType, ownerMerchantSlug, ra.ID, authcore.SubjectKindRemoteApp, role),
 			"assign merchant role to remote_application")
 	}
 
@@ -707,7 +707,7 @@ func (s *Surface) RegisterDelegatedIssuer(slug, ownerMerchantSlug string) *Deleg
 		Enabled:           true,
 	})
 	require.NoError(h.t, err, "register delegated issuer")
-	require.NoError(h.t, core.AssignGroupRole(h.ctx, controlplane.MerchantType, ownerMerchantSlug, ra.ID, authcore.SubjectKindRemoteApp, controlplane.MerchantRoleOwner),
+	require.NoError(h.t, core.Genesis().AssignGroupRole(h.ctx, controlplane.MerchantType, ownerMerchantSlug, ra.ID, authcore.SubjectKindRemoteApp, controlplane.MerchantRoleOwner),
 		"assign merchant owner role to delegated issuer")
 	require.NoError(h.t, cp.ReloadRemoteApplications(h.ctx), "reload remote_applications")
 
@@ -801,7 +801,7 @@ func (s *Surface) RegisterDelegatedCaller(slug, ownerMerchantSlug, subject strin
 		// #567: merchant groups have fixed catalog roles (no custom roles). Grant
 		// the merchant `owner` role (= merchant:*); the delegated token's claim is
 		// then bounded down to its requested subset at verify/gate time.
-		require.NoError(h.t, core.AssignGroupRole(h.ctx, controlplane.MerchantType, ownerMerchantSlug, ra.ID, authcore.SubjectKindRemoteApp, controlplane.MerchantRoleOwner),
+		require.NoError(h.t, core.Genesis().AssignGroupRole(h.ctx, controlplane.MerchantType, ownerMerchantSlug, ra.ID, authcore.SubjectKindRemoteApp, controlplane.MerchantRoleOwner),
 			"assign merchant owner role to delegated remote_application")
 	}
 	require.NoError(h.t, cp.ReloadRemoteApplications(h.ctx), "reload remote_applications")
@@ -848,7 +848,7 @@ func (s *Surface) RegisterServiceJWTIssuer(slug, ownerMerchantSlug string, permi
 	require.NoError(h.t, err, "register service-JWT issuer")
 	// #567: assign the merchant `owner` role (= merchant:*); the service JWT's
 	// claimed permissions are bounded down to its requested subset at verify time.
-	require.NoError(h.t, core.AssignGroupRole(h.ctx, controlplane.MerchantType, ownerMerchantSlug, ra.ID, authcore.SubjectKindRemoteApp, controlplane.MerchantRoleOwner),
+	require.NoError(h.t, core.Genesis().AssignGroupRole(h.ctx, controlplane.MerchantType, ownerMerchantSlug, ra.ID, authcore.SubjectKindRemoteApp, controlplane.MerchantRoleOwner),
 		"assign merchant owner role to service-JWT remote_application")
 	require.NoError(h.t, cp.ReloadRemoteApplications(h.ctx), "reload remote_applications")
 
@@ -975,7 +975,7 @@ func (h *Harness) ensureAPIKeyActor(cp *controlplane.ControlPlane, merchantSlug 
 		user, err = cp.Core().CreateUser(h.ctx, email, username)
 	}
 	require.NoError(h.t, err, "ensure API-key actor")
-	require.NoError(h.t, cp.Core().AssignGroupRole(h.ctx, controlplane.MerchantType, merchantSlug, user.ID, authcore.SubjectKindUser, controlplane.MerchantRoleOwner),
+	require.NoError(h.t, cp.Core().Genesis().AssignGroupRole(h.ctx, controlplane.MerchantType, merchantSlug, user.ID, authcore.SubjectKindUser, controlplane.MerchantRoleOwner),
 		"assign API-key actor merchant owner")
 	return user.ID
 }

--- a/internal/integrationharness/platform_merchants_http_test.go
+++ b/internal/integrationharness/platform_merchants_http_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	authcore "github.com/open-rails/authkit/embedded"
 	"github.com/google/uuid"
+	authcore "github.com/open-rails/authkit/embedded"
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-rails/openrails/internal/controlplane"
@@ -57,7 +57,7 @@ func mintPlatformOperatorToken(t *testing.T, ctx context.Context, s *Surface, ro
 		_, err = core.EnsureRootGroup(ctx)
 		require.NoError(t, err, "ensure root group")
 		require.NoError(t,
-			core.AssignGroupRole(ctx, authcore.RootPersona, "", user.ID, authcore.SubjectKindUser, role),
+			core.Genesis().AssignGroupRole(ctx, authcore.RootPersona, "", user.ID, authcore.SubjectKindUser, role),
 			"assign root role %s", role)
 	}
 	token, _, err := core.IssueAccessToken(ctx, user.ID, nil)

--- a/pkg/embedded/controlplane/controlplane.go
+++ b/pkg/embedded/controlplane/controlplane.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	authcore "github.com/open-rails/authkit/embedded"
+	"github.com/open-rails/authkit/ratelimit"
 
 	"github.com/open-rails/openrails/config"
 	"github.com/open-rails/openrails/internal/app"
@@ -70,14 +71,16 @@ import (
 // authcore.Option (engine-construction functional options):
 //   - WithEmailSender / WithSMSSender: FORWARDED via AttachOptions.EmailSender
 //     / SMSSender (#738).
-//   - WithEphemeralStore / embedded.WithRedis: NOT forwarded — DISCOVERED GAP,
-//     not fixed here (out of #743's scope): the control-plane engine built by
-//     internal/controlplane.New never wires Redis/an ephemeral store at all.
+//   - WithEphemeralStore / embedded.WithRedis: FORWARDED (#753) — AttachWithOptions
+//     wires the app graph's OWN Redis client (app.App.RedisClient, the same
+//     client pkg/embedded.Options.Redis produced) into
+//     controlplane.WithRedis whenever the app has one, rather than adding a
+//     redundant AttachOptions field for state the app graph already holds.
 //     authhttp's own construction-time validate() hard-fails when
-//     Environment is not dev-like and no Redis was supplied — so today ANY
-//     hosted attach with a production-like Environment string and no Redis
-//     wired some other way will fail to boot. Flagged for a follow-up issue,
-//     not silently absorbed into this one.
+//     Environment is not dev-like and no Redis was supplied, so a hosted
+//     attach in a non-development environment now requires the app to have
+//     Redis configured (pkg/embedded.Options.Redis / app.BootstrapOptions.Redis);
+//     the resulting error names the requirement.
 //   - WithEntitlements / WithClickHouse: NOT forwarded — unrelated feature
 //     areas OpenRails' control plane does not use.
 //
@@ -87,13 +90,15 @@ import (
 //     "normal knob", per its own doc); exposing a raw ClientIPFunc would let a
 //     host inject arbitrary, unaudited client-IP logic. Advanced/test-only by
 //     authhttp's own doc.
-//   - WithRateLimiter / WithoutRateLimiter: NOT forwarded — BLOCKED on authkit
-//     #242 (a merge-style per-bucket override API). The raw options are a
-//     full-policy-replacement footgun ("ADVANCED/TEST ONLY" per authhttp's own
-//     doc); forwarding them today would let a host disable rate limiting
-//     entirely instead of tuning one bucket. Tracked, not implemented.
-//   - WithRedis: NOT forwarded — see the WithEphemeralStore gap above; the
-//     HTTP layer reuses whatever the engine wired (nothing, today).
+//   - WithRateLimiter / WithoutRateLimiter: NOT forwarded — full-policy-replacement
+//     footguns ("ADVANCED/TEST ONLY" per authhttp's own doc); forwarding them
+//     would let a host disable rate limiting entirely instead of tuning one
+//     bucket. Use AuthRateLimitOverrides for per-bucket tuning instead.
+//   - WithRateLimitOverrides: FORWARDED (#743 task 3, unblocked by authkit
+//     v0.79.0's merge-style override API) via AttachOptions.AuthRateLimitOverrides.
+//   - WithRedis: NOT separately forwarded — the HTTP layer automatically
+//     reuses whatever Redis client the engine was wired with above (authkit
+//     v0.79.0, #210); a host never needs to pass Redis twice.
 //   - WithLanguageConfig: NOT forwarded — i18n is not wired into
 //     AttachOptions; no host has asked for it yet.
 type AttachOptions struct {
@@ -136,6 +141,15 @@ type AttachOptions struct {
 	// deliberately a standalone AttachOptions field, not a shared config key,
 	// until that unification lands.
 	TrustedProxies []string
+
+	// AuthRateLimitOverrides overlays bucket-specific limits onto AuthKit's
+	// built-in rate-limit defaults (#743 task 3, unblocked by authkit
+	// v0.79.0's authhttp.WithRateLimitOverrides). Keys are AuthKit's exported
+	// bucket names (authhttp.RLPasswordLogin, authhttp.RLAuthRegister, ...);
+	// a host tunes only the buckets it names, every other bucket keeps
+	// AuthKit's default. The type is authkit/ratelimit's own exported Limit —
+	// no OpenRails wrapper needed, matching Frontend/EmailSender above.
+	AuthRateLimitOverrides map[string]ratelimit.Limit
 }
 
 // Get recovers the concrete *controlplane.ControlPlane attached to the app, or
@@ -193,6 +207,19 @@ func AttachWithOptions(ctx context.Context, a *app.App, cfg *config.Config, inje
 	}
 	if len(opts.TrustedProxies) > 0 {
 		cpOpts = append(cpOpts, controlplane.WithTrustedProxies(opts.TrustedProxies))
+	}
+	if len(opts.AuthRateLimitOverrides) > 0 {
+		cpOpts = append(cpOpts, controlplane.WithRateLimitOverrides(opts.AuthRateLimitOverrides))
+	}
+	// #753: reuse the app graph's OWN Redis client (the same client
+	// pkg/embedded.Options.Redis / app.BootstrapOptions.Redis produced) as
+	// AuthKit's ephemeral store, rather than adding a redundant AttachOptions
+	// field for state the app already holds. Nil (no Redis configured) is
+	// passed through unchanged — authhttp.NewServer below fails construction
+	// with a clear error naming the Redis requirement whenever Environment
+	// is non-development and no Redis was wired.
+	if a.RedisClient != nil {
+		cpOpts = append(cpOpts, controlplane.WithRedis(a.RedisClient))
 	}
 	cp, err := controlplane.New(ctx, cfg, pool, cpOpts...)
 	if err != nil {

--- a/pkg/embedded/controlplane/provision.go
+++ b/pkg/embedded/controlplane/provision.go
@@ -26,7 +26,7 @@ type ProvisionMerchantRequest struct {
 	// user-chosen slug and branch on Created; a slug squatter cannot be granted
 	// ownership of someone else's merchant). Re-runs stay idempotent: the
 	// creating call already seeded the owner. Later owner changes go through
-	// Core().AssignGroupRole explicitly.
+	// Core().Genesis().AssignGroupRole explicitly (authkit v0.79.0, #241).
 	OwnerUserID string
 }
 


### PR DESCRIPTION
## Summary
- Bump `github.com/open-rails/authkit` v0.78.0 -> v0.79.0 (`go get` + `go mod tidy`).
- Migrate off the unchecked genesis mutators authkit dropped from `authkit.Client` (#241): `ControlPlane.Core()` now returns the concrete `*authcore.Client` (still satisfies `authkit.Client` in full) so it additionally exposes `.Genesis()`. All bootstrap/seed/lazy-materialization call sites (`internal/controlplane/bootstrap.go`, `customer_group.go`, `internal/bootstrap/merchant_manifest.go`, the integration harness, and their tests) migrated to `Core().Genesis().AssignGroupRole(...)`.
- Unblocks #743 task 3: forward `authhttp.WithRateLimitOverrides` via new `AttachOptions.AuthRateLimitOverrides` / `controlplane.WithRateLimitOverrides` (authkit's own #242 merge-over-defaults API, not the full-policy-replacement `WithRateLimiter`/`WithoutRateLimiter`).
- Fixes #753: wire the app graph's own Redis client (`app.App.RedisClient`) into the AuthKit engine (`controlplane.WithRedis` -> `authcore.WithRedis`) from `pkg/embedded/controlplane.AttachWithOptions`. authkit v0.79.0's `authhttp.NewServer` (#210) auto-reuses that same client for its own HTTP-layer rate limiter/state caches, so one wire satisfies both layers — a hosted attach in a non-development environment now boots instead of hard-failing when Redis is present, and fails with a clear Redis-naming error when it isn't.

## Test plan
- [x] `gofmt`/`go vet`/`go vet -tags=integration` clean; `go build ./...` and `go build -tags=integration ./...` clean.
- [x] `go test ./...` green.
- [x] `go test -tags=integration -count=1 ./internal/controlplane/... ./pkg/embedded/controlplane/... ./internal/integrationharness/... ./internal/bootstrap/...` green.
- [x] New integration tests: `TestNew_HostedStagingWithRedis_Succeeds` / `TestNew_HostedStagingWithoutRedis_FailsNamingRedis` (`internal/controlplane/redis_requirement_integration_test.go`) prove #753's fix against a real Postgres pool + real dbtest Redis with `Environment: "staging"` + hosted posture.