### PR TITLE
#755 dashboard add-widget: NL-first, axe the manual query builder

### DIFF
--- a/docs/admin-console.md
+++ b/docs/admin-console.md
@@ -119,7 +119,7 @@ manifest publish with plan preview, drift view + refresh), Ops (findings queue w
 approve/ignore, repair alerts, worker health), Settings (merchant profile, payment
 providers, credit limit, trust tier).
 
-## Dashboard (#741)
+## Dashboard (#741, #755)
 
 The Dashboard page is a per-merchant WIDGET GRID over the #733 metrics API: every tile
 is a saved metrics query + viz (stat/line/area/bar/donut/table) + grid position,
@@ -129,13 +129,24 @@ activity). Drag/resize/add/edit/remove; changes save automatically (debounced PU
 Reads need `merchant:metrics:read`; writes + generation need `merchant:dashboard:update`
 (owner + support roles).
 
-Widgets can be added two ways: a schema-driven manual builder (always available), and a
-natural-language prompt ("count of users who cancelled per day, for the past 7 days")
-that a server-side LLM turns into a validated query — the model only ever sees the
-metrics schema, never data, and its output must pass the same compiler validation as any
-client query (corrective errors are fed back, max 2 retries). FAIL-CLOSED: with no LLM
-configured the generate endpoint answers 501 and `config.json` carries
-`nl_widgets_enabled: false`, hiding the NL box; the dashboard is fully usable without it.
+Widget queries are written by the LLM ONLY — by design (#755, there is no manual query
+builder). Creating a widget = a natural-language prompt ("count of users who cancelled
+per day, for the past 7 days") that a server-side LLM turns into a validated query — the
+model only ever sees the metrics schema, never data, and its output must pass the same
+compiler validation as any client query (corrective errors are fed back, max 2 retries).
+The result previews live through `/v1/merchant/metrics/query` before saving; the only
+human knobs are the title and the viz type (the LLM suggests both). Editing an existing
+widget is a REFINEMENT: the instruction ("make it weekly", "split by rail") is sent with
+the widget's current query as `base_query`, and the LLM edits it instead of starting
+over. Direct title/viz edits never touch the LLM. `GET /v1/merchant/metrics/schema`
+stays public for programmatic clients.
+
+FAIL-CLOSED, but visible: with no LLM configured the generate endpoint answers 501 and
+`config.json` carries `nl_widgets_enabled: false`; the add-widget button stays visible
+and opens a pointed empty-state naming the fix (`llm.api_key` / env `LLM_API_KEY`).
+Everything else works keyless: the seeded default template, drag/resize/delete,
+per-widget refresh, and direct title/viz edits of existing widgets — only creating or
+refining queries needs the key.
 
 ```yaml
 llm:

--- a/internal/http/handlers/merchant_dashboard.go
+++ b/internal/http/handlers/merchant_dashboard.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -59,7 +60,9 @@ func PutMerchantDashboard(r *httprequest.Request) {
 // GenerateDashboardWidget handles POST /v1/merchant/dashboard/widgets/generate:
 // prompt → VALIDATED {query, title, viz} via the server-side LLM (#741). The
 // LLM sees only the metrics schema, never data; unconfigured deployments
-// answer 501 (fail-closed — the console hides the NL box too).
+// answer 501 (fail-closed — the console shows a pointed empty-state, #755).
+// Optional base_query (an existing widget's query, validated like any client
+// query) makes the prompt a REFINEMENT of that query instead of a fresh start.
 func GenerateDashboardWidget(r *httprequest.Request) {
 	svc := r.State.DashboardService
 	if svc == nil {
@@ -68,17 +71,33 @@ func GenerateDashboardWidget(r *httprequest.Request) {
 	}
 	if !svc.NLConfigured() {
 		r.ErrorJSON(http.StatusNotImplemented,
-			"natural-language widget generation is not configured on this deployment: set llm.api_key (env LLM_API_KEY); the manual widget builder works without it")
+			"natural-language widget generation is not configured on this deployment: set llm.api_key (env LLM_API_KEY) — see docs/admin-console.md")
 		return
 	}
 	var body struct {
-		Prompt string `json:"prompt"`
+		Prompt    string          `json:"prompt"`
+		BaseQuery json.RawMessage `json:"base_query"`
 	}
 	if err := json.NewDecoder(r.Request.Body).Decode(&body); err != nil || strings.TrimSpace(body.Prompt) == "" {
-		r.ErrorJSON(http.StatusBadRequest, `body must be {"prompt":"<what the widget should show>"}`)
+		r.ErrorJSON(http.StatusBadRequest, `body must be {"prompt":"<what the widget should show>","base_query":<optional existing query to refine>}`)
 		return
 	}
-	res, err := svc.Generate(r.Request.Context(), strings.TrimSpace(body.Prompt))
+	var base *metrics.Query
+	if len(body.BaseQuery) > 0 && string(body.BaseQuery) != "null" {
+		q, verr := metrics.DecodeQuery(bytes.NewReader(body.BaseQuery))
+		if verr == nil {
+			_, verr = metrics.Validate(q)
+		}
+		if verr != nil {
+			for i := range verr.Errors {
+				verr.Errors[i].Param = "base_query." + verr.Errors[i].Param
+			}
+			dashboardValidationError(r, verr)
+			return
+		}
+		base = q
+	}
+	res, err := svc.Generate(r.Request.Context(), strings.TrimSpace(body.Prompt), base)
 	if err != nil {
 		var invalid *dashboard.GenerateInvalidError
 		switch {

--- a/internal/integrationharness/dashboard_http_test.go
+++ b/internal/integrationharness/dashboard_http_test.go
@@ -349,6 +349,45 @@ func TestDashboardWidgetGenerate(t *testing.T) {
 		require.Contains(t, feedback, "cancellations", "did-you-mean must be fed back")
 	})
 
+	t.Run("refine: base_query rides into the llm turn as current-query context", func(t *testing.T) {
+		weekly := `{"query":{"measures":["cancellations"],"by":["time"],"grain":"week","range":{"last":"12w"}},"title":"Cancellations per week","viz":"line"}`
+		fake := &scriptedLLM{responses: []string{weekly}}
+		svc.SetLLM(fake)
+		status, body := requestJSON(t, http.MethodPost, surface.BaseURL+"/v1/merchant/dashboard/widgets/generate",
+			token, map[string]any{
+				"prompt": "make it weekly",
+				"base_query": map[string]any{
+					"measures": []string{"cancellations"},
+					"by":       []string{"time"},
+					"grain":    "day",
+					"range":    map[string]string{"last": "7d"},
+				},
+			})
+		require.Equalf(t, http.StatusOK, status, "refine: %s", string(body))
+		require.Contains(t, string(body), `"week"`)
+		require.Len(t, fake.calls, 1)
+		turn := fake.calls[0][0].Content
+		require.Contains(t, turn, "Current query to modify:")
+		require.Contains(t, turn, `"grain":"day"`, "existing query must ride in as context")
+		require.Contains(t, turn, "Instruction: make it weekly")
+	})
+
+	t.Run("invalid base_query is a 400 with compiler errors", func(t *testing.T) {
+		fake := &scriptedLLM{responses: []string{goldenWidgetJSON}}
+		svc.SetLLM(fake)
+		status, body := requestJSON(t, http.MethodPost, surface.BaseURL+"/v1/merchant/dashboard/widgets/generate",
+			token, map[string]any{
+				"prompt": "make it weekly",
+				"base_query": map[string]any{
+					"measures": []string{"cancelations"},
+					"range":    map[string]string{"last": "7d"},
+				},
+			})
+		require.Equal(t, http.StatusBadRequest, status)
+		require.Contains(t, string(body), "base_query.measures[0]")
+		require.Empty(t, fake.calls, "invalid base must never reach the LLM")
+	})
+
 	t.Run("exhausted retries return the corrective errors", func(t *testing.T) {
 		invalid := `{"query":{"measures":["nope"],"range":{"last":"7d"}},"title":"x","viz":"stat"}`
 		fake := &scriptedLLM{responses: []string{invalid}}

--- a/internal/modules/dashboard/dashboard_test.go
+++ b/internal/modules/dashboard/dashboard_test.go
@@ -76,7 +76,7 @@ const goldenResponse = `{"query":{"measures":["cancellations"],"by":["time"],"gr
 func TestGenerate_HappyPathGolden(t *testing.T) {
 	llm := &fakeLLM{responses: []string{goldenResponse}}
 	svc := NewService(nil, llm, nil)
-	res, err := svc.Generate(context.Background(), "count of users who cancelled per day, for the past 7 days")
+	res, err := svc.Generate(context.Background(), "count of users who cancelled per day, for the past 7 days", nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"cancellations"}, res.Query.Measures)
 	require.Equal(t, []string{"time"}, res.Query.By)
@@ -91,7 +91,7 @@ func TestGenerate_RetryLoopFeedsErrorsBack(t *testing.T) {
 	invalid := `{"query":{"measures":["cancelations"],"by":["time"],"grain":"day","range":{"last":"7d"}},"title":"Cancellations","viz":"line"}`
 	llm := &fakeLLM{responses: []string{invalid, goldenResponse}}
 	svc := NewService(nil, llm, nil)
-	res, err := svc.Generate(context.Background(), "cancelled per day past week")
+	res, err := svc.Generate(context.Background(), "cancelled per day past week", nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"cancellations"}, res.Query.Measures)
 	require.Len(t, llm.calls, 2)
@@ -111,7 +111,7 @@ func TestGenerate_ExhaustedRetriesReturnsErrors(t *testing.T) {
 	invalid := `{"query":{"measures":["nope"],"range":{"last":"7d"}},"title":"x","viz":"stat"}`
 	llm := &fakeLLM{responses: []string{invalid, invalid, invalid}}
 	svc := NewService(nil, llm, nil)
-	_, err := svc.Generate(context.Background(), "whatever")
+	_, err := svc.Generate(context.Background(), "whatever", nil)
 	var gerr *GenerateInvalidError
 	require.ErrorAs(t, err, &gerr)
 	require.NotEmpty(t, gerr.Errors)
@@ -120,15 +120,38 @@ func TestGenerate_ExhaustedRetriesReturnsErrors(t *testing.T) {
 
 func TestGenerate_Unconfigured(t *testing.T) {
 	svc := NewService(nil, nil, nil)
-	_, err := svc.Generate(context.Background(), "anything")
+	_, err := svc.Generate(context.Background(), "anything", nil)
 	require.ErrorIs(t, err, ErrLLMNotConfigured)
 	require.False(t, svc.NLConfigured())
+}
+
+// Refine (#755): a base query rides into the user turn as "current query to
+// modify" so the instruction edits it instead of starting over.
+func TestGenerate_BaseQueryRidesIntoUserTurn(t *testing.T) {
+	weekly := `{"query":{"measures":["cancellations"],"by":["time"],"grain":"week","range":{"last":"12w"}},"title":"Cancellations per week","viz":"line"}`
+	llm := &fakeLLM{responses: []string{weekly}}
+	svc := NewService(nil, llm, nil)
+	base := &metrics.Query{
+		Measures: []string{"cancellations"},
+		By:       []string{"time"},
+		Grain:    "day",
+		Range:    &metrics.QueryRange{Last: "7d"},
+	}
+	res, err := svc.Generate(context.Background(), "make it weekly", base)
+	require.NoError(t, err)
+	require.Equal(t, "week", res.Query.Grain)
+	require.Len(t, llm.calls, 1)
+	turn := llm.calls[0][0]
+	require.Equal(t, "user", turn.Role)
+	require.Contains(t, turn.Content, "Current query to modify:")
+	require.Contains(t, turn.Content, `"grain":"day"`, "base query JSON must ride in verbatim")
+	require.Contains(t, turn.Content, "Instruction: make it weekly")
 }
 
 func TestGenerate_StripsCodeFences(t *testing.T) {
 	llm := &fakeLLM{responses: []string{"```json\n" + goldenResponse + "\n```"}}
 	svc := NewService(nil, llm, nil)
-	res, err := svc.Generate(context.Background(), "cancellations per day")
+	res, err := svc.Generate(context.Background(), "cancellations per day", nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"cancellations"}, res.Query.Measures)
 }

--- a/internal/modules/dashboard/generate.go
+++ b/internal/modules/dashboard/generate.go
@@ -46,12 +46,24 @@ type GenerateResult struct {
 // data — and its output is validated by the same compiler that gates client
 // queries; on errors, the compiler's corrective messages are fed back verbatim
 // (max 2 retries). It never executes queries.
-func (s *Service) Generate(ctx context.Context, prompt string) (*GenerateResult, error) {
+//
+// base, when non-nil, is an existing (already validated) widget query the
+// prompt refines — it rides into the user turn as "current query to modify"
+// so instructions like "make it weekly" edit rather than start over.
+func (s *Service) Generate(ctx context.Context, prompt string, base *metrics.Query) (*GenerateResult, error) {
 	if s.llm == nil {
 		return nil, ErrLLMNotConfigured
 	}
 	system := generateSystemPrompt(s.clock.Now().UTC())
-	msgs := []LLMMessage{{Role: "user", Content: prompt}}
+	userTurn := prompt
+	if base != nil {
+		baseJSON, err := json.Marshal(base)
+		if err != nil {
+			return nil, fmt.Errorf("dashboard: marshal base query: %w", err)
+		}
+		userTurn = "Current query to modify:\n" + string(baseJSON) + "\n\nInstruction: " + prompt
+	}
+	msgs := []LLMMessage{{Role: "user", Content: userTurn}}
 
 	var lastErrs []metrics.FieldError
 	for attempt := 0; attempt < generateMaxAttempts; attempt++ {
@@ -154,6 +166,7 @@ Respond with ONLY one JSON object — no prose, no code fences:
 
 Viz guidance: "stat" = a single number (no time dimension; add "compare":"previous_period" for a delta); "line"/"area"/"bar" = time series ("by" includes "time"); "donut" = share across ONE non-time dimension; "table" = ranked lists or multi-column breakdowns.
 Prefer relative ranges ({"range":{"last":"7d"}}) so saved widgets stay current; use explicit dates only when the request names them.
+When the request includes a "current query to modify", treat the instruction as an EDIT to that query: change only what the instruction asks for and keep everything else as-is.
 If the request is ambiguous, pick the closest supported query instead of asking questions.`,
 		now.Format("2006-01-02"), schemaJSON)
 }

--- a/web/admin/src/lib/api/metrics.ts
+++ b/web/admin/src/lib/api/metrics.ts
@@ -45,38 +45,6 @@ export interface MetricsResult {
   compare_rows?: MetricsCell[][]
 }
 
-// --- metrics schema (drives the manual builder) --------------------------------
-
-export interface SchemaMeasure {
-  name: string
-  class: string
-  unit: string
-  description: string
-  formula: string
-  dims: string[]
-  money?: boolean
-}
-
-export interface SchemaDimension {
-  name: string
-  description: string
-  values?: string[]
-}
-
-export interface SchemaExample {
-  intent: string
-  query: MetricsQuery
-}
-
-export interface MetricsSchema {
-  measures: SchemaMeasure[]
-  dimensions: SchemaDimension[]
-  grains: string[]
-  examples: SchemaExample[]
-  limits: { max_buckets: number; max_limit: number }
-  query_shape: string
-}
-
 // --- dashboard ---------------------------------------------------------------
 
 export type WidgetViz = "stat" | "line" | "area" | "bar" | "donut" | "table"
@@ -116,15 +84,15 @@ export interface GeneratedWidget {
 export const metricsQuery = (query: MetricsQuery) =>
   api<MetricsResult>("/merchant/metrics/query", { method: "POST", body: query })
 
-export const metricsSchema = () => api<MetricsSchema>("/merchant/metrics/schema")
-
 export const getDashboard = () => api<Dashboard>("/merchant/dashboard")
 
 export const putDashboard = (widgets: Widget[]) =>
   api<Dashboard>("/merchant/dashboard", { method: "PUT", body: { widgets } })
 
-export const generateWidget = (prompt: string) =>
+// generateWidget: NL prompt → validated {query,title,viz}. baseQuery (an
+// existing widget's query) makes the prompt a refinement of it (#755).
+export const generateWidget = (prompt: string, baseQuery?: MetricsQuery) =>
   api<GeneratedWidget>("/merchant/dashboard/widgets/generate", {
     method: "POST",
-    body: { prompt },
+    body: baseQuery ? { prompt, base_query: baseQuery } : { prompt },
   })

--- a/web/admin/src/pages/dashboard/lib.ts
+++ b/web/admin/src/pages/dashboard/lib.ts
@@ -13,15 +13,6 @@ export function newWidgetId(): string {
   return crypto.randomUUID()
 }
 
-export const RANGE_PRESETS = [
-  { value: "7d", label: "Past 7 days" },
-  { value: "14d", label: "Past 14 days" },
-  { value: "30d", label: "Past 30 days" },
-  { value: "12w", label: "Past 12 weeks" },
-  { value: "6m", label: "Past 6 months" },
-  { value: "1y", label: "Past year" },
-] as const
-
 // formatMeasure renders one measure cell by its column unit.
 export function formatMeasure(value: MetricsCell, unit: string | undefined, currency?: string): string {
   if (value === null || value === undefined) return "—"

--- a/web/admin/src/pages/dashboard/widget-editor.tsx
+++ b/web/admin/src/pages/dashboard/widget-editor.tsx
@@ -1,7 +1,11 @@
-// Add/edit widget dialog: natural-language prompt (only when the deployment
-// has an LLM configured — fail-closed) and a schema-driven manual builder.
-// Both paths end in the same place: a live PREVIEW through the real
-// /metrics/query endpoint, then save. The server validates again on PUT.
+// Add/edit widget dialog (#755, NL-first): a natural-language prompt is THE
+// way to create and refine widget queries — the LLM writes the query, the
+// dialog previews it live through the real /metrics/query endpoint, and the
+// only human knobs are the viz-type toggle and the title. Editing an existing
+// widget seeds the current query and sends it as base_query so instructions
+// like "make it weekly" refine instead of starting over; direct title/viz
+// edits never touch the LLM. With no LLM configured, creation shows a pointed
+// empty-state (existing widgets stay directly editable).
 import * as React from "react"
 import { Loader2Icon, SparklesIcon } from "lucide-react"
 
@@ -14,7 +18,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
@@ -24,102 +27,22 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { Switch } from "@/components/ui/switch"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
-import { useApiData } from "@/hooks/use-api-data"
 import { ApiError } from "@/lib/api/client"
 import {
   generateWidget,
   metricsQuery,
-  metricsSchema,
   WIDGET_VIZ,
   type MetricsQuery,
   type MetricsResult,
-  type MetricsSchema,
   type Widget,
   type WidgetViz,
 } from "@/lib/api/metrics"
-import { cn } from "@/lib/utils"
 
-import { RANGE_PRESETS } from "./lib"
 import { WidgetVizView } from "./widget-viz"
 
-interface FilterRow {
-  dim: string
-  values: string
-}
-
-interface BuilderState {
-  measures: string[]
-  by: string[] // non-time dims
-  time: boolean
-  grain: string
-  rangePreset: string // one of RANGE_PRESETS values or "custom"
-  from: string
-  to: string
-  filters: FilterRow[]
-  compare: boolean
-  // Pass-through for query knobs the builder doesn't surface (order/limit
-  // from generated queries) so editing never silently drops them.
-  order?: MetricsQuery["order"]
-  limit?: number
-}
-
-function stateFromQuery(q: MetricsQuery): BuilderState {
-  const by = q.by ?? []
-  return {
-    measures: [...(q.measures ?? [])],
-    by: by.filter((d) => d !== "time"),
-    time: by.includes("time"),
-    grain: q.grain || "day",
-    rangePreset: q.range?.last && RANGE_PRESETS.some((p) => p.value === q.range.last) ? q.range.last : q.range?.last ? "custom-last" : "custom",
-    from: q.range?.from ?? "",
-    to: q.range?.to ?? "",
-    filters: Object.entries(q.filters ?? {}).map(([dim, values]) => ({ dim, values: values.join(", ") })),
-    compare: q.compare === "previous_period",
-    order: q.order,
-    limit: q.limit,
-  }
-}
-
-function queryFromState(s: BuilderState, rawLast?: string): MetricsQuery {
-  const q: MetricsQuery = {
-    measures: s.measures,
-    range:
-      s.rangePreset === "custom"
-        ? { from: s.from, to: s.to }
-        : { last: s.rangePreset === "custom-last" ? rawLast || "30d" : s.rangePreset },
-  }
-  const by = [...(s.time ? ["time"] : []), ...s.by]
-  if (by.length) q.by = by
-  if (s.time) q.grain = s.grain
-  const filters: Record<string, string[]> = {}
-  for (const f of s.filters) {
-    const values = f.values
-      .split(",")
-      .map((v) => v.trim())
-      .filter(Boolean)
-    if (f.dim && values.length) filters[f.dim] = values
-  }
-  if (Object.keys(filters).length) q.filters = filters
-  if (s.compare) q.compare = "previous_period"
-  if (s.order?.length) q.order = s.order
-  if (s.limit) q.limit = s.limit
-  return q
-}
-
-const defaultState: BuilderState = {
-  measures: [],
-  by: [],
-  time: true,
-  grain: "day",
-  rangePreset: "30d",
-  from: "",
-  to: "",
-  filters: [],
-  compare: false,
-}
+const KEYLESS_MESSAGE =
+  "Widget creation needs an LLM key: set llm.api_key (env LLM_API_KEY) — see docs/admin-console.md"
 
 export function WidgetEditor({
   open,
@@ -134,12 +57,9 @@ export function WidgetEditor({
   nlEnabled: boolean
   onSave: (data: { title: string; viz: WidgetViz; query: MetricsQuery }) => void
 }) {
-  const { data: schema } = useApiData(metricsSchema, [])
-
   const [title, setTitle] = React.useState("")
   const [viz, setViz] = React.useState<WidgetViz>("line")
-  const [builder, setBuilder] = React.useState<BuilderState>(defaultState)
-  const [rawLast, setRawLast] = React.useState<string | undefined>(undefined)
+  const [query, setQuery] = React.useState<MetricsQuery | null>(null)
   const [prompt, setPrompt] = React.useState("")
   const [generating, setGenerating] = React.useState(false)
   const [genError, setGenError] = React.useState<string | null>(null)
@@ -147,32 +67,7 @@ export function WidgetEditor({
   const [previewError, setPreviewError] = React.useState<string | null>(null)
   const [previewing, setPreviewing] = React.useState(false)
 
-  // Reset per open.
-  React.useEffect(() => {
-    if (!open) return
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- deliberate: reset the dialog's draft state each time it opens
-    setPrompt("")
-    setGenError(null)
-    setPreview(null)
-    setPreviewError(null)
-    if (initial) {
-      setTitle(initial.title)
-      setViz(initial.viz)
-      setBuilder(stateFromQuery(initial.query))
-      setRawLast(initial.query.range?.last)
-    } else {
-      setTitle("")
-      setViz("line")
-      setBuilder(defaultState)
-      setRawLast(undefined)
-    }
-  }, [open, initial])
-
-  const query = React.useMemo(() => queryFromState(builder, rawLast), [builder, rawLast])
-  const canPreview = builder.measures.length > 0
-  const canSave = canPreview && title.trim().length > 0
-
-  const runPreview = async (q: MetricsQuery) => {
+  const runPreview = React.useCallback(async (q: MetricsQuery) => {
     setPreviewing(true)
     setPreviewError(null)
     try {
@@ -183,18 +78,40 @@ export function WidgetEditor({
     } finally {
       setPreviewing(false)
     }
-  }
+  }, [])
+
+  // Reset per open; editing seeds the widget's current state and previews it.
+  React.useEffect(() => {
+    if (!open) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- deliberate: reset the dialog's draft state each time it opens
+    setPrompt("")
+    setGenError(null)
+    setPreview(null)
+    setPreviewError(null)
+    if (initial) {
+      setTitle(initial.title)
+      setViz(initial.viz)
+      setQuery(initial.query)
+      void runPreview(initial.query)
+    } else {
+      setTitle("")
+      setViz("line")
+      setQuery(null)
+    }
+  }, [open, initial, runPreview])
 
   const generate = async () => {
     if (!prompt.trim()) return
     setGenerating(true)
     setGenError(null)
     try {
-      const res = await generateWidget(prompt.trim())
+      // The current query (saved or freshly generated) rides as base_query so
+      // the prompt refines it; absent, the LLM starts fresh.
+      const res = await generateWidget(prompt.trim(), query ?? undefined)
       setTitle(res.title)
       setViz(res.viz)
-      setBuilder(stateFromQuery(res.query))
-      setRawLast(res.query.range?.last)
+      setQuery(res.query)
+      setPrompt("")
       void runPreview(res.query)
     } catch (err) {
       setGenError(err instanceof ApiError ? err.message : "generation failed")
@@ -203,336 +120,152 @@ export function WidgetEditor({
     }
   }
 
+  const canSave = query !== null && title.trim().length > 0
+  const keylessCreate = !nlEnabled && !initial
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[90vh] flex-col overflow-hidden sm:max-w-4xl">
+      <DialogContent className="flex max-h-[90vh] flex-col overflow-hidden sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>{initial ? "Edit widget" : "Add widget"}</DialogTitle>
           <DialogDescription>
-            {nlEnabled
-              ? "Describe the widget in plain language, or build the query by hand — preview before saving."
-              : "Pick measures, dimensions and a range from the metrics schema — preview before saving."}
+            {keylessCreate
+              ? "Natural-language widget creation is not available on this deployment."
+              : initial
+                ? "Refine the widget with an instruction, or edit the title and viz directly — preview before saving."
+                : "Describe what the widget should show — the query is generated, previewed live, then saved."}
           </DialogDescription>
         </DialogHeader>
 
-        <div className="grid min-h-0 flex-1 gap-4 overflow-y-auto md:grid-cols-2">
-          <div className="flex flex-col gap-4">
-            <Tabs defaultValue={nlEnabled && !initial ? "nl" : "manual"}>
-              {nlEnabled ? (
-                <TabsList>
-                  <TabsTrigger value="nl">
-                    <SparklesIcon className="size-3.5" /> Describe it
-                  </TabsTrigger>
-                  <TabsTrigger value="manual">Build manually</TabsTrigger>
-                </TabsList>
-              ) : null}
-              {nlEnabled ? (
-                <TabsContent value="nl" className="flex flex-col gap-2 pt-2">
-                  <Textarea
-                    placeholder='e.g. "count of users who cancelled per day, for the past 7 days"'
-                    value={prompt}
-                    onChange={(e) => setPrompt(e.target.value)}
-                    rows={3}
-                  />
-                  <div className="flex items-center gap-2">
-                    <Button size="sm" onClick={generate} disabled={generating || !prompt.trim()}>
-                      {generating ? <Loader2Icon className="size-3.5 animate-spin" /> : <SparklesIcon className="size-3.5" />}
-                      Generate
-                    </Button>
-                    <span className="text-muted-foreground text-xs">
-                      The result lands in the builder below — tweak it before saving.
-                    </span>
-                  </div>
-                  {genError ? <p className="text-destructive text-xs">{genError}</p> : null}
-                </TabsContent>
-              ) : null}
-              <TabsContent value="manual" className="pt-2">
-                {schema ? (
-                  <BuilderForm schema={schema} state={builder} onChange={setBuilder} />
-                ) : (
-                  <p className="text-muted-foreground text-sm">Loading schema…</p>
-                )}
-              </TabsContent>
-            </Tabs>
+        {keylessCreate ? (
+          <div className="text-muted-foreground flex min-h-32 items-center justify-center rounded-lg border border-dashed p-6 text-center text-sm">
+            {KEYLESS_MESSAGE}
           </div>
-
-          <div className="flex flex-col gap-3">
-            <div className="grid grid-cols-[1fr_auto] gap-2">
-              <div className="flex flex-col gap-1">
-                <Label htmlFor="widget-title">Title</Label>
-                <Input
-                  id="widget-title"
-                  value={title}
-                  onChange={(e) => setTitle(e.target.value)}
-                  placeholder="Widget title"
+        ) : (
+          <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
+            {nlEnabled ? (
+              <div className="flex flex-col gap-2">
+                <Textarea
+                  placeholder={
+                    query
+                      ? 'Refine it — e.g. "make it weekly" or "split by rail"'
+                      : 'e.g. "count of users who cancelled per day, for the past 7 days"'
+                  }
+                  value={prompt}
+                  onChange={(e) => setPrompt(e.target.value)}
+                  rows={3}
                 />
+                <div className="flex items-center gap-2">
+                  <Button size="sm" onClick={generate} disabled={generating || !prompt.trim()}>
+                    {generating ? (
+                      <Loader2Icon className="size-3.5 animate-spin" />
+                    ) : (
+                      <SparklesIcon className="size-3.5" />
+                    )}
+                    {query ? "Refine" : "Generate"}
+                  </Button>
+                  <span className="text-muted-foreground text-xs">
+                    {query
+                      ? "The instruction edits the current query — the preview updates."
+                      : "The generated widget previews below — adjust title and viz before saving."}
+                  </span>
+                </div>
+                {genError ? <p className="text-destructive text-xs whitespace-pre-wrap">{genError}</p> : null}
               </div>
-              <div className="flex flex-col gap-1">
-                <Label>Viz</Label>
-                <Select value={viz} onValueChange={(v) => setViz(v as WidgetViz)}>
-                  <SelectTrigger className="w-28">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {WIDGET_VIZ.map((v) => (
-                      <SelectItem key={v} value={v}>
-                        {v}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+            ) : (
+              <p className="text-muted-foreground rounded-md border border-dashed p-2 text-xs">
+                {KEYLESS_MESSAGE}. Title and viz stay editable below.
+              </p>
+            )}
+
+            {query ? (
+              <>
+                <div className="grid grid-cols-[1fr_auto] gap-2">
+                  <div className="flex flex-col gap-1">
+                    <Label htmlFor="widget-title">Title</Label>
+                    <Input
+                      id="widget-title"
+                      value={title}
+                      onChange={(e) => setTitle(e.target.value)}
+                      placeholder="Widget title"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1">
+                    <Label>Viz</Label>
+                    <Select value={viz} onValueChange={(v) => setViz(v as WidgetViz)}>
+                      <SelectTrigger className="w-28">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {WIDGET_VIZ.map((v) => (
+                          <SelectItem key={v} value={v}>
+                            {v}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+
+                <div className="bg-muted/30 flex min-h-56 flex-1 flex-col rounded-lg border p-3">
+                  <div className="mb-2 flex items-center justify-between">
+                    <span className="text-muted-foreground text-xs font-medium uppercase">Preview</span>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => void runPreview(query)}
+                      disabled={previewing}
+                    >
+                      {previewing ? <Loader2Icon className="size-3.5 animate-spin" /> : null}
+                      Refresh
+                    </Button>
+                  </div>
+                  <div className="min-h-0 flex-1">
+                    {previewError ? (
+                      <p className="text-destructive text-xs whitespace-pre-wrap">{previewError}</p>
+                    ) : preview ? (
+                      <WidgetVizView viz={viz} result={preview} />
+                    ) : (
+                      <p className="text-muted-foreground flex h-full items-center justify-center text-xs">
+                        {previewing ? "Running…" : "No preview yet"}
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                <details className="text-muted-foreground text-xs">
+                  <summary className="cursor-pointer select-none">Query JSON</summary>
+                  <pre className="bg-muted/30 mt-1 overflow-x-auto rounded-md border p-2">
+                    {JSON.stringify(query, null, 2)}
+                  </pre>
+                </details>
+              </>
+            ) : nlEnabled ? (
+              <div className="text-muted-foreground flex min-h-32 items-center justify-center rounded-lg border border-dashed text-xs">
+                Describe the widget above to generate a preview.
               </div>
-            </div>
-            <div className="bg-muted/30 flex min-h-56 flex-1 flex-col rounded-lg border p-3">
-              <div className="mb-2 flex items-center justify-between">
-                <span className="text-muted-foreground text-xs font-medium uppercase">Preview</span>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => void runPreview(query)}
-                  disabled={!canPreview || previewing}
-                >
-                  {previewing ? <Loader2Icon className="size-3.5 animate-spin" /> : null}
-                  Run preview
-                </Button>
-              </div>
-              <div className="min-h-0 flex-1">
-                {previewError ? (
-                  <p className="text-destructive text-xs whitespace-pre-wrap">{previewError}</p>
-                ) : preview ? (
-                  <WidgetVizView viz={viz} result={preview} />
-                ) : (
-                  <p className="text-muted-foreground flex h-full items-center justify-center text-xs">
-                    {canPreview ? "Run preview to see live data" : "Pick at least one measure"}
-                  </p>
-                )}
-              </div>
-            </div>
+            ) : null}
           </div>
-        </div>
+        )}
 
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button
-            onClick={() => {
-              onSave({ title: title.trim(), viz, query })
-              onOpenChange(false)
-            }}
-            disabled={!canSave}
-          >
-            {initial ? "Save changes" : "Add widget"}
-          </Button>
+          {keylessCreate ? null : (
+            <Button
+              onClick={() => {
+                if (!query) return
+                onSave({ title: title.trim(), viz, query })
+                onOpenChange(false)
+              }}
+              disabled={!canSave}
+            >
+              {initial ? "Save changes" : "Add widget"}
+            </Button>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  )
-}
-
-// --- schema-driven manual builder ------------------------------------------------
-
-function TogglePill({
-  active,
-  onClick,
-  children,
-  title,
-}: {
-  active: boolean
-  onClick: () => void
-  children: React.ReactNode
-  title?: string
-}) {
-  return (
-    <button type="button" onClick={onClick} title={title}>
-      <Badge variant={active ? "default" : "outline"} className={cn("cursor-pointer select-none")}>
-        {children}
-      </Badge>
-    </button>
-  )
-}
-
-function BuilderForm({
-  schema,
-  state,
-  onChange,
-}: {
-  schema: MetricsSchema
-  state: BuilderState
-  onChange: (s: BuilderState) => void
-}) {
-  const set = (patch: Partial<BuilderState>) => onChange({ ...state, ...patch })
-
-  // Dims the currently selected measures all support (plus time).
-  const allowedDims = React.useMemo(() => {
-    const selected = schema.measures.filter((m) => state.measures.includes(m.name))
-    if (selected.length === 0) return schema.dimensions.map((d) => d.name).filter((d) => d !== "time")
-    const sets = selected.map((m) => new Set(m.dims))
-    return schema.dimensions
-      .map((d) => d.name)
-      .filter((d) => d !== "time" && sets.every((s) => s.has(d)))
-  }, [schema, state.measures])
-
-  const toggleMeasure = (name: string) =>
-    set({
-      measures: state.measures.includes(name)
-        ? state.measures.filter((m) => m !== name)
-        : [...state.measures, name],
-    })
-
-  const toggleDim = (name: string) =>
-    set({ by: state.by.includes(name) ? state.by.filter((d) => d !== name) : [...state.by, name] })
-
-  return (
-    <div className="flex flex-col gap-3">
-      <div>
-        <Label className="mb-1 block">Measures</Label>
-        <div className="flex max-h-36 flex-wrap gap-1 overflow-y-auto rounded-md border p-2">
-          {schema.measures.map((m) => (
-            <TogglePill
-              key={m.name}
-              active={state.measures.includes(m.name)}
-              onClick={() => toggleMeasure(m.name)}
-              title={m.description}
-            >
-              {m.name}
-            </TogglePill>
-          ))}
-        </div>
-      </div>
-
-      <div>
-        <Label className="mb-1 block">Group by</Label>
-        <div className="flex max-h-28 flex-wrap gap-1 overflow-y-auto rounded-md border p-2">
-          <TogglePill active={state.time} onClick={() => set({ time: !state.time })} title="bucket by time">
-            time
-          </TogglePill>
-          {allowedDims.map((d) => (
-            <TogglePill key={d} active={state.by.includes(d)} onClick={() => toggleDim(d)}>
-              {d}
-            </TogglePill>
-          ))}
-        </div>
-      </div>
-
-      <div className="grid grid-cols-2 gap-2">
-        {state.time ? (
-          <div className="flex flex-col gap-1">
-            <Label>Grain</Label>
-            <Select value={state.grain} onValueChange={(v) => set({ grain: v })}>
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {schema.grains.map((g) => (
-                  <SelectItem key={g} value={g}>
-                    {g}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        ) : null}
-        <div className="flex flex-col gap-1">
-          <Label>Range</Label>
-          <Select value={state.rangePreset} onValueChange={(v) => set({ rangePreset: v })}>
-            <SelectTrigger>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {RANGE_PRESETS.map((p) => (
-                <SelectItem key={p.value} value={p.value}>
-                  {p.label}
-                </SelectItem>
-              ))}
-              <SelectItem value="custom">Custom dates</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-      </div>
-
-      {state.rangePreset === "custom" ? (
-        <div className="grid grid-cols-2 gap-2">
-          <div className="flex flex-col gap-1">
-            <Label htmlFor="range-from">From</Label>
-            <Input
-              id="range-from"
-              type="date"
-              value={state.from}
-              onChange={(e) => set({ from: e.target.value })}
-            />
-          </div>
-          <div className="flex flex-col gap-1">
-            <Label htmlFor="range-to">To</Label>
-            <Input id="range-to" type="date" value={state.to} onChange={(e) => set({ to: e.target.value })} />
-          </div>
-        </div>
-      ) : null}
-
-      <div>
-        <div className="mb-1 flex items-center justify-between">
-          <Label>Filters</Label>
-          <Button
-            size="sm"
-            variant="ghost"
-            className="h-6 px-2 text-xs"
-            onClick={() => set({ filters: [...state.filters, { dim: "", values: "" }] })}
-          >
-            + add filter
-          </Button>
-        </div>
-        {state.filters.map((f, i) => {
-          const dimDef = schema.dimensions.find((d) => d.name === f.dim)
-          return (
-            <div key={i} className="mb-1 grid grid-cols-[10rem_1fr_auto] items-center gap-1">
-              <Select
-                value={f.dim || undefined}
-                onValueChange={(v) => {
-                  const filters = [...state.filters]
-                  filters[i] = { ...filters[i], dim: v }
-                  set({ filters })
-                }}
-              >
-                <SelectTrigger className="h-8">
-                  <SelectValue placeholder="dimension" />
-                </SelectTrigger>
-                <SelectContent>
-                  {allowedDims.map((d) => (
-                    <SelectItem key={d} value={d}>
-                      {d}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <Input
-                className="h-8"
-                placeholder={dimDef?.values ? dimDef.values.join(" | ") : "comma-separated values"}
-                value={f.values}
-                onChange={(e) => {
-                  const filters = [...state.filters]
-                  filters[i] = { ...filters[i], values: e.target.value }
-                  set({ filters })
-                }}
-              />
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-8 px-2 text-xs"
-                onClick={() => set({ filters: state.filters.filter((_, j) => j !== i) })}
-              >
-                ×
-              </Button>
-            </div>
-          )
-        })}
-      </div>
-
-      <div className="flex items-center gap-2">
-        <Switch id="compare" checked={state.compare} onCheckedChange={(v) => set({ compare: v })} />
-        <Label htmlFor="compare" className="text-sm">
-          Compare with previous period
-        </Label>
-      </div>
-    </div>
   )
 }


### PR DESCRIPTION
Hard cut per #755: the natural-language prompt becomes THE way to create and edit dashboard widget queries; the manual measure/dimension/grain/range/filter builder is deleted.

## What changed

**Frontend (web/admin, source only — no dist committed per #754)**
- `widget-editor.tsx` rewritten NL-first (538 → 271 lines): prompt → `POST /widgets/generate` → live preview via `/v1/merchant/metrics/query` → save. Only two human knobs survive on the preview: viz-type toggle (stat|line|area|bar|donut|table — LLM suggests, human may override) and title edit. `BuilderForm`, `TogglePill`, `BuilderState` + the state↔query mappers are gone; a read-only "Query JSON" details block replaces them for transparency.
- Refine flow: editing a widget seeds its current title/viz/query (preview auto-runs) and the prompt box becomes "Refine" — the current query rides as `base_query` so "make it weekly" / "split by rail" edit instead of starting over. Direct title/viz edits never call the LLM.
- Keyless (`nl_widgets_enabled:false`): the add-widget button stays visible and opens a pointed empty-state — "Widget creation needs an LLM key: set llm.api_key (env LLM_API_KEY) — see docs/admin-console.md". Editing existing widgets keyless keeps title/viz knobs + preview + save; only prompt-based creation/refinement is gated. Seeded default template, drag/resize/delete, per-widget refresh all unchanged.
- Dead code removed: frontend `/schema` client + `MetricsSchema` types, `RANGE_PRESETS` (the API `/schema` endpoint itself stays — it exists for the LLM and programmatic clients).

**Backend (small, additive)**
- `POST /v1/merchant/dashboard/widgets/generate` gains optional `base_query`: strictly decoded + compiler-validated like any client query (errors 400 with `base_query.`-prefixed params, never reaching the LLM), then fed into the user turn as "Current query to modify: … Instruction: …"; the system prompt tells the model to treat the instruction as an edit.
- 501 keyless message updated (no manual-builder fallback to point at anymore).

**Docs**: `docs/admin-console.md` dashboard section rewritten — creation is LLM-only by design, the refine flow, exactly what works keyless.

## Tests
- Unit: fake-LLM suite updated + new `TestGenerate_BaseQueryRidesIntoUserTurn` — green.
- Integration (Postgres+Garnet): `internal/modules/dashboard`, `internal/http`, `internal/integrationharness` all green (`-count=1`), incl. two new generate subtests: refine base_query rides into the LLM turn; invalid base_query is a 400 that never reaches the LLM.
- `go build`/`go vet` clean on both tag sets; `tsc --noEmit`, eslint (0 errors; one pre-existing TanStack warning), `vite build` clean; `task admin-build` produces a working dist (not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)