### PR TITLE
ask-your-metrics: free-form LLM Q&A over the metrics query API (#756)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -85,10 +85,13 @@ admin_console:
   # auth_base_url: /auth   # AuthKit authhttp base; embedded hosts set their host issuer base
   # api_base_url: /v1      # merchant API base; embedded hosts typically /billing/v1
 
-# Server-side LLM for the dashboard natural-language widget generator (#741).
-# FAIL-CLOSED: no api_key = the generate endpoint answers 501 and the console
-# hides the NL box; the dashboard's manual builder works without it.
+# Server-side LLM for the dashboard natural-language widget generator (#741)
+# and metrics Q&A (#756). FAIL-CLOSED: no api_key = the generate/ask endpoints
+# answer 501 and the console hides the NL box; the dashboard works without it.
 # llm:
 #   provider: anthropic      # default (only supported value)
 #   model: claude-haiku-4-5-20251001   # default (cheapest capable; schema does the heavy lifting)
 #   api_key: ""              # SECRET — set env LLM_API_KEY or a mounted secret file
+#   ask_enabled: false       # #756 consent: /metrics/ask sends aggregate query RESULTS to the
+#                            # LLM provider (widget generation sends only the schema) — opt in
+#                            # explicitly; env LLM_ASK_ENABLED

--- a/config/config.go
+++ b/config/config.go
@@ -329,7 +329,8 @@ const LLMProviderAnthropic = "anthropic"
 // bigger model only if generation quality measurably demands it.
 const LLMDefaultModel = "claude-haiku-4-5-20251001"
 
-// LLMConfig configures the #741 natural-language widget generator.
+// LLMConfig configures the #741 natural-language widget generator and the
+// #756 metrics Q&A endpoint.
 type LLMConfig struct {
 	// Provider selects the API dialect. Empty = "anthropic" (the only
 	// supported value today); unknown values refuse to boot.
@@ -339,11 +340,21 @@ type LLMConfig struct {
 	// APIKey is the provider credential (SECRET — env LLM_API_KEY or a
 	// mounted secret file, never committed config). Empty = feature off.
 	APIKey string `koanf:"api_key,omitempty"`
+	// AskEnabled arms POST /v1/merchant/metrics/ask (#756). SEPARATE consent
+	// from the api_key gate because the data flow differs: widget generation
+	// (#741) only ever sends the metrics schema to the provider, while /ask
+	// sends aggregate query RESULTS too. Default false (fail-closed). Env:
+	// LLM_ASK_ENABLED.
+	AskEnabled bool `koanf:"ask_enabled,omitempty"`
 }
 
 // IsConfigured reports whether NL widget generation can run (fail-closed on a
 // missing key).
 func (c *LLMConfig) IsConfigured() bool { return c != nil && strings.TrimSpace(c.APIKey) != "" }
+
+// AskConfigured reports whether metrics Q&A can run: a key AND the explicit
+// ask_enabled consent (results flow to the provider — never implied by the key).
+func (c *LLMConfig) AskConfigured() bool { return c.IsConfigured() && c.AskEnabled }
 
 // ResolvedProvider returns the effective provider name.
 func (c *LLMConfig) ResolvedProvider() string {

--- a/docs/admin-console.md
+++ b/docs/admin-console.md
@@ -155,4 +155,30 @@ llm:
   # /schema examples + all-at-once corrective errors are designed so query generation needs
   # no model cleverness; configure a bigger model only if generation quality demands it
   api_key: "..."             # SECRET — prefer env LLM_API_KEY or a mounted secret file
+  # ask_enabled: true        # #756 metrics Q&A consent — see below; env LLM_ASK_ENABLED
 ```
+
+## Ask your metrics (#756)
+
+The Ask panel on the Dashboard page answers free-form questions ("why did revenue dip
+last week?") via `POST /v1/merchant/metrics/ask`: the server-side LLM runs
+compiler-validated #733 queries as tools (RLS-pinned to the caller's merchant,
+aggregates only — never entity rows) and answers from the results. The response shows
+its work: the answer PLUS the verbatim result of every executed query as evidence
+tables — on-screen numbers come from the API responses, never from the model's prose.
+Each evidence query has an "Add as widget" button into the normal preview/save flow.
+One-shot: a new question replaces the previous answer. Asking needs only
+`merchant:metrics:read` (it is read-only over the same data as `/query`); each merchant
+is rate-limited (10 asks/min, 200/day) and each ask is capped at 5 queries.
+
+DATA-FLOW CONSENT — why a second flag: NL widget generation (#741) sends ONLY the
+metrics schema to the LLM provider; `/ask` also sends the AGGREGATE QUERY RESULTS
+(that is the point — the model reads the numbers to answer). So ask has its own
+fail-closed flag, `llm.ask_enabled` (env `LLM_ASK_ENABLED`, default false), on top of
+the key: a merchant deployment can have NL widgets without NL answers. Keyless or
+unconsented, the endpoint answers 501, `config.json` carries `ask_enabled: false`, and
+the panel renders a pointed empty-state naming both knobs.
+
+External agents get the same power against the raw API (schema + query endpoints with
+a merchant API key) — see `docs/metrics-for-llms.md` for the two-endpoint recipe and a
+copy-paste tool definition.

--- a/docs/metrics-for-llms.md
+++ b/docs/metrics-for-llms.md
@@ -1,0 +1,105 @@
+# Metrics for LLMs — wiring any agent to the OpenRails query API
+
+Any LLM agent with a merchant API key can answer analytics questions against OpenRails
+directly. The API was designed for this (#733): the schema endpoint IS the machine-readable
+documentation, validation errors are corrective instructions returned all at once, and
+results are token-lean tables. Two endpoints, no SDK.
+
+The hosted `POST /v1/merchant/metrics/ask` endpoint (#756, the admin console's Ask panel)
+is exactly this pattern operated server-side — same schema-as-context, same query tool,
+same validation loop. An MCP server wrapper is a trivial future step: the tool definition
+below is its spec.
+
+## Auth
+
+- A merchant **API key** sent as `Authorization: Bearer <key>`, carrying the
+  `merchant:metrics:read` permission. Mint one from the console (Settings) or the
+  merchant API.
+- Everything is scoped to the key's merchant at the database layer (RLS) — there is no
+  cross-merchant read, and the metrics API serves **aggregates only** (never entity rows).
+- Bases: standalone `https://<host>/v1`, embedded typically `https://<host>/billing/v1`.
+
+## Step 1 — fetch the schema (the context document)
+
+```
+GET /v1/merchant/metrics/schema
+```
+
+Self-describing registry, designed to ride in an LLM context: every measure carries a
+one-line description + formula + allowed dimensions; dimensions carry their enum values;
+`query_shape` states the body grammar; `examples` pairs natural-language intents with
+correct query JSON (imitate them); `derived` lists formulas to compose client-side
+(e.g. `arpu = mrr / subscriptions[active]`); `caveats` states what the data is NOT
+(e.g. revenue is gross of processor fees). Put the whole JSON in the system prompt.
+
+## Step 2 — run queries
+
+```
+POST /v1/merchant/metrics/query
+{"measures":["cancellations"],"by":["time"],"grain":"day","range":{"last":"7d"}}
+```
+
+Response: `{columns, rows, grain, range, compare_range?, compare_rows?}` — tabular, one
+row per group-key combination. Time series **zero-fill** every bucket in range (a zero is
+data, not an omission). Money values are **micros** (1,000,000 micros = 1 currency unit);
+money never sums across currencies — `currency` appears as an implicit group-by when
+ambiguous.
+
+## Error semantics (the self-correction loop)
+
+Validation failures are `400` with **every** error at once — one retry fixes everything:
+
+```json
+{"error":{"code":"metrics_query_invalid","metadata":{"errors":[
+  {"code":"unknown_measure","param":"measures[0]",
+   "message":"unknown measure \"cancelations\": did you mean \"cancellations\"?",
+   "did_you_mean":"cancellations","valid":["..."]}
+]}}}
+```
+
+Unknown names get did-you-mean + the full valid list for that slot; an illegal
+dimension-for-measure names that measure's supported dims; unknown JSON **keys** in the
+body are 400s too (a typo'd `"filter"` fails loudly, never silently ignored). Feed the
+`errors` array back to the model verbatim and retry.
+
+## Copy-paste tool definition
+
+Works in any agent framework (Anthropic tool use shown; the same name/description/schema
+drops into OpenAI functions, MCP, etc.). Execute it by POSTing the arguments verbatim to
+`/v1/merchant/metrics/query`; on 400, return the response's `errors` array as the tool
+error; put the `/schema` JSON in the system prompt for vocabulary.
+
+```json
+{
+  "name": "run_metrics_query",
+  "description": "Run one OpenRails metrics query (the POST /v1/merchant/metrics/query body) against the merchant's own data. Measures, dimensions, grains and worked examples are defined in the metrics schema document (GET /v1/merchant/metrics/schema) — use only names from it. Returns tabular {columns, rows}; time series are zero-filled over the whole range (a zero means genuinely zero). Validation errors come back all at once with corrective context (did-you-mean, valid lists).",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "measures": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Measure names from the metrics schema."},
+      "by": {"type": "array", "items": {"type": "string"}, "description": "Group-by dimensions; include \"time\" for a time series."},
+      "grain": {"type": "string", "enum": ["day", "week", "month", "quarter", "year"], "description": "Time bucket size; required when \"by\" includes \"time\"."},
+      "range": {
+        "type": "object",
+        "properties": {
+          "from": {"type": "string", "description": "YYYY-MM-DD (inclusive UTC day) or RFC3339."},
+          "to": {"type": "string", "description": "YYYY-MM-DD (inclusive UTC day) or RFC3339."},
+          "last": {"type": "string", "description": "Relative trailing window ending today: <N>d|<N>w|<N>m|<N>y, e.g. \"7d\". Mutually exclusive with from/to."}
+        },
+        "additionalProperties": false
+      },
+      "filters": {"type": "object", "additionalProperties": {"type": "array", "items": {"type": "string"}}, "description": "Dimension name -> allowed values (OR within a dimension, AND across)."},
+      "order": {"type": "array", "items": {"type": "object", "properties": {"measure": {"type": "string"}, "dimension": {"type": "string"}, "dir": {"type": "string", "enum": ["asc", "desc"]}}, "additionalProperties": false}},
+      "limit": {"type": "integer", "minimum": 1},
+      "compare": {"type": "string", "enum": ["previous_period"], "description": "Also return the same query over the immediately preceding period."}
+    },
+    "required": ["measures", "range"],
+    "additionalProperties": false
+  }
+}
+```
+
+Suggested system-prompt rules (what the hosted /ask uses): every number in an answer must
+come from a tool result — never improvise; if the schema can't answer, say what's missing;
+state money in whole currency units (results are micros); prefer one query with a group-by
+over many single queries.

--- a/internal/app/build_runtime.go
+++ b/internal/app/build_runtime.go
@@ -797,11 +797,27 @@ func createServices(database *db.DB, cfg *config.Config, railSet config.RailMerc
 	metricsService := metrics.NewService(database)
 	// #741 dashboard: NL widget generation is armed only when an LLM key is
 	// configured — nil LLM = the generate endpoint fail-closes with 501.
+	// #756 metrics Q&A additionally requires the llm.ask_enabled consent
+	// (aggregate query results flow to the provider) and is rate-limited
+	// per merchant (Redis-backed when available, in-process fallback).
 	var dashboardLLM dashboard.LLM
 	if cfg.LLM.IsConfigured() {
 		dashboardLLM = dashboard.NewAnthropicLLM(cfg.LLM.APIKey, cfg.LLM.ResolvedModel(), "")
 	}
-	dashboardService := dashboard.NewService(database, dashboardLLM, clock)
+	var askLimiter dashboard.AskLimiter
+	if redisClient != nil {
+		askLimiter = dashboard.NewAskLimiter(redisClient, clock.Now)
+	} else {
+		askLimiter = dashboard.NewAskLimiter(nil, clock.Now)
+	}
+	dashboardService := dashboard.NewService(dashboard.Deps{
+		DB:         database,
+		Metrics:    metricsService,
+		LLM:        dashboardLLM,
+		AskEnabled: cfg.LLM != nil && cfg.LLM.AskEnabled,
+		AskLimiter: askLimiter,
+		Clock:      clock,
+	})
 	railCustomerService := payments.NewRailCustomerService(database)
 	profileRepo := identity.NewProfileRepo(database)
 

--- a/internal/controlplane/bootstrap_integration_test.go
+++ b/internal/controlplane/bootstrap_integration_test.go
@@ -315,7 +315,7 @@ func TestGeneratedCustomerRemoteApplicationRoute_LazyCreatesGroup(t *testing.T) 
 	_, err = cp.Core().ResolveGroupIDForSlug(ctx, CustomerType, customerID)
 	require.ErrorIs(t, err, authkit.ErrGroupNotFound)
 
-	token, _, err := cp.Core().IssueAccessToken(ctx, owner.ID, nil)
+	token, _, err := cp.Core().MintAccessToken(ctx, owner.ID, nil)
 	require.NoError(t, err)
 
 	mux := http.NewServeMux()

--- a/internal/http/handlers/merchant_metrics.go
+++ b/internal/http/handlers/merchant_metrics.go
@@ -1,9 +1,15 @@
 package handlers
 
 import (
+	"encoding/json"
+	"errors"
+	"math"
 	"net/http"
+	"strconv"
+	"strings"
 
 	httprequest "github.com/open-rails/openrails/internal/http/request"
+	"github.com/open-rails/openrails/internal/modules/dashboard"
 	"github.com/open-rails/openrails/internal/modules/metrics"
 	"github.com/open-rails/openrails/pkg/api"
 )
@@ -40,4 +46,52 @@ func MerchantMetricsQuery(r *httprequest.Request) {
 	}
 	r.APIError(api.NewAPIError(http.StatusBadRequest, api.ErrorTypeInvalidRequest, "metrics_query_invalid", verr.Error()).
 		WithMetadata(map[string]any{"errors": verr.Errors}))
+}
+
+// MerchantMetricsAsk handles POST /v1/merchant/metrics/ask (#756): a free-form
+// question answered by an LLM that runs compiler-validated metrics queries as
+// tools on the caller's RLS-pinned merchant context. UNLIKE widget generation
+// (#741, schema-only), the model sees aggregate query RESULTS — so this is
+// gated on the separate llm.ask_enabled consent (fail-closed 501) and
+// rate-limited per merchant. The response carries the model's answer plus the
+// VERBATIM result of every executed query as evidence.
+func MerchantMetricsAsk(r *httprequest.Request) {
+	svc := r.State.DashboardService
+	if svc == nil {
+		r.ErrorJSON(http.StatusServiceUnavailable, "dashboard service not configured")
+		return
+	}
+	if !svc.AskConfigured() {
+		if !svc.NLConfigured() {
+			r.ErrorJSON(http.StatusNotImplemented,
+				"metrics Q&A is not configured on this deployment: set llm.api_key (env LLM_API_KEY) AND llm.ask_enabled (env LLM_ASK_ENABLED=true) — see docs/admin-console.md")
+			return
+		}
+		r.ErrorJSON(http.StatusNotImplemented,
+			"metrics Q&A is disabled: unlike widget generation, /ask sends aggregate query RESULTS to the LLM provider — set llm.ask_enabled (env LLM_ASK_ENABLED=true) to consent; see docs/admin-console.md")
+		return
+	}
+	var body struct {
+		Question string `json:"question"`
+	}
+	if err := json.NewDecoder(r.Request.Body).Decode(&body); err != nil || strings.TrimSpace(body.Question) == "" {
+		r.ErrorJSON(http.StatusBadRequest, `body must be {"question":"<what you want to know>"}`)
+		return
+	}
+	res, err := svc.Ask(r.Request.Context(), strings.TrimSpace(body.Question))
+	if err != nil {
+		var limited *dashboard.AskRateLimitedError
+		var noAnswer *dashboard.AskNoAnswerError
+		switch {
+		case errors.As(err, &limited):
+			r.SetHeader("Retry-After", strconv.Itoa(int(math.Ceil(limited.RetryAfter.Seconds()))))
+			r.ErrorJSON(http.StatusTooManyRequests, "ask rate limit exceeded — try again later")
+		case errors.As(err, &noAnswer):
+			r.ErrorJSON(http.StatusBadGateway, "the model did not produce an answer within the query budget — try a narrower question")
+		default:
+			r.ErrorJSON(http.StatusBadGateway, "metrics Q&A failed: the LLM request did not complete")
+		}
+		return
+	}
+	r.JSON(http.StatusOK, res)
 }

--- a/internal/http/routes/routes.go
+++ b/internal/http/routes/routes.go
@@ -617,6 +617,10 @@ func registerMerchantSupportRoutes(rr router.Router, opts Options, dbMW ...route
 	metricsGrp := rr.Group("/metrics")
 	metricsGrp.Handle(http.MethodPost, "/query", h(httphandlers.MerchantMetricsQuery), metricsRead...)
 	metricsGrp.Handle(http.MethodGet, "/schema", h(httphandlers.MerchantMetricsSchema), metricsRead...)
+	// #756 metrics Q&A: read-only over the same data as /query (evidence IS
+	// /query output), so it shares the metrics-read permission; the LLM-cost
+	// axis is guarded by the per-merchant ask rate limit + fail-closed consent.
+	metricsGrp.Handle(http.MethodPost, "/ask", h(httphandlers.MerchantMetricsAsk), metricsRead...)
 
 	// #741 configurable dashboard: reads share the metrics permission (a
 	// dashboard is a saved view over metrics); writes + NL generation (the

--- a/internal/http/routes_admin_console.go
+++ b/internal/http/routes_admin_console.go
@@ -26,6 +26,7 @@ func (s *Server) registerAdminConsoleRoutes(mux *http.ServeMux) error {
 		AuthBaseURL:      s.cfg.AdminConsole.AuthBaseURL,
 		APIBaseURL:       s.cfg.AdminConsole.APIBaseURL,
 		NLWidgetsEnabled: s.cfg.LLM.IsConfigured(),
+		AskEnabled:       s.cfg.LLM.AskConfigured(),
 	}
 	if cfg.AuthBaseURL == "" {
 		cfg.AuthBaseURL = ControlPlaneAuthPrefix

--- a/internal/integrationharness/cross_merchant_isolation_test.go
+++ b/internal/integrationharness/cross_merchant_isolation_test.go
@@ -267,7 +267,7 @@ func TestStandaloneMerchantAdmitAcceptsUserSessionByPermissionHTTP(t *testing.T)
 		user, err := core.CreateUser(ctx, email, username)
 		require.NoError(t, err, "create user")
 		require.NoError(t, core.Genesis().AssignGroupRole(ctx, controlplane.MerchantType, dbtest.TestMerchantSlug, user.ID, authcore.SubjectKindUser, roleForPerms(perms)), "assign merchant role")
-		token, _, err := core.IssueAccessToken(ctx, user.ID, nil)
+		token, _, err := core.MintAccessToken(ctx, user.ID, nil)
 		require.NoError(t, err, "issue access token")
 		return token
 	}
@@ -399,7 +399,7 @@ func TestCoreDoesNotMountPlatformAdminRoutesHTTP(t *testing.T) {
 	// #567: assign the merchant `owner` role directly in the merchant group (no
 	// separate group membership step).
 	require.NoError(t, core.Genesis().AssignGroupRole(ctx, controlplane.MerchantType, dbtest.TestMerchantSlug, user.ID, authcore.SubjectKindUser, controlplane.MerchantRoleOwner), "assign merchant admin role")
-	token, _, err := core.IssueAccessToken(ctx, user.ID, nil)
+	token, _, err := core.MintAccessToken(ctx, user.ID, nil)
 	require.NoError(t, err, "issue merchant admin user access token")
 
 	// #721: the platform directory is mounted on the standalone surface but

--- a/internal/integrationharness/dashboard_http_test.go
+++ b/internal/integrationharness/dashboard_http_test.go
@@ -5,6 +5,7 @@ package integrationharness
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
@@ -253,6 +254,10 @@ func (f *scriptedLLM) Complete(_ context.Context, _ string, msgs []dashboard.LLM
 		i = len(f.responses) - 1
 	}
 	return f.responses[i], nil
+}
+
+func (f *scriptedLLM) CompleteTools(context.Context, string, []dashboard.ToolDef, []dashboard.ToolMessage, int) (*dashboard.ToolTurn, error) {
+	return nil, errors.New("scriptedLLM: tool use not scripted")
 }
 
 const goldenWidgetJSON = `{"query":{"measures":["cancellations"],"by":["time"],"grain":"day","range":{"last":"7d"}},"title":"Cancellations per day","viz":"line"}`

--- a/internal/integrationharness/harness.go
+++ b/internal/integrationharness/harness.go
@@ -608,7 +608,7 @@ func (s *Surface) MintUserAccessToken(username string) string {
 	require.NotNil(h.t, cp, "control plane attached")
 	user, err := cp.Core().CreateUser(h.ctx, username+"@example.com", username)
 	require.NoError(h.t, err, "create user")
-	token, _, err := cp.Core().IssueAccessToken(h.ctx, user.ID, nil)
+	token, _, err := cp.Core().MintAccessToken(h.ctx, user.ID, nil)
 	require.NoError(h.t, err, "mint user access token")
 	return token
 }

--- a/internal/integrationharness/metrics_ask_http_test.go
+++ b/internal/integrationharness/metrics_ask_http_test.go
@@ -1,0 +1,302 @@
+//go:build integration
+
+package integrationharness
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/controlplane"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/internal/modules/dashboard"
+)
+
+// #756 metrics Q&A: fail-closed consent gating (501 + config.json flag),
+// tool-loop execution against the REAL metrics service on the caller's
+// RLS-pinned merchant context (evidence == direct /query, cross-merchant
+// isolation), and the per-merchant ask rate limit. The LLM is a deterministic
+// scripted stub injected via SetLLM — no network ever.
+
+// askScriptLLM scripts tool turns as a function of the conversation so far
+// (deterministic across repeated asks) and records every conversation.
+type askScriptLLM struct {
+	script func(msgs []dashboard.ToolMessage) *dashboard.ToolTurn
+
+	mu    sync.Mutex
+	convs [][]dashboard.ToolMessage
+}
+
+func (f *askScriptLLM) Complete(context.Context, string, []dashboard.LLMMessage) (string, error) {
+	return "", errors.New("askScriptLLM: text completion not scripted")
+}
+
+func (f *askScriptLLM) CompleteTools(_ context.Context, _ string, _ []dashboard.ToolDef, msgs []dashboard.ToolMessage, _ int) (*dashboard.ToolTurn, error) {
+	f.mu.Lock()
+	f.convs = append(f.convs, append([]dashboard.ToolMessage(nil), msgs...))
+	f.mu.Unlock()
+	return f.script(msgs), nil
+}
+
+// oneQueryThenAnswer scripts the canonical ask: one run_metrics_query call,
+// then a prose answer.
+func oneQueryThenAnswer(query, answer string) func(msgs []dashboard.ToolMessage) *dashboard.ToolTurn {
+	return func(msgs []dashboard.ToolMessage) *dashboard.ToolTurn {
+		if len(msgs) == 1 {
+			return &dashboard.ToolTurn{ToolCalls: []dashboard.ToolCall{{
+				ID: "call-1", Name: "run_metrics_query", Input: json.RawMessage(query),
+			}}}
+		}
+		return &dashboard.ToolTurn{Text: answer}
+	}
+}
+
+func askOnce(t *testing.T, baseURL, token, question string) (int, []byte) {
+	t.Helper()
+	return requestJSON(t, http.MethodPost, baseURL+"/v1/merchant/metrics/ask", token,
+		map[string]string{"question": question})
+}
+
+type askEvidenceResp struct {
+	Answer   string `json:"answer"`
+	Evidence []struct {
+		Query   json.RawMessage `json:"query"`
+		Grain   string          `json:"grain"`
+		Columns json.RawMessage `json:"columns"`
+		Rows    json.RawMessage `json:"rows"`
+	} `json:"evidence"`
+}
+
+func TestMerchantMetricsAsk(t *testing.T) {
+	ctx := context.Background()
+	h := New(t, ctx)
+
+	t.Run("keyless fails closed naming both knobs", func(t *testing.T) {
+		surface := h.StartStandalone("usd")
+		token := surface.MintAPIKey(dbtest.TestMerchantSlug, "ask-keyless-"+uuid.NewString(),
+			[]string{controlplane.PermMerchantMetricsRead})
+		status, body := askOnce(t, surface.BaseURL, token, "how is revenue?")
+		require.Equal(t, http.StatusNotImplemented, status)
+		require.Contains(t, string(body), "LLM_API_KEY")
+		require.Contains(t, string(body), "LLM_ASK_ENABLED")
+	})
+
+	t.Run("key without ask consent fails closed naming the consent flag", func(t *testing.T) {
+		surface := h.StartStandalone("usd",
+			WithConsoleAssets(fixtureConsoleAssets()),
+			WithConfig(func(cfg *config.Config) {
+				cfg.AdminConsole = &config.AdminConsoleConfig{Enabled: true}
+				cfg.LLM = &config.LLMConfig{APIKey: "test-key-never-used"} // ask_enabled NOT set
+			}))
+		token := surface.MintAPIKey(dbtest.TestMerchantSlug, "ask-noconsent-"+uuid.NewString(),
+			[]string{controlplane.PermMerchantMetricsRead})
+		status, body := askOnce(t, surface.BaseURL, token, "how is revenue?")
+		require.Equal(t, http.StatusNotImplemented, status)
+		require.Contains(t, string(body), "LLM_ASK_ENABLED")
+		require.Contains(t, string(body), "RESULTS", "the message must state the data-flow difference")
+
+		// config.json: NL widgets armed, ask not — distinct consents.
+		status, cfgBody, _ := getRaw(t, surface.BaseURL+"/admin/config.json")
+		require.Equal(t, http.StatusOK, status)
+		require.Contains(t, cfgBody, `"nl_widgets_enabled":true`)
+		require.Contains(t, cfgBody, `"ask_enabled":false`)
+	})
+
+	// One armed surface for the live flows.
+	surface := h.StartStandalone("usd",
+		WithConsoleAssets(fixtureConsoleAssets()),
+		WithConfig(func(cfg *config.Config) {
+			cfg.AdminConsole = &config.AdminConsoleConfig{Enabled: true}
+			cfg.LLM = &config.LLMConfig{APIKey: "test-key-never-used", AskEnabled: true}
+		}))
+	svc := surface.App().Runtime.DashboardService
+	require.True(t, svc.AskConfigured())
+
+	t.Run("config.json advertises ask when armed", func(t *testing.T) {
+		status, cfgBody, _ := getRaw(t, surface.BaseURL+"/admin/config.json")
+		require.Equal(t, http.StatusOK, status)
+		require.Contains(t, cfgBody, `"ask_enabled":true`)
+	})
+
+	// Two merchants with DIFFERENT seeded usage so isolation is observable.
+	a := surface.ProvisionOwnedMerchant("aska" + strings.ReplaceAll(uuid.NewString(), "-", ""))
+	b := surface.ProvisionOwnedMerchant("askb" + strings.ReplaceAll(uuid.NewString(), "-", ""))
+	aToken := surface.MintAPIKey(a.MerchantSlug, "ask-a-"+uuid.NewString(),
+		[]string{controlplane.PermMerchantMetricsRead})
+	bToken := surface.MintAPIKey(b.MerchantSlug, "ask-b-"+uuid.NewString(),
+		[]string{controlplane.PermMerchantMetricsRead})
+
+	pool := h.sharedPool()
+	// usage_units = COUNT(usage_events): seed a DIFFERENT event count per
+	// merchant so cross-merchant leakage would be visible in the numbers.
+	seedUsage := func(merchantID uuid.UUID, events int) {
+		customerID := uuid.New()
+		_, err := pool.Exec(ctx,
+			`INSERT INTO openrails.customers (id, merchant_id, subject) VALUES ($1, $2, $3)`,
+			customerID, merchantID, "ask-usage-"+uuid.NewString())
+		require.NoError(t, err)
+		for i := 0; i < events; i++ {
+			_, err = pool.Exec(ctx,
+				`INSERT INTO openrails.usage_events (merchant_id, customer_id, invoker_id, currency, resource, event_type, amount, source, source_id)
+				 VALUES ($1, $2, 'ask-test', 'usd', 'api', 'call', 1000, 'test', $3)`,
+				merchantID, customerID, uuid.NewString())
+			require.NoError(t, err)
+		}
+	}
+	const aUnits, bUnits = 3, 5
+	seedUsage(uuid.UUID(a.MerchantID), aUnits)
+	seedUsage(uuid.UUID(b.MerchantID), bUnits)
+
+	unitsOf := func(t *testing.T, rows json.RawMessage) float64 {
+		t.Helper()
+		var parsed [][]any
+		require.NoError(t, json.Unmarshal(rows, &parsed))
+		require.Len(t, parsed, 1)
+		require.Len(t, parsed[0], 1)
+		n, ok := parsed[0][0].(float64)
+		require.True(t, ok, "usage_units cell must be numeric, got %T", parsed[0][0])
+		return n
+	}
+
+	const usageQuery = `{"measures":["usage_units"],"range":{"last":"7d"}}`
+
+	t.Run("tool loop executes on the caller's merchant; evidence is the verbatim query result", func(t *testing.T) {
+		svc.SetLLM(&askScriptLLM{script: oneQueryThenAnswer(usageQuery, "You used 3 units in the past 7 days.")})
+
+		status, body := askOnce(t, surface.BaseURL, aToken, "how many usage units this week?")
+		require.Equalf(t, http.StatusOK, status, "ask: %s", string(body))
+		var res askEvidenceResp
+		require.NoError(t, json.Unmarshal(body, &res))
+		require.Equal(t, "You used 3 units in the past 7 days.", res.Answer)
+		require.Len(t, res.Evidence, 1)
+
+		// Evidence must match a DIRECT /query call for merchant A exactly.
+		status, direct := requestJSON(t, http.MethodPost, surface.BaseURL+"/v1/merchant/metrics/query", aToken,
+			json.RawMessage(usageQuery))
+		require.Equalf(t, http.StatusOK, status, "direct query: %s", string(direct))
+		var directRes struct {
+			Columns json.RawMessage `json:"columns"`
+			Rows    json.RawMessage `json:"rows"`
+		}
+		require.NoError(t, json.Unmarshal(direct, &directRes))
+		require.JSONEq(t, string(directRes.Columns), string(res.Evidence[0].Columns))
+		require.JSONEq(t, string(directRes.Rows), string(res.Evidence[0].Rows))
+
+		// RLS isolation: A sees A's count, never B's.
+		require.EqualValues(t, aUnits, unitsOf(t, res.Evidence[0].Rows))
+
+		// The same question as B sees B's numbers — same query, different rows.
+		svc.SetLLM(&askScriptLLM{script: oneQueryThenAnswer(usageQuery, "5 units.")})
+		status, bBody := askOnce(t, surface.BaseURL, bToken, "how many usage units this week?")
+		require.Equalf(t, http.StatusOK, status, "ask as B: %s", string(bBody))
+		var bRes askEvidenceResp
+		require.NoError(t, json.Unmarshal(bBody, &bRes))
+		require.Len(t, bRes.Evidence, 1)
+		require.EqualValues(t, bUnits, unitsOf(t, bRes.Evidence[0].Rows))
+	})
+
+	t.Run("invalid tool args get corrective errors fed back, corrected call executes", func(t *testing.T) {
+		invalid := `{"measures":["usage_unitz"],"range":{"last":"7d"}}`
+		fake := &askScriptLLM{script: func(msgs []dashboard.ToolMessage) *dashboard.ToolTurn {
+			switch len(msgs) {
+			case 1:
+				return &dashboard.ToolTurn{ToolCalls: []dashboard.ToolCall{{ID: "bad", Name: "run_metrics_query", Input: json.RawMessage(invalid)}}}
+			case 3:
+				return &dashboard.ToolTurn{ToolCalls: []dashboard.ToolCall{{ID: "good", Name: "run_metrics_query", Input: json.RawMessage(usageQuery)}}}
+			default:
+				return &dashboard.ToolTurn{Text: "1111 units."}
+			}
+		}}
+		svc.SetLLM(fake)
+		status, body := askOnce(t, surface.BaseURL, aToken, "usage units, week")
+		require.Equalf(t, http.StatusOK, status, "ask: %s", string(body))
+		var res askEvidenceResp
+		require.NoError(t, json.Unmarshal(body, &res))
+		require.Len(t, res.Evidence, 1, "only the corrected call may produce evidence")
+
+		// The corrective errors (did-you-mean) rode back into the conversation.
+		fake.mu.Lock()
+		defer fake.mu.Unlock()
+		require.GreaterOrEqual(t, len(fake.convs), 2)
+		second := fake.convs[1]
+		feedback := second[len(second)-1].ToolResults[0]
+		require.True(t, feedback.IsError)
+		require.Contains(t, feedback.Content, "unknown_measure")
+		require.Contains(t, feedback.Content, "usage_units", "did-you-mean must ride back")
+	})
+
+	t.Run("can't-answer path returns prose with no evidence", func(t *testing.T) {
+		svc.SetLLM(&askScriptLLM{script: func([]dashboard.ToolMessage) *dashboard.ToolTurn {
+			return &dashboard.ToolTurn{Text: "The metrics schema has no page-view data, so I cannot answer that."}
+		}})
+		status, body := askOnce(t, surface.BaseURL, aToken, "how many page views yesterday?")
+		require.Equal(t, http.StatusOK, status)
+		var res askEvidenceResp
+		require.NoError(t, json.Unmarshal(body, &res))
+		require.Empty(t, res.Evidence)
+		require.Contains(t, res.Answer, "no page-view data")
+	})
+
+	t.Run("auth gates", func(t *testing.T) {
+		status, _ := askOnce(t, surface.BaseURL, "", "anything")
+		require.Equal(t, http.StatusUnauthorized, status)
+		// Ask is gated on metrics:read only (#733 gating): the read-only viewer
+		// role can ask — every merchant catalog role carries metrics:read, so
+		// there is no mintable merchant key without it to probe a 403 here (the
+		// permission middleware's deny path is covered by the dashboard tests).
+		viewer := surface.MintAPIKey(a.MerchantSlug, "ask-viewer-"+uuid.NewString(),
+			[]string{controlplane.PermMerchantMetricsRead, controlplane.PermMerchantCatalogRead})
+		svc.SetLLM(&askScriptLLM{script: func([]dashboard.ToolMessage) *dashboard.ToolTurn {
+			return &dashboard.ToolTurn{Text: "viewer answer"}
+		}})
+		status, body := askOnce(t, surface.BaseURL, viewer, "anything")
+		require.Equalf(t, http.StatusOK, status, "viewer (metrics:read) must be allowed to ask: %s", string(body))
+	})
+
+	t.Run("per-merchant rate limit trips with Retry-After", func(t *testing.T) {
+		// Fresh merchant so earlier subtests' asks don't count against it.
+		c := surface.ProvisionOwnedMerchant("askc" + strings.ReplaceAll(uuid.NewString(), "-", ""))
+		cToken := surface.MintAPIKey(c.MerchantSlug, "ask-c-"+uuid.NewString(),
+			[]string{controlplane.PermMerchantMetricsRead})
+		svc.SetLLM(&askScriptLLM{script: func([]dashboard.ToolMessage) *dashboard.ToolTurn {
+			return &dashboard.ToolTurn{Text: "quick answer"}
+		}})
+
+		// 10/minute per merchant: fire enough requests that at least one 429
+		// must occur even if a fixed-window boundary rolls mid-test.
+		var limited *http.Response
+		okCount := 0
+		for i := 0; i < 25; i++ {
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, surface.BaseURL+"/v1/merchant/metrics/ask",
+				bytes.NewReader([]byte(`{"question":"q`+fmt.Sprint(i)+`"}`)))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+cToken)
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			if resp.StatusCode == http.StatusTooManyRequests {
+				limited = resp
+				break
+			}
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+			okCount++
+			resp.Body.Close()
+		}
+		require.NotNil(t, limited, "ask rate limit never tripped in 25 requests (allowed %d)", okCount)
+		require.NotEmpty(t, limited.Header.Get("Retry-After"))
+		limited.Body.Close()
+		// Merchant A is unaffected by C's exhaustion.
+		status, body := askOnce(t, surface.BaseURL, aToken, "still fine?")
+		require.Equalf(t, http.StatusOK, status, "merchant A must not share C's budget: %s", string(body))
+	})
+}

--- a/internal/integrationharness/platform_merchants_http_test.go
+++ b/internal/integrationharness/platform_merchants_http_test.go
@@ -60,7 +60,7 @@ func mintPlatformOperatorToken(t *testing.T, ctx context.Context, s *Surface, ro
 			core.Genesis().AssignGroupRole(ctx, authcore.RootPersona, "", user.ID, authcore.SubjectKindUser, role),
 			"assign root role %s", role)
 	}
-	token, _, err := core.IssueAccessToken(ctx, user.ID, nil)
+	token, _, err := core.MintAccessToken(ctx, user.ID, nil)
 	require.NoError(t, err, "issue access token")
 	return token
 }

