### PR TITLE
#750: typed provisioning errors + export engine-owned constants

### DIFF
--- a/internal/bootstrap/merchant_manifest.go
+++ b/internal/bootstrap/merchant_manifest.go
@@ -697,7 +697,7 @@ func provisionMerchantIdentity(ctx context.Context, cfg *config.Config, database
 	if err != nil {
 		return nil, err
 	}
-	tn, err := svc.Provision(ctx, merchants.ProvisionRequest{
+	tn, _, err := svc.Provision(ctx, merchants.ProvisionRequest{
 		Slug:              slug,
 		PermissionGroupID: groupID,
 	})

--- a/internal/controlplane/service.go
+++ b/internal/controlplane/service.go
@@ -307,8 +307,8 @@ func New(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, opts ...Op
 		},
 		Token: authcore.TokenConfig{
 			Issuer:            issuer,
-			IssuedAudiences:   []string{"openrails"},
-			ExpectedAudiences: []string{"openrails"},
+			IssuedAudiences:   []string{billingauth.TokenAudience},
+			ExpectedAudiences: []string{billingauth.TokenAudience},
 		},
 		Frontend:    resolveFrontendConfig(issuer, options.frontend),
 		APIKeys:     authcore.APIKeysConfig{Prefix: APIKeyPrefix},
@@ -384,7 +384,7 @@ func New(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, opts ...Op
 		verify.WithAPIKeyPrefix(APIKeyPrefix),
 		verify.WithSSRFGuard(),
 	)
-	if err := userVerifier.AddIssuer(issuer, []string{"openrails"}, verify.IssuerOptions{
+	if err := userVerifier.AddIssuer(issuer, []string{billingauth.TokenAudience}, verify.IssuerOptions{
 		RawKeys: authClient.PublicKeysByKID(),
 		IsLocal: true,
 	}); err != nil {
@@ -419,7 +419,7 @@ func New(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, opts ...Op
 		delegatedVerifier:  delegatedVerifier,
 		userVerifier:       userVerifier,
 		issuer:             issuer,
-		delegatedAudiences: []string{"openrails"},
+		delegatedAudiences: []string{billingauth.TokenAudience},
 	}
 
 	// Load AuthKit's ACTIVE remote_applications into the multi-issuer verifier

--- a/internal/http/routes_merchant_webhook_integration_test.go
+++ b/internal/http/routes_merchant_webhook_integration_test.go
@@ -43,9 +43,9 @@ func TestMerchantWebhookRouteHTTPResolvesMerchantBeforeVerifyingStripe(t *testin
 	svc, err := merchants.NewService(db.WrapPool(pool, ""), secrets, "test")
 	require.NoError(t, err)
 
-	acme, err := svc.Provision(ctx, merchants.ProvisionRequest{Slug: "acme", PermissionGroupID: "group-acme"})
+	acme, _, err := svc.Provision(ctx, merchants.ProvisionRequest{Slug: "acme", PermissionGroupID: "group-acme"})
 	require.NoError(t, err)
-	evil, err := svc.Provision(ctx, merchants.ProvisionRequest{Slug: "evil", PermissionGroupID: "group-evil"})
+	evil, _, err := svc.Provision(ctx, merchants.ProvisionRequest{Slug: "evil", PermissionGroupID: "group-evil"})
 	require.NoError(t, err)
 	seedRailMerchantAccount(t, pool, acme.ID.String(), "stripe", "acct_acme")
 	seedRailMerchantAccount(t, pool, evil.ID.String(), "stripe", "acct_evil")

--- a/internal/merchants/lifecycle.go
+++ b/internal/merchants/lifecycle.go
@@ -110,35 +110,47 @@ func (s *Service) Secrets() MerchantSecretStore { return s.secrets }
 // so provisioning is safe to retry. Default-merchant seeding of catalog/credit
 // definitions is left to the existing bootstrap/seed paths and is not duplicated
 // here.
-func (s *Service) Provision(ctx context.Context, req ProvisionRequest) (*Merchant, error) {
+//
+// The returned bool reports whether THIS call inserted the directory row
+// (true) or the row already existed (false) — derived from the INSERT's own
+// RETURNING, not a separate existence check, so it stays correct under
+// concurrent first-provisions of the same slug: exactly one racing caller
+// observes true (#750).
+func (s *Service) Provision(ctx context.Context, req ProvisionRequest) (*Merchant, bool, error) {
 	slug := normalizeSlug(req.Slug)
 	if slug == "" {
-		return nil, errors.New("merchants: provision requires a slug")
+		return nil, false, errors.New("merchants: provision requires a slug")
 	}
 	// #567: the merchant slug must be a legal AuthKit permission-group instance slug.
 	if err := merchant.ValidateSlug(slug); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	groupID := strings.TrimSpace(req.PermissionGroupID)
 	if groupID == "" {
-		return nil, ErrPermissionGroupRequired
+		return nil, false, ErrPermissionGroupRequired
 	}
 
-	// 1. Upsert the merchant directory row. ON CONFLICT(slug) DO NOTHING keeps the
-	//    existing row, then we re-read so provision is idempotent. The merchant's
-	//    permission-group id is resolved/created by the caller and recorded here.
-	_, err := s.pool.Exec(ctx, `
+	// 1. Insert the merchant directory row. ON CONFLICT(slug) DO NOTHING keeps
+	//    the existing row; RETURNING only yields a row when THIS statement
+	//    performed the insert, which is how `created` is derived race-safely.
+	var insertedID string
+	err := s.pool.QueryRow(ctx, `
 		INSERT INTO openrails.merchants (slug, status, permission_group_id)
 		VALUES ($1, 'active', NULLIF($2,''))
 		ON CONFLICT (slug) DO NOTHING
-	`, slug, groupID)
-	if err != nil {
-		return nil, fmt.Errorf("merchants: insert merchant %q: %w", slug, err)
+		RETURNING id::text
+	`, slug, groupID).Scan(&insertedID)
+	created := true
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		created = false
+	case err != nil:
+		return nil, false, fmt.Errorf("merchants: insert merchant %q: %w", slug, err)
 	}
 
 	t, err := s.merchantBySlug(ctx, slug)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	// 2. Record the merchant's own permission-group id (#567). Idempotent.
@@ -147,11 +159,15 @@ func (s *Service) Provision(ctx context.Context, req ProvisionRequest) (*Merchan
 			   SET permission_group_id = $2, updated_at = current_timestamp
 			 WHERE id = $1::uuid AND permission_group_id IS DISTINCT FROM $2
 		`, t.ID.String(), groupID); uerr != nil {
-		return nil, fmt.Errorf("merchants: record permission group on merchant: %w", uerr)
+		return nil, false, fmt.Errorf("merchants: record permission group on merchant: %w", uerr)
 	}
 	t.PermissionGroupID = groupID
 
-	return s.merchantBySlug(ctx, slug)
+	t, err = s.merchantBySlug(ctx, slug)
+	if err != nil {
+		return nil, false, err
+	}
+	return t, created, nil
 }
 
 // Get returns the merchant directory row by id.

--- a/internal/merchants/lifecycle_integration_test.go
+++ b/internal/merchants/lifecycle_integration_test.go
@@ -202,7 +202,7 @@ func seedArchivedRailMerchantAccount(t *testing.T, svc *Service, merchantID merc
 func TestArchivedRailMerchantAccountRejectsNewWorkButResolvesByAccountID(t *testing.T) {
 	ctx := context.Background()
 	svc := newSvc(t)
-	tn, err := svc.Provision(ctx, ProvisionRequest{Slug: "archived-rail", PermissionGroupID: "group-archived-rail"})
+	tn, _, err := svc.Provision(ctx, ProvisionRequest{Slug: "archived-rail", PermissionGroupID: "group-archived-rail"})
 	require.NoError(t, err)
 
 	const accountID = "archived-nmi-account"
@@ -225,7 +225,7 @@ func TestArchivedRailMerchantAccountRejectsNewWorkButResolvesByAccountID(t *test
 func TestArchivedRailMerchantAccountDrainState(t *testing.T) {
 	ctx := context.Background()
 	svc := newSvc(t)
-	tn, err := svc.Provision(ctx, ProvisionRequest{Slug: "archived-drain", PermissionGroupID: "group-archived-drain"})
+	tn, _, err := svc.Provision(ctx, ProvisionRequest{Slug: "archived-drain", PermissionGroupID: "group-archived-drain"})
 	require.NoError(t, err)
 
 	const accountID = "draining-nmi-account"
@@ -258,28 +258,30 @@ func TestProvision_Idempotent(t *testing.T) {
 	// #500: provisioning a merchant namespace requires the caller to provide the
 	// durable AuthKit permission group id. The lifecycle service does not mint it.
 	req := ProvisionRequest{Slug: "acme", PermissionGroupID: "group-acme"}
-	first, err := svc.Provision(ctx, req)
+	first, created, err := svc.Provision(ctx, req)
 	require.NoError(t, err)
+	require.True(t, created, "first provision inserts the row")
 	require.Equal(t, "acme", first.Slug)
 	require.Equal(t, "group-acme", first.PermissionGroupID, "explicit permission-group link recorded (never auto-minted)")
 
-	// Re-provision: same merchant id, no duplicate row (idempotent).
-	second, err := svc.Provision(ctx, req)
+	// Re-provision: same merchant id, no duplicate row (idempotent), created=false.
+	second, created, err := svc.Provision(ctx, req)
 	require.NoError(t, err)
+	require.False(t, created, "re-provision must not report a fresh insert")
 	require.Equal(t, first.ID, second.ID)
 
 	var count int
 	require.NoError(t, svc.pool.QueryRow(ctx, `SELECT count(*) FROM openrails.merchants WHERE slug='acme'`).Scan(&count))
 	require.Equal(t, 1, count, "provision must not create a duplicate merchant row")
 
-	_, err = svc.Provision(ctx, ProvisionRequest{Slug: "noown"})
+	_, _, err = svc.Provision(ctx, ProvisionRequest{Slug: "noown"})
 	require.ErrorIs(t, err, ErrPermissionGroupRequired, "control-plane provisioning must not create an ownerless merchant")
 }
 
 func TestDelete_RequiresExport(t *testing.T) {
 	ctx := context.Background()
 	svc := newSvc(t)
-	tn, err := svc.Provision(ctx, ProvisionRequest{Slug: "acme", PermissionGroupID: "group-acme"})
+	tn, _, err := svc.Provision(ctx, ProvisionRequest{Slug: "acme", PermissionGroupID: "group-acme"})
 	require.NoError(t, err)
 
 	// Seed a merchant-owned row + a secret so the purge has something to remove.
@@ -323,7 +325,7 @@ func TestDelete_RequiresExport(t *testing.T) {
 func TestCredentialRotation_LoadsRailMerchantAccountScopedSecret(t *testing.T) {
 	ctx := context.Background()
 	svc := newSvc(t)
-	tn, err := svc.Provision(ctx, ProvisionRequest{Slug: "acme", PermissionGroupID: "group-acme"})
+	tn, _, err := svc.Provision(ctx, ProvisionRequest{Slug: "acme", PermissionGroupID: "group-acme"})
 	require.NoError(t, err)
 
 	seedRailMerchantAccount(t, svc, tn.ID, "stripe", "live", "acct_test")
@@ -347,7 +349,7 @@ func TestCredentialRotation_LoadsRailMerchantAccountScopedSecret(t *testing.T) {
 func TestWebhookRouting_ResolvesThenCallerVerifies(t *testing.T) {
 	ctx := context.Background()
 	svc := newSvc(t)
-	tn, err := svc.Provision(ctx, ProvisionRequest{Slug: "acme", PermissionGroupID: "group-acme"})
+	tn, _, err := svc.Provision(ctx, ProvisionRequest{Slug: "acme", PermissionGroupID: "group-acme"})
 	require.NoError(t, err)
 
 	// Resolve by slug.

--- a/internal/merchants/provider_account_webhook_secret_integration_test.go
+++ b/internal/merchants/provider_account_webhook_secret_integration_test.go
@@ -16,7 +16,7 @@ import (
 func TestLoadNMIWebhookSigningSecretForAccount(t *testing.T) {
 	ctx := context.Background()
 	svc := newSvc(t)
-	tn, err := svc.Provision(ctx, ProvisionRequest{Slug: "acme", PermissionGroupID: "group-acme"})
+	tn, _, err := svc.Provision(ctx, ProvisionRequest{Slug: "acme", PermissionGroupID: "group-acme"})
 	require.NoError(t, err)
 
 	// Two NMI accounts on one merchant (mobius primary, paykings secondary).
@@ -54,7 +54,7 @@ func TestLoadNMIWebhookSigningSecretForAccount(t *testing.T) {
 func TestLoadStripeCredentialsForAccount(t *testing.T) {
 	ctx := context.Background()
 	svc := newSvc(t)
-	tn, err := svc.Provision(ctx, ProvisionRequest{Slug: "acme", PermissionGroupID: "group-acme"})
+	tn, _, err := svc.Provision(ctx, ProvisionRequest{Slug: "acme", PermissionGroupID: "group-acme"})
 	require.NoError(t, err)
 
 	seedRailMerchantAccount(t, svc, tn.ID, "stripe", "live", "acct_new")

--- a/internal/merchants/sandbox_posture_integration_test.go
+++ b/internal/merchants/sandbox_posture_integration_test.go
@@ -25,7 +25,7 @@ func TestSandboxPostureResolvesTestScopedCredentials(t *testing.T) {
 	svc, err := NewService(dbp, store, "test")
 	require.NoError(t, err)
 
-	tn, err := svc.Provision(ctx, ProvisionRequest{Slug: "sandbox-681", PermissionGroupID: "group-sandbox-681"})
+	tn, _, err := svc.Provision(ctx, ProvisionRequest{Slug: "sandbox-681", PermissionGroupID: "group-sandbox-681"})
 	require.NoError(t, err)
 
 	// Stripe: test-env account + real secret rows.
@@ -75,7 +75,7 @@ func TestSandboxPostureResolvesTestScopedCredentials(t *testing.T) {
 
 	// Posture isolation: a merchant with ONLY live rows resolves nothing under
 	// test posture (no silent cross-environment bleed).
-	liveOnly, err := svc.Provision(ctx, ProvisionRequest{Slug: "live-only-681", PermissionGroupID: "group-live-only-681"})
+	liveOnly, _, err := svc.Provision(ctx, ProvisionRequest{Slug: "live-only-681", PermissionGroupID: "group-live-only-681"})
 	require.NoError(t, err)
 	seedRailMerchantAccount(t, svc, liveOnly.ID, "stripe", "live", "acct_liveonly681")
 	liveSecretName, err := RailMerchantAccountSecretName("stripe", "live", "acct_liveonly681", "secret_key")

--- a/pkg/billingauth/token.go
+++ b/pkg/billingauth/token.go
@@ -1,0 +1,9 @@
+package billingauth
+
+// TokenAudience is the fixed `aud` claim OpenRails' control plane issues and
+// expects on its own tokens (issued access tokens, delegated self-service
+// tokens, the JWKS-external verifier registration, ...). It is an OpenRails
+// PRODUCT constant, not a per-host/per-deployment config value — every
+// internal mint/verify site and every embedding host must use this exact
+// constant so the two can never drift apart (#750).
+const TokenAudience = "openrails"

--- a/pkg/embedded/controlplane/constants.go
+++ b/pkg/embedded/controlplane/constants.go
@@ -1,0 +1,29 @@
+package controlplane
+
+import (
+	"github.com/open-rails/openrails/internal/controlplane"
+)
+
+// MerchantType / CustomerType re-export the OpenRails permission-group
+// persona strings (#567) so an embedding host doesn't re-type the literals
+// "merchant"/"customer" (#750) when inspecting ListSubjectGroups results or
+// similar. They are aliases for internal/controlplane's own constants — the
+// two can never drift.
+const (
+	MerchantType = controlplane.MerchantType
+	CustomerType = controlplane.CustomerType
+)
+
+// CustomerGroupSlug returns the AuthKit permission-group instance_slug for a
+// user's own customer group. By OpenRails convention (#567) that slug IS the
+// user's own id — EnsureCustomerPermissionGroup and
+// AuthorizePermissionGroupRoute both key off exactly this equality
+// internally. Hosts walking a subject's ListSubjectGroups memberships use
+// this helper (instead of re-deriving the convention as
+// `g.InstanceSlug == userID`) to recognize a `CustomerType` membership as the
+// caller's own self-owned group, e.g.:
+//
+//	if g.Persona == embcp.CustomerType && g.InstanceSlug == embcp.CustomerGroupSlug(userID) { ... }
+func CustomerGroupSlug(userID string) string {
+	return userID
+}

--- a/pkg/embedded/controlplane/controlplane.go
+++ b/pkg/embedded/controlplane/controlplane.go
@@ -39,10 +39,10 @@ import (
 // authcore.Config (the AuthKit engine):
 //   - Token (Issuer/Audiences/durations/SessionMaxPerUser): NOT forwarded.
 //     Issuer comes from cfg.Auth.Issuer (already host-configurable at the
-//     config layer); the "openrails" audience is an OpenRails product
-//     constant, not a per-host dial (#750 tracks exporting it as a named
-//     constant instead of a literal). Token durations/session caps have no
-//     AttachOptions knob yet — an open gap, not yet requested by a host.
+//     config layer); the audience is the OpenRails product constant
+//     billingauth.TokenAudience, not a per-host dial (#750). Token
+//     durations/session caps have no AttachOptions knob yet — an open gap,
+//     not yet requested by a host.
 //   - Frontend: FORWARDED (this issue) via AttachOptions.Frontend.
 //   - Registration: NOT a raw forward. OpenRails computes it from
 //     HostedPosture (open+required vs closed+none) — this is product policy

--- a/pkg/embedded/controlplane/provision.go
+++ b/pkg/embedded/controlplane/provision.go
@@ -30,6 +30,12 @@ type ProvisionMerchantRequest struct {
 	OwnerUserID string
 }
 
+// ErrInvalidSlug wraps pkg/merchant's slug-validation error (errors.Is-able)
+// so a host can map a bad slug to 400 without string-matching the error
+// text. The validation detail (pkg/merchant.ValidateSlug's own message) is
+// preserved in the wrap.
+var ErrInvalidSlug = errors.New("control plane provision: invalid slug")
+
 // ProvisionMerchantResult reports what ProvisionMerchant ensured.
 type ProvisionMerchantResult struct {
 	// MerchantID is the openrails.merchants directory row id.
@@ -63,7 +69,7 @@ func ProvisionMerchant(ctx context.Context, a *app.App, req ProvisionMerchantReq
 	}
 	slug := merchant.NormalizeSlug(req.Slug)
 	if err := merchant.ValidateSlug(slug); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrInvalidSlug, err)
 	}
 	owner := strings.TrimSpace(req.OwnerUserID)
 
@@ -77,6 +83,31 @@ func ProvisionMerchant(ctx context.Context, a *app.App, req ProvisionMerchantReq
 
 	// Resolve-or-create the merchant permission-group — the merchant IS the
 	// group (#567): type=merchant, resourceRef=slug, parent=root.
+	//
+	// Race handling (#750): two concurrent first-creates of the same fresh
+	// slug both observe ErrGroupNotFound and race CreatePermissionGroup; the
+	// loser hits the DB's uniqueness constraint on (persona, instance_slug),
+	// which authkit's PermissionGroupStore.CreateGroup wraps in a bare
+	// fmt.Errorf (no stable "already exists" sentinel to errors.Is against —
+	// confirmed against authkit v0.80.0). Rather than string-matching that
+	// error, the loser re-resolves once: if the winner's row is now visible,
+	// the loser proceeds exactly like any other already-provisioned merchant
+	// (groupCreated stays false) — the SAME retry-resolve pattern
+	// EnsureCustomerPermissionGroup already uses for the identical race on
+	// customer groups (customer_group.go). Only when the re-resolve ALSO
+	// fails do we conclude CreatePermissionGroup's error was a genuine
+	// failure (DB outage, etc.), not a slug race, and return it wrapped as
+	// before (hosts 500 it).
+	//
+	// Deliberately no ErrSlugTaken sentinel: the retry-resolve converts every
+	// race loser into the ordinary Created=false idempotent path callers
+	// already handle — a genuine slug conflict (a pre-existing merchant owned
+	// by someone else) is ALSO Created=false, and hosts distinguish "mine"
+	// vs. "taken" by checking ownership afterward (see
+	// openrails-saas/internal/api/accounts.go's handleCreateMerchant). If a
+	// future authkit release exposes a stable duplicate-group sentinel,
+	// mapping it to a typed ErrSlugTaken here — skipping the extra
+	// round-trip — is a non-breaking follow-up.
 	groupCreated := false
 	groupID, err := core.ResolveGroupIDForSlug(ctx, controlplane.MerchantType, slug)
 	switch {
@@ -88,27 +119,31 @@ func ProvisionMerchant(ctx context.Context, a *app.App, req ProvisionMerchantReq
 			OwnerSubjectID: owner,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("control plane provision: create merchant group %q: %w", slug, err)
+			createErr := err
+			if resolvedID, rerr := core.ResolveGroupIDForSlug(ctx, controlplane.MerchantType, slug); rerr == nil {
+				groupID = resolvedID
+			} else {
+				return nil, fmt.Errorf("control plane provision: create merchant group %q: %w", slug, createErr)
+			}
+		} else {
+			groupCreated = true
 		}
-		groupCreated = true
 	case err != nil:
 		return nil, fmt.Errorf("control plane provision: resolve merchant group %q: %w", slug, err)
 	}
 
 	// Create/link the directory row (permission_group_id) via the merchants
 	// lifecycle slice — the same row bootstrap requires to pre-exist (#480);
-	// runtime provisioning creates it.
+	// runtime provisioning creates it. Provision's own `rowCreated` return
+	// (derived from its INSERT ... RETURNING, not a separate existence check)
+	// is what stays race-safe under concurrent first-provisions of the same
+	// slug — a pre-check-then-insert here would let both racers observe
+	// "did not yet exist" and both wrongly report Created=true.
 	dir, err := merchants.NewDirectoryService(cp.Pool())
 	if err != nil {
 		return nil, fmt.Errorf("control plane provision: build merchant directory service: %w", err)
 	}
-	rowExisted := true
-	if _, gerr := dir.GetBySlug(ctx, slug); errors.Is(gerr, merchants.ErrMerchantNotFound) {
-		rowExisted = false
-	} else if gerr != nil {
-		return nil, fmt.Errorf("control plane provision: resolve merchant directory row %q: %w", slug, gerr)
-	}
-	m, err := dir.Provision(ctx, merchants.ProvisionRequest{Slug: slug, PermissionGroupID: groupID})
+	m, rowCreated, err := dir.Provision(ctx, merchants.ProvisionRequest{Slug: slug, PermissionGroupID: groupID})
 	if err != nil {
 		return nil, fmt.Errorf("control plane provision: provision merchant directory row %q: %w", slug, err)
 	}
@@ -116,6 +151,6 @@ func ProvisionMerchant(ctx context.Context, a *app.App, req ProvisionMerchantReq
 	return &ProvisionMerchantResult{
 		MerchantID: m.ID,
 		GroupID:    groupID,
-		Created:    groupCreated || !rowExisted,
+		Created:    groupCreated || rowCreated,
 	}, nil
 }

--- a/pkg/embedded/controlplane/provision_integration_test.go
+++ b/pkg/embedded/controlplane/provision_integration_test.go
@@ -207,6 +207,59 @@ func TestHostedPosture_RegisterVerifyProvision(t *testing.T) {
 	require.Contains(t, err.Error(), "no control plane attached")
 }
 
+// TestProvisionMerchant_ConcurrentFirstCreateRace proves the #750 race design
+// end-to-end: two goroutines calling ProvisionMerchant for the SAME fresh slug
+// at once must both succeed with the identical MerchantID/GroupID, and
+// exactly one observes Created=true. ProvisionMerchant's retry-resolve (see
+// its doc comment) — not a separate ErrSlugTaken sentinel — converts the race
+// loser into the ordinary idempotent path. Repeated across several fresh
+// slugs so the goroutine-scheduling race is likely to actually overlap inside
+// the DB (CreatePermissionGroup's unique-constraint conflict).
+func TestProvisionMerchant_ConcurrentFirstCreateRace(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+	cfg := hostedTestConfig(dsn, "https://race.openrails.test")
+	e := newHostApp(t, cfg)
+	require.NoError(t, embcp.Attach(ctx, e.App(), cfg, nil))
+
+	// Warm up the root group/containment (idempotent, but not the race under
+	// test) with a throwaway slug first, so every iteration below races ONLY
+	// on the merchant group's own creation — matching how a real deployment's
+	// bootstrap already runs ahead of user-triggered provisioning.
+	_, err := embcp.ProvisionMerchant(ctx, e.App(), embcp.ProvisionMerchantRequest{
+		Slug: "race-warmup-" + strings.ToLower(uuid.NewString()[:8]),
+	})
+	require.NoError(t, err)
+
+	const iterations = 5
+	for i := 0; i < iterations; i++ {
+		slug := "race-" + strings.ToLower(uuid.NewString()[:8])
+
+		var wg sync.WaitGroup
+		results := make([]*embcp.ProvisionMerchantResult, 2)
+		errs := make([]error, 2)
+		start := make(chan struct{})
+		for g := 0; g < 2; g++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				<-start
+				results[idx], errs[idx] = embcp.ProvisionMerchant(ctx, e.App(), embcp.ProvisionMerchantRequest{
+					Slug: slug,
+				})
+			}(g)
+		}
+		close(start)
+		wg.Wait()
+
+		require.NoError(t, errs[0], "iteration %d goroutine 0", i)
+		require.NoError(t, errs[1], "iteration %d goroutine 1", i)
+		require.Equal(t, results[0].MerchantID, results[1].MerchantID, "iteration %d: same merchant id", i)
+		require.Equal(t, results[0].GroupID, results[1].GroupID, "iteration %d: same group id", i)
+		require.NotEqual(t, results[0].Created, results[1].Created, "iteration %d: exactly one Created=true", i)
+	}
+}
+
 // TestSelfHostedPosture_RegistrationStaysClosed guards the default posture: a
 // plain Attach (no options, no sender) still boots, and the public registration
 // surface is not mounted.

--- a/pkg/merchant/reserved.go
+++ b/pkg/merchant/reserved.go
@@ -1,0 +1,18 @@
+package merchant
+
+// ReservedHostedSlugs is an advisory DEFAULT reserved-slug list for hosted
+// products where merchants self-provision by slug over code paths
+// (merchant_source=api, #738): platform routes, brand terms, and common
+// infrastructure subdomains a hosted product typically must not let a
+// merchant claim (seeded from openrails-saas's own list, #750).
+//
+// ValidateSlug deliberately does NOT consult this: slug MECHANISM (charset,
+// length, shape) is this package's job; slug RESERVATION is host policy. A
+// host is free to use this list verbatim, extend it, replace it outright, or
+// ignore it — nothing in this package reads it.
+var ReservedHostedSlugs = []string{
+	"www", "api", "app", "admin", "auth",
+	"billing", "platform", "openrails", "saas",
+	"docs", "status", "support", "dev", "staging",
+	"checkout", "pay", "root", "internal",
+}


### PR DESCRIPTION
## Summary

- `ProvisionMerchant` returns `errors.Is`-able `ErrInvalidSlug` instead of a bare `fmt.Errorf`. The concurrent first-create race (two goroutines racing `CreatePermissionGroup` for the same fresh slug — the loser hits authkit's DB unique-constraint violation, confirmed no stable sentinel exists in authkit v0.80.0) retry-resolves once and converts the race loser into the ordinary `Created=false` idempotent path, mirroring the existing `EnsureCustomerPermissionGroup` pattern (`internal/controlplane/customer_group.go`). **No `ErrSlugTaken` sentinel** — the retry-resolve makes every race loser indistinguishable from an ordinary already-provisioned merchant, which callers already handle (see doc comment on `ProvisionMerchant` for the full reasoning and the non-breaking follow-up path if authkit ever exposes a stable duplicate-group sentinel).
- Found and fixed a **second, latent race** while wiring the integration test: `merchants.Service.Provision`'s directory-row creation used a pre-check-then-insert (`GetBySlug` then `INSERT ... ON CONFLICT DO NOTHING`), which let both racers observe "row does not exist yet" and both report `Created=true`. `Provision` now derives `created` from the `INSERT ... RETURNING`'s own result (signature changed to `(*Merchant, bool, error)`; its two callers updated).
- Exported the constants hosts were re-hardcoding (#750's second half):
  - `billingauth.TokenAudience = "openrails"` — wired through `internal/controlplane/service.go`'s `IssuedAudiences`/`ExpectedAudiences`/verifier/delegated-audience sites so mint and verify can't drift.
  - `embcp.MerchantType` / `embcp.CustomerType` — aliases of `internal/controlplane`'s own persona constants.
  - `embcp.CustomerGroupSlug(userID string) string` — documents/encodes the "customer group instance_slug == user id" convention hosts were re-deriving.
  - `merchant.ReservedHostedSlugs` — an advisory DEFAULT reserved-slug list for hosted products (seeded from openrails-saas's own list), explicitly NOT wired into `ValidateSlug` (mechanism stays pure; reservation is host policy).

## Test plan

- [x] `gofmt -l` clean on all changed/new files
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` clean
- [x] `go test -count=1 ./...` green
- [x] `go test -tags=integration -count=1 ./pkg/embedded/controlplane/...` green, including new `TestProvisionMerchant_ConcurrentFirstCreateRace` (two goroutines, 5 fresh-slug iterations; verified meaningful by temporarily reverting the retry-resolve and confirming the test fails with the exact unique-constraint error the design targets)
- [x] `go test -tags=integration -count=1 ./internal/controlplane/... ./internal/merchants/... ./internal/bootstrap/... ./internal/http/...` green, modulo the pre-existing unrelated `TestFindingsQueueApproveCCBillCancelAndRefund` failure (reproduced identically on a clean `origin/master` checkout — see #742/#744/#745/#748 notes for the same finding)

Not in this PR (per the issue's own scoping): updating openrails-saas to consume the new constants/errors — that rides the next engine version bump.