### PR TITLE
#757 merchant self-serve API keys: scoped credentials for agents/integrations

### DIFF
--- a/docs/admin-console.md
+++ b/docs/admin-console.md
@@ -117,7 +117,44 @@ NMI payment-method change), Payments (filters, detail, rail-aware refund — dis
 rails without API refunds), Catalog (products/prices CRUD + activate/deactivate,
 manifest publish with plan preview, drift view + refresh), Ops (findings queue with
 approve/ignore, repair alerts, worker health), Settings (merchant profile, payment
-providers, credit limit, trust tier).
+providers, API keys, credit limit, trust tier).
+
+## API keys (#757)
+
+Settings → **API keys** mints scoped, revocable Bearer credentials for agents and
+integrations — the easy alternative to session JWTs for programmatic callers
+(LLM agents querying `/v1/merchant/metrics/*`, server-side billing automation).
+Everything goes through AuthKit core; OpenRails never stores the secret (hash only).
+
+- **Mint** — `POST /v1/merchant/api-keys` `{name, role}` → `201` with the full key
+  in `secret`, returned EXACTLY ONCE (the console shows a copy-once modal). `role`
+  must be one of the fixed merchant catalog roles (#567):
+  - `viewer` — read-only (metrics query/schema, payments, subscriptions, catalog,
+    settings reads). **The role to mint for LLM agents** — it can answer any
+    analytics question and cannot refund, cancel, or mutate anything.
+  - `support` — viewer reads plus customer operations (refunds, subscription
+    changes, entitlement grants). No settings/catalog/provider/credential writes.
+  - `owner` — `merchant:*`, full control. Explicit choice only; never the default.
+- **List** — `GET /v1/merchant/api-keys` → metadata only (`id`, `name`, `role`,
+  `prefix`, `created_at`, `last_used_at`, `revoked_at`); never secret material.
+  `prefix` is the non-secret token head (`openrails_st_<key_id>`) for matching a
+  stored credential.
+- **Revoke** — `DELETE /v1/merchant/api-keys/{id}`; takes effect immediately, keys
+  stay listed with `revoked_at` for audit. Revocation is the only recovery from a
+  lost or leaked secret.
+
+The three routes are gated on `merchant:credentials:manage` — held only by the
+merchant **owner** in the fixed catalog (deliberately the same permission string
+AuthKit's own mint authorization checks). No-escalation holds on every path: a
+caller can only mint roles whose permissions its own credential already covers.
+Keys are per-merchant: merchant A's keys are invisible to (and irrevocable by) B.
+
+Use a key as a normal Bearer token against the same `/v1/merchant/*` surface:
+
+```sh
+curl -H "Authorization: Bearer openrails_st_..." \
+  https://billing.example.com/v1/merchant/metrics/schema
+```
 
 ## Dashboard (#741, #755)
 

--- a/internal/controlplane/bootstrap_integration_test.go
+++ b/internal/controlplane/bootstrap_integration_test.go
@@ -315,7 +315,7 @@ func TestGeneratedCustomerRemoteApplicationRoute_LazyCreatesGroup(t *testing.T) 
 	_, err = cp.Core().ResolveGroupIDForSlug(ctx, CustomerType, customerID)
 	require.ErrorIs(t, err, authkit.ErrGroupNotFound)
 
-	token, _, err := cp.Core().IssueAccessToken(ctx, owner.ID, nil)
+	token, _, err := cp.Core().MintAccessToken(ctx, owner.ID, nil)
 	require.NoError(t, err)
 
 	mux := http.NewServeMux()

--- a/internal/controlplane/catalog.go
+++ b/internal/controlplane/catalog.go
@@ -164,6 +164,7 @@ const (
 	PermMerchantDashboardUpdate        = permissions.MerchantDashboardUpdate
 	PermMerchantFindingsResolve        = permissions.MerchantFindingsResolve
 	PermMerchantBillingImport          = permissions.MerchantBillingImport
+	PermMerchantCredentialsManage      = permissions.MerchantCredentialsManage
 
 	// --- Platform operator (root persona, #721): cross-merchant directory
 	// authority checked against the singleton root group, never a merchant

--- a/internal/controlplane/merchant_api_keys.go
+++ b/internal/controlplane/merchant_api_keys.go
@@ -1,0 +1,196 @@
+package controlplane
+
+// Merchant self-serve API keys (#757): the control-plane surface behind
+// /v1/merchant/api-keys. Everything goes through AuthKit CORE calls
+// (MintAPIKeyWithOptions / ListAPIKeys / RevokeAPIKey) — never raw AuthKit SQL
+// (bootstrap.go doctrine). Keys are minted under the merchant permission-group
+// against one of the FIXED merchant catalog roles (#567): owner / support /
+// viewer. `viewer` is the metrics/read-only role for LLM agents.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/open-rails/authkit"
+	authcore "github.com/open-rails/authkit/embedded"
+
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// ErrUnknownMerchantRole indicates a requested API-key role outside the fixed
+// merchant catalog (#567: owner/support/viewer — merchants have no custom roles).
+var ErrUnknownMerchantRole = errors.New("controlplane: unknown merchant role")
+
+// MerchantAPIKey is the non-secret view of a merchant API key served by the
+// self-serve surface. The secret exists only in the mint response; Prefix is
+// the non-secret leading token part ("openrails_st_<key_id>") a holder can
+// match against a stored credential.
+type MerchantAPIKey struct {
+	ID         string     `json:"id"`
+	Name       string     `json:"name"`
+	Role       string     `json:"role"`
+	Prefix     string     `json:"prefix"`
+	CreatedAt  time.Time  `json:"created_at"`
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
+	ExpiresAt  *time.Time `json:"expires_at,omitempty"`
+	RevokedAt  *time.Time `json:"revoked_at,omitempty"`
+}
+
+// MerchantAPIKeyRoles returns the fixed catalog roles a merchant API key may
+// hold, least privilege first.
+func MerchantAPIKeyRoles() []string {
+	return []string{MerchantRoleViewer, MerchantRoleSupport, MerchantRoleOwner}
+}
+
+// MerchantRolePermissions resolves a fixed merchant catalog role to its
+// effective permission set (owner = the merchant:* owner grant). ok is false
+// for anything outside the catalog.
+func MerchantRolePermissions(role string) ([]string, bool) {
+	role = strings.ToLower(strings.TrimSpace(role))
+	if role == MerchantRoleOwner {
+		return []string{authcore.OwnerGrant(MerchantType)}, true
+	}
+	for _, gt := range Groups() {
+		if gt.Name != MerchantType {
+			continue
+		}
+		for _, r := range gt.Roles {
+			if r.Name == role {
+				return append([]string(nil), r.Permissions...), true
+			}
+		}
+	}
+	return nil, false
+}
+
+// MerchantRoleCoveredBy reports whether grants cover EVERY permission the given
+// catalog role confers (authkit glob semantics): the no-escalation rule for
+// non-user principals minting keys — you may only hand out authority you hold.
+// Unknown roles are never covered.
+func MerchantRoleCoveredBy(role string, grants []string) bool {
+	perms, ok := MerchantRolePermissions(role)
+	if !ok {
+		return false
+	}
+	for _, perm := range perms {
+		covered := false
+		for _, grant := range grants {
+			if authkit.PermMatches(grant, perm) {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			return false
+		}
+	}
+	return true
+}
+
+// MintMerchantAPIKey mints a key under the merchant's permission-group against
+// role (fixed catalog only). actorUserID is the acting AuthKit user: AuthKit
+// core enforces the credential-management capability + no-escalation against
+// it. Empty actorUserID (non-user principals: admin API key, in-process host,
+// delegated token) falls back to the genesis owner actor — the operator-CLI
+// idiom — so the CALLER must have already enforced owner-level authority (the
+// route gate + MerchantRoleCoveredBy). Returns the metadata and the one-time
+// plaintext secret: it is never stored and never retrievable again.
+func (c *ControlPlane) MintMerchantAPIKey(ctx context.Context, mid merchant.ID, name, role, actorUserID string) (MerchantAPIKey, string, error) {
+	if c == nil || c.Core() == nil {
+		return MerchantAPIKey{}, "", ErrNoControlPlane
+	}
+	role = strings.ToLower(strings.TrimSpace(role))
+	if _, ok := MerchantRolePermissions(role); !ok {
+		return MerchantAPIKey{}, "", ErrUnknownMerchantRole
+	}
+	slug, err := c.merchantSlugForID(ctx, mid)
+	if err != nil {
+		return MerchantAPIKey{}, "", err
+	}
+	actorUserID = strings.TrimSpace(actorUserID)
+	if actorUserID == "" {
+		actorUserID, err = c.EnsureMerchantAPIKeyActor(ctx, slug)
+		if err != nil {
+			return MerchantAPIKey{}, "", err
+		}
+	}
+	key, secret, err := c.Core().MintAPIKeyWithOptions(ctx, MerchantType, slug, authkit.APIKeyMintOptions{
+		Name:      strings.TrimSpace(name),
+		Role:      role,
+		CreatedBy: actorUserID,
+	})
+	if err != nil {
+		return MerchantAPIKey{}, "", err
+	}
+	return c.merchantAPIKeyView(key), secret, nil
+}
+
+// ListMerchantAPIKeys returns every key of the merchant's permission-group —
+// live, expired, and revoked (status is part of the audit view). NEVER any
+// secret material: AuthKit stores only the secret hash.
+func (c *ControlPlane) ListMerchantAPIKeys(ctx context.Context, mid merchant.ID) ([]MerchantAPIKey, error) {
+	if c == nil || c.Core() == nil {
+		return nil, ErrNoControlPlane
+	}
+	slug, err := c.merchantSlugForID(ctx, mid)
+	if err != nil {
+		return nil, err
+	}
+	keys, err := c.Core().ListAPIKeys(ctx, MerchantType, slug)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]MerchantAPIKey, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, c.merchantAPIKeyView(k))
+	}
+	return out, nil
+}
+
+// RevokeMerchantAPIKey revokes the key by internal id, scoped to the merchant's
+// group (a key can never be revoked across merchants). Returns false when no
+// live key with that id exists in this merchant's group.
+func (c *ControlPlane) RevokeMerchantAPIKey(ctx context.Context, mid merchant.ID, id string) (bool, error) {
+	if c == nil || c.Core() == nil {
+		return false, ErrNoControlPlane
+	}
+	slug, err := c.merchantSlugForID(ctx, mid)
+	if err != nil {
+		return false, err
+	}
+	return c.Core().RevokeAPIKey(ctx, MerchantType, slug, strings.TrimSpace(id))
+}
+
+func (c *ControlPlane) merchantAPIKeyView(k authkit.APIKey) MerchantAPIKey {
+	return MerchantAPIKey{
+		ID:         k.ID,
+		Name:       k.Name,
+		Role:       k.Role,
+		Prefix:     authkit.APIKeyMarker(c.TokenPrefix()) + k.KeyID,
+		CreatedAt:  k.CreatedAt,
+		LastUsedAt: k.LastUsedAt,
+		ExpiresAt:  k.ExpiresAt,
+		RevokedAt:  k.RevokedAt,
+	}
+}
+
+// merchantSlugForID resolves an active merchant's slug (== its permission-group
+// resource ref, #548) from its id. Missing/deleted/suspended merchants fail
+// closed as ErrServiceCredentialMerchantUnresolved.
+func (c *ControlPlane) merchantSlugForID(ctx context.Context, mid merchant.ID) (string, error) {
+	if mid.IsZero() {
+		return "", ErrServiceCredentialMerchantUnresolved
+	}
+	_, slug, err := c.merchantDirectoryRow(ctx, `id::text = $1`, mid.UUID().String())
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", ErrServiceCredentialMerchantUnresolved
+	}
+	if err != nil {
+		return "", fmt.Errorf("controlplane: resolve merchant slug: %w", err)
+	}
+	return slug, nil
+}