--- a/internal/integrationharness/testdata/standalone_route_surface.txt
+++ b/internal/integrationharness/testdata/standalone_route_surface.txt
@@ -116,6 +116,7 @@ POST /v1/merchant/customers/{customer_id}/payments/off-channel
 POST /v1/merchant/customers/{customer_id}/product-access
 POST /v1/merchant/dashboard/widgets/generate
 POST /v1/merchant/findings/{id}/resolve
+POST /v1/merchant/metrics/ask
 POST /v1/merchant/metrics/query
 POST /v1/merchant/payments/{id}/refunds
 POST /v1/merchant/subscriptions/{id}/cancel

--- a/internal/modules/dashboard/ask.go
+++ b/internal/modules/dashboard/ask.go
@@ -1,0 +1,264 @@
+package dashboard
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/open-rails/openrails/internal/modules/metrics"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// Ask-loop caps (#756): every cost axis is bounded — tool calls (queries per
+// question), response tokens per model turn, model turns, and the total bytes
+// of query results fed into the model's context.
+const (
+	askToolName = "run_metrics_query"
+	// askMaxToolCalls caps tool-call ATTEMPTS per question (invalid calls
+	// consume budget too, like generate's fixed retry budget).
+	askMaxToolCalls = 5
+	// askMaxTokens is the per-turn response-token cap.
+	askMaxTokens = 2048
+	// askMaxTurns bounds the loop: worst case one tool call per turn for the
+	// whole budget, one budget-exhausted grace turn, one final answer turn.
+	askMaxTurns = askMaxToolCalls + 2
+	// askToolResultMaxBytes caps one tool result fed to the model (rows are
+	// truncated with an explicit marker; evidence keeps the verbatim result).
+	askToolResultMaxBytes = 48 << 10
+	// askContextMaxBytes caps the cumulative tool-result bytes fed to the model.
+	askContextMaxBytes = 192 << 10
+)
+
+// ErrAskNotConfigured: no LLM key or no llm.ask_enabled consent — the endpoint
+// answers 501 with a pointed message.
+var ErrAskNotConfigured = errors.New("dashboard: metrics ask not configured")
+
+// AskRateLimitedError: the merchant exceeded the per-merchant ask budget.
+type AskRateLimitedError struct{ RetryAfter time.Duration }
+
+func (e *AskRateLimitedError) Error() string {
+	return fmt.Sprintf("dashboard: ask rate limit exceeded (retry after %s)", e.RetryAfter)
+}
+
+// AskNoAnswerError: the model never produced a text answer within the loop
+// budget (kept asking for tools).
+type AskNoAnswerError struct{ ToolCalls int }
+
+func (e *AskNoAnswerError) Error() string {
+	return fmt.Sprintf("dashboard: model produced no answer within the tool budget (%d tool calls)", e.ToolCalls)
+}
+
+// AskEvidence is one executed tool call: the query plus its VERBATIM result
+// (the embedded metrics.Result flattens to grain/range/columns/rows/...). The
+// UI renders these as tables — on-screen numbers come from here, never from
+// the model's prose.
+type AskEvidence struct {
+	Query metrics.Query `json:"query"`
+	metrics.Result
+}
+
+// AskResult is the POST /v1/merchant/metrics/ask response.
+type AskResult struct {
+	Answer   string        `json:"answer"`
+	Evidence []AskEvidence `json:"evidence"`
+}
+
+// Ask answers a natural-language metrics question by letting the model run
+// compiler-validated #733 queries as tools (executed through the normal
+// metrics service on the caller's RLS-pinned merchant context) and answering
+// from the results. Unlike Generate, the model DOES see aggregate query
+// results — hence the separate llm.ask_enabled consent.
+func (s *Service) Ask(ctx context.Context, question string) (*AskResult, error) {
+	if !s.AskConfigured() {
+		return nil, ErrAskNotConfigured
+	}
+	if s.askLimiter != nil {
+		merchantID, err := merchant.Require(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("dashboard ask: no merchant in context: %w", err)
+		}
+		allowed, retry, err := s.askLimiter.AllowAsk(ctx, uuid.UUID(merchantID).String())
+		if err != nil {
+			return nil, fmt.Errorf("dashboard ask: rate limiter: %w", err)
+		}
+		if !allowed {
+			return nil, &AskRateLimitedError{RetryAfter: retry}
+		}
+	}
+
+	system := askSystemPrompt(s.clock.Now().UTC())
+	tools := []ToolDef{askToolDef()}
+	msgs := []ToolMessage{{Role: "user", Text: question}}
+	var evidence []AskEvidence
+	attempts := 0
+	fedBytes := 0
+
+	for turn := 0; turn < askMaxTurns; turn++ {
+		resp, err := s.llm.CompleteTools(ctx, system, tools, msgs, askMaxTokens)
+		if err != nil {
+			return nil, err
+		}
+		if len(resp.ToolCalls) == 0 {
+			answer := strings.TrimSpace(resp.Text)
+			if answer == "" {
+				return nil, fmt.Errorf("dashboard ask: empty model response (stop_reason %q)", resp.StopReason)
+			}
+			return &AskResult{Answer: answer, Evidence: evidence}, nil
+		}
+		results := make([]ToolResult, 0, len(resp.ToolCalls))
+		for _, call := range resp.ToolCalls {
+			results = append(results, s.runAskTool(ctx, call, &evidence, &attempts, &fedBytes))
+		}
+		msgs = append(msgs,
+			ToolMessage{Role: "assistant", Text: resp.Text, ToolCalls: resp.ToolCalls},
+			ToolMessage{Role: "user", ToolResults: results},
+		)
+	}
+	return nil, &AskNoAnswerError{ToolCalls: attempts}
+}
+
+// runAskTool handles one tool call: budget checks, strict decode,
+// compiler validation (corrective errors go back to the model, all at once),
+// then execution through the metrics service. Executed calls append their
+// verbatim result to evidence.
+func (s *Service) runAskTool(ctx context.Context, call ToolCall, evidence *[]AskEvidence, attempts, fedBytes *int) ToolResult {
+	errResult := func(msg string) ToolResult {
+		return ToolResult{ToolUseID: call.ID, Content: msg, IsError: true}
+	}
+	if call.Name != askToolName {
+		return errResult(fmt.Sprintf("unknown tool %q: only %q is available", call.Name, askToolName))
+	}
+	if *attempts >= askMaxToolCalls {
+		return errResult(fmt.Sprintf("tool-call budget exhausted (max %d queries per question) — answer now from the results you already have, or say what you could not determine", askMaxToolCalls))
+	}
+	if *fedBytes >= askContextMaxBytes {
+		return errResult("context budget exhausted — answer now from the results you already have")
+	}
+	*attempts++
+
+	q, verr := metrics.DecodeQuery(bytes.NewReader(call.Input))
+	var plan *metrics.Plan
+	if verr == nil {
+		plan, verr = metrics.ValidateAt(q, s.clock.Now().UTC())
+	}
+	if verr != nil {
+		feedback, _ := json.Marshal(struct {
+			Errors []metrics.FieldError `json:"errors"`
+		}{verr.Errors})
+		return errResult("query failed validation. Fix ALL of these errors and call the tool again:\n" + string(feedback))
+	}
+	if s.metrics == nil {
+		return errResult("metrics engine unavailable on this deployment")
+	}
+	result, err := s.metrics.Execute(ctx, plan)
+	if err != nil {
+		log.WithError(err).Warn("dashboard ask: metrics query execution failed")
+		return errResult("query execution failed — try a different query")
+	}
+	*evidence = append(*evidence, AskEvidence{Query: *q, Result: *result})
+	payload := askToolPayload(result)
+	*fedBytes += len(payload)
+	return ToolResult{ToolUseID: call.ID, Content: payload}
+}
+
+// askFeedPayload is the token-lean tool-result document fed to the model.
+type askFeedPayload struct {
+	Grain        string            `json:"grain,omitempty"`
+	Range        metrics.RangeOut  `json:"range"`
+	Columns      []metrics.Column  `json:"columns"`
+	Rows         [][]any           `json:"rows"`
+	CompareRange *metrics.RangeOut `json:"compare_range,omitempty"`
+	CompareRows  [][]any           `json:"compare_rows,omitempty"`
+	Truncated    bool              `json:"truncated,omitempty"`
+	RowsTotal    int               `json:"rows_total,omitempty"`
+	Note         string            `json:"note,omitempty"`
+}
+
+// askToolPayload serializes a result for the model, truncating rows (with an
+// explicit marker — the model must know it is not seeing everything) when the
+// per-result feed cap is exceeded. Evidence keeps the full result regardless.
+func askToolPayload(res *metrics.Result) string {
+	p := askFeedPayload{
+		Grain: res.Grain, Range: res.Range, Columns: res.Columns, Rows: res.Rows,
+		CompareRange: res.CompareRange, CompareRows: res.CompareRows,
+	}
+	b, _ := json.Marshal(p)
+	for len(b) > askToolResultMaxBytes && len(p.Rows) > 0 {
+		p.Rows = p.Rows[:len(p.Rows)/2]
+		p.CompareRows = nil
+		p.Truncated = true
+		p.RowsTotal = len(res.Rows)
+		p.Note = "result truncated for context — narrow the query (filters, coarser grain, limit) if you need the rest"
+		b, _ = json.Marshal(p)
+	}
+	return string(b)
+}
+
+// askToolInputSchema is the JSON Schema for run_metrics_query's arguments —
+// the #733 query body. Vocabulary (measure/dimension/filter names) lives in
+// the metrics schema document riding in the system prompt; this only pins the
+// SHAPE. The same definition is published for external agents in
+// docs/metrics-for-llms.md.
+const askToolInputSchema = `{
+  "type": "object",
+  "properties": {
+    "measures": {"type": "array", "items": {"type": "string"}, "minItems": 1, "description": "Measure names from the metrics schema."},
+    "by": {"type": "array", "items": {"type": "string"}, "description": "Group-by dimensions; include \"time\" for a time series."},
+    "grain": {"type": "string", "enum": ["day", "week", "month", "quarter", "year"], "description": "Time bucket size; required when \"by\" includes \"time\"."},
+    "range": {
+      "type": "object",
+      "properties": {
+        "from": {"type": "string", "description": "YYYY-MM-DD (inclusive UTC day) or RFC3339."},
+        "to": {"type": "string", "description": "YYYY-MM-DD (inclusive UTC day) or RFC3339."},
+        "last": {"type": "string", "description": "Relative trailing window ending today: <N>d|<N>w|<N>m|<N>y, e.g. \"7d\". Mutually exclusive with from/to."}
+      },
+      "additionalProperties": false
+    },
+    "filters": {"type": "object", "additionalProperties": {"type": "array", "items": {"type": "string"}}, "description": "Dimension name -> allowed values (OR within a dimension, AND across)."},
+    "order": {"type": "array", "items": {"type": "object", "properties": {"measure": {"type": "string"}, "dimension": {"type": "string"}, "dir": {"type": "string", "enum": ["asc", "desc"]}}, "additionalProperties": false}},
+    "limit": {"type": "integer", "minimum": 1},
+    "compare": {"type": "string", "enum": ["previous_period"], "description": "Also return the same query over the immediately preceding period."}
+  },
+  "required": ["measures", "range"],
+  "additionalProperties": false
+}`
+
+func askToolDef() ToolDef {
+	return ToolDef{
+		Name:        askToolName,
+		Description: "Run one OpenRails metrics query (the POST /v1/merchant/metrics/query body) against the merchant's own data. Measures, dimensions, grains and worked examples are defined in the metrics schema in the system prompt — use only names from it. Returns tabular {columns, rows}; time series are zero-filled over the whole range (a zero means genuinely zero). Validation errors come back all at once with corrective context.",
+		InputSchema: json.RawMessage(askToolInputSchema),
+	}
+}
+
+// askSystemPrompt builds the Q&A context: the metrics /schema document (the
+// one source of truth, #733) plus the answering rules — including the honesty
+// path: what the schema cannot answer is named as missing, never improvised.
+func askSystemPrompt(now time.Time) string {
+	schemaJSON, _ := json.Marshal(metrics.Schema())
+	return fmt.Sprintf(`You answer a merchant's questions about their billing and revenue data by querying the OpenRails metrics API with the %s tool, then answering from the results.
+
+Today's date (UTC): %s.
+
+The complete metrics schema (measures, dimensions, grains, query shape, worked examples) is the JSON below. Use ONLY measure/dimension/grain/filter names that appear in it; the "examples" array pairs intents with correct queries — imitate them.
+
+<schema>
+%s
+</schema>
+
+Rules:
+- Query first, answer second: every number in your answer must come from a tool result. NEVER improvise, estimate or extrapolate numbers.
+- If the schema cannot answer the question, say plainly what is missing (the schema's descriptions state what does not exist) — do not answer with unrelated numbers.
+- You have at most %d queries per question — plan deliberately; prefer one query with a group-by over many single queries.
+- If a tool call returns validation errors, fix ALL of them in the next call.
+- Money values in results are micros (1,000,000 micros = 1 currency unit); state amounts in whole currency units with the currency.
+- Answer concisely with the numbers you retrieved. The UI shows every query result as a table next to your answer, so summarize and interpret — do not repeat whole tables in prose.`,
+		askToolName, now.Format("2006-01-02"), schemaJSON, askMaxToolCalls)
+}

