### PR TITLE
docs(#754): invoke console build script via bash from the module cache

### DIFF
--- a/docs/admin-console.md
+++ b/docs/admin-console.md
@@ -62,10 +62,11 @@ import "embed"
 var FS embed.FS
 ```
 
-Build the dist from the openrails module cache (no vendoring, no checkout):
+Build the dist from the openrails module cache (no vendoring, no checkout —
+via `bash`, since module-cache files are not executable):
 
 ```sh
-"$(go list -m -f '{{.Dir}}' github.com/open-rails/openrails)/scripts/build-admin-console.sh" internal/consoleassets/dist
+bash "$(go list -m -f '{{.Dir}}' github.com/open-rails/openrails)/scripts/build-admin-console.sh" internal/consoleassets/dist
 ```
 
 (The script copies `web/admin` out of the read-only module cache to a temp dir

--- a/scripts/build-admin-console.sh
+++ b/scripts/build-admin-console.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Build the merchant admin console SPA (web/admin) into <output-dir> (#754).
 #
-# Works in-repo AND from a module consumer:
+# Works in-repo AND from a module consumer (module-cache files are read-only
+# and NOT executable — invoke via bash):
 #   in-repo:   ./scripts/build-admin-console.sh cmd/openrails/consoleassets/dist
-#   consumer:  "$(go list -m -f '{{.Dir}}' github.com/open-rails/openrails)/scripts/build-admin-console.sh" internal/webassets/dist
+#   consumer:  bash "$(go list -m -f '{{.Dir}}' github.com/open-rails/openrails)/scripts/build-admin-console.sh" internal/webassets/dist
 #
 # The Go module cache is read-only, so when the SPA source isn't writable it is
 # copied to a temp dir before `npm ci` (npm must write node_modules).


### PR DESCRIPTION
Found while adopting the host flow in openrails-saas: files in the Go module cache are read-only AND non-executable, so the documented direct invocation of `scripts/build-admin-console.sh` fails with "Permission denied". Docs + script header now show `bash "$(go list -m -f '{{.Dir}}' …)/scripts/build-admin-console.sh" <out>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)