### PR TITLE
Vestigial-surface cleanup + River-fold recipe (#749); inline-PEM warning (#752); BuildTransit Supervisor gap (#751)

### DIFF
--- a/embed/embed.go
+++ b/embed/embed.go
@@ -46,13 +46,6 @@ func WithAdminConsole(assets fs.FS) Option {
 	return func(o *Options) { o.ConsoleAssets = assets }
 }
 
-// HandlerOptions selects the HTTP route groups for Runtime.Handler. It is
-// pkg/embedded.HTTPHandlerOptions; zero value uses EmbeddedDefaultRouteSets.
-type HandlerOptions = embedded.HTTPHandlerOptions
-
-// ProviderRoutes selects provider-specific public routes for HandlerOptions.
-type ProviderRoutes = embedded.ProviderRoutes
-
 // RouteSet names a mountable billing HTTP route group.
 type RouteSet = embedded.RouteSet
 
@@ -202,18 +195,9 @@ func (r *Runtime) Service() *service.Service { return r.svc }
 // (control plane attach, river client injection, embedded.MountHandler).
 func (r *Runtime) Embedded() *embedded.Embedded { return r.emb }
 
-// Handler returns the mountable embedded HTTP surface (/billing/v1/*) — a thin
-// passthrough to pkg/embedded.NewHTTPHandler (which records the active route sets
-// for ActiveRouteSets / capability discovery). The service-credential-authenticated
-// /billing/v1/merchant/* surface is opt-in via embedded.RouteSetMerchantAPI; an
-// embedded host normally uses Client() instead.
-func (r *Runtime) Handler(opts HandlerOptions) http.Handler {
-	return r.emb.NewHTTPHandler(opts)
-}
-
 // ActiveRouteSets returns the route groups of the most recently mounted HTTP
-// surface (Handler or embedded.MountHandler); nil before any mount. It is the
-// in-process twin of GET /v1/capabilities — same source.
+// surface (embedded.MountHandler); nil before any mount. It is the in-process
+// twin of GET /v1/capabilities — same source.
 func (r *Runtime) ActiveRouteSets() []RouteSet {
 	if r == nil {
 		return nil

--- a/embed/river_fold_integration_test.go
+++ b/embed/river_fold_integration_test.go
@@ -1,0 +1,108 @@
+//go:build integration
+
+package embed_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+	riverpgxv5 "github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/embed"
+	"github.com/open-rails/openrails/internal/dbtest"
+	riverjobs "github.com/open-rails/openrails/internal/river"
+	"github.com/open-rails/openrails/pkg/embedded"
+)
+
+// noopWorker is a trivial host worker folded into the SAME registry as
+// billing's workers, proving FoldIntoRiver's contract: workers must be fixed
+// BEFORE river.NewClient, so both the host's own worker and billing's workers
+// must already be in the same *river.Workers by the time the client is built.
+type noopJobArgs struct{}
+
+func (noopJobArgs) Kind() string { return "embed_test_noop" }
+
+type noopWorker struct {
+	river.WorkerDefaults[noopJobArgs]
+}
+
+func (noopWorker) Work(context.Context, *river.Job[noopJobArgs]) error { return nil }
+
+// TestFoldIntoRiver_HostSharedClientDrainsBillingJobs proves the #546 recipe
+// end-to-end: fold billing's workers/periodic jobs into a host-owned
+// river.Workers/river.Client (the exact shape doujins/hentai0 hand-wrote as
+// Service.RegisterRiverWorkers/RegisterRiverClient), then confirm the
+// resulting SHARED client (a) is the one the embedded engine now reports via
+// HasExternalRiverClient, (b) actually drains a billing job enqueued through
+// it, and (c) surfaces billing's periodic jobs for the host to register.
+func TestFoldIntoRiver_HostSharedClientDrainsBillingJobs(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+
+	rt, err := embed.New(ctx, embed.Options{
+		Options: embedded.Options{
+			Config: &config.Config{
+				Env:      "dev",
+				TestMode: config.CredentialPostureSandbox,
+				DB:       &config.DBConfig{URL: dsn},
+			},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rt.Close(context.Background()) })
+
+	emb := rt.Embedded()
+	require.False(t, emb.HasExternalRiverClient(), "no client injected yet")
+
+	// Host builds its own worker registry with its own worker already added —
+	// FoldIntoRiver must be callable on top of that, not require an empty one.
+	workers := river.NewWorkers()
+	river.AddWorkerSafely(workers, &noopWorker{})
+
+	periodic, register, err := embedded.FoldIntoRiver(ctx, emb, workers)
+	require.NoError(t, err)
+	require.NotEmpty(t, periodic, "billing has at least one periodic job to fold in")
+
+	pool, err := pgxpool.New(ctx, dsn)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	client, err := river.NewClient(riverpgxv5.New(pool), &river.Config{
+		Queues: map[string]river.QueueConfig{
+			river.QueueDefault:     {MaxWorkers: 2},
+			riverjobs.QueueBilling: {MaxWorkers: 2},
+		},
+		Workers: workers,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, register(client))
+	require.True(t, emb.HasExternalRiverClient(), "register must inject the client (SetRiverClient)")
+
+	require.NoError(t, client.Start(ctx))
+	t.Cleanup(func() { _ = client.Stop(context.Background()) })
+
+	// A billing job enqueued through the SHARED client is drained by the
+	// billing worker FoldIntoRiver added to `workers` — proving AddWorkersTo
+	// actually wired the worker, not just that the call didn't error.
+	res, err := client.Insert(ctx, riverjobs.CleanupExpiredDataArgs{}, &river.InsertOpts{Queue: riverjobs.QueueBilling})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		var state string
+		row := pool.QueryRow(ctx, `SELECT state FROM river_job WHERE id = $1`, res.Job.ID)
+		return row.Scan(&state) == nil && state == "completed"
+	}, 5*time.Second, 100*time.Millisecond, "billing job must complete on the host's shared client")
+}
+
+// TestFoldIntoRiver_NilEmbeddedErrors pins the not-initialized guard: calling
+// FoldIntoRiver before the engine exists must error, not panic.
+func TestFoldIntoRiver_NilEmbeddedErrors(t *testing.T) {
+	_, _, err := embedded.FoldIntoRiver(context.Background(), nil, river.NewWorkers())
+	require.ErrorIs(t, err, embedded.ErrNotInitialized)
+}

--- a/internal/bootstrap/merchant_manifest.go
+++ b/internal/bootstrap/merchant_manifest.go
@@ -584,19 +584,19 @@ func ReconcileMerchantManifestData(ctx context.Context, cfg *config.Config, cp *
 // are NOT persisted — the running server holds its own from its boot manifest).
 func manifestReconcileSecretStore(ctx context.Context, cfg *config.Config, cp *controlplane.ControlPlane, opts MerchantManifestReconcileOptions) (merchants.MerchantSecretStore, solana.TransitClient, error) {
 	if opts.SecretStore != nil {
-		transit, err := merchantsecrets.BuildTransit(ctx, cfg)
+		transitStore, err := merchantsecrets.BuildTransit(ctx, cfg)
 		if err != nil {
 			return nil, nil, fmt.Errorf("merchant bootstrap: %w", err)
 		}
-		return opts.SecretStore, transit, nil
+		return opts.SecretStore, transitStore.SolanaTransit, nil
 	}
 	if cfg.IsManifestMerchantSource() {
 		log.Info("merchant bootstrap: merchant_source=manifest — DB projections reconcile; secrets validate in memory only and are NOT persisted (#723: the server loads them from its boot manifest)")
-		transit, err := merchantsecrets.BuildTransit(ctx, cfg)
+		transitStore, err := merchantsecrets.BuildTransit(ctx, cfg)
 		if err != nil {
 			return nil, nil, fmt.Errorf("merchant bootstrap: %w", err)
 		}
-		return merchants.NewMemorySecretStore(), transit, nil
+		return merchants.NewMemorySecretStore(), transitStore.SolanaTransit, nil
 	}
 	secretBackend, err := merchantsecrets.Build(ctx, cfg, cp.Pool())
 	if err != nil {

--- a/internal/controlplane/bootstrap.go
+++ b/internal/controlplane/bootstrap.go
@@ -209,9 +209,11 @@ func (c *ControlPlane) ensureBootstrapAPIKeyActor(ctx context.Context) (string, 
 	return u.ID, nil
 }
 
-// EnsureMerchantAPIKeyActor returns the genesis actor used for operator CLI
-// API-key mints and ensures it is allowed to mint the requested merchant role.
-func (c *ControlPlane) EnsureMerchantAPIKeyActor(ctx context.Context, merchantSlug string) (string, error) {
+// ensureMerchantAPIKeyActor returns the genesis actor used as the CreatedBy
+// fallback when MintMerchantAPIKey (#757) is called with no resolvable
+// AuthKit user (operator CLI, admin API key, in-process host, delegated
+// token), and ensures that actor holds the requested merchant role.
+func (c *ControlPlane) ensureMerchantAPIKeyActor(ctx context.Context, merchantSlug string) (string, error) {
 	merchantSlug = strings.ToLower(strings.TrimSpace(merchantSlug))
 	if merchantSlug == "" {
 		return "", errors.New("controlplane: merchant slug is required")

--- a/internal/controlplane/issuer_registry.go
+++ b/internal/controlplane/issuer_registry.go
@@ -36,18 +36,6 @@ func (c *ControlPlane) ReloadRemoteApplications(ctx context.Context) error {
 	return c.loadRemoteApplications(ctx)
 }
 
-// BrowserCORSOrigins returns the default browser Origin allow-list for standalone
-// CORS. AuthKit no longer owns remote-application origins, so the control plane
-// has no AuthKit-derived browser allow-list; hosts that want browser CORS should
-// wire an OpenRails-owned source at the server layer.
-func (c *ControlPlane) BrowserCORSOrigins(ctx context.Context) ([]string, error) {
-	_ = ctx
-	if c == nil || c.delegatedVerifier == nil {
-		return nil, ErrDelegatedNotConfigured
-	}
-	return nil, nil
-}
-
 // merchantForIssuer resolves the OpenRails MERCHANT a VALIDATED token issuer may
 // act on (#567). The chain is group-based, never identity: validated `iss` ->
 // AuthKit remote_application -> its controlling permission-group id (the merchant

--- a/internal/controlplane/merchant_api_keys.go
+++ b/internal/controlplane/merchant_api_keys.go
@@ -113,7 +113,7 @@ func (c *ControlPlane) MintMerchantAPIKey(ctx context.Context, mid merchant.ID, 
 	}
 	actorUserID = strings.TrimSpace(actorUserID)
 	if actorUserID == "" {
-		actorUserID, err = c.EnsureMerchantAPIKeyActor(ctx, slug)
+		actorUserID, err = c.ensureMerchantAPIKeyActor(ctx, slug)
 		if err != nil {
 			return MerchantAPIKey{}, "", err
 		}

--- a/internal/controlplane/service.go
+++ b/internal/controlplane/service.go
@@ -223,6 +223,14 @@ func resolveControlPlaneKeySource(cfg *config.Config) (jwtkit.KeySource, error) 
 		if err != nil {
 			return nil, fmt.Errorf("controlplane: load JWT keys from ACTIVE_KEY_ID/ACTIVE_PRIVATE_KEY_PEM: %w", err)
 		}
+		// #752: inline PEM is frozen for the process lifetime by construction —
+		// unlike keys_path (FILE-watched, hot-rotates), there is no way to rotate
+		// or emergency-revoke this key without a restart. Development is exempt
+		// (short-lived, disposable processes); every other environment gets a
+		// loud, one-time-per-boot heads-up naming the tradeoff.
+		if !cfg.IsDev() {
+			log.Warnf("controlplane: signing keys loaded from inline PEM (ACTIVE_KEY_ID/ACTIVE_PRIVATE_KEY_PEM) outside development — this key is FROZEN for the process lifetime: no hot rotation and no emergency revocation without a restart. keys_path (%s) is the FILE-watched, hot-rotating production path (#752); switch to it if you need no-restart key rotation or revocation.", jwtkit.DefaultAuthKeysPath)
+		}
 		return ks, nil
 	}
 	keysPath := strings.TrimSpace(cfg.Auth.KeysPath)

--- a/internal/controlplane/service_test.go
+++ b/internal/controlplane/service_test.go
@@ -2,10 +2,114 @@ package controlplane
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
 	"testing"
+
+	log "github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 
 	"github.com/open-rails/openrails/config"
 )
+
+// testEd25519PrivateKeyPEM generates a throwaway ed25519 private key PEM
+// (PKCS8), the smallest key type resolveControlPlaneKeySource's
+// jwtkit.NewStaticKeySourceFromPEM accepts.
+func testEd25519PrivateKeyPEM(t *testing.T) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate ed25519 key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal pkcs8 key: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+}
+
+// TestResolveControlPlaneKeySource_InlinePEMWarnsOutsideDev pins #752: inline
+// ACTIVE_PRIVATE_KEY_PEM is frozen for the process lifetime (no hot rotation,
+// no emergency revocation without a restart) — a non-development boot on this
+// path must say so loudly.
+func TestResolveControlPlaneKeySource_InlinePEMWarnsOutsideDev(t *testing.T) {
+	cfg := &config.Config{
+		Env: "production",
+		Auth: &config.AuthConfig{
+			ActiveKeyID:         "test-key",
+			ActivePrivateKeyPEM: testEd25519PrivateKeyPEM(t),
+		},
+	}
+
+	hook := logtest.NewGlobal()
+	defer hook.Reset()
+
+	if _, err := resolveControlPlaneKeySource(cfg); err != nil {
+		t.Fatalf("resolveControlPlaneKeySource: %v", err)
+	}
+
+	var warned bool
+	for _, e := range hook.AllEntries() {
+		if e.Level == log.WarnLevel && strings.Contains(e.Message, "inline PEM") && strings.Contains(e.Message, "FROZEN") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatal("expected a non-development inline-PEM rotation-tradeoff warning")
+	}
+}
+
+// TestResolveControlPlaneKeySource_InlinePEMSilentInDev: development is
+// exempt (short-lived, disposable processes) — no warning noise there.
+func TestResolveControlPlaneKeySource_InlinePEMSilentInDev(t *testing.T) {
+	cfg := &config.Config{
+		Env: "development",
+		Auth: &config.AuthConfig{
+			ActiveKeyID:         "test-key",
+			ActivePrivateKeyPEM: testEd25519PrivateKeyPEM(t),
+		},
+	}
+
+	hook := logtest.NewGlobal()
+	defer hook.Reset()
+
+	if _, err := resolveControlPlaneKeySource(cfg); err != nil {
+		t.Fatalf("resolveControlPlaneKeySource: %v", err)
+	}
+
+	for _, e := range hook.AllEntries() {
+		if e.Level == log.WarnLevel && strings.Contains(e.Message, "inline PEM") {
+			t.Fatalf("unexpected inline-PEM warning in development: %q", e.Message)
+		}
+	}
+}
+
+// TestResolveControlPlaneKeySource_KeysPathNoWarning: the keys_path/keys.json
+// delivery route is the hot-rotating prod path — it must never trip the #752
+// inline-PEM warning, even outside development.
+func TestResolveControlPlaneKeySource_KeysPathNoWarning(t *testing.T) {
+	cfg := &config.Config{
+		Env: "production",
+		Auth: &config.AuthConfig{
+			KeysPath: t.TempDir(),
+		},
+	}
+
+	hook := logtest.NewGlobal()
+	defer hook.Reset()
+
+	// No keys.json present and not dev -> ResolveKeySource is expected to
+	// error; only the ABSENCE of the inline-PEM warning is under test here.
+	_, _ = resolveControlPlaneKeySource(cfg)
+
+	for _, e := range hook.AllEntries() {
+		if e.Level == log.WarnLevel && strings.Contains(e.Message, "inline PEM") {
+			t.Fatalf("unexpected inline-PEM warning for keys_path delivery: %q", e.Message)
+		}
+	}
+}
 
 func TestNew_RequiresAuthIssuer(t *testing.T) {
 	// HARD CUT (#469): the control plane is mandatory; standalone needs an

--- a/internal/http/routes/routes.go
+++ b/internal/http/routes/routes.go
@@ -665,19 +665,27 @@ func registerMerchantSupportRoutes(rr router.Router, opts Options, dbMW ...route
 	findings.Handle(http.MethodPost, "/:id/resolve", h(httphandlers.AdminResolveFinding), findingsResolve...)
 }
 
-// RegisterWebhookRoutes mounts the legacy configured-merchant webhook surface.
-// Standalone and embedded defaults do not call this; hosts should prefer
-// RegisterMerchantWebhookRoutes.
+// RegisterWebhookRoutes mounts the CANONICAL standalone webhook surface (#650):
+// POST /webhooks/:provider (NMI/CCBill; the merchant is derived from the
+// payload's account identity, not the path) and /webhooks/:provider/:account_id
+// (direct Stripe). This is the live production entry point for inbound
+// NMI/CCBill webhooks — standalone mounts it. Embedded hosts use
+// RegisterMerchantWebhookRoutes instead, since they pin one merchant in context
+// and have no payload-derived merchant to resolve.
 func RegisterWebhookRoutes(rr router.Router, rt *app.Runtime) {
 	rr.Handle(http.MethodPost, "/:provider/:account_id", h(httphandlers.Webhook))
 	rr.Handle(http.MethodPost, "/:provider", h(httphandlers.Webhook))
 }
 
-// RegisterMerchantWebhookRoutes mounts the CANONICAL merchant-scoped webhook surface
-// (POST /merchants/:merchant/webhooks/:provider, issue #529) — the active inbound
-// webhook surface for every deployment. One handler (httphandlers.MerchantWebhook,
-// Stripe + NMI-backed rails + CCBill) is shared by both the standalone gin server and the
-// embedded mux, so the two cannot drift.
+// RegisterMerchantWebhookRoutes mounts the merchant-scoped webhook surface
+// (POST /merchants/:merchant/webhooks/:provider, issue #529): the merchant is
+// resolved from the URL slug, then THAT merchant's signing secret verifies the
+// payload. Embedded hosts mount this as their only webhook surface (a pinned
+// merchant needs no payload-derived resolution); standalone also mounts it
+// alongside RegisterWebhookRoutes as a transition alias for integrations
+// already using this URL shape. One handler (httphandlers.MerchantWebhook,
+// Stripe + NMI-backed rails + CCBill) is shared by both the standalone gin
+// server and the embedded mux, so the two cannot drift.
 func RegisterMerchantWebhookRoutes(rr router.Router, rt *app.Runtime) {
 	rr.Handle(http.MethodPost, "/merchants/:merchant/webhooks/:provider", h(httphandlers.MerchantWebhook))
 	// #641: per-account endpoint — account_id in the path selects which account the

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -74,8 +74,9 @@ type Server struct {
 	merchants *merchants.Service
 
 	// browserCORSOriginSource is the standalone browser CORS origin source.
-	// Production leaves this nil and reads AuthKit remote_application state via
-	// controlPlane; tests can override it without a live database.
+	// OpenRails ships no default: AuthKit no longer owns remote-application
+	// origins, so unset means no browser CORS. A host that wants browser CORS
+	// wires an OpenRails-owned source here.
 	browserCORSOriginSource middleware.CORSOriginSource
 
 	// publicHandler is the single "full surface" HTTP handler: health + user +
@@ -430,10 +431,7 @@ func (s *Server) browserCORSOrigins(ctx context.Context) ([]string, error) {
 	if s != nil && s.browserCORSOriginSource != nil {
 		return s.browserCORSOriginSource(ctx)
 	}
-	if s == nil || s.controlPlane == nil {
-		return nil, controlplane.ErrDelegatedNotConfigured
-	}
-	return s.controlPlane.BrowserCORSOrigins(ctx)
+	return nil, nil
 }
 
 // Handler returns the full public HTTP surface: health + user + self/customer

--- a/internal/merchantsecrets/store.go
+++ b/internal/merchantsecrets/store.go
@@ -245,35 +245,37 @@ func BuildManifest(ctx context.Context, cfg *config.Config, store *merchants.Man
 	if store == nil {
 		return nil, fmt.Errorf("build manifest secret plane: store is required")
 	}
-	transit, err := BuildTransit(ctx, cfg)
+	transitStore, err := BuildTransit(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
 	return &Store{
 		Secrets:       store,
-		SolanaTransit: transit,
+		SolanaTransit: transitStore.SolanaTransit,
 		SolanaCanSign: true,
 		SecretWrite:   true,
+		VaultAuth:     transitStore.VaultAuth,
+		vclient:       transitStore.vclient,
 	}, nil
 }
 
 // BuildTransit opens the Vault Transit signing client when Vault is enabled
-// (nil otherwise). Standalone of the KV store — MODE 1 uses it for Solana
-// vault_transit signers with no KV backend at all.
+// (a zero-value *Store, SolanaTransit nil, otherwise). Standalone of the KV
+// store — MODE 1 uses it for Solana vault_transit signers with no KV backend
+// at all.
 //
-// The #751 re-auth Supervisor still runs in the background here (Login
-// starts it unconditionally) — the transit client's token stays fresh across
-// re-logins the same as the KV path's — but its AuthState() handle is
-// discarded because this exported function's signature is depended on
-// outside this package (internal/bootstrap, pkg/embedded); a future readiness
-// wiring (#748) that wants transit-only auth health will need a small
-// signature change here, noted in the tracker for that follow-up.
-func BuildTransit(ctx context.Context, cfg *config.Config) (solanaint.TransitClient, error) {
+// Threaded like the KV path in Build (#751 follow-up): the Supervisor from
+// vault.Login is kept on the returned Store (VaultAuth) and vclient is kept
+// too, so Store.Ping folds in auth-health + reachability for transit-only
+// connections exactly as it does for the KV path — callers that only need the
+// transit client read Store.SolanaTransit; callers that also want liveness
+// call Store.Ping.
+func BuildTransit(ctx context.Context, cfg *config.Config) (*Store, error) {
 	if cfg == nil || cfg.Vault == nil || !cfg.Vault.Enabled {
-		return nil, nil
+		return &Store{}, nil
 	}
 	vc := cfg.Vault
-	client, _, err := vault.Login(ctx, vault.Config{
+	client, sup, err := vault.Login(ctx, vault.Config{
 		Address:    vc.Address,
 		AuthMethod: vc.AuthMethod,
 		Token:      vc.Token,
@@ -284,7 +286,11 @@ func BuildTransit(ctx context.Context, cfg *config.Config) (solanaint.TransitCli
 	if err != nil {
 		return nil, fmt.Errorf("vault login: %w", err)
 	}
-	return vault.NewTransitAdapter(client, vaultTransitMount), nil
+	return &Store{
+		SolanaTransit: vault.NewTransitAdapter(client, vaultTransitMount),
+		VaultAuth:     sup,
+		vclient:       client,
+	}, nil
 }
 
 // enforceEncryptionPosture is the #667 boot gate on the DB-backed (fallback)

--- a/internal/merchantsecrets/vault_scenarios_integration_test.go
+++ b/internal/merchantsecrets/vault_scenarios_integration_test.go
@@ -299,6 +299,37 @@ func TestVaultCapabilityGating_RealPolicies(t *testing.T) {
 	})
 }
 
+// --- #751 follow-up: BuildTransit threads the Supervisor onto its Store --------
+
+// TestBuildTransit_ThreadsVaultAuthForTransitOnlyConnections proves the #751
+// gap closed: a transit-only Vault connection (no KV access at all — the MODE
+// 1 vault_transit-signer shape) now gets the SAME re-auth supervision + Ping
+// liveness signal the KV path already had, instead of silently discarding the
+// Supervisor vault.Login handed back.
+func TestBuildTransit_ThreadsVaultAuthForTransitOnlyConnections(t *testing.T) {
+	ctx := context.Background()
+	addr, _ := vaulttest.Addr(t)
+	toToken := vaulttest.TokenWithPolicy(t, "or-ms-buildtransit-only", vaulttest.PolicyTransitOnly)
+
+	cfg := &config.Config{
+		Env:   "production",
+		Vault: &config.VaultConfig{Enabled: true, Address: addr, AuthMethod: "token", Token: toToken},
+	}
+	store, err := BuildTransit(ctx, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, store.SolanaTransit, "transit client must still be served")
+	require.NotNil(t, store.VaultAuth, "the Supervisor must no longer be discarded (#751 gap)")
+	require.NoError(t, store.Ping(ctx), "Ping must fold in auth-health + reachability like the KV path")
+
+	// Vault disabled: BuildTransit's old (nil, nil) contract at the field level —
+	// a non-nil Store whose fields are all zero, so Ping stays a safe no-op.
+	disabled, err := BuildTransit(ctx, &config.Config{Env: "production"})
+	require.NoError(t, err)
+	require.Nil(t, disabled.SolanaTransit)
+	require.Nil(t, disabled.VaultAuth)
+	require.NoError(t, disabled.Ping(ctx))
+}
+
 // --- Outage semantics: pause/unpause a dedicated container ----------------------
 
 func TestVaultOutage_FailClosedAtBootAndRead_RecoverWithoutRestart(t *testing.T) {

--- a/pkg/embedded/embedded.go
+++ b/pkg/embedded/embedded.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
-	"net/http"
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -95,9 +94,9 @@ func New(opts Options) (*Embedded, error) {
 	}
 
 	// Build the application graph only; HTTP surfaces (StandaloneHandler /
-	// NewHTTPHandler / MountHandler) are constructed from this App on demand.
-	// (#711: the bootstrap.Options relay layer is gone — this calls the app
-	// composition root directly.)
+	// MountHandler) are constructed from this App on demand. (#711: the
+	// bootstrap.Options relay layer is gone — this calls the app composition
+	// root directly.)
 	application, err := app.BootstrapWithOptions(opts.Config, &app.BootstrapOptions{
 		PGXPool: opts.PGXPool,
 		Redis:   opts.Redis,
@@ -164,17 +163,6 @@ func (e *Embedded) App() *app.App {
 	return e.app
 }
 
-// HTTPHandlerOptions controls which billing HTTP route groups are included in the returned handler.
-//
-// A zero RouteSets slice uses EmbeddedDefaultRouteSets.
-//
-// Note: billing health endpoints are not exposed in embedded mode.
-// If a host wants billing readiness, call (*Embedded).Ready (#748) and include it in the host's /readyz.
-type HTTPHandlerOptions struct {
-	RouteSets      []RouteSet
-	ProviderRoutes *ProviderRoutes
-}
-
 // ProviderRoutes selects provider-specific public routes for an embedded mount.
 // Leave nil to derive from configured provider accounts when possible.
 type ProviderRoutes struct {
@@ -195,30 +183,10 @@ func (p ProviderRoutes) internal() routesurface.ProviderRoutes {
 	}
 }
 
-// NewHTTPHandler returns a single mountable `http.Handler` for the selected route groups.
-//
-// Embedded routes live under `/billing/v1/*`.
-func (e *Embedded) NewHTTPHandler(opts HTTPHandlerOptions) http.Handler {
-	if e == nil || e.app == nil {
-		return nil
-	}
-	active := e.MountRouteSets(opts.RouteSets)
-	var providerRoutes *routesurface.ProviderRoutes
-	if opts.ProviderRoutes != nil {
-		v := opts.ProviderRoutes.internal()
-		providerRoutes = &v
-	}
-	return embedhttp.FromApp(e.app).NewHTTPHandler(embedhttp.Options{
-		RouteSets:          active,
-		AdvertiseRouteSets: active,
-		ProviderRoutes:     providerRoutes,
-	})
-}
-
 // ActiveRouteSets returns the route groups of the most recently mounted HTTP
-// surface (NewHTTPHandler / MountHandler), recorded at mount time; nil before
-// any mount. Returns a copy. The typical host mounts once, so this reflects its
-// live surface.
+// surface (MountHandler), recorded at mount time; nil before any mount.
+// Returns a copy. The typical host mounts once, so this reflects its live
+// surface.
 func (e *Embedded) ActiveRouteSets() []RouteSet {
 	if e == nil {
 		return nil

--- a/pkg/embedded/mount.go
+++ b/pkg/embedded/mount.go
@@ -70,15 +70,16 @@ func MountHandler(e *Embedded, opts MountOptions) (http.Handler, error) {
 // embedded host (issues #339/#467), authenticated by a host-supplied
 // billingauth.DelegatedAuthenticator.
 //
-// Routes are served at the CANONICAL embedded paths, alongside the
-// NewHTTPHandler surface:
+// Routes are served at the CANONICAL embedded paths, alongside the rest of
+// the embedded billing surface:
 //
 //	/billing/v1/me/*                      (self-service)
 //	/billing/v1/customers/:customer_id/*  (customer treasury)
 //
-// so a host that mounts NewHTTPHandler under /billing without prefix stripping
-// can route this subtree to this handler and everything else to the base
-// handler. Most hosts should use MountHandler, which does that routing itself.
+// so a host that mounts the base embedded surface under /billing without
+// prefix stripping can route this subtree to this handler and everything else
+// to the base handler. Most hosts should use MountHandler, which does that
+// routing itself.
 // Errors when the app graph is not initialized or no identity source can be
 // derived — the surface is never mounted without authentication.
 func SelfHandler(e *Embedded, authn billingauth.DelegatedAuthenticator) (http.Handler, error) {

--- a/pkg/embedded/pull_provider.go
+++ b/pkg/embedded/pull_provider.go
@@ -391,10 +391,11 @@ func pullProviderManifestPlane(ctx context.Context, cfg *config.Config, database
 			return nil, fmt.Errorf("pull-provider: merchant manifest %s: %w", path, err)
 		}
 	}
-	transit, err := merchantsecrets.BuildTransit(ctx, cfg)
+	transitStore, err := merchantsecrets.BuildTransit(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("pull-provider: %w", err)
 	}
+	transit := transitStore.SolanaTransit
 	plane := merchants.NewManifestSecretStore()
 	seeder := plane.Seeder()
 	for slug, mt := range manifest.Merchants {

--- a/pkg/embedded/ready.go
+++ b/pkg/embedded/ready.go
@@ -6,9 +6,9 @@ import (
 )
 
 // Ready is the embedded engine's REAL, supported readiness probe (#748) —
-// what the HTTPHandlerOptions doc above used to point hosts at under the name
-// IsBillingReady, which never existed. Call this from the host's own
-// /readyz/health-check handler.
+// billing health endpoints are not exposed in embedded mode, so a host that
+// wants billing readiness calls this (not the never-existent IsBillingReady)
+// from its own /readyz/health-check handler.
 //
 // It delegates to the internal/app.Runtime checks shared with the standalone
 // surface's /readyz, so both report the SAME posture: Postgres, Redis (only

--- a/pkg/embedded/river.go
+++ b/pkg/embedded/river.go
@@ -31,6 +31,7 @@ package embedded
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/riverqueue/river"
@@ -141,4 +142,55 @@ func (e *Embedded) HasExternalRiverClient() bool {
 		return false
 	}
 	return e.app.Runtime.HasExternalRiverClient()
+}
+
+// FoldIntoRiver folds billing's River workers and periodic jobs into a host's
+// SHARED river.Workers/river.Client (#546), in the one order River's own API
+// allows: Workers is fixed at river.NewClient, and periodic jobs must be
+// registered before Client.Start. It replaces the AddWorkersTo/GetPeriodicJobs/
+// SetRiverClient three-call dance (each host previously hand-wrote this as
+// Service.RegisterRiverWorkers/RegisterRiverClient, ~40 near-identical lines).
+//
+// Call FoldIntoRiver once, with your own workers already added to workers,
+// BEFORE building your river.Client:
+//
+//	workers := river.NewWorkers()
+//	river.AddWorkerSafely(workers, &MyAppWorker{})
+//	periodic, register, err := embedded.FoldIntoRiver(ctx, openrails, workers)
+//	// err != nil: engine not initialized.
+//
+//	client, err := river.NewClient(driver, &river.Config{Workers: workers})
+//	// periodic is billing's periodic jobs, exposed for logging/inspection —
+//	// register (below) is what actually adds them to the client.
+//	_ = periodic
+//	if err := register(client); err != nil {
+//	    // err != nil: client is nil.
+//	}
+//	client.Start(ctx)
+//
+// register (called AFTER NewClient, BEFORE Start) adds periodic to the client
+// and calls SetRiverClient, injecting it so billing enqueues through it and
+// never builds its own.
+func FoldIntoRiver(ctx context.Context, e *Embedded, workers *river.Workers) (periodic []*river.PeriodicJob, register func(*river.Client[pgx.Tx]) error, err error) {
+	if e == nil || e.app == nil || e.app.Runtime == nil {
+		return nil, nil, ErrNotInitialized
+	}
+	if err := e.AddWorkersTo(ctx, workers); err != nil {
+		return nil, nil, err
+	}
+	jobs, err := e.GetPeriodicJobs(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	register = func(client *river.Client[pgx.Tx]) error {
+		if client == nil {
+			return fmt.Errorf("embedded billing: river client required")
+		}
+		for _, job := range jobs {
+			_ = client.PeriodicJobs().Add(job)
+		}
+		e.SetRiverClient(client)
+		return nil
+	}
+	return jobs, register, nil
 }


### PR DESCRIPTION
## Summary

**#749 — vestigial-surface cleanup + River-fold recipe**
- Deleted `ControlPlane.BrowserCORSOrigins` + its dead `server.go` fallback (the host-supplied `browserCORSOriginSource` field is the one real seam now).
- Unexported `EnsureMerchantAPIKeyActor` -> `ensureMerchantAPIKeyActor`: #757 gave it a real in-package caller after this issue was filed (`MintMerchantAPIKey`'s actor fallback), but it still has zero external/exported consumers, so unexport rather than delete.
- Fixed the webhook-surface doc contradiction in `routes.go`: `RegisterWebhookRoutes` (provider-only) is the canonical standalone surface (#650); `RegisterMerchantWebhookRoutes` is embedded's only surface + standalone's transition alias.
- Deleted genuinely zero-consumer seams: `Embedded.NewHTTPHandler`/`HTTPHandlerOptions`, `embed.Runtime.Handler`/`HandlerOptions`, `embed.ProviderRoutes`.
- Kept (with justification) `pkg/embedded.ProviderRoutes`, `RouteSetPaymentProviders`, `RouteSetMerchantAPI`, `ActiveRouteSets` — all four are exercised by real integration tests through `MountHandler`/`embed.New`, and the RouteSet constants are independently load-bearing for standalone's own capability advertisement. Zero-external-consumer today (no host opts in), not dead code.
- New `pkg/embedded.FoldIntoRiver` replaces the ~40-line River-fold dance doujins/hentai0 each hand-wrote identically. Neither host repo touched (out of scope); they migrate on their next openrails bump.

**#752 — inline-PEM keys forfeit hot rotation silently**
- `resolveControlPlaneKeySource` now warns loudly when signing keys resolve from inline `ACTIVE_KEY_ID`/`ACTIVE_PRIVATE_KEY_PEM` outside development, naming the tradeoff (no hot rotation, no emergency revocation without a restart) and pointing at `keys_path`. Development exempt; `keys_path` delivery never warns.

**#751 gap — BuildTransit discarded its Supervisor**
- `BuildTransit` now returns `(*Store, error)` instead of a bare `TransitClient`, threading the Vault Supervisor onto `Store.VaultAuth` exactly like the KV path, so `Store.Ping` folds in auth-health + reachability for transit-only (MODE 1) connections too. `BuildManifest` forwards the same fields. Updated the two in-repo callers; no external host affected (both `internal/`).

## Test plan
- [x] `gofmt -l`, `go vet ./...`, `go vet -tags=integration ./...`, `go build ./...` clean
- [x] `go test ./...` green
- [x] `go test -tags=integration -count=1 ./internal/merchantsecrets/... ./pkg/embedded/... ./internal/http/...` green, except one **pre-existing** failure (`TestFindingsQueueApproveCCBillCancelAndRefund`) reproduced identically on a pristine `origin/master` checkout — unrelated to this branch, already flagged in #744's tracker note
- [x] New tests: `internal/controlplane/service_test.go` (inline-PEM warning, dev/non-dev/keys_path), `internal/merchantsecrets/vault_scenarios_integration_test.go` (`TestBuildTransit_ThreadsVaultAuthForTransitOnlyConnections`, real vaulttest Vault), `embed/river_fold_integration_test.go` (`TestFoldIntoRiver_HostSharedClientDrainsBillingJobs`, real river client end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)