--- a/internal/modules/dashboard/ask_limiter.go
+++ b/internal/modules/dashboard/ask_limiter.go
@@ -1,0 +1,125 @@
+package dashboard
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/open-rails/openrails/internal/modules/ratelimit"
+)
+
+// Per-merchant ask budget (#756): every ask is up to askMaxTurns LLM requests,
+// so this is the deployment's LLM spend guard. Fixed windows via the generic
+// ratelimit primitive; both must fit.
+const (
+	askRatePerMinute = 10
+	askRatePerDay    = 200
+)
+
+var askRatePolicy = ratelimit.Policy{Windows: []ratelimit.Limit{
+	{Unit: "request", Window: time.Minute, Max: askRatePerMinute},
+	{Unit: "request", Window: 24 * time.Hour, Max: askRatePerDay},
+}}
+
+// AskLimiter rate-limits metrics Q&A per merchant. retryAfter is meaningful
+// only when allowed is false.
+type AskLimiter interface {
+	AllowAsk(ctx context.Context, merchantID string) (allowed bool, retryAfter time.Duration, err error)
+}
+
+// NewAskLimiter builds the production limiter: the Redis-backed fixed-window
+// primitive (internal/modules/ratelimit) when Redis is configured, else an
+// in-process fallback with the same windows (mirrors the HTTP rate-limit
+// middleware's redis→memory doctrine; fine for single-process deployments).
+func NewAskLimiter(rdb redis.Cmdable, now func() time.Time) AskLimiter {
+	if now == nil {
+		now = time.Now
+	}
+	if rdb == nil {
+		return &memoryAskLimiter{now: now, counters: map[string]*memoryAskCounter{}}
+	}
+	l := ratelimit.NewLimiter(rdb)
+	l.SetClock(now)
+	return &redisAskLimiter{limiter: l}
+}
+
+type redisAskLimiter struct{ limiter *ratelimit.Limiter }
+
+func (r *redisAskLimiter) AllowAsk(ctx context.Context, merchantID string) (bool, time.Duration, error) {
+	dec, err := r.limiter.Check(ctx, "metrics-ask:"+merchantID, askRatePolicy, map[string]int64{"request": 1})
+	if err != nil {
+		// Redis down: allow (rate limiting is defense-in-depth; the ask loop's
+		// own caps bound per-request cost) but say so.
+		log.WithError(err).Warn("ask rate limiter unavailable; allowing request")
+		return true, 0, nil
+	}
+	if dec.Allowed {
+		return true, 0, nil
+	}
+	var retry time.Duration
+	for _, w := range dec.Windows {
+		if w.Remaining <= 0 && w.ResetAfter > retry {
+			retry = w.ResetAfter
+		}
+	}
+	if retry <= 0 {
+		retry = time.Minute
+	}
+	return false, retry, nil
+}
+
+// memoryAskLimiter is the no-Redis fallback: same fixed windows, one process.
+type memoryAskLimiter struct {
+	mu       sync.Mutex
+	now      func() time.Time
+	counters map[string]*memoryAskCounter
+}
+
+type memoryAskCounter struct {
+	bucket int64
+	count  int64
+}
+
+func (m *memoryAskLimiter) AllowAsk(_ context.Context, merchantID string) (bool, time.Duration, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	now := m.now().UTC()
+
+	// All-or-nothing across windows, like the Redis script.
+	type slot struct {
+		c     *memoryAskCounter
+		reset time.Duration
+	}
+	slots := make([]slot, 0, len(askRatePolicy.Windows))
+	var retry time.Duration
+	blocked := false
+	for _, w := range askRatePolicy.Windows {
+		secs := int64(w.Window / time.Second)
+		bucket := now.Unix() / secs
+		key := fmt.Sprintf("%s:%d", merchantID, secs)
+		c, ok := m.counters[key]
+		if !ok || c.bucket != bucket {
+			c = &memoryAskCounter{bucket: bucket}
+			m.counters[key] = c
+		}
+		reset := time.Duration(secs-(now.Unix()%secs)) * time.Second
+		if c.count+1 > w.Max {
+			blocked = true
+			if reset > retry {
+				retry = reset
+			}
+		}
+		slots = append(slots, slot{c: c, reset: reset})
+	}
+	if blocked {
+		return false, retry, nil
+	}
+	for _, s := range slots {
+		s.c.count++
+	}
+	return true, 0, nil
+}

--- a/internal/modules/dashboard/ask_test.go
+++ b/internal/modules/dashboard/ask_test.go
@@ -1,0 +1,286 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/modules/metrics"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// toolScriptLLM plays ToolTurns in order (last repeats) and records every
+// conversation + system prompt.
+type toolScriptLLM struct {
+	turns   []*ToolTurn
+	convs   [][]ToolMessage
+	systems []string
+}
+
+func (f *toolScriptLLM) Complete(context.Context, string, []LLMMessage) (string, error) {
+	return "", errors.New("toolScriptLLM: text completion not scripted")
+}
+
+func (f *toolScriptLLM) CompleteTools(_ context.Context, system string, _ []ToolDef, msgs []ToolMessage, _ int) (*ToolTurn, error) {
+	f.systems = append(f.systems, system)
+	f.convs = append(f.convs, append([]ToolMessage(nil), msgs...))
+	i := len(f.convs) - 1
+	if i >= len(f.turns) {
+		i = len(f.turns) - 1
+	}
+	return f.turns[i], nil
+}
+
+// fakeExecutor returns canned results in order (last repeats).
+type fakeExecutor struct {
+	results []*metrics.Result
+	plans   []*metrics.Plan
+}
+
+func (f *fakeExecutor) Execute(_ context.Context, plan *metrics.Plan) (*metrics.Result, error) {
+	f.plans = append(f.plans, plan)
+	i := len(f.plans) - 1
+	if i >= len(f.results) {
+		i = len(f.results) - 1
+	}
+	return f.results[i], nil
+}
+
+func askService(llm LLM, exec MetricsExecutor) *Service {
+	return NewService(Deps{Metrics: exec, LLM: llm, AskEnabled: true})
+}
+
+func toolCall(id, query string) *ToolTurn {
+	return &ToolTurn{ToolCalls: []ToolCall{{ID: id, Name: askToolName, Input: json.RawMessage(query)}}}
+}
+
+func cannedResult(measure string, value int64) *metrics.Result {
+	return &metrics.Result{
+		Columns: []metrics.Column{{Name: measure, Kind: "measure", Unit: "micros"}},
+		Rows:    [][]any{{value}},
+	}
+}
+
+const (
+	askQ1 = `{"measures":["net_revenue"],"range":{"last":"7d"}}`
+	askQ2 = `{"measures":["cancellations"],"by":["time"],"grain":"day","range":{"last":"7d"}}`
+)
+
+func TestAsk_MultiToolLoopCollectsEvidenceInOrder(t *testing.T) {
+	llm := &toolScriptLLM{turns: []*ToolTurn{
+		toolCall("t1", askQ1),
+		toolCall("t2", askQ2),
+		{Text: "Net revenue was $1.20; cancellations held steady."},
+	}}
+	exec := &fakeExecutor{results: []*metrics.Result{
+		cannedResult("net_revenue", 1_200_000),
+		cannedResult("cancellations", 3),
+	}}
+	res, err := askService(llm, exec).Ask(context.Background(), "why did revenue dip last week?")
+	require.NoError(t, err)
+	require.Equal(t, "Net revenue was $1.20; cancellations held steady.", res.Answer)
+
+	// Evidence: every executed call, in order, verbatim.
+	require.Len(t, res.Evidence, 2)
+	require.Equal(t, []string{"net_revenue"}, res.Evidence[0].Query.Measures)
+	require.Equal(t, [][]any{{int64(1_200_000)}}, res.Evidence[0].Rows)
+	require.Equal(t, []string{"cancellations"}, res.Evidence[1].Query.Measures)
+	require.Equal(t, "day", res.Evidence[1].Query.Grain)
+
+	// The loop replayed the assistant tool calls and fed results back.
+	require.Len(t, llm.convs, 3)
+	second := llm.convs[1]
+	require.Len(t, second, 3) // question, assistant tool_use, user tool_result
+	require.Equal(t, "assistant", second[1].Role)
+	require.Len(t, second[1].ToolCalls, 1)
+	require.Len(t, second[2].ToolResults, 1)
+	require.Equal(t, "t1", second[2].ToolResults[0].ToolUseID)
+	require.False(t, second[2].ToolResults[0].IsError)
+	require.Contains(t, second[2].ToolResults[0].Content, "1200000")
+
+	// Evidence marshals to the wire contract: query + flattened result fields.
+	wire, err := json.Marshal(res.Evidence[0])
+	require.NoError(t, err)
+	require.Contains(t, string(wire), `"query"`)
+	require.Contains(t, string(wire), `"columns"`)
+	require.Contains(t, string(wire), `"rows"`)
+}
+
+func TestAsk_ToolCallCapForcesAnswer(t *testing.T) {
+	// The model asks 6 times, then answers: the 6th call must be refused with
+	// a budget-exhausted error; only 5 execute.
+	turns := make([]*ToolTurn, 0, 7)
+	for i := 0; i < 6; i++ {
+		turns = append(turns, toolCall(fmt.Sprintf("t%d", i), askQ1))
+	}
+	turns = append(turns, &ToolTurn{Text: "Answering with what I have."})
+	llm := &toolScriptLLM{turns: turns}
+	exec := &fakeExecutor{results: []*metrics.Result{cannedResult("net_revenue", 1)}}
+
+	res, err := askService(llm, exec).Ask(context.Background(), "dig deep")
+	require.NoError(t, err)
+	require.Equal(t, "Answering with what I have.", res.Answer)
+	require.Len(t, res.Evidence, askMaxToolCalls)
+	require.Len(t, exec.plans, askMaxToolCalls)
+
+	last := llm.convs[len(llm.convs)-1]
+	tr := last[len(last)-1].ToolResults[0]
+	require.True(t, tr.IsError)
+	require.Contains(t, tr.Content, "budget exhausted")
+}
+
+func TestAsk_ModelNeverAnswersIsAnError(t *testing.T) {
+	llm := &toolScriptLLM{turns: []*ToolTurn{toolCall("t", askQ1)}} // repeats forever
+	exec := &fakeExecutor{results: []*metrics.Result{cannedResult("net_revenue", 1)}}
+	_, err := askService(llm, exec).Ask(context.Background(), "loop forever")
+	var noAnswer *AskNoAnswerError
+	require.ErrorAs(t, err, &noAnswer)
+	require.Equal(t, askMaxToolCalls, noAnswer.ToolCalls)
+	require.Len(t, llm.convs, askMaxTurns, "loop must stop at the turn ceiling")
+}
+
+func TestAsk_InvalidToolArgsGetCorrectiveErrorsThenCorrectedCall(t *testing.T) {
+	invalid := `{"measures":["cancelations"],"by":["time"],"grain":"day","range":{"last":"7d"}}`
+	llm := &toolScriptLLM{turns: []*ToolTurn{
+		toolCall("bad", invalid),
+		toolCall("good", askQ2),
+		{Text: "3 cancellations."},
+	}}
+	exec := &fakeExecutor{results: []*metrics.Result{cannedResult("cancellations", 3)}}
+	res, err := askService(llm, exec).Ask(context.Background(), "cancellations per day")
+	require.NoError(t, err)
+
+	// The invalid call executed nothing and produced no evidence.
+	require.Len(t, res.Evidence, 1)
+	require.Equal(t, []string{"cancellations"}, res.Evidence[0].Query.Measures)
+	require.Len(t, exec.plans, 1)
+
+	// The compiler's corrective errors (did-you-mean) went back to the model.
+	second := llm.convs[1]
+	tr := second[len(second)-1].ToolResults[0]
+	require.True(t, tr.IsError)
+	require.Equal(t, "bad", tr.ToolUseID)
+	require.Contains(t, tr.Content, "unknown_measure")
+	require.Contains(t, tr.Content, "cancellations", "did-you-mean must ride back")
+}
+
+func TestAsk_UnknownToolNameIsRejectedWithoutExecuting(t *testing.T) {
+	llm := &toolScriptLLM{turns: []*ToolTurn{
+		{ToolCalls: []ToolCall{{ID: "x", Name: "delete_everything", Input: json.RawMessage(`{}`)}}},
+		{Text: "ok"},
+	}}
+	exec := &fakeExecutor{results: []*metrics.Result{cannedResult("net_revenue", 1)}}
+	res, err := askService(llm, exec).Ask(context.Background(), "hi")
+	require.NoError(t, err)
+	require.Empty(t, res.Evidence)
+	require.Empty(t, exec.plans)
+	tr := llm.convs[1][len(llm.convs[1])-1].ToolResults[0]
+	require.True(t, tr.IsError)
+	require.Contains(t, tr.Content, "unknown tool")
+}
+
+func TestAsk_CannotAnswerPathReturnsProseWithNoEvidence(t *testing.T) {
+	llm := &toolScriptLLM{turns: []*ToolTurn{
+		{Text: "The metrics schema has no page-view data, so I cannot answer that."},
+	}}
+	res, err := askService(llm, &fakeExecutor{results: []*metrics.Result{cannedResult("x", 0)}}).
+		Ask(context.Background(), "how many page views did I get?")
+	require.NoError(t, err)
+	require.Empty(t, res.Evidence)
+	require.Contains(t, res.Answer, "no page-view data")
+}
+
+func TestAsk_NotConfigured(t *testing.T) {
+	// No LLM at all.
+	_, err := NewService(Deps{}).Ask(context.Background(), "anything")
+	require.ErrorIs(t, err, ErrAskNotConfigured)
+	// LLM present but no ask consent.
+	svc := NewService(Deps{LLM: &toolScriptLLM{turns: []*ToolTurn{{Text: "x"}}}})
+	require.True(t, svc.NLConfigured())
+	require.False(t, svc.AskConfigured())
+	_, err = svc.Ask(context.Background(), "anything")
+	require.ErrorIs(t, err, ErrAskNotConfigured)
+}
+
+type denyLimiter struct{ retry time.Duration }
+
+func (d denyLimiter) AllowAsk(context.Context, string) (bool, time.Duration, error) {
+	return false, d.retry, nil
+}
+
+func TestAsk_RateLimited(t *testing.T) {
+	svc := NewService(Deps{
+		LLM:        &toolScriptLLM{turns: []*ToolTurn{{Text: "never reached"}}},
+		AskEnabled: true,
+		AskLimiter: denyLimiter{retry: 30 * time.Second},
+	})
+	ctx := merchant.WithID(context.Background(), merchant.ID(uuid.New()))
+	_, err := svc.Ask(ctx, "anything")
+	var limited *AskRateLimitedError
+	require.ErrorAs(t, err, &limited)
+	require.Equal(t, 30*time.Second, limited.RetryAfter)
+}
+
+func TestMemoryAskLimiter_WindowsAndIsolation(t *testing.T) {
+	now := time.Now()
+	l := NewAskLimiter(nil, func() time.Time { return now })
+	ctx := context.Background()
+	for i := 0; i < askRatePerMinute; i++ {
+		ok, _, err := l.AllowAsk(ctx, "merchant-a")
+		require.NoError(t, err)
+		require.Truef(t, ok, "call %d within budget must pass", i)
+	}
+	ok, retry, err := l.AllowAsk(ctx, "merchant-a")
+	require.NoError(t, err)
+	require.False(t, ok, "minute window must trip")
+	require.Greater(t, retry, time.Duration(0))
+	// Another merchant is unaffected.
+	ok, _, _ = l.AllowAsk(ctx, "merchant-b")
+	require.True(t, ok)
+	// The window rolls over.
+	now = now.Add(2 * time.Minute)
+	ok, _, _ = l.AllowAsk(ctx, "merchant-a")
+	require.True(t, ok)
+}
+
+func TestAskToolPayload_TruncatesOversizedResults(t *testing.T) {
+	rows := make([][]any, 0, 20000)
+	for i := 0; i < 20000; i++ {
+		rows = append(rows, []any{fmt.Sprintf("2026-06-%02dT00:00:00Z", i%28+1), i})
+	}
+	res := &metrics.Result{
+		Columns: []metrics.Column{{Name: "time", Kind: "time"}, {Name: "payment_count", Kind: "measure"}},
+		Rows:    rows,
+	}
+	payload := askToolPayload(res)
+	require.LessOrEqual(t, len(payload), askToolResultMaxBytes+1024)
+	require.Contains(t, payload, `"truncated":true`)
+	require.Contains(t, payload, `"rows_total":20000`)
+	require.Len(t, res.Rows, 20000, "the verbatim result (evidence) must stay whole")
+}
+
+func TestAskSystemPromptAndToolDef(t *testing.T) {
+	p := askSystemPrompt(time.Date(2026, 7, 4, 0, 0, 0, 0, time.UTC))
+	require.Contains(t, p, "2026-07-04")
+	require.Contains(t, p, "<schema>")
+	require.Contains(t, p, "NEVER improvise", "honesty rule must ride in")
+	require.Contains(t, p, "say plainly what is missing")
+	require.Contains(t, p, "Answer concisely")
+	var doc metrics.SchemaDoc
+	start := strings.Index(p, "<schema>\n")
+	end := strings.Index(p, "\n</schema>")
+	require.Greater(t, end, start)
+	require.NoError(t, json.Unmarshal([]byte(p[start+len("<schema>\n"):end]), &doc))
+	require.NotEmpty(t, doc.Examples)
+
+	def := askToolDef()
+	require.Equal(t, askToolName, def.Name)
+	require.True(t, json.Valid(def.InputSchema), "tool input schema must be valid JSON")
+}