--- a/internal/http/embedhttp/embedhttp.go
+++ b/internal/http/embedhttp/embedhttp.go
@@ -23,6 +23,7 @@ import (
 	authpolicy "github.com/open-rails/openrails/internal/auth/policy"
 	"github.com/open-rails/openrails/internal/captcha"
 	captchaembed "github.com/open-rails/openrails/internal/captcha/embed"
+	httphandlers "github.com/open-rails/openrails/internal/http/handlers"
 	"github.com/open-rails/openrails/internal/http/middleware"
 	"github.com/open-rails/openrails/internal/http/router"
 	httproutes "github.com/open-rails/openrails/internal/http/routes"
@@ -63,7 +64,11 @@ type Assembler struct {
 	// *controlplane.ControlPlane satisfies it.
 	AdminChecker              authpolicy.AdminPermissionChecker
 	ServiceCredentialResolver httproutes.ServiceCredentialResolver
-	CaptchaStore              *captcha.ChallengeStore
+	// APIKeys is the #757 merchant self-serve API-key manager (the attached
+	// control plane). nil for hosts without a control plane — the /api-keys
+	// routes then answer 501.
+	APIKeys      httphandlers.MerchantAPIKeyManager
+	CaptchaStore *captcha.ChallengeStore
 	// RDB is the Redis/Garnet client backing the rate-limit counters + captcha
 	// challenge store. nil falls back to per-process in-memory rate-limit windows.
 	RDB           *redis.Client
@@ -93,11 +98,16 @@ func FromApp(a *app.App) *Assembler {
 	if c, ok := a.ControlPlane.(httproutes.ServiceCredentialResolver); ok {
 		resolver = c
 	}
+	var apiKeys httphandlers.MerchantAPIKeyManager
+	if c, ok := a.ControlPlane.(httphandlers.MerchantAPIKeyManager); ok {
+		apiKeys = c
+	}
 	asm := &Assembler{
 		Cfg:                       a.Config,
 		Runtime:                   a.Runtime,
 		AdminChecker:              checker,
 		ServiceCredentialResolver: resolver,
+		APIKeys:                   apiKeys,
 		CaptchaStore:              captcha.NewChallengeStore(a.RedisClient),
 		RDB:                       a.RedisClient,
 	}
@@ -160,7 +170,8 @@ func (s *Assembler) NewHTTPHandler(opts Options) http.Handler {
 	}
 	if routeSets[RouteSetMerchantAdmin] {
 		adminOpts := httproutes.Options{
-			Gate: s.Gate,
+			Gate:    s.Gate,
+			APIKeys: s.APIKeys,
 		}
 		// #528: per-user `/admin` retired; the delegated admin surface is mounted
 		// via embgin.SelfHandler (issuer→owner), not the base handler.

--- a/internal/http/handlers/merchant_api_keys.go
+++ b/internal/http/handlers/merchant_api_keys.go
@@ -1,0 +1,206 @@
+package handlers
+
+// Merchant self-serve API keys (#757): mint/list/revoke scoped credentials for
+// agents and integrations, all through AuthKit core via the control plane.
+// The routes are gated on merchant:credentials:manage (owner-only in the fixed
+// #567 catalog). The secret is returned EXACTLY ONCE, in the mint response.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/open-rails/authkit"
+
+	"github.com/open-rails/openrails/internal/controlplane"
+	httprequest "github.com/open-rails/openrails/internal/http/request"
+	"github.com/open-rails/openrails/pkg/api"
+	"github.com/open-rails/openrails/pkg/billingauth"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// MerchantAPIKeyManager is the control-plane surface behind the self-serve
+// API-key routes. Implemented by *controlplane.ControlPlane; nil (an embedded
+// host without a control plane) leaves the routes answering 501.
+type MerchantAPIKeyManager interface {
+	MintMerchantAPIKey(ctx context.Context, mid merchant.ID, name, role, actorUserID string) (controlplane.MerchantAPIKey, string, error)
+	ListMerchantAPIKeys(ctx context.Context, mid merchant.ID) ([]controlplane.MerchantAPIKey, error)
+	RevokeMerchantAPIKey(ctx context.Context, mid merchant.ID, id string) (bool, error)
+}
+
+// merchantRoutePrincipal returns the gate-resolved principal the merchant
+// permission middleware pinned onto the request.
+func merchantRoutePrincipal(r *httprequest.Request) (billingauth.Principal, bool) {
+	v, ok := r.Get(MerchantRoutePrincipalContextKey)
+	if !ok {
+		return billingauth.Principal{}, false
+	}
+	p, ok := v.(billingauth.Principal)
+	return p, ok
+}
+
+func apiKeyMerchantScope(r *httprequest.Request) (merchant.ID, bool) {
+	mid, ok := merchant.FromContext(r.Request.Context())
+	if !ok || mid.IsZero() {
+		r.ErrorJSON(http.StatusForbidden, "merchant_unresolved")
+		return merchant.ID{}, false
+	}
+	return mid, true
+}
+
+func apiKeyServiceUnavailable(r *httprequest.Request) {
+	r.ErrorJSON(http.StatusNotImplemented, "API-key management requires the OpenRails control plane (not attached on this deployment)")
+}
+
+// MerchantCreateAPIKey handles POST /v1/merchant/api-keys {name, role} → 201
+// {id, name, role, prefix, created_at, secret}. The secret is shown exactly
+// once — it is never stored and never retrievable again. role must be one of
+// the fixed merchant catalog roles (#567): viewer (read-only — the right
+// choice for LLM agents), support, or owner.
+func MerchantCreateAPIKey(svc MerchantAPIKeyManager) func(*httprequest.Request) {
+	return func(r *httprequest.Request) {
+		if svc == nil {
+			apiKeyServiceUnavailable(r)
+			return
+		}
+		mid, ok := apiKeyMerchantScope(r)
+		if !ok {
+			return
+		}
+		var req struct {
+			Name string `json:"name"`
+			Role string `json:"role"`
+		}
+		if !r.BindJSON(&req) {
+			return
+		}
+		req.Name = strings.TrimSpace(req.Name)
+		req.Role = strings.ToLower(strings.TrimSpace(req.Role))
+		if req.Name == "" || len(req.Name) > 120 {
+			r.APIError(api.NewAPIError(http.StatusBadRequest, api.ErrorTypeInvalidRequest, "invalid_name",
+				"name is required (max 120 chars)"))
+			return
+		}
+		if _, known := controlplane.MerchantRolePermissions(req.Role); !known {
+			r.APIError(api.NewAPIError(http.StatusBadRequest, api.ErrorTypeInvalidRequest, "unknown_role",
+				"role must be one of: "+strings.Join(controlplane.MerchantAPIKeyRoles(), ", ")))
+			return
+		}
+
+		// Two actor shapes (mirroring the gate): a USER SESSION carries an AuthKit
+		// user id and no resolved grant set — pass it as the mint actor so AuthKit
+		// core enforces capability + no-escalation against live group state. Every
+		// NON-USER credential (API key, service JWT, in-process host, delegated
+		// token) carries its resolved grants on the principal instead — the same
+		// no-escalation rule is enforced HERE (the requested role's permissions
+		// must be covered by the caller's own) before a genesis-actor mint.
+		principal, hasPrincipal := merchantRoutePrincipal(r)
+		var actor string
+		if hasPrincipal && len(principal.Permissions) > 0 {
+			if !controlplane.MerchantRoleCoveredBy(req.Role, principal.Permissions) {
+				r.APIError(api.NewAPIError(http.StatusForbidden, api.ErrorTypeAuthorization, "role_escalation",
+					"cannot mint a key with authority beyond your own credential's"))
+				return
+			}
+		} else {
+			uc, _ := r.UserContext()
+			actor = strings.TrimSpace(uc.UserID)
+			if actor == "" {
+				// Fail closed: no user actor and no resolved grant set.
+				r.APIError(api.NewAPIError(http.StatusForbidden, api.ErrorTypeAuthorization, "credentials_manage_required",
+					"caller identity does not support minting API keys"))
+				return
+			}
+		}
+
+		key, secret, err := svc.MintMerchantAPIKey(r.Request.Context(), mid, req.Name, req.Role, actor)
+		if err != nil {
+			switch {
+			case errors.Is(err, controlplane.ErrUnknownMerchantRole):
+				r.APIError(api.NewAPIError(http.StatusBadRequest, api.ErrorTypeInvalidRequest, "unknown_role",
+					"role must be one of: "+strings.Join(controlplane.MerchantAPIKeyRoles(), ", ")))
+			case errors.Is(err, authkit.ErrInsufficientRoleAuthority):
+				r.APIError(api.NewAPIError(http.StatusForbidden, api.ErrorTypeAuthorization, "credentials_manage_required",
+					"your account lacks credential-management authority on this merchant"))
+			case errors.Is(err, authkit.ErrRoleAssignmentEscalation):
+				r.APIError(api.NewAPIError(http.StatusForbidden, api.ErrorTypeAuthorization, "role_escalation",
+					"cannot mint a key with authority beyond your own"))
+			case errors.Is(err, controlplane.ErrServiceCredentialMerchantUnresolved):
+				r.ErrorJSON(http.StatusForbidden, "merchant_unresolved")
+			default:
+				r.ErrorJSON(http.StatusInternalServerError, "failed to mint API key")
+			}
+			return
+		}
+		r.JSON(http.StatusCreated, struct {
+			controlplane.MerchantAPIKey
+			Secret string `json:"secret"`
+		}{MerchantAPIKey: key, Secret: secret})
+	}
+}
+
+// MerchantListAPIKeys handles GET /v1/merchant/api-keys: every key of the
+// caller's merchant (live, expired, revoked — status is the audit view),
+// WITHOUT secret material.
+func MerchantListAPIKeys(svc MerchantAPIKeyManager) func(*httprequest.Request) {
+	return func(r *httprequest.Request) {
+		if svc == nil {
+			apiKeyServiceUnavailable(r)
+			return
+		}
+		mid, ok := apiKeyMerchantScope(r)
+		if !ok {
+			return
+		}
+		keys, err := svc.ListMerchantAPIKeys(r.Request.Context(), mid)
+		if err != nil {
+			if errors.Is(err, controlplane.ErrServiceCredentialMerchantUnresolved) {
+				r.ErrorJSON(http.StatusForbidden, "merchant_unresolved")
+				return
+			}
+			r.ErrorJSON(http.StatusInternalServerError, "failed to list API keys")
+			return
+		}
+		r.JSON(http.StatusOK, map[string]any{"data": keys})
+	}
+}
+
+// MerchantRevokeAPIKey handles DELETE /v1/merchant/api-keys/{id}: revokes the
+// key, scoped to the caller's merchant (cross-merchant ids 404).
+func MerchantRevokeAPIKey(svc MerchantAPIKeyManager) func(*httprequest.Request) {
+	return func(r *httprequest.Request) {
+		if svc == nil {
+			apiKeyServiceUnavailable(r)
+			return
+		}
+		mid, ok := apiKeyMerchantScope(r)
+		if !ok {
+			return
+		}
+		id := strings.TrimSpace(r.Param("id"))
+		if _, err := uuid.Parse(id); err != nil {
+			// Key ids are UUIDs; a malformed id can't match anything (and would
+			// otherwise error inside the ::uuid cast).
+			r.APIError(api.NewAPIError(http.StatusNotFound, api.ErrorTypeInvalidRequest, "not_found",
+				"no live API key with that id in this merchant"))
+			return
+		}
+		revoked, err := svc.RevokeMerchantAPIKey(r.Request.Context(), mid, id)
+		if err != nil {
+			if errors.Is(err, controlplane.ErrServiceCredentialMerchantUnresolved) {
+				r.ErrorJSON(http.StatusForbidden, "merchant_unresolved")
+				return
+			}
+			r.ErrorJSON(http.StatusInternalServerError, "failed to revoke API key")
+			return
+		}
+		if !revoked {
+			r.APIError(api.NewAPIError(http.StatusNotFound, api.ErrorTypeInvalidRequest, "not_found",
+				"no live API key with that id in this merchant"))
+			return
+		}
+		r.JSON(http.StatusOK, map[string]any{"revoked": true, "id": id})
+	}
+}

--- a/internal/http/routes/routes.go
+++ b/internal/http/routes/routes.go
@@ -32,6 +32,12 @@ type Options struct {
 	// broad standalone surface; embedded single-merchant mounts pass an explicit
 	// value derived from configured provider accounts.
 	ProviderRoutes *routesurface.ProviderRoutes
+
+	// APIKeys is the #757 merchant self-serve API-key manager (mint/list/revoke
+	// through AuthKit core). Implemented by *controlplane.ControlPlane. Nil
+	// (an embedded host without a control plane) keeps the /api-keys routes
+	// mounted but answering 501.
+	APIKeys httphandlers.MerchantAPIKeyManager
 }
 
 type GateOptions struct {
@@ -316,7 +322,9 @@ func (opts Options) merchantActionPermissionMW(perm string) router.Middleware {
 			if principal.UserContext.UserID != "" {
 				r.SetUserContext(principal.UserContext)
 			}
-			r.Set(httphandlers.MerchantRoutePrincipalContextKey, true)
+			// The full gate-resolved principal (existing consumers only check
+			// presence; #757 api-key handlers read Permissions for no-escalation).
+			r.Set(httphandlers.MerchantRoutePrincipalContextKey, principal)
 			next(r)
 		}
 	}
@@ -340,7 +348,7 @@ func (g legacyGate) Authorize(ctx context.Context, req *http.Request, perm strin
 		if !resolved.HasPermission(perm) {
 			return billingauth.Principal{}, billingauth.GateError{Status: http.StatusForbidden, Message: "permission_required"}
 		}
-		return billingauth.Principal{MerchantID: hp.MerchantID}, nil
+		return billingauth.Principal{MerchantID: hp.MerchantID, Permissions: resolved.Permissions}, nil
 	}
 	if resolved, err, handled := g.resolveServiceCredential(ctx, req, g.Authenticator != nil); handled {
 		if err != nil {
@@ -359,7 +367,7 @@ func (g legacyGate) Authorize(ctx context.Context, req *http.Request, perm strin
 		if !resolved.HasPermission(perm) {
 			return billingauth.Principal{}, billingauth.GateError{Status: http.StatusForbidden, Message: "permission_required"}
 		}
-		return billingauth.Principal{MerchantID: resolved.MerchantID}, nil
+		return billingauth.Principal{MerchantID: resolved.MerchantID, Permissions: resolved.Permissions}, nil
 	}
 	if g.DelegatedResolver != nil && req != nil {
 		if token := bearerToken(req.Header.Get("Authorization")); controlplane.LooksLikeJWT(token) {
@@ -381,6 +389,7 @@ func (g legacyGate) Authorize(ctx context.Context, req *http.Request, perm strin
 						Username:      resolved.Username,
 						Merchant:      resolved.Merchant,
 					},
+					Permissions: resolved.Permissions,
 				}, nil
 			}
 		}
@@ -406,6 +415,7 @@ func (g legacyGate) Authorize(ctx context.Context, req *http.Request, perm strin
 				Username:      resolved.Username,
 				Merchant:      resolved.Merchant,
 			},
+			Permissions: resolved.Permissions,
 		}, nil
 	}
 	if g.Authenticator == nil {
@@ -625,6 +635,17 @@ func registerMerchantSupportRoutes(rr router.Router, opts Options, dbMW ...route
 	rr.Handle(http.MethodGet, "/dashboard", h(httphandlers.GetMerchantDashboard), metricsRead...)
 	rr.Handle(http.MethodPut, "/dashboard", h(httphandlers.PutMerchantDashboard), dashboardWrite...)
 	rr.Handle(http.MethodPost, "/dashboard/widgets/generate", h(httphandlers.GenerateDashboardWidget), dashboardWrite...)
+
+	// #757 merchant self-serve API keys: mint/list/revoke scoped credentials
+	// through AuthKit core. Gated on merchant:credentials:manage — the SAME
+	// string AuthKit's own mint authorization checks; only the merchant owner
+	// (merchant:*) holds it in the fixed #567 catalog. No MerchantDBConnMW:
+	// these handlers touch only the control plane, never the runtime DB.
+	credentialsManage := opts.merchantActionPermissionMW(controlplane.PermMerchantCredentialsManage)
+	apiKeys := rr.Group("/api-keys")
+	apiKeys.Handle(http.MethodPost, "", h(httphandlers.MerchantCreateAPIKey(opts.APIKeys)), credentialsManage)
+	apiKeys.Handle(http.MethodGet, "", h(httphandlers.MerchantListAPIKeys(opts.APIKeys)), credentialsManage)
+	apiKeys.Handle(http.MethodDelete, "/:id", h(httphandlers.MerchantRevokeAPIKey(opts.APIKeys)), credentialsManage)
 
 	rr.Handle(http.MethodGet, "/repair-alerts", h(httphandlers.GetAdminRepairAlerts), repairRead...)
 	// #689: worker-health dashboard — same operator repair surface/permission.

--- a/internal/http/routes_admin.go
+++ b/internal/http/routes_admin.go
@@ -17,6 +17,8 @@ func (s *Server) registerMerchantActionRoutesAt(mux *http.ServeMux, apiPrefix st
 			DelegatedResolver:         s.controlPlane,
 			DelegatedAuthenticator:    s.delegatedAuthenticator,
 		}),
+		// #757 self-serve API keys (mint/list/revoke via AuthKit core).
+		APIKeys: s.controlPlane,
 	}
 	// #555 HARD CUT: the merchant API surface is `/v1/merchant/*`. Standalone
 	// mounts every merchant route set here: human admin/support, settings/catalog,

--- a/internal/integrationharness/cross_merchant_isolation_test.go
+++ b/internal/integrationharness/cross_merchant_isolation_test.go
@@ -267,7 +267,7 @@ func TestStandaloneMerchantAdmitAcceptsUserSessionByPermissionHTTP(t *testing.T)
 		user, err := core.CreateUser(ctx, email, username)
 		require.NoError(t, err, "create user")
 		require.NoError(t, core.Genesis().AssignGroupRole(ctx, controlplane.MerchantType, dbtest.TestMerchantSlug, user.ID, authcore.SubjectKindUser, roleForPerms(perms)), "assign merchant role")
-		token, _, err := core.IssueAccessToken(ctx, user.ID, nil)
+		token, _, err := core.MintAccessToken(ctx, user.ID, nil)
 		require.NoError(t, err, "issue access token")
 		return token
 	}
@@ -399,7 +399,7 @@ func TestCoreDoesNotMountPlatformAdminRoutesHTTP(t *testing.T) {
 	// #567: assign the merchant `owner` role directly in the merchant group (no
 	// separate group membership step).
 	require.NoError(t, core.Genesis().AssignGroupRole(ctx, controlplane.MerchantType, dbtest.TestMerchantSlug, user.ID, authcore.SubjectKindUser, controlplane.MerchantRoleOwner), "assign merchant admin role")
-	token, _, err := core.IssueAccessToken(ctx, user.ID, nil)
+	token, _, err := core.MintAccessToken(ctx, user.ID, nil)
 	require.NoError(t, err, "issue merchant admin user access token")
 
 	// #721: the platform directory is mounted on the standalone surface but

--- a/internal/integrationharness/harness.go
+++ b/internal/integrationharness/harness.go
@@ -608,7 +608,7 @@ func (s *Surface) MintUserAccessToken(username string) string {
 	require.NotNil(h.t, cp, "control plane attached")
 	user, err := cp.Core().CreateUser(h.ctx, username+"@example.com", username)
 	require.NoError(h.t, err, "create user")
-	token, _, err := cp.Core().IssueAccessToken(h.ctx, user.ID, nil)
+	token, _, err := cp.Core().MintAccessToken(h.ctx, user.ID, nil)
 	require.NoError(h.t, err, "mint user access token")
 	return token
 }

--- a/internal/integrationharness/merchant_api_keys_http_test.go
+++ b/internal/integrationharness/merchant_api_keys_http_test.go
@@ -194,7 +194,7 @@ func TestMerchantSelfServeAPIKeys(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, core.Genesis().AssignGroupRole(ctx, controlplane.MerchantType,
 				dbtest.TestMerchantSlug, user.ID, authcore.SubjectKindUser, role))
-			token, _, err := core.IssueAccessToken(ctx, user.ID, nil)
+			token, _, err := core.MintAccessToken(ctx, user.ID, nil)
 			require.NoError(t, err)
 			return token
 		}

--- a/internal/integrationharness/merchant_api_keys_http_test.go
+++ b/internal/integrationharness/merchant_api_keys_http_test.go
@@ -1,0 +1,244 @@
+//go:build integration
+
+package integrationharness
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/authkit"
+	authcore "github.com/open-rails/authkit/embedded"
+
+	"github.com/open-rails/openrails/internal/controlplane"
+	"github.com/open-rails/openrails/internal/dbtest"
+	embcp "github.com/open-rails/openrails/pkg/embedded/controlplane"
+)
+
+// #757 merchant self-serve API keys over the REAL standalone server + AuthKit
+// control plane: mint/list/revoke, role scoping (viewer = read-only for LLM
+// agents), owner gating, no-escalation, revocation, and cross-merchant isolation.
+
+type mintedKeyResp struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Role      string `json:"role"`
+	Prefix    string `json:"prefix"`
+	CreatedAt string `json:"created_at"`
+	Secret    string `json:"secret"`
+}
+
+func mintKeyHTTP(t *testing.T, baseURL, token, name, role string) (int, mintedKeyResp, []byte) {
+	t.Helper()
+	status, body := requestJSON(t, http.MethodPost, baseURL+"/v1/merchant/api-keys", token,
+		map[string]any{"name": name, "role": role})
+	var out mintedKeyResp
+	if status == http.StatusCreated {
+		require.NoError(t, json.Unmarshal(body, &out))
+	}
+	return status, out, body
+}
+
+func listKeysHTTP(t *testing.T, baseURL, token string) (int, []map[string]any, []byte) {
+	t.Helper()
+	status, body := requestJSON(t, http.MethodGet, baseURL+"/v1/merchant/api-keys", token, nil)
+	var envelope struct {
+		Data []map[string]any `json:"data"`
+	}
+	if status == http.StatusOK {
+		require.NoError(t, json.Unmarshal(body, &envelope))
+	}
+	return status, envelope.Data, body
+}
+
+const metricsQueryBody = `{"measures":["cancellations"],"by":["time"],"grain":"day","range":{"last":"7d"}}`
+
+func TestMerchantSelfServeAPIKeys(t *testing.T) {
+	ctx := context.Background()
+	h := New(t, ctx)
+	surface := h.StartStandalone("usd")
+	admin := surface.Token // the real bootstrap-minted owner admin key
+	base := surface.BaseURL
+
+	t.Run("unauthenticated is rejected", func(t *testing.T) {
+		status, _, _ := listKeysHTTP(t, base, "")
+		require.Equal(t, http.StatusUnauthorized, status)
+	})
+
+	t.Run("unknown role is rejected against the fixed catalog", func(t *testing.T) {
+		for _, role := range []string{"superadmin", "admin", "member", ""} {
+			status, _, body := mintKeyHTTP(t, base, admin, "bad-role-key", role)
+			require.Equalf(t, http.StatusBadRequest, status, "role %q: %s", role, string(body))
+			require.Contains(t, string(body), "unknown_role")
+		}
+	})
+
+	var viewerKey mintedKeyResp
+	var viewerToken string
+	t.Run("owner mints a viewer key; secret shown once with prefix", func(t *testing.T) {
+		status, minted, body := mintKeyHTTP(t, base, admin, "llm-agent", "viewer")
+		require.Equalf(t, http.StatusCreated, status, "mint: %s", string(body))
+		require.NotEmpty(t, minted.ID)
+		require.Equal(t, "llm-agent", minted.Name)
+		require.Equal(t, "viewer", minted.Role)
+		require.NotEmpty(t, minted.Secret)
+		require.True(t, strings.HasPrefix(minted.Prefix, "openrails_st_"), "prefix %q", minted.Prefix)
+		require.True(t, strings.HasPrefix(minted.Secret, minted.Prefix),
+			"the presented token must start with the listed prefix")
+		require.NotEmpty(t, minted.CreatedAt)
+		viewerKey = minted
+		viewerToken = minted.Secret
+	})
+
+	t.Run("viewer key CAN read metrics schema and run queries", func(t *testing.T) {
+		status, body := requestJSON(t, http.MethodGet, base+"/v1/merchant/metrics/schema", viewerToken, nil)
+		require.Equalf(t, http.StatusOK, status, "schema: %s", string(body))
+		require.Contains(t, string(body), "measures")
+
+		status, body = requestJSON(t, http.MethodPost, base+"/v1/merchant/metrics/query", viewerToken,
+			json.RawMessage(metricsQueryBody))
+		require.Equalf(t, http.StatusOK, status, "query: %s", string(body))
+	})
+
+	t.Run("viewer key CANNOT refund", func(t *testing.T) {
+		status, body := requestJSON(t, http.MethodPost,
+			base+"/v1/merchant/payments/"+uuid.NewString()+"/refunds", viewerToken,
+			map[string]any{"amount": 1000000})
+		require.Equalf(t, http.StatusForbidden, status, "refund: %s", string(body))
+	})
+
+	t.Run("viewer key CANNOT manage API keys (owner-gated)", func(t *testing.T) {
+		status, _, _ := listKeysHTTP(t, base, viewerToken)
+		require.Equal(t, http.StatusForbidden, status)
+		status, _, _ = mintKeyHTTP(t, base, viewerToken, "escalate", "viewer")
+		require.Equal(t, http.StatusForbidden, status)
+		status, _ = requestJSON(t, http.MethodDelete, base+"/v1/merchant/api-keys/"+viewerKey.ID, viewerToken, nil)
+		require.Equal(t, http.StatusForbidden, status)
+	})
+
+	t.Run("list shows metadata but never secret material", func(t *testing.T) {
+		status, keys, raw := listKeysHTTP(t, base, admin)
+		require.Equal(t, http.StatusOK, status)
+		require.NotEmpty(t, keys)
+		var found bool
+		for _, k := range keys {
+			require.NotContains(t, k, "secret")
+			require.NotEmpty(t, k["prefix"])
+			if k["id"] == viewerKey.ID {
+				found = true
+				require.Equal(t, "viewer", k["role"])
+				require.Equal(t, "llm-agent", k["name"])
+			}
+		}
+		require.True(t, found, "minted key must appear in the list")
+		// The secret part after the prefix must not appear ANYWHERE in the payload.
+		secretPart := strings.TrimPrefix(viewerToken, viewerKey.Prefix)
+		require.NotEmpty(t, secretPart)
+		require.NotContains(t, string(raw), secretPart)
+	})
+
+	t.Run("cross-merchant isolation", func(t *testing.T) {
+		b := surface.ProvisionOwnedMerchant("keyiso" + strings.ReplaceAll(uuid.NewString(), "-", "")[:12])
+		status, bKey, body := mintKeyHTTP(t, base, b.APIKey, "b-integration", "viewer")
+		require.Equalf(t, http.StatusCreated, status, "mint under B: %s", string(body))
+
+		// A's list never contains B's key; B's list never contains A's.
+		_, aKeys, _ := listKeysHTTP(t, base, admin)
+		for _, k := range aKeys {
+			require.NotEqual(t, bKey.ID, k["id"])
+		}
+		_, bKeys, _ := listKeysHTTP(t, base, b.APIKey)
+		for _, k := range bKeys {
+			require.NotEqual(t, viewerKey.ID, k["id"])
+		}
+
+		// A cannot revoke B's key by id (scoped to A's group -> 404).
+		status, body = requestJSON(t, http.MethodDelete, base+"/v1/merchant/api-keys/"+bKey.ID, admin, nil)
+		require.Equalf(t, http.StatusNotFound, status, "cross-merchant revoke: %s", string(body))
+		// ... and B's key still works.
+		status, _ = requestJSON(t, http.MethodGet, base+"/v1/merchant/metrics/schema", bKey.Secret, nil)
+		require.Equal(t, http.StatusOK, status)
+	})
+
+	t.Run("non-owner-covering credential cannot mint above itself", func(t *testing.T) {
+		// A delegated token bounded to credentials:manage alone passes the route
+		// gate but covers no catalog role's permission set -> every mint is a
+		// no-escalation 403. A merchant:*-bounded one mints fine.
+		bounded := surface.RegisterDelegatedCaller("apikeymgr"+strings.ReplaceAll(uuid.NewString(), "-", "")[:8],
+			dbtest.TestMerchantSlug, uuid.NewString(), []string{controlplane.PermMerchantCredentialsManage})
+		for _, role := range []string{"owner", "support", "viewer"} {
+			status, _, body := mintKeyHTTP(t, base, bounded.Token, "escalated-"+role, role)
+			require.Equalf(t, http.StatusForbidden, status, "role %q: %s", role, string(body))
+			require.Contains(t, string(body), "role_escalation")
+		}
+		full := surface.RegisterDelegatedCaller("apikeyown"+strings.ReplaceAll(uuid.NewString(), "-", "")[:8],
+			dbtest.TestMerchantSlug, uuid.NewString(), []string{"merchant:*"})
+		status, minted, body := mintKeyHTTP(t, base, full.Token, "delegated-minted", "viewer")
+		require.Equalf(t, http.StatusCreated, status, "owner-covering delegated mint: %s", string(body))
+		require.NotEmpty(t, minted.Secret)
+	})
+
+	t.Run("user sessions: owner user can mint, viewer user cannot", func(t *testing.T) {
+		cp := embcp.Get(surface.App())
+		require.NotNil(t, cp)
+		core := cp.Core()
+
+		mintUserToken := func(role string) string {
+			name := "apikeyuser" + strings.ReplaceAll(uuid.NewString(), "-", "")[:10]
+			user, err := core.CreateUser(ctx, name+"@example.com", name)
+			require.NoError(t, err)
+			require.NoError(t, core.Genesis().AssignGroupRole(ctx, controlplane.MerchantType,
+				dbtest.TestMerchantSlug, user.ID, authcore.SubjectKindUser, role))
+			token, _, err := core.IssueAccessToken(ctx, user.ID, nil)
+			require.NoError(t, err)
+			return token
+		}
+
+		ownerSession := mintUserToken(controlplane.MerchantRoleOwner)
+		status, minted, body := mintKeyHTTP(t, base, ownerSession, "console-minted", "viewer")
+		require.Equalf(t, http.StatusCreated, status, "owner user mint: %s", string(body))
+		require.NotEmpty(t, minted.Secret)
+
+		viewerSession := mintUserToken(controlplane.MerchantRoleViewer)
+		status, _, body = mintKeyHTTP(t, base, viewerSession, "console-escalate", "viewer")
+		require.Equalf(t, http.StatusForbidden, status, "viewer user mint: %s", string(body))
+	})
+
+	t.Run("revoked key is rejected everywhere", func(t *testing.T) {
+		status, body := requestJSON(t, http.MethodDelete, base+"/v1/merchant/api-keys/"+viewerKey.ID, admin, nil)
+		require.Equalf(t, http.StatusOK, status, "revoke: %s", string(body))
+		require.Contains(t, string(body), `"revoked":true`)
+
+		// The revoked key is dead on every surface.
+		status, _ = requestJSON(t, http.MethodGet, base+"/v1/merchant/metrics/schema", viewerToken, nil)
+		require.Equal(t, http.StatusUnauthorized, status)
+		status, _ = requestJSON(t, http.MethodPost, base+"/v1/merchant/metrics/query", viewerToken,
+			json.RawMessage(metricsQueryBody))
+		require.Equal(t, http.StatusUnauthorized, status)
+		status, _, _ = listKeysHTTP(t, base, viewerToken)
+		require.Equal(t, http.StatusUnauthorized, status)
+
+		// Second revoke -> 404 (no live key); the list still shows it, revoked.
+		status, _ = requestJSON(t, http.MethodDelete, base+"/v1/merchant/api-keys/"+viewerKey.ID, admin, nil)
+		require.Equal(t, http.StatusNotFound, status)
+		_, keys, _ := listKeysHTTP(t, base, admin)
+		var revokedSeen bool
+		for _, k := range keys {
+			if k["id"] == viewerKey.ID {
+				revokedSeen = true
+				require.NotEmpty(t, k["revoked_at"], "revoked key stays listed with revoked_at")
+			}
+		}
+		require.True(t, revokedSeen)
+	})
+
+	t.Run("resolved key still parses as an authkit token", func(t *testing.T) {
+		// Guard the wire format assumption behind Prefix: marker + key id.
+		require.True(t, authkit.HasAPIKeyPrefix(controlplane.APIKeyPrefix, viewerToken))
+	})
+}

--- a/internal/integrationharness/platform_merchants_http_test.go
+++ b/internal/integrationharness/platform_merchants_http_test.go
@@ -60,7 +60,7 @@ func mintPlatformOperatorToken(t *testing.T, ctx context.Context, s *Surface, ro
 			core.Genesis().AssignGroupRole(ctx, authcore.RootPersona, "", user.ID, authcore.SubjectKindUser, role),
 			"assign root role %s", role)
 	}
-	token, _, err := core.IssueAccessToken(ctx, user.ID, nil)
+	token, _, err := core.MintAccessToken(ctx, user.ID, nil)
 	require.NoError(t, err, "issue access token")
 	return token
 }

--- a/internal/integrationharness/testdata/standalone_route_surface.txt
+++ b/internal/integrationharness/testdata/standalone_route_surface.txt
@@ -1,5 +1,6 @@
 DELETE /v1/customers/{customer_id}/payment-methods/{id}
 DELETE /v1/me/payment-methods/{id}
+DELETE /v1/merchant/api-keys/{id}
 DELETE /v1/merchant/customers/{customer_id}/entitlements/{id}
 DELETE /v1/merchant/customers/{customer_id}/product-access/{id}
 DELETE /v1/merchant/payment-providers/{provider}
@@ -38,6 +39,7 @@ GET /v1/me/subscriptions
 GET /v1/me/subscriptions/{id}
 GET /v1/me/transactions
 GET /v1/me/usage
+GET /v1/merchant/api-keys
 GET /v1/merchant/catalog/drift
 GET /v1/merchant/catalog/prices
 GET /v1/merchant/catalog/prices/{id}
@@ -101,6 +103,7 @@ POST /v1/me/subscriptions/{id}/solana-tier-change/confirm
 POST /v1/merchant/admissions
 POST /v1/merchant/admissions/{id}/capture
 POST /v1/merchant/admissions/{id}/release
+POST /v1/merchant/api-keys
 POST /v1/merchant/catalog/drift/refresh
 POST /v1/merchant/catalog/prices
 POST /v1/merchant/catalog/prices/{id}/activate

--- a/permissions/permissions.go
+++ b/permissions/permissions.go
@@ -39,6 +39,13 @@ const (
 	// DeclaredBilling book import writes subscriptions/payments/payment methods
 	// wholesale — owner/automation authority, not a support-role grant.
 	MerchantBillingImport = "merchant:billing:import"
+	// MerchantCredentialsManage gates the merchant self-serve API-key surface
+	// (#757: /v1/merchant/api-keys mint/list/revoke). Deliberately the SAME
+	// string as AuthKit's per-persona credential-management capability
+	// (`<persona>:credentials:manage`), so the OpenRails route gate and AuthKit
+	// core's own mint authorization agree exactly. In the fixed merchant role
+	// catalog (#567) only the owner (merchant:*) holds it.
+	MerchantCredentialsManage = "merchant:credentials:manage"
 )
 
 // Platform-operator (root) permissions (#721). AuthKit's #111 rename made

--- a/pkg/billingauth/gate.go
+++ b/pkg/billingauth/gate.go
@@ -16,6 +16,12 @@ type Gate interface {
 type Principal struct {
 	MerchantID  merchant.ID
 	UserContext UserContext
+	// Permissions is the credential's resolved grant set for NON-USER principals
+	// (API keys, service JWTs, host/delegated principals) — consumers that need
+	// no-escalation checks (#757 api-key minting) read it. Empty for user
+	// sessions: those carry UserContext.UserID and are checked against live
+	// AuthKit group state instead.
+	Permissions []string
 }
 
 // GateError maps authorization failures to stable HTTP responses.

--- a/web/admin/src/lib/api/endpoints.ts
+++ b/web/admin/src/lib/api/endpoints.ts
@@ -11,7 +11,9 @@ import type {
   CustomerSummary,
   Finding,
   FindingsListResponse,
+  MerchantAPIKey,
   MerchantSettings,
+  MintedAPIKey,
   PaymentMethodResponse,
   PaymentObject,
   PaymentProviderConfig,
@@ -248,6 +250,16 @@ export const deletePaymentProvider = (rail: string, environment?: string) =>
     method: "DELETE",
     query: environment ? { environment } : undefined,
   })
+
+// --- API keys (#757) ---
+
+export const listApiKeys = () => api<{ data: MerchantAPIKey[] | null }>("/merchant/api-keys")
+
+export const createApiKey = (name: string, role: string) =>
+  api<MintedAPIKey>("/merchant/api-keys", { method: "POST", body: { name, role } })
+
+export const revokeApiKey = (id: string) =>
+  api<{ revoked: boolean; id: string }>(`/merchant/api-keys/${id}`, { method: "DELETE" })
 
 export const getCreditLimit = (customerId: string, currency: string) =>
   api<{ currency: string; credit_limit_amount: number }>("/merchant/credit-limit", {

--- a/web/admin/src/lib/api/types.ts
+++ b/web/admin/src/lib/api/types.ts
@@ -322,6 +322,25 @@ export interface PaymentProviderConfig {
   updated_at: string
 }
 
+// --- API keys (#757) ---
+
+export interface MerchantAPIKey {
+  id: string
+  name: string
+  role: string
+  // Non-secret leading token part ("openrails_st_<key_id>") for matching a
+  // stored credential. The secret itself is shown once, at mint time only.
+  prefix: string
+  created_at: string
+  last_used_at?: string
+  expires_at?: string
+  revoked_at?: string
+}
+
+export interface MintedAPIKey extends MerchantAPIKey {
+  secret: string
+}
+
 // --- Auth (AuthKit authhttp) ---
 
 export interface AuthCapabilities {

--- a/web/admin/src/pages/settings/api-keys.tsx
+++ b/web/admin/src/pages/settings/api-keys.tsx
@@ -1,0 +1,305 @@
+import * as React from "react"
+import { toast } from "sonner"
+
+import { TypedConfirmDialog } from "@/components/typed-confirm-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useApiData } from "@/hooks/use-api-data"
+import { createApiKey, listApiKeys, revokeApiKey } from "@/lib/api/endpoints"
+import type { MerchantAPIKey, MintedAPIKey } from "@/lib/api/types"
+import { cn } from "@/lib/utils"
+import { formatDate } from "@/lib/format"
+import { toastApiError } from "@/lib/toast"
+
+// Fixed merchant catalog roles (#567) a key can hold, least privilege first.
+// The API validates against the same catalog; these descriptions are the
+// plain-language contract of each role.
+const ROLES: { value: string; label: string; description: string }[] = [
+  {
+    value: "viewer",
+    label: "Viewer — read-only (recommended)",
+    description:
+      "Can query metrics and read payments, subscriptions, catalog, and settings. " +
+      "Cannot change anything or move money. The right choice for LLM agents, " +
+      "reporting, and analytics integrations.",
+  },
+  {
+    value: "support",
+    label: "Support — customer operations",
+    description:
+      "Everything Viewer can, plus customer fixes: refunds, subscription changes, " +
+      "and entitlement grants. Cannot change merchant settings, catalog, payment " +
+      "providers, or API keys.",
+  },
+  {
+    value: "owner",
+    label: "Owner — full control",
+    description:
+      "Full authority over this merchant, including settings, payment providers, " +
+      "and minting or revoking API keys. Only for trusted server automation.",
+  },
+]
+
+export function ApiKeysTab() {
+  const { data, loading, error, reload } = useApiData(() => listApiKeys(), [])
+  React.useEffect(() => {
+    if (error) toastApiError(error, "Load API keys")
+  }, [error])
+
+  if (loading) return <p className="text-sm text-muted-foreground">Loading…</p>
+
+  const keys = data?.data ?? []
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-start justify-between gap-4">
+        <p className="max-w-2xl text-sm text-muted-foreground">
+          Scoped credentials for agents and integrations. A key holds one role of the
+          merchant catalog; least privilege (Viewer) is the default. The secret is
+          shown once at creation and can never be retrieved again — only revoked.
+        </p>
+        <CreateKeyDialog onDone={reload} />
+      </div>
+      {keys.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No API keys yet.</p>
+      ) : (
+        <div className="overflow-x-auto rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead>Key</TableHead>
+                <TableHead>Created</TableHead>
+                <TableHead>Last used</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {keys.map((k) => (
+                <KeyRow key={k.id} apiKey={k} onDone={reload} />
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function keyStatus(k: MerchantAPIKey): "active" | "revoked" | "expired" {
+  if (k.revoked_at) return "revoked"
+  if (k.expires_at && new Date(k.expires_at).getTime() <= Date.now()) return "expired"
+  return "active"
+}
+
+function KeyRow({ apiKey, onDone }: { apiKey: MerchantAPIKey; onDone: () => void }) {
+  const [confirmOpen, setConfirmOpen] = React.useState(false)
+  const status = keyStatus(apiKey)
+  return (
+    <TableRow className={status !== "active" ? "opacity-60" : undefined}>
+      <TableCell className="font-medium">{apiKey.name}</TableCell>
+      <TableCell>
+        <Badge variant="secondary">{apiKey.role}</Badge>
+      </TableCell>
+      <TableCell className="font-mono text-xs">{apiKey.prefix}…</TableCell>
+      <TableCell>{formatDate(apiKey.created_at)}</TableCell>
+      <TableCell>{apiKey.last_used_at ? formatDate(apiKey.last_used_at) : "never"}</TableCell>
+      <TableCell>
+        {status === "active" ? (
+          <Badge variant="secondary" className="bg-emerald-500/15 text-emerald-600 dark:text-emerald-400">
+            active
+          </Badge>
+        ) : (
+          <Badge variant="secondary">{status}</Badge>
+        )}
+      </TableCell>
+      <TableCell className="text-right">
+        {status === "active" && (
+          <>
+            <Button variant="outline" size="sm" onClick={() => setConfirmOpen(true)}>
+              Revoke
+            </Button>
+            <TypedConfirmDialog
+              open={confirmOpen}
+              onOpenChange={setConfirmOpen}
+              title={`Revoke "${apiKey.name}"?`}
+              description="Every request using this key will be rejected immediately. This cannot be undone."
+              confirmationWord="REVOKE"
+              actionLabel="Revoke key"
+              onConfirm={async () => {
+                try {
+                  await revokeApiKey(apiKey.id)
+                  toast.success("API key revoked")
+                  onDone()
+                } catch (err) {
+                  toastApiError(err, "Revoke API key")
+                }
+              }}
+            />
+          </>
+        )}
+      </TableCell>
+    </TableRow>
+  )
+}
+
+function CreateKeyDialog({ onDone }: { onDone: () => void }) {
+  const [open, setOpen] = React.useState(false)
+  const [name, setName] = React.useState("")
+  const [role, setRole] = React.useState("viewer")
+  const [busy, setBusy] = React.useState(false)
+  const [minted, setMinted] = React.useState<MintedAPIKey | null>(null)
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next)
+    if (!next) {
+      setName("")
+      setRole("viewer")
+      setMinted(null)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button size="sm">Create API key</Button>
+      </DialogTrigger>
+      <DialogContent>
+        {minted ? (
+          <ShowOnceSecret minted={minted} onClose={() => handleOpenChange(false)} />
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>Create API key</DialogTitle>
+              <DialogDescription>
+                Pick the least-privileged role that can do the job — you can always
+                mint another key with more authority later.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-3">
+              <div className="grid gap-1.5">
+                <Label htmlFor="ak-name">Name</Label>
+                <Input
+                  id="ak-name"
+                  placeholder="e.g. metrics-agent"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                />
+              </div>
+              <div className="grid gap-1.5">
+                <Label>Role</Label>
+                <div className="grid gap-2">
+                  {ROLES.map((r) => (
+                    <button
+                      key={r.value}
+                      type="button"
+                      onClick={() => setRole(r.value)}
+                      aria-pressed={role === r.value}
+                      className={cn(
+                        "rounded-md border p-3 text-left transition-colors",
+                        role === r.value ? "border-primary bg-primary/5" : "hover:bg-muted/50",
+                      )}
+                    >
+                      <p className="text-sm font-medium">{r.label}</p>
+                      <p className="mt-1 text-xs text-muted-foreground">{r.description}</p>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+            <DialogFooter>
+              <Button
+                disabled={busy || !name.trim()}
+                onClick={async () => {
+                  setBusy(true)
+                  try {
+                    const created = await createApiKey(name.trim(), role)
+                    setMinted(created)
+                    onDone()
+                  } catch (err) {
+                    toastApiError(err, "Create API key")
+                  } finally {
+                    setBusy(false)
+                  }
+                }}
+              >
+                {busy ? "Creating…" : "Create key"}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function ShowOnceSecret({ minted, onClose }: { minted: MintedAPIKey; onClose: () => void }) {
+  const [copied, setCopied] = React.useState(false)
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>API key created</DialogTitle>
+        <DialogDescription>
+          Copy the key now and store it somewhere safe.{" "}
+          <span className="font-semibold text-foreground">
+            You won&apos;t see this key again
+          </span>{" "}
+          — if it is lost, revoke it and mint a new one.
+        </DialogDescription>
+      </DialogHeader>
+      <div className="grid gap-3">
+        <p className="text-sm">
+          <span className="font-medium">{minted.name}</span>{" "}
+          <Badge variant="secondary">{minted.role}</Badge>
+        </p>
+        <div className="flex items-center gap-2">
+          <code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap rounded-md border bg-muted px-3 py-2 font-mono text-xs">
+            {minted.secret}
+          </code>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={async () => {
+              try {
+                await navigator.clipboard.writeText(minted.secret)
+                setCopied(true)
+                toast.success("Key copied to clipboard")
+              } catch {
+                toast.error("Copy failed — select the key text manually")
+              }
+            }}
+          >
+            {copied ? "Copied" : "Copy"}
+          </Button>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Use it as a Bearer token: <code className="font-mono">Authorization: Bearer {minted.prefix}…</code>
+        </p>
+      </div>
+      <DialogFooter>
+        <Button onClick={onClose}>Done</Button>
+      </DialogFooter>
+    </>
+  )
+}

--- a/web/admin/src/pages/settings/index.tsx
+++ b/web/admin/src/pages/settings/index.tsx
@@ -45,6 +45,7 @@ import {
 import type { PaymentProviderConfig } from "@/lib/api/types"
 import { formatDate, formatMicros, microsFromInput } from "@/lib/format"
 import { toastApiError } from "@/lib/toast"
+import { ApiKeysTab } from "./api-keys"
 
 export function SettingsPage() {
   return (
@@ -52,6 +53,7 @@ export function SettingsPage() {
       <TabsList>
         <TabsTrigger value="merchant">Merchant</TabsTrigger>
         <TabsTrigger value="providers">Payment providers</TabsTrigger>
+        <TabsTrigger value="api-keys">API keys</TabsTrigger>
         <TabsTrigger value="customer-controls">Customer controls</TabsTrigger>
       </TabsList>
       <TabsContent value="merchant">
@@ -59,6 +61,9 @@ export function SettingsPage() {
       </TabsContent>
       <TabsContent value="providers">
         <ProvidersTab />
+      </TabsContent>
+      <TabsContent value="api-keys">
+        <ApiKeysTab />
       </TabsContent>
       <TabsContent value="customer-controls">
         <CustomerControlsTab />


### PR DESCRIPTION
Implements tracker #757: the merchant-facing self-serve surface over the existing AuthKit API-key machinery (mint existed via `MintAPIKeyWithOptions`; `ResolveAPIKey` already authenticated keys on every `/v1/merchant/*` request).

## Endpoints (owner-gated)
- `POST /v1/merchant/api-keys` `{name, role}` → 201 `{id, name, role, prefix, created_at, secret}` — **secret returned exactly once**, never stored, never retrievable again
- `GET /v1/merchant/api-keys` → metadata only (id, name, role, prefix, created_at, last_used_at, revoked_at) — never secret material; revoked keys stay listed for audit
- `DELETE /v1/merchant/api-keys/{id}` → immediate revocation, merchant-scoped

All three go through AuthKit CORE (`MintAPIKeyWithOptions` / `ListAPIKeys` / `RevokeAPIKey`) via new `internal/controlplane` wrappers — never raw SQL (bootstrap.go doctrine). `last_used_at` is included: AuthKit already tracks it cheaply (async touch, 5-min in-query throttle).

## Roles & gating
- Role must be one of the fixed #567 merchant catalog roles: `viewer` / `support` / `owner`. **`viewer` is the metrics/read-only role for LLM agents** (metrics query+schema, reads everywhere, no refunds/mutations) and is the console default.
- Routes gate on `merchant:credentials:manage` — deliberately the SAME string AuthKit's own mint authorization checks (`PermCredentialsManage("merchant")`), owner-only in the fixed catalog.
- No-escalation on every path: user sessions pass their AuthKit user as the mint actor (AuthKit enforces capability + no-step-up against live group state); non-user principals (admin API key, host, delegated) carry their resolved grants on `billingauth.Principal` and the handler enforces the same rule (requested role's perms ⊆ caller's grants) before a genesis-actor mint.

## Console
Settings → **API keys** tab: least-privilege role picker (viewer default, plain-language description per role), show-once secret modal with copy button and "you won't see this again", list with status/last-used, revoke with typed `REVOKE` confirmation. `tsc`/`eslint`/`vite build`/`task admin-build` verified; no dist committed (#754).

## Tests (integration, all green)
`internal/integrationharness/merchant_api_keys_http_test.go` against the real standalone server + AuthKit control plane: viewer key CAN metrics schema/query, CANNOT refund (403); revoked key rejected everywhere; list never contains secret material; cross-merchant isolation (list + revoke); owner-gating on mint/list/revoke; escalation denials for bounded delegated credentials and viewer-role user sessions; owner user-session mint works.

Also fixes a cross-PR skew: the authkit v0.80.0 bump renamed `Core().IssueAccessToken` → `MintAccessToken` but missed the integration-tagged call sites (master was red under `-tags integration`).

#670 route golden updated; `docs/admin-console.md` gains the API-keys section (the metrics-for-llms doc is being created by #756 — cross-link noted in the tracker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)