--- a/internal/modules/dashboard/dashboard_test.go
+++ b/internal/modules/dashboard/dashboard_test.go
@@ -3,6 +3,7 @@ package dashboard
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -71,11 +72,15 @@ func (f *fakeLLM) Complete(_ context.Context, _ string, msgs []LLMMessage) (stri
 	return f.responses[len(f.calls)-1], nil
 }
 
+func (f *fakeLLM) CompleteTools(context.Context, string, []ToolDef, []ToolMessage, int) (*ToolTurn, error) {
+	return nil, errors.New("fakeLLM: tool use not scripted")
+}
+
 const goldenResponse = `{"query":{"measures":["cancellations"],"by":["time"],"grain":"day","range":{"last":"7d"}},"title":"Cancellations per day","viz":"line"}`
 
 func TestGenerate_HappyPathGolden(t *testing.T) {
 	llm := &fakeLLM{responses: []string{goldenResponse}}
-	svc := NewService(nil, llm, nil)
+	svc := NewService(Deps{LLM: llm})
 	res, err := svc.Generate(context.Background(), "count of users who cancelled per day, for the past 7 days", nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"cancellations"}, res.Query.Measures)
@@ -90,7 +95,7 @@ func TestGenerate_HappyPathGolden(t *testing.T) {
 func TestGenerate_RetryLoopFeedsErrorsBack(t *testing.T) {
 	invalid := `{"query":{"measures":["cancelations"],"by":["time"],"grain":"day","range":{"last":"7d"}},"title":"Cancellations","viz":"line"}`
 	llm := &fakeLLM{responses: []string{invalid, goldenResponse}}
-	svc := NewService(nil, llm, nil)
+	svc := NewService(Deps{LLM: llm})
 	res, err := svc.Generate(context.Background(), "cancelled per day past week", nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"cancellations"}, res.Query.Measures)
@@ -110,7 +115,7 @@ func TestGenerate_RetryLoopFeedsErrorsBack(t *testing.T) {
 func TestGenerate_ExhaustedRetriesReturnsErrors(t *testing.T) {
 	invalid := `{"query":{"measures":["nope"],"range":{"last":"7d"}},"title":"x","viz":"stat"}`
 	llm := &fakeLLM{responses: []string{invalid, invalid, invalid}}
-	svc := NewService(nil, llm, nil)
+	svc := NewService(Deps{LLM: llm})
 	_, err := svc.Generate(context.Background(), "whatever", nil)
 	var gerr *GenerateInvalidError
 	require.ErrorAs(t, err, &gerr)
@@ -119,7 +124,7 @@ func TestGenerate_ExhaustedRetriesReturnsErrors(t *testing.T) {
 }
 
 func TestGenerate_Unconfigured(t *testing.T) {
-	svc := NewService(nil, nil, nil)
+	svc := NewService(Deps{})
 	_, err := svc.Generate(context.Background(), "anything", nil)
 	require.ErrorIs(t, err, ErrLLMNotConfigured)
 	require.False(t, svc.NLConfigured())
@@ -130,7 +135,7 @@ func TestGenerate_Unconfigured(t *testing.T) {
 func TestGenerate_BaseQueryRidesIntoUserTurn(t *testing.T) {
 	weekly := `{"query":{"measures":["cancellations"],"by":["time"],"grain":"week","range":{"last":"12w"}},"title":"Cancellations per week","viz":"line"}`
 	llm := &fakeLLM{responses: []string{weekly}}
-	svc := NewService(nil, llm, nil)
+	svc := NewService(Deps{LLM: llm})
 	base := &metrics.Query{
 		Measures: []string{"cancellations"},
 		By:       []string{"time"},
@@ -150,7 +155,7 @@ func TestGenerate_BaseQueryRidesIntoUserTurn(t *testing.T) {
 
 func TestGenerate_StripsCodeFences(t *testing.T) {
 	llm := &fakeLLM{responses: []string{"```json\n" + goldenResponse + "\n```"}}
-	svc := NewService(nil, llm, nil)
+	svc := NewService(Deps{LLM: llm})
 	res, err := svc.Generate(context.Background(), "cancellations per day", nil)
 	require.NoError(t, err)
 	require.Equal(t, []string{"cancellations"}, res.Query.Measures)
@@ -159,7 +164,7 @@ func TestGenerate_StripsCodeFences(t *testing.T) {
 // The system prompt is the LLM's whole world: it must carry the schema
 // document and the output contract.
 func TestGenerateSystemPrompt_CarriesSchema(t *testing.T) {
-	svc := NewService(nil, &fakeLLM{responses: []string{goldenResponse}}, nil)
+	svc := NewService(Deps{LLM: &fakeLLM{responses: []string{goldenResponse}}})
 	p := generateSystemPrompt(svc.clock.Now())
 	require.Contains(t, p, `"measures"`)
 	require.Contains(t, p, "cancellations")   // registry rode in

--- a/internal/modules/dashboard/llm.go
+++ b/internal/modules/dashboard/llm.go
@@ -17,11 +17,51 @@ type LLMMessage struct {
 	Content string
 }
 
-// LLM is the provider seam for natural-language widget generation. The
-// production implementation is AnthropicLLM; tests inject a deterministic
-// stub. Implementations return the model's text response verbatim.
+// ToolDef declares one tool for a tool-use turn (#756 ask loop).
+type ToolDef struct {
+	Name        string
+	Description string
+	InputSchema json.RawMessage // JSON Schema for the tool arguments
+}
+
+// ToolCall is one tool invocation the model requested.
+type ToolCall struct {
+	ID    string
+	Name  string
+	Input json.RawMessage
+}
+
+// ToolResult is the outcome fed back for one ToolCall.
+type ToolResult struct {
+	ToolUseID string
+	Content   string
+	IsError   bool
+}
+
+// ToolMessage is one conversation turn in a tool loop. Exactly one of the
+// optional fields is populated per role: user turns carry Text or ToolResults;
+// assistant turns replay the model's Text + ToolCalls verbatim.
+type ToolMessage struct {
+	Role        string // "user" | "assistant"
+	Text        string
+	ToolCalls   []ToolCall
+	ToolResults []ToolResult
+}
+
+// ToolTurn is one model response in a tool loop: prose and/or tool calls.
+type ToolTurn struct {
+	Text       string
+	ToolCalls  []ToolCall
+	StopReason string
+}
+
+// LLM is the provider seam for the dashboard module's model calls: text
+// completion (widget generation, #741) and tool-use turns (metrics Q&A, #756).
+// The production implementation is AnthropicLLM; tests inject deterministic
+// stubs via Service.SetLLM.
 type LLM interface {
 	Complete(ctx context.Context, system string, msgs []LLMMessage) (string, error)
+	CompleteTools(ctx context.Context, system string, tools []ToolDef, msgs []ToolMessage, maxTokens int) (*ToolTurn, error)
 }
 
 const (
@@ -66,16 +106,88 @@ type anthropicMessage struct {
 	Content string `json:"content"`
 }
 
+type anthropicToolsRequest struct {
+	Model     string                  `json:"model"`
+	MaxTokens int                     `json:"max_tokens"`
+	System    string                  `json:"system,omitempty"`
+	Tools     []anthropicToolDef      `json:"tools,omitempty"`
+	Messages  []anthropicBlockMessage `json:"messages"`
+}
+
+type anthropicToolDef struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+type anthropicBlockMessage struct {
+	Role    string           `json:"role"`
+	Content []anthropicBlock `json:"content"`
+}
+
+// anthropicBlock is one content block: text, tool_use (ID/Name/Input) or
+// tool_result (ToolUseID/Content/IsError).
+type anthropicBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Content   string          `json:"content,omitempty"`
+	IsError   bool            `json:"is_error,omitempty"`
+}
+
 type anthropicResponse struct {
 	Content []struct {
-		Type string `json:"type"`
-		Text string `json:"text"`
+		Type  string          `json:"type"`
+		Text  string          `json:"text"`
+		ID    string          `json:"id"`
+		Name  string          `json:"name"`
+		Input json.RawMessage `json:"input"`
 	} `json:"content"`
 	StopReason string `json:"stop_reason"`
 	Error      *struct {
 		Type    string `json:"type"`
 		Message string `json:"message"`
 	} `json:"error"`
+}
+
+// send posts one Messages-API request body and parses the response envelope.
+func (a *AnthropicLLM) send(ctx context.Context, reqBody any) (*anthropicResponse, error) {
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("dashboard llm: marshal request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, a.baseURL+"/v1/messages", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("dashboard llm: build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("x-api-key", a.apiKey)
+	httpReq.Header.Set("anthropic-version", anthropicAPIVersion)
+
+	resp, err := a.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("dashboard llm: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("dashboard llm: read response: %w", err)
+	}
+	var out anthropicResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("dashboard llm: non-JSON response (status %d)", resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		msg := "unknown error"
+		if out.Error != nil {
+			msg = fmt.Sprintf("%s: %s", out.Error.Type, out.Error.Message)
+		}
+		return nil, fmt.Errorf("dashboard llm: anthropic API error (status %d): %s", resp.StatusCode, msg)
+	}
+	return &out, nil
 }
 
 // Complete sends one Messages-API turn and returns the concatenated text
@@ -85,37 +197,9 @@ func (a *AnthropicLLM) Complete(ctx context.Context, system string, msgs []LLMMe
 	for _, m := range msgs {
 		req.Messages = append(req.Messages, anthropicMessage(m))
 	}
-	body, err := json.Marshal(req)
+	out, err := a.send(ctx, req)
 	if err != nil {
-		return "", fmt.Errorf("dashboard llm: marshal request: %w", err)
-	}
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, a.baseURL+"/v1/messages", bytes.NewReader(body))
-	if err != nil {
-		return "", fmt.Errorf("dashboard llm: build request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("x-api-key", a.apiKey)
-	httpReq.Header.Set("anthropic-version", anthropicAPIVersion)
-
-	resp, err := a.client.Do(httpReq)
-	if err != nil {
-		return "", fmt.Errorf("dashboard llm: request failed: %w", err)
-	}
-	defer resp.Body.Close()
-	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if err != nil {
-		return "", fmt.Errorf("dashboard llm: read response: %w", err)
-	}
-	var out anthropicResponse
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return "", fmt.Errorf("dashboard llm: non-JSON response (status %d)", resp.StatusCode)
-	}
-	if resp.StatusCode != http.StatusOK {
-		msg := "unknown error"
-		if out.Error != nil {
-			msg = fmt.Sprintf("%s: %s", out.Error.Type, out.Error.Message)
-		}
-		return "", fmt.Errorf("dashboard llm: anthropic API error (status %d): %s", resp.StatusCode, msg)
+		return "", err
 	}
 	var b strings.Builder
 	for _, block := range out.Content {
@@ -128,4 +212,46 @@ func (a *AnthropicLLM) Complete(ctx context.Context, system string, msgs []LLMMe
 		return "", fmt.Errorf("dashboard llm: empty response (stop_reason %q)", out.StopReason)
 	}
 	return text, nil
+}
+
+// CompleteTools sends one tool-use turn: the conversation (with prior
+// tool_use/tool_result blocks replayed verbatim) plus the tool definitions,
+// returning the model's text and requested tool calls.
+func (a *AnthropicLLM) CompleteTools(ctx context.Context, system string, tools []ToolDef, msgs []ToolMessage, maxTokens int) (*ToolTurn, error) {
+	if maxTokens <= 0 {
+		maxTokens = anthropicMaxTokens
+	}
+	req := anthropicToolsRequest{Model: a.model, MaxTokens: maxTokens, System: system}
+	for _, t := range tools {
+		req.Tools = append(req.Tools, anthropicToolDef(t))
+	}
+	for _, m := range msgs {
+		blocks := make([]anthropicBlock, 0, 1+len(m.ToolCalls)+len(m.ToolResults))
+		for _, tr := range m.ToolResults {
+			blocks = append(blocks, anthropicBlock{Type: "tool_result", ToolUseID: tr.ToolUseID, Content: tr.Content, IsError: tr.IsError})
+		}
+		if m.Text != "" {
+			blocks = append(blocks, anthropicBlock{Type: "text", Text: m.Text})
+		}
+		for _, tc := range m.ToolCalls {
+			blocks = append(blocks, anthropicBlock{Type: "tool_use", ID: tc.ID, Name: tc.Name, Input: tc.Input})
+		}
+		req.Messages = append(req.Messages, anthropicBlockMessage{Role: m.Role, Content: blocks})
+	}
+	out, err := a.send(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	turn := &ToolTurn{StopReason: out.StopReason}
+	var b strings.Builder
+	for _, block := range out.Content {
+		switch block.Type {
+		case "text":
+			b.WriteString(block.Text)
+		case "tool_use":
+			turn.ToolCalls = append(turn.ToolCalls, ToolCall{ID: block.ID, Name: block.Name, Input: block.Input})
+		}
+	}
+	turn.Text = strings.TrimSpace(b.String())
+	return turn, nil
 }

--- a/internal/modules/dashboard/service.go
+++ b/internal/modules/dashboard/service.go
@@ -11,31 +11,64 @@ import (
 
 	"github.com/open-rails/openrails/internal/db"
 	"github.com/open-rails/openrails/internal/db/gen"
+	"github.com/open-rails/openrails/internal/modules/metrics"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
 
-// Service persists per-merchant dashboards and drives NL widget generation.
-// All reads/writes ride the request's RLS-pinned merchant connection.
+// MetricsExecutor executes validated metrics plans (the #733 service; an
+// interface so ask-loop unit tests inject canned results).
+type MetricsExecutor interface {
+	Execute(ctx context.Context, plan *metrics.Plan) (*metrics.Result, error)
+}
+
+// Service persists per-merchant dashboards, drives NL widget generation and
+// the #756 metrics Q&A loop. All reads/writes ride the request's RLS-pinned
+// merchant connection.
 type Service struct {
-	db    *db.DB
-	llm   LLM
-	clock clockwork.Clock
+	db         *db.DB
+	metrics    MetricsExecutor
+	llm        LLM
+	askEnabled bool
+	askLimiter AskLimiter
+	clock      clockwork.Clock
 }
 
-// NewService binds the dashboard module. llm may be nil (NL generation
-// disabled, fail-closed); clock nil = wall clock.
-func NewService(database *db.DB, llm LLM, clock clockwork.Clock) *Service {
-	if clock == nil {
-		clock = clockwork.NewRealClock()
+// Deps are the dashboard module's collaborators. LLM may be nil (NL features
+// fail closed); AskEnabled is the llm.ask_enabled consent flag; AskLimiter may
+// be nil (no per-merchant ask rate limiting); Clock nil = wall clock.
+type Deps struct {
+	DB         *db.DB
+	Metrics    MetricsExecutor
+	LLM        LLM
+	AskEnabled bool
+	AskLimiter AskLimiter
+	Clock      clockwork.Clock
+}
+
+// NewService binds the dashboard module.
+func NewService(d Deps) *Service {
+	if d.Clock == nil {
+		d.Clock = clockwork.NewRealClock()
 	}
-	return &Service{db: database, llm: llm, clock: clock}
+	return &Service{
+		db:         d.DB,
+		metrics:    d.Metrics,
+		llm:        d.LLM,
+		askEnabled: d.AskEnabled,
+		askLimiter: d.AskLimiter,
+		clock:      d.Clock,
+	}
 }
 
-// SetLLM swaps the generation backend (tests inject a deterministic stub).
+// SetLLM swaps the model backend (tests inject a deterministic stub).
 func (s *Service) SetLLM(l LLM) { s.llm = l }
 
 // NLConfigured reports whether natural-language generation is available.
 func (s *Service) NLConfigured() bool { return s != nil && s.llm != nil }
+
+// AskConfigured reports whether metrics Q&A is available: an LLM AND the
+// explicit llm.ask_enabled consent (query results flow to the provider).
+func (s *Service) AskConfigured() bool { return s.NLConfigured() && s.askEnabled }
 
 // Get returns the merchant's saved dashboard, or the seeded default template
 // when none exists (usage widgets only if the merchant has usage activity).

--- a/pkg/adminconsole/adminconsole.go
+++ b/pkg/adminconsole/adminconsole.go
@@ -28,6 +28,11 @@ type Config struct {
 	// natural-language widget box entirely (the generate endpoint would 501).
 	// The manual widget builder is always available.
 	NLWidgetsEnabled bool `json:"nl_widgets_enabled"`
+	// AskEnabled mirrors the #756 metrics Q&A gate (llm.ask_enabled AND an LLM
+	// key): false renders the Ask panel as a pointed empty-state (the ask
+	// endpoint would 501). Distinct consent from NLWidgetsEnabled because /ask
+	// sends aggregate query results to the LLM provider.
+	AskEnabled bool `json:"ask_enabled"`
 }
 
 // Present reports whether assets hold a servable console build: a non-nil

--- a/web/admin/src/lib/api/client.ts
+++ b/web/admin/src/lib/api/client.ts
@@ -8,6 +8,9 @@ export interface BootstrapConfig {
   // #741 fail-closed LLM gate: false hides the natural-language widget box
   // entirely (the generate endpoint would answer 501).
   nl_widgets_enabled: boolean
+  // #756 metrics Q&A gate (llm.ask_enabled AND an LLM key): false renders the
+  // Ask panel as a pointed empty-state (the ask endpoint would answer 501).
+  ask_enabled: boolean
 }
 
 export interface TokenPair {

--- a/web/admin/src/lib/api/metrics.ts
+++ b/web/admin/src/lib/api/metrics.ts
@@ -96,3 +96,21 @@ export const generateWidget = (prompt: string, baseQuery?: MetricsQuery) =>
     method: "POST",
     body: baseQuery ? { prompt, base_query: baseQuery } : { prompt },
   })
+
+// --- metrics ask (#756) --------------------------------------------------------
+
+// AskEvidence is one executed tool query: the query plus its VERBATIM result
+// (a MetricsResult) — on-screen numbers come from here, never from prose.
+export interface AskEvidence extends MetricsResult {
+  query: MetricsQuery
+}
+
+export interface AskResponse {
+  answer: string
+  evidence: AskEvidence[]
+}
+
+// askMetrics: free-form question → LLM-run metrics queries + answer. 501 when
+// llm.ask_enabled / the LLM key are not configured.
+export const askMetrics = (question: string) =>
+  api<AskResponse>("/merchant/metrics/ask", { method: "POST", body: { question } })

--- a/web/admin/src/pages/dashboard/ask-panel.tsx
+++ b/web/admin/src/pages/dashboard/ask-panel.tsx
@@ -1,0 +1,151 @@
+// Ask panel (#756): free-form Q&A over the metrics API. The server-side LLM
+// runs compiler-validated queries as tools; the answer renders WITH the
+// verbatim result of every executed query as evidence tables — numbers on
+// screen come from the API responses, never from prose. One-shot: a new
+// question replaces the previous answer. Each evidence query can be saved as
+// a dashboard widget through the normal #755 preview/save flow.
+import * as React from "react"
+import { Loader2Icon, MessageCircleQuestionIcon, PlusIcon, XIcon } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { ApiError } from "@/lib/api/client"
+import {
+  askMetrics,
+  type AskEvidence,
+  type AskResponse,
+  type MetricsQuery,
+  type WidgetViz,
+} from "@/lib/api/metrics"
+
+import { WidgetVizView } from "./widget-viz"
+
+const ASK_DISABLED_MESSAGE =
+  "Metrics Q&A needs explicit consent: set llm.ask_enabled (env LLM_ASK_ENABLED=true) plus an LLM key (llm.api_key / env LLM_API_KEY) — unlike widget generation, answers send aggregate query results to the LLM provider. See docs/admin-console.md."
+
+// suggestViz picks a sensible default viz for saving an evidence query as a
+// widget (the editor lets the user override it).
+function suggestViz(query: MetricsQuery): WidgetViz {
+  if (query.by?.includes("time")) return "line"
+  if ((query.by?.length ?? 0) > 0 || query.measures.length > 1) return "table"
+  return "stat"
+}
+
+export function AskPanel({
+  enabled,
+  onAddWidget,
+}: {
+  enabled: boolean
+  onAddWidget: (draft: { title: string; viz: WidgetViz; query: MetricsQuery }) => void
+}) {
+  const [question, setQuestion] = React.useState("")
+  const [asking, setAsking] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  const [result, setResult] = React.useState<AskResponse | null>(null)
+  const [asked, setAsked] = React.useState("")
+
+  const ask = async () => {
+    const q = question.trim()
+    if (!q || asking) return
+    setAsking(true)
+    setError(null)
+    setResult(null) // one-shot: a new question replaces the previous answer
+    setAsked(q)
+    try {
+      setResult(await askMetrics(q))
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "ask failed")
+    } finally {
+      setAsking(false)
+    }
+  }
+
+  const addAsWidget = (ev: AskEvidence) => {
+    onAddWidget({
+      title: asked.length > 60 ? asked.slice(0, 57) + "…" : asked,
+      viz: suggestViz(ev.query),
+      query: ev.query,
+    })
+  }
+
+  if (!enabled) {
+    return (
+      <div className="text-muted-foreground rounded-xl border border-dashed p-4 text-xs">
+        <span className="text-foreground mr-1 font-medium">Ask your metrics:</span>
+        {ASK_DISABLED_MESSAGE}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border p-4">
+      <form
+        className="flex items-center gap-2"
+        onSubmit={(e) => {
+          e.preventDefault()
+          void ask()
+        }}
+      >
+        <MessageCircleQuestionIcon className="text-muted-foreground size-4 shrink-0" />
+        <Input
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          placeholder='Ask your metrics — e.g. "why did revenue dip last week?" or "how many members did I lose in June?"'
+          className="flex-1"
+        />
+        <Button type="submit" size="sm" disabled={asking || !question.trim()}>
+          {asking ? <Loader2Icon className="size-3.5 animate-spin" /> : null}
+          Ask
+        </Button>
+      </form>
+
+      {asking ? <p className="text-muted-foreground text-xs">Querying your metrics…</p> : null}
+      {error ? <p className="text-destructive text-xs whitespace-pre-wrap">{error}</p> : null}
+
+      {result ? (
+        <div className="flex flex-col gap-3">
+          <div className="flex items-start justify-between gap-2">
+            <p className="text-sm whitespace-pre-wrap">{result.answer}</p>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-6 shrink-0"
+              aria-label="Dismiss answer"
+              onClick={() => {
+                setResult(null)
+                setError(null)
+              }}
+            >
+              <XIcon className="size-3.5" />
+            </Button>
+          </div>
+          {result.evidence.length > 0 ? (
+            <div className="flex flex-col gap-2">
+              {result.evidence.map((ev, i) => (
+                <div key={i} className="bg-muted/30 rounded-lg border p-2">
+                  <div className="mb-1 flex items-center justify-between gap-2">
+                    <span className="text-muted-foreground text-xs font-medium uppercase">
+                      Query {i + 1} result
+                    </span>
+                    <Button size="sm" variant="outline" onClick={() => addAsWidget(ev)}>
+                      <PlusIcon className="size-3.5" /> Add as widget
+                    </Button>
+                  </div>
+                  <div className="max-h-64 overflow-auto">
+                    <WidgetVizView viz="table" result={ev} />
+                  </div>
+                  <details className="text-muted-foreground mt-1 text-xs">
+                    <summary className="cursor-pointer select-none">Query JSON</summary>
+                    <pre className="bg-muted/30 mt-1 overflow-x-auto rounded-md border p-2">
+                      {JSON.stringify(ev.query, null, 2)}
+                    </pre>
+                  </details>
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/web/admin/src/pages/dashboard/index.tsx
+++ b/web/admin/src/pages/dashboard/index.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/lib/api/metrics"
 import { toastApiError } from "@/lib/toast"
 
+import { AskPanel } from "./ask-panel"
 import { newWidgetId } from "./lib"
 import { WidgetEditor } from "./widget-editor"
 import { WidgetTile } from "./widget-tile"
@@ -35,6 +36,14 @@ function nlWidgetsEnabled(): boolean {
   }
 }
 
+function askEnabled(): boolean {
+  try {
+    return getBootstrap().ask_enabled
+  } catch {
+    return false
+  }
+}
+
 // Default tile size per viz for newly added widgets.
 function defaultSize(viz: WidgetViz): { w: number; h: number } {
   return viz === "stat" ? { w: 3, h: 2 } : { w: 6, h: 4 }
@@ -45,6 +54,8 @@ export function DashboardPage() {
   const [widgets, setWidgets] = React.useState<Widget[] | null>(null)
   const [editorOpen, setEditorOpen] = React.useState(false)
   const [editing, setEditing] = React.useState<Widget | null>(null)
+  // seed pre-fills the editor for a NEW widget (ask evidence → add-as-widget).
+  const [seed, setSeed] = React.useState<{ title: string; viz: WidgetViz; query: MetricsQuery } | null>(null)
   const { width, containerRef, mounted } = useContainerWidth()
   const saveTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -140,6 +151,14 @@ export function DashboardPage() {
 
   return (
     <div className="flex flex-col gap-3">
+      <AskPanel
+        enabled={askEnabled()}
+        onAddWidget={(draft) => {
+          setEditing(null)
+          setSeed(draft)
+          setEditorOpen(true)
+        }}
+      />
       <div className="flex items-center gap-3">
         {data?.is_default ? (
           <p className="text-muted-foreground text-sm">
@@ -153,6 +172,7 @@ export function DashboardPage() {
           className="ml-auto"
           onClick={() => {
             setEditing(null)
+            setSeed(null)
             setEditorOpen(true)
           }}
         >
@@ -176,6 +196,7 @@ export function DashboardPage() {
                   widget={w}
                   onEdit={() => {
                     setEditing(w)
+                    setSeed(null)
                     setEditorOpen(true)
                   }}
                   onDelete={() => removeWidget(w.id)}
@@ -194,6 +215,7 @@ export function DashboardPage() {
         open={editorOpen}
         onOpenChange={setEditorOpen}
         initial={editing}
+        seed={seed}
         nlEnabled={nlWidgetsEnabled()}
         onSave={(draft) => (editing ? editWidget(editing.id, draft) : addWidget(draft))}
       />

--- a/web/admin/src/pages/dashboard/widget-editor.tsx
+++ b/web/admin/src/pages/dashboard/widget-editor.tsx
@@ -48,12 +48,17 @@ export function WidgetEditor({
   open,
   onOpenChange,
   initial,
+  seed,
   nlEnabled,
   onSave,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
   initial: Widget | null
+  // seed pre-fills a NEW widget draft (#756 ask evidence → add-as-widget):
+  // the query previews immediately and the prompt refines it, but saving
+  // still ADDS a widget (initial stays null).
+  seed?: { title: string; viz: WidgetViz; query: MetricsQuery } | null
   nlEnabled: boolean
   onSave: (data: { title: string; viz: WidgetViz; query: MetricsQuery }) => void
 }) {
@@ -93,12 +98,17 @@ export function WidgetEditor({
       setViz(initial.viz)
       setQuery(initial.query)
       void runPreview(initial.query)
+    } else if (seed) {
+      setTitle(seed.title)
+      setViz(seed.viz)
+      setQuery(seed.query)
+      void runPreview(seed.query)
     } else {
       setTitle("")
       setViz("line")
       setQuery(null)
     }
-  }, [open, initial, runPreview])
+  }, [open, initial, seed, runPreview])
 
   const generate = async () => {
     if (!prompt.trim()) return


### PR DESCRIPTION
Implements tracker #756: a merchant types a question ("why did revenue dip last week?") and the LLM answers it by RUNNING #733 metrics queries as tools — the natural completion of "the LLM is the query interface", assembled from existing parts (schema-as-context, compiler validation, RLS-pinned execution, the #741 dashboard LLM client).

## Endpoint + loop

- `POST /v1/merchant/metrics/ask {question}` → `{answer, evidence:[{query, columns, rows, grain, range, …}]}` on the merchant surface behind `merchant:metrics:read` (#733 gating; read-only over the same data as `/query`). #670 route golden updated.
- Anthropic tool-use loop in `internal/modules/dashboard` (reuses the module's LLM client + `SetLLM` test seam, now a two-method seam: `Complete` + `CompleteTools`). ONE tool `run_metrics_query` whose args are the #733 query body: strict decode → `metrics.Validate` (corrective errors fed back to the model ALL at once, same spirit as generate's retry) → execute through the normal metrics service on the caller's RLS-pinned merchant context.
- Evidence = the VERBATIM result of every executed tool call, in order — the UI renders those tables; numbers on screen come from the API, never prose. System prompt = the metrics /schema JSON + rules incl. the honesty path ("if the schema cannot answer, say what's missing — never improvise numbers") and "answer concisely with the numbers you retrieved".
- Caps: ≤5 tool calls/question (invalid attempts consume budget), 2048 response tokens/turn, 7-turn ceiling, 48KB/tool-result + 192KB total fed context (truncation is explicitly marked to the model; evidence stays whole).

## Consent + rate limit

- NEW fail-closed flag `llm.ask_enabled` (env `LLM_ASK_ENABLED`, default false) — distinct from the #741 key gate because the DATA FLOW differs: generation sends only the schema to the provider, /ask sends aggregate query RESULTS. Off/keyless → pointed 501 naming the exact knob; `/admin/config.json` gains `ask_enabled`.
- Per-merchant rate limit (10/min, 200/day) reusing the generic Redis fixed-window limiter (`internal/modules/ratelimit`, Lua all-or-nothing multi-window) keyed `metrics-ask:<merchant_id>`, with an in-process fallback when Redis is absent (mirrors the HTTP middleware's redis→memory doctrine). 429 + Retry-After.

## Console + docs

- Ask panel on the dashboard page: question → loading → answer + each evidence query as a table (reuses the table viz) + per-evidence "Add as widget" that seeds the #755 editor (preview → viz/title knobs → save). One-shot: a new question replaces the previous answer. Flag-off/keyless → the #755-style visible empty-state naming `LLM_ASK_ENABLED` / `LLM_API_KEY`.
- NEW `docs/metrics-for-llms.md`: the external-agent recipe (auth, GET /schema as context, POST /query, all-at-once corrective 400s + did-you-mean) with a copy-paste `run_metrics_query` tool definition for any agent framework; notes the hosted /ask is the same pattern server-side and that an MCP wrapper is a trivial future step (the tool definition IS its spec). `docs/admin-console.md` gains the ask section + consent/data-flow note.

## Also

- Cross-PR skew fix (separate commit): authkit v0.80.0 (bump 09dd5bd6, go.mod-only) renamed embedded `IssueAccessToken` → `MintAccessToken`; integration-tagged callers on master did not build. Verified broken on origin/master before fixing.

## Tests

- Fake-LLM unit suite (no network): multi-call loop evidence order/verbatim-ness, cap forces answer (budget-exhausted tool errors), never-answers → error at the turn ceiling, invalid args → corrective did-you-mean errors fed back → corrected call, unknown tool rejected, can't-answer path, not-configured, limiter windows + per-merchant isolation + rollover, payload truncation marking, system-prompt/tool-schema contracts.
- Integration: keyless and no-consent 501s naming the exact knobs, config.json flags (nl true/ask false split), evidence rows deep-equal a direct /query for the same merchant, cross-merchant RLS isolation on distinct seeded counts, viewer (metrics:read) can ask, unauthenticated 401, per-merchant 429 with Retry-After (boundary-roll tolerant), fresh-merchant budget isolation.
- go build/vet clean on both tag sets (+`console_assets`); repo-wide unit tests green; integrationharness (incl. #670 golden + #741 dashboard suite), dashboard, metrics, controlplane, http integration packages green — only red is the known pre-existing `TestFindingsQueueApproveCCBillCancelAndRefund` (verified red on origin/master in the same environment). `task admin-build` + tsc/eslint/vite clean; NO dist committed (#754).

🤖 Generated with [Claude Code](https://claude.com/claude-code)