### PR TITLE
#736 console UI: metric threshold alerting (Settings → Alerts + notification bell)

### DIFF
--- a/web/admin/src/components/notification-bell.tsx
+++ b/web/admin/src/components/notification-bell.tsx
@@ -46,7 +46,7 @@ export function NotificationBell() {
     const tick = async () => {
       try {
         const res = await getUnreadCount()
-        if (!cancelled) setCount(res.count ?? 0)
+        if (!cancelled) setCount(res.unread ?? 0)
       } catch {
         /* ignore poll errors */
       }

--- a/web/admin/src/components/notification-bell.tsx
+++ b/web/admin/src/components/notification-bell.tsx
@@ -1,0 +1,182 @@
+import * as React from "react"
+import { BellIcon, CircleAlertIcon, TriangleAlertIcon } from "lucide-react"
+import { useNavigate } from "react-router-dom"
+
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  getUnreadCount,
+  listNotifications,
+  markNotificationRead,
+} from "@/lib/api/endpoints"
+import type { MerchantNotification } from "@/lib/api/types"
+import { timeAgo } from "@/lib/format"
+import { cn } from "@/lib/utils"
+
+const POLL_MS = 30_000
+
+// normalizeLink maps an alert's stored link to an in-app router path (basename
+// /admin) or an external URL. Returns { path } for router navigation or { href }
+// to open in a new tab.
+function normalizeLink(link?: string | null): { path?: string; href?: string } {
+  if (!link) return {}
+  if (/^https?:\/\//i.test(link)) return { href: link }
+  let path = link
+  if (path.startsWith("/admin/")) path = path.slice("/admin".length)
+  else if (path === "/admin") path = "/"
+  if (!path.startsWith("/")) path = `/${path}`
+  return { path }
+}
+
+export function NotificationBell() {
+  const navigate = useNavigate()
+  const [open, setOpen] = React.useState(false)
+  const [count, setCount] = React.useState(0)
+  const [items, setItems] = React.useState<MerchantNotification[]>([])
+  const [loading, setLoading] = React.useState(false)
+
+  // Poll the unread badge on a modest interval. Errors are swallowed — the bell
+  // must never spam toasts (and the endpoint may 404 on an un-migrated server).
+  React.useEffect(() => {
+    let cancelled = false
+    const tick = async () => {
+      try {
+        const res = await getUnreadCount()
+        if (!cancelled) setCount(res.count ?? 0)
+      } catch {
+        /* ignore poll errors */
+      }
+    }
+    tick()
+    const h = setInterval(tick, POLL_MS)
+    return () => {
+      cancelled = true
+      clearInterval(h)
+    }
+  }, [])
+
+  const loadList = React.useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await listNotifications()
+      setItems(res.data ?? [])
+    } catch {
+      setItems([])
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const handleOpen = (next: boolean) => {
+    setOpen(next)
+    if (next) loadList()
+  }
+
+  const isUnread = (n: MerchantNotification) => !n.read_at
+
+  const onItemClick = async (n: MerchantNotification) => {
+    setOpen(false)
+    if (isUnread(n)) {
+      try {
+        await markNotificationRead(n.id)
+        setItems((prev) => prev.map((x) => (x.id === n.id ? { ...x, read_at: new Date().toISOString() } : x)))
+        setCount((c) => Math.max(0, c - 1))
+      } catch {
+        /* best effort */
+      }
+    }
+    const { path, href } = normalizeLink(n.link)
+    if (href) window.open(href, "_blank", "noopener,noreferrer")
+    else if (path) navigate(path)
+  }
+
+  // No bulk endpoint in the contract — mark each currently-listed unread item.
+  const markAll = async () => {
+    const unread = items.filter(isUnread)
+    if (unread.length === 0) return
+    await Promise.allSettled(unread.map((n) => markNotificationRead(n.id)))
+    const now = new Date().toISOString()
+    setItems((prev) => prev.map((x) => (x.read_at ? x : { ...x, read_at: now })))
+    setCount(0)
+  }
+
+  return (
+    <DropdownMenu open={open} onOpenChange={handleOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" aria-label="Notifications" className="relative">
+          <BellIcon className="size-4" />
+          {count > 0 && (
+            <span className="absolute -top-0.5 -right-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-medium text-white">
+              {count > 9 ? "9+" : count}
+            </span>
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-80 p-0 sm:w-96">
+        <div className="flex items-center justify-between border-b px-3 py-2">
+          <span className="text-sm font-medium">Notifications</span>
+          {items.some(isUnread) && (
+            <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={markAll}>
+              Mark all read
+            </Button>
+          )}
+        </div>
+        <div className="max-h-96 overflow-y-auto">
+          {loading ? (
+            <p className="px-3 py-6 text-center text-sm text-muted-foreground">Loading…</p>
+          ) : items.length === 0 ? (
+            <div className="flex flex-col items-center gap-1 px-3 py-8 text-center">
+              <BellIcon className="size-5 text-muted-foreground" />
+              <p className="text-sm text-muted-foreground">You&apos;re all caught up.</p>
+              <p className="max-w-[16rem] text-xs text-muted-foreground">
+                Threshold alerts land here. Configure rules in Settings → Alerts.
+              </p>
+            </div>
+          ) : (
+            items.map((n) => (
+              <button
+                key={n.id}
+                type="button"
+                onClick={() => onItemClick(n)}
+                className={cn(
+                  "flex w-full items-start gap-2 border-b px-3 py-2 text-left last:border-b-0 hover:bg-muted/50",
+                  isUnread(n) && "bg-primary/[0.04]",
+                )}
+              >
+                <span className="mt-0.5 shrink-0">
+                  {n.severity === "critical" ? (
+                    <CircleAlertIcon className="size-4 text-red-500" />
+                  ) : (
+                    <TriangleAlertIcon className="size-4 text-amber-500" />
+                  )}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="flex items-center justify-between gap-2">
+                    <span className={cn("truncate text-sm", isUnread(n) && "font-medium")}>
+                      {n.title}
+                    </span>
+                    <span className="shrink-0 text-[11px] text-muted-foreground">
+                      {timeAgo(n.created_at)}
+                    </span>
+                  </span>
+                  {n.body && (
+                    <span className="mt-0.5 line-clamp-2 block text-xs text-muted-foreground">
+                      {n.body}
+                    </span>
+                  )}
+                </span>
+                {isUnread(n) && (
+                  <span className="mt-1.5 size-2 shrink-0 rounded-full bg-primary" aria-label="unread" />
+                )}
+              </button>
+            ))
+          )}
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/web/admin/src/components/site-header.tsx
+++ b/web/admin/src/components/site-header.tsx
@@ -1,6 +1,7 @@
 import { LogOutIcon, MoonIcon, SunIcon, UserIcon } from "lucide-react"
 import { useNavigate } from "react-router-dom"
 
+import { NotificationBell } from "@/components/notification-bell"
 import { useTheme } from "@/components/theme-provider"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -27,6 +28,7 @@ export function SiteHeader({ title }: { title: string }) {
       <Separator orientation="vertical" className="mr-2 h-4" />
       <h1 className="text-sm font-medium">{title}</h1>
       <div className="ml-auto flex items-center gap-2">
+        <NotificationBell />
         <Button
           variant="ghost"
           size="icon"

--- a/web/admin/src/lib/api/endpoints.ts
+++ b/web/admin/src/lib/api/endpoints.ts
@@ -3,9 +3,12 @@
 import { api, type ItemsEnvelope, type ListEnvelope } from "./client"
 import type {
   AdminSubscription,
+  AlertChannelRef,
+  AlertDeliveryResult,
   AlertRule,
   AlertSeverity,
   AlertTemplate,
+  AlertTemplateInfo,
   CatalogDriftEvent,
   CatalogDriftReport,
   CatalogPrice,
@@ -283,13 +286,20 @@ export const getTrustLevel = (customerId: string, currency: string) =>
     query: { customer_id: customerId, currency },
   })
 
+// --- Alerting: rule templates (#736) ---
+
+// listAlertTemplates fetches the in-code template registry (key, param schema,
+// defaults) the create/edit dialog renders its fields from.
+export const listAlertTemplates = () =>
+  api<{ data: AlertTemplateInfo[] }>("/merchant/alerts/templates")
+
 // --- Alerting: rules (#736) ---
 
 export interface AlertRuleRequest {
   template: AlertTemplate
   params: Record<string, unknown>
   severity: AlertSeverity
-  channels: unknown // AlertChannels wire shape (see channelsToWire)
+  channels: AlertChannelRef[]
   enabled: boolean
 }
 
@@ -302,11 +312,15 @@ export const updateAlertRule = (id: string, body: Partial<AlertRuleRequest>) =>
   api<AlertRule>(`/merchant/alerts/rules/${id}`, { method: "PATCH", body })
 
 export const deleteAlertRule = (id: string) =>
-  api<{ message: string }>(`/merchant/alerts/rules/${id}`, { method: "DELETE" })
+  api<{ deleted: boolean; id: string }>(`/merchant/alerts/rules/${id}`, { method: "DELETE" })
 
-// testAlertRule fires one test delivery through the rule's channels.
+// testAlertRule fires one test delivery through the rule's real channels —
+// the ONLY test-fire surface (there is no per-webhook test endpoint).
 export const testAlertRule = (id: string) =>
-  api<{ message?: string }>(`/merchant/alerts/rules/${id}/test`, { method: "POST", body: {} })
+  api<{ results: AlertDeliveryResult[] }>(`/merchant/alerts/rules/${id}/test`, {
+    method: "POST",
+    body: {},
+  })
 
 // --- Alerting: webhooks (#736) ---
 
@@ -323,25 +337,19 @@ export const createWebhook = (body: WebhookRequest) =>
   api<MerchantWebhook>("/merchant/webhooks", { method: "POST", body })
 
 export const deleteWebhook = (id: string) =>
-  api<{ message: string }>(`/merchant/webhooks/${id}`, { method: "DELETE" })
-
-// testWebhook posts a sample payload to one webhook so the operator can verify
-// their Discord/Slack/custom receiver before wiring it to a rule.
-// RECONCILE: not in the pinned HTTP list (which only pins the per-RULE test
-// path); the per-webhook TEST button needs this endpoint from Agent A. If the
-// engine names it differently, adjust this path.
-export const testWebhook = (id: string) =>
-  api<{ message?: string }>(`/merchant/webhooks/${id}/test`, { method: "POST", body: {} })
+  api<{ deleted: boolean; id: string }>(`/merchant/webhooks/${id}`, { method: "DELETE" })
 
 // --- Alerting: notifications (in_app store / header bell, #736) ---
 
 export const listNotifications = (unread?: boolean) =>
-  api<ListEnvelope<MerchantNotification>>("/merchant/notifications", {
+  api<{ data: MerchantNotification[] | null }>("/merchant/notifications", {
     query: unread !== undefined ? { unread } : undefined,
   })
 
 export const markNotificationRead = (id: string) =>
-  api<{ message?: string }>(`/merchant/notifications/${id}/read`, { method: "POST", body: {} })
+  api<{ read: boolean; id: string }>(`/merchant/notifications/${id}/read`, {
+    method: "POST",
+    body: {},
+  })
 
-export const getUnreadCount = () =>
-  api<{ count: number }>("/merchant/notifications/unread-count")
+export const getUnreadCount = () => api<{ unread: number }>("/merchant/notifications/unread-count")

--- a/web/admin/src/lib/api/endpoints.ts
+++ b/web/admin/src/lib/api/endpoints.ts
@@ -3,6 +3,9 @@
 import { api, type ItemsEnvelope, type ListEnvelope } from "./client"
 import type {
   AdminSubscription,
+  AlertRule,
+  AlertSeverity,
+  AlertTemplate,
   CatalogDriftEvent,
   CatalogDriftReport,
   CatalogPrice,
@@ -12,13 +15,16 @@ import type {
   Finding,
   FindingsListResponse,
   MerchantAPIKey,
+  MerchantNotification,
   MerchantSettings,
+  MerchantWebhook,
   MintedAPIKey,
   PaymentMethodResponse,
   PaymentObject,
   PaymentProviderConfig,
   RawEntitlement,
   RepairAlert,
+  WebhookFormat,
   WorkerHealth,
 } from "./types"
 
@@ -276,3 +282,66 @@ export const getTrustLevel = (customerId: string, currency: string) =>
   api<{ currency: string; trust_level: string }>("/merchant/trust-level", {
     query: { customer_id: customerId, currency },
   })
+
+// --- Alerting: rules (#736) ---
+
+export interface AlertRuleRequest {
+  template: AlertTemplate
+  params: Record<string, unknown>
+  severity: AlertSeverity
+  channels: unknown // AlertChannels wire shape (see channelsToWire)
+  enabled: boolean
+}
+
+export const listAlertRules = () => api<{ data: AlertRule[] | null }>("/merchant/alerts/rules")
+
+export const createAlertRule = (body: AlertRuleRequest) =>
+  api<AlertRule>("/merchant/alerts/rules", { method: "POST", body })
+
+export const updateAlertRule = (id: string, body: Partial<AlertRuleRequest>) =>
+  api<AlertRule>(`/merchant/alerts/rules/${id}`, { method: "PATCH", body })
+
+export const deleteAlertRule = (id: string) =>
+  api<{ message: string }>(`/merchant/alerts/rules/${id}`, { method: "DELETE" })
+
+// testAlertRule fires one test delivery through the rule's channels.
+export const testAlertRule = (id: string) =>
+  api<{ message?: string }>(`/merchant/alerts/rules/${id}/test`, { method: "POST", body: {} })
+
+// --- Alerting: webhooks (#736) ---
+
+export interface WebhookRequest {
+  name: string
+  url: string
+  format: WebhookFormat
+  enabled?: boolean
+}
+
+export const listWebhooks = () => api<{ data: MerchantWebhook[] | null }>("/merchant/webhooks")
+
+export const createWebhook = (body: WebhookRequest) =>
+  api<MerchantWebhook>("/merchant/webhooks", { method: "POST", body })
+
+export const deleteWebhook = (id: string) =>
+  api<{ message: string }>(`/merchant/webhooks/${id}`, { method: "DELETE" })
+
+// testWebhook posts a sample payload to one webhook so the operator can verify
+// their Discord/Slack/custom receiver before wiring it to a rule.
+// RECONCILE: not in the pinned HTTP list (which only pins the per-RULE test
+// path); the per-webhook TEST button needs this endpoint from Agent A. If the
+// engine names it differently, adjust this path.
+export const testWebhook = (id: string) =>
+  api<{ message?: string }>(`/merchant/webhooks/${id}/test`, { method: "POST", body: {} })
+
+// --- Alerting: notifications (in_app store / header bell, #736) ---
+
+export const listNotifications = (unread?: boolean) =>
+  api<ListEnvelope<MerchantNotification>>("/merchant/notifications", {
+    query: unread !== undefined ? { unread } : undefined,
+  })
+
+export const markNotificationRead = (id: string) =>
+  api<{ message?: string }>(`/merchant/notifications/${id}/read`, { method: "POST", body: {} })
+
+export const getUnreadCount = () =>
+  api<{ count: number }>("/merchant/notifications/unread-count")

--- a/web/admin/src/lib/api/types.ts
+++ b/web/admin/src/lib/api/types.ts
@@ -303,9 +303,9 @@ export interface MerchantSettings {
   collection_threshold?: number
   monthly_floor?: number
   billing_period_boundary?: string
-  // Destination for operator alert emails (#736). Unset ⇒ the email channel is
-  // inactive (fail-soft to in_app + webhooks). RECONCILE: if Agent A nests this
-  // under profile, move the read/write in pages/settings/alerts.tsx.
+  // Destination for operator alert emails (#736), top-level per the as-built
+  // engine (service_admission.go). Unset ⇒ the email channel is inactive
+  // (fail-soft to in_app + webhooks).
   alert_email?: string
 }
 
@@ -378,35 +378,60 @@ export interface Me {
 // --- Alerting (#736) ---
 
 export type AlertSeverity = "warning" | "critical"
-export type AlertTemplate =
-  | "chargeback_rate"
-  | "dunning_spike"
-  | "payers_at_depletion_risk"
-  | "payment_methods_expiring"
+// Template keys come from GET /merchant/alerts/templates (AlertTemplateInfo.key)
+// — the v1 set is chargeback_rate_by_rail_account | dunning_spike |
+// payers_at_depletion_risk | payment_methods_expiring — treated as an opaque
+// server-driven string rather than a hardcoded union.
+export type AlertTemplate = string
 export type WebhookFormat = "generic" | "discord" | "slack"
+export type AlertChannelType = "in_app" | "email" | "webhook"
 
-// AlertChannels is the wire shape for a rule's channel set. in_app is always
-// on; email is fail-soft (inactive when merchant alert_email is unset);
-// webhook_ids reference merchant_webhooks rows.
-// RECONCILE (Agent A as-built): if the engine serializes channels as a typed
-// array instead of this object, adjust channelsFromWire/channelsToWire in
-// pages/settings/alerts.tsx — the rest of the UI is shape-agnostic.
-export interface AlertChannels {
-  in_app: boolean
-  email: boolean
-  webhook_ids: string[]
+// AlertChannelRef is one entry in a rule's ordered channel array — the ONE wire
+// shape (engine as-built): [{"type":"in_app"},{"type":"email"},
+// {"type":"webhook","webhook_id":"<uuid>"}].
+export interface AlertChannelRef {
+  type: AlertChannelType
+  webhook_id?: string
+}
+
+export type AlertParamType = "number" | "integer" | "window"
+
+// AlertParamSpec documents one template parameter; the create/edit dialog
+// renders its fields from this instead of a hardcoded shape.
+export interface AlertParamSpec {
+  name: string
+  type: AlertParamType
+  required: boolean
+  default?: number | string
+  min?: number
+  max?: number
+  description: string
+}
+
+// AlertTemplateInfo is the schema view of a template — GET /merchant/alerts/templates.
+export interface AlertTemplateInfo {
+  key: string
+  display_name: string
+  description: string
+  default_severity: AlertSeverity
+  digest: boolean
+  metric: string
+  params: AlertParamSpec[]
 }
 
 export interface AlertRule {
   id: string
+  name: string
   template: AlertTemplate
   params: Record<string, unknown>
   severity: AlertSeverity
-  channels: AlertChannels
+  channels: AlertChannelRef[]
   enabled: boolean
   // Edge-trigger state: set while the rule is currently firing.
   fired_at?: string | null
   cleared_at?: string | null
+  last_evaluated_at?: string | null
+  last_value?: number | null
   created_at: string
   updated_at?: string
 }
@@ -421,6 +446,13 @@ export interface MerchantWebhook {
   updated_at?: string
 }
 
+export interface AlertDeliveryResult {
+  channel: string
+  ok: boolean
+  detail?: string
+  attempts?: number
+}
+
 // MerchantNotification is the in_app store — MERCHANT-operator-facing (distinct
 // from the customer notification_queue). Surfaced as the header bell.
 export interface MerchantNotification {
@@ -429,6 +461,7 @@ export interface MerchantNotification {
   title: string
   body: string
   link?: string | null
+  rule_id?: string | null
   created_at: string
   read_at?: string | null
 }

--- a/web/admin/src/lib/api/types.ts
+++ b/web/admin/src/lib/api/types.ts
@@ -303,6 +303,10 @@ export interface MerchantSettings {
   collection_threshold?: number
   monthly_floor?: number
   billing_period_boundary?: string
+  // Destination for operator alert emails (#736). Unset ⇒ the email channel is
+  // inactive (fail-soft to in_app + webhooks). RECONCILE: if Agent A nests this
+  // under profile, move the read/write in pages/settings/alerts.tsx.
+  alert_email?: string
 }
 
 export interface PaymentProviderConfig {
@@ -369,4 +373,62 @@ export interface Me {
   username?: string
   roles?: string[]
   entitlements?: string[]
+}
+
+// --- Alerting (#736) ---
+
+export type AlertSeverity = "warning" | "critical"
+export type AlertTemplate =
+  | "chargeback_rate"
+  | "dunning_spike"
+  | "payers_at_depletion_risk"
+  | "payment_methods_expiring"
+export type WebhookFormat = "generic" | "discord" | "slack"
+
+// AlertChannels is the wire shape for a rule's channel set. in_app is always
+// on; email is fail-soft (inactive when merchant alert_email is unset);
+// webhook_ids reference merchant_webhooks rows.
+// RECONCILE (Agent A as-built): if the engine serializes channels as a typed
+// array instead of this object, adjust channelsFromWire/channelsToWire in
+// pages/settings/alerts.tsx — the rest of the UI is shape-agnostic.
+export interface AlertChannels {
+  in_app: boolean
+  email: boolean
+  webhook_ids: string[]
+}
+
+export interface AlertRule {
+  id: string
+  template: AlertTemplate
+  params: Record<string, unknown>
+  severity: AlertSeverity
+  channels: AlertChannels
+  enabled: boolean
+  // Edge-trigger state: set while the rule is currently firing.
+  fired_at?: string | null
+  cleared_at?: string | null
+  created_at: string
+  updated_at?: string
+}
+
+export interface MerchantWebhook {
+  id: string
+  name: string
+  url: string
+  format: WebhookFormat
+  enabled: boolean
+  created_at: string
+  updated_at?: string
+}
+
+// MerchantNotification is the in_app store — MERCHANT-operator-facing (distinct
+// from the customer notification_queue). Surfaced as the header bell.
+export interface MerchantNotification {
+  id: string
+  severity: AlertSeverity
+  title: string
+  body: string
+  link?: string | null
+  created_at: string
+  read_at?: string | null
 }

--- a/web/admin/src/lib/format.ts
+++ b/web/admin/src/lib/format.ts
@@ -44,3 +44,21 @@ export function formatUnix(seconds?: number): string {
 export function shortId(id: string, n = 8): string {
   return id.length > n ? `${id.slice(0, n)}…` : id
 }
+
+// timeAgo renders a compact relative time ("3m", "2h", "5d") for feeds like the
+// notification bell; falls back to a short date past a week.
+export function timeAgo(iso?: string | null): string {
+  if (!iso) return ""
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return ""
+  const secs = Math.round((Date.now() - then) / 1000)
+  if (secs < 45) return "just now"
+  if (secs < 90) return "1m"
+  const mins = Math.round(secs / 60)
+  if (mins < 60) return `${mins}m`
+  const hours = Math.round(mins / 60)
+  if (hours < 24) return `${hours}h`
+  const days = Math.round(hours / 24)
+  if (days < 7) return `${days}d`
+  return new Date(then).toLocaleDateString(undefined, { month: "short", day: "numeric" })
+}

--- a/web/admin/src/pages/settings/alerts.tsx
+++ b/web/admin/src/pages/settings/alerts.tsx
@@ -1,0 +1,1050 @@
+import * as React from "react"
+import { BellIcon, MailIcon, PlusIcon, SendIcon, Trash2Icon, WebhookIcon } from "lucide-react"
+import { toast } from "sonner"
+
+import { TypedConfirmDialog } from "@/components/typed-confirm-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useApiData } from "@/hooks/use-api-data"
+import {
+  createAlertRule,
+  createWebhook,
+  deleteAlertRule,
+  deleteWebhook,
+  getMerchantSettings,
+  listAlertRules,
+  listWebhooks,
+  putMerchantSettings,
+  testAlertRule,
+  testWebhook,
+  updateAlertRule,
+  type AlertRuleRequest,
+} from "@/lib/api/endpoints"
+import type {
+  AlertChannels,
+  AlertRule,
+  AlertSeverity,
+  AlertTemplate,
+  MerchantSettings,
+  MerchantWebhook,
+  WebhookFormat,
+} from "@/lib/api/types"
+import { cn } from "@/lib/utils"
+import { toastApiError } from "@/lib/toast"
+
+// --- Template registry (v1 set, per the #736 contract) --------------------
+// Each template maps to a #733 registry query the evaluator runs on the slow
+// tick. Params here are the merchant-tunable knobs with the pinned defaults;
+// their numeric SEMANTICS are owned by the engine (Agent A) — the UI only
+// presents labelled fields and round-trips the values.
+
+type ParamKind = "number" | "duration"
+
+interface ParamSpec {
+  key: string
+  label: string
+  help?: string
+  kind: ParamKind
+  default: string
+  suffix?: string
+  step?: string
+  min?: string
+}
+
+interface TemplateDef {
+  key: AlertTemplate
+  label: string
+  description: string
+  defaultSeverity: AlertSeverity
+  cadenceNote?: string
+  params: ParamSpec[]
+}
+
+const TEMPLATES: TemplateDef[] = [
+  {
+    key: "chargeback_rate",
+    label: "Chargeback ratio per merchant account",
+    description:
+      "Warns before card-network monitoring thresholds. Fires per rail account when its " +
+      "chargeback ratio approaches the network limit (VAMP ≈ 0.9%) — the alert that gets a " +
+      "high-risk merchant fined.",
+    defaultSeverity: "critical",
+    params: [
+      {
+        key: "threshold",
+        label: "Warn at fraction of the network limit",
+        help: "0.7 = warn at 70% of VAMP (≈ 0.9%), i.e. once chargebacks reach ~0.63%.",
+        kind: "number",
+        default: "0.7",
+        step: "0.05",
+        min: "0",
+      },
+      {
+        key: "window",
+        label: "Measurement window",
+        help: "Trailing window the chargeback ratio is measured over (e.g. 30d).",
+        kind: "duration",
+        default: "30d",
+      },
+    ],
+  },
+  {
+    key: "dunning_spike",
+    label: "Dunning spike",
+    description:
+      "Fires when the number of subscriptions in dunning (past_due) jumps versus its trailing " +
+      "baseline — an early signal that a rail is suddenly declining hard.",
+    defaultSeverity: "critical",
+    params: [
+      {
+        key: "multiplier",
+        label: "Spike multiplier",
+        help: "Fire when the in-dunning count exceeds this multiple of the baseline (2 = doubled).",
+        kind: "number",
+        default: "2",
+        step: "0.5",
+        min: "1",
+      },
+      {
+        key: "window",
+        label: "Baseline window",
+        help: "Trailing window used to compute the baseline (e.g. 7d).",
+        kind: "duration",
+        default: "7d",
+      },
+    ],
+  },
+  {
+    key: "payers_at_depletion_risk",
+    label: "Payers approaching credit depletion",
+    description:
+      "Fires when a batch of prepaid payers are about to run out of credits — the top-up revenue " +
+      "moment, and a churn-risk signal for usage-billing platforms.",
+    defaultSeverity: "warning",
+    params: [
+      {
+        key: "min_count",
+        label: "Minimum payers at risk",
+        help: "Only alert when at least this many payers are at risk.",
+        kind: "number",
+        default: "10",
+        min: "1",
+      },
+      {
+        key: "runway_days",
+        label: "Runway",
+        suffix: "days",
+        help: "Count payers whose balance runs out within this many days at their recent burn rate.",
+        kind: "number",
+        default: "7",
+        min: "1",
+      },
+    ],
+  },
+  {
+    key: "payment_methods_expiring",
+    label: "Payment methods expiring (monthly digest)",
+    description:
+      "A monthly heads-up of cards expiring soon so you can prompt updates before involuntary " +
+      "churn hits.",
+    defaultSeverity: "warning",
+    cadenceNote: "Sent monthly.",
+    params: [
+      {
+        key: "days_ahead",
+        label: "Look-ahead",
+        suffix: "days",
+        help: "Include payment methods expiring within this many days.",
+        kind: "number",
+        default: "30",
+        min: "1",
+      },
+    ],
+  },
+]
+
+function templateDef(key: AlertTemplate): TemplateDef {
+  return TEMPLATES.find((t) => t.key === key) ?? TEMPLATES[0]
+}
+
+// --- Channel wire adapters (localized reconciliation seam) -----------------
+
+interface ChannelSelection {
+  in_app: boolean
+  email: boolean
+  webhookIds: string[]
+}
+
+function channelsFromWire(raw: unknown): ChannelSelection {
+  if (Array.isArray(raw)) {
+    const sel: ChannelSelection = { in_app: false, email: false, webhookIds: [] }
+    for (const c of raw) {
+      if (c === "in_app") sel.in_app = true
+      else if (c === "email") sel.email = true
+      else if (typeof c === "string" && c.startsWith("webhook:")) sel.webhookIds.push(c.slice(8))
+      else if (c && typeof c === "object") {
+        const o = c as Record<string, unknown>
+        if (o.type === "in_app") sel.in_app = true
+        else if (o.type === "email") sel.email = true
+        else if (o.type === "webhook" && typeof o.webhook_id === "string")
+          sel.webhookIds.push(o.webhook_id)
+      }
+    }
+    return sel
+  }
+  const o = (raw ?? {}) as Partial<AlertChannels>
+  return {
+    in_app: o.in_app ?? true,
+    email: o.email ?? false,
+    webhookIds: Array.isArray(o.webhook_ids) ? o.webhook_ids : [],
+  }
+}
+
+// in_app is always on; email/webhooks are the operator's choice.
+function channelsToWire(sel: ChannelSelection): AlertChannels {
+  return { in_app: true, email: sel.email, webhook_ids: sel.webhookIds }
+}
+
+// --- Page ------------------------------------------------------------------
+
+export function AlertsTab() {
+  const settings = useApiData(() => getMerchantSettings(), [])
+  const rules = useApiData(() => listAlertRules(), [])
+  const webhooks = useApiData(() => listWebhooks(), [])
+
+  React.useEffect(() => {
+    if (settings.error) toastApiError(settings.error, "Load settings")
+  }, [settings.error])
+  React.useEffect(() => {
+    if (rules.error) toastApiError(rules.error, "Load alert rules")
+  }, [rules.error])
+  React.useEffect(() => {
+    if (webhooks.error) toastApiError(webhooks.error, "Load webhooks")
+  }, [webhooks.error])
+
+  const alertEmail = settings.data?.alert_email ?? ""
+  const hooks = webhooks.data?.data ?? []
+
+  return (
+    <div className="flex max-w-4xl flex-col gap-6">
+      <AlertEmailCard
+        key={settings.data?.alert_email ?? "∅"}
+        settings={settings.data ?? undefined}
+        loading={settings.loading}
+        onSaved={settings.reload}
+      />
+      <RulesSection
+        rules={rules.data?.data ?? []}
+        loading={rules.loading}
+        webhooks={hooks}
+        alertEmail={alertEmail}
+        onChanged={rules.reload}
+      />
+      <WebhooksSection webhooks={hooks} loading={webhooks.loading} onChanged={webhooks.reload} />
+    </div>
+  )
+}
+
+// --- Alert email -----------------------------------------------------------
+
+function AlertEmailCard({
+  settings,
+  loading,
+  onSaved,
+}: {
+  settings?: MerchantSettings
+  loading: boolean
+  onSaved: () => void
+}) {
+  // Initial value is seeded from props; the parent remounts this card (key on
+  // alert_email) when the saved value changes, so no props→state effect.
+  const initial = settings?.alert_email ?? ""
+  const [email, setEmail] = React.useState(initial)
+  const [busy, setBusy] = React.useState(false)
+
+  const dirty = email.trim() !== initial
+
+  return (
+    <Card className="max-w-xl">
+      <CardHeader>
+        <CardTitle className="text-sm">Alert email</CardTitle>
+        <CardDescription>
+          Where operator alerts are sent when a rule uses the email channel. Leave empty and the
+          email channel stays inactive — alerts fail soft to in-app and any webhooks.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-[1fr_auto] gap-2">
+          <Input
+            type="email"
+            placeholder="alerts@example.com"
+            value={email}
+            disabled={loading}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <Button
+            variant="outline"
+            disabled={busy || loading || !dirty}
+            onClick={async () => {
+              setBusy(true)
+              try {
+                // Preserve existing settings; only change alert_email.
+                await putMerchantSettings({ ...(settings ?? {}), alert_email: email.trim() || undefined })
+                toast.success(email.trim() ? "Alert email saved" : "Alert email cleared")
+                onSaved()
+              } catch (err) {
+                toastApiError(err, "Save alert email")
+              } finally {
+                setBusy(false)
+              }
+            }}
+          >
+            {busy ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+// --- Rules -----------------------------------------------------------------
+
+function ruleIsFiring(rule: AlertRule): boolean {
+  if (!rule.fired_at) return false
+  if (!rule.cleared_at) return true
+  return new Date(rule.fired_at).getTime() > new Date(rule.cleared_at).getTime()
+}
+
+function SeverityBadge({ severity }: { severity: AlertSeverity }) {
+  return (
+    <Badge
+      variant="secondary"
+      className={
+        severity === "critical"
+          ? "bg-red-500/15 text-red-600 dark:text-red-400"
+          : "bg-amber-500/15 text-amber-600 dark:text-amber-400"
+      }
+    >
+      {severity}
+    </Badge>
+  )
+}
+
+function ChannelSummary({ channels }: { channels: AlertChannels }) {
+  const sel = channelsFromWire(channels)
+  return (
+    <span className="flex flex-wrap items-center gap-1 text-xs text-muted-foreground">
+      <span className="inline-flex items-center gap-1">
+        <BellIcon className="size-3" /> in-app
+      </span>
+      {sel.email && (
+        <span className="inline-flex items-center gap-1">
+          <MailIcon className="size-3" /> email
+        </span>
+      )}
+      {sel.webhookIds.length > 0 && (
+        <span className="inline-flex items-center gap-1">
+          <WebhookIcon className="size-3" /> {sel.webhookIds.length} webhook
+          {sel.webhookIds.length > 1 ? "s" : ""}
+        </span>
+      )}
+    </span>
+  )
+}
+
+function RulesSection({
+  rules,
+  loading,
+  webhooks,
+  alertEmail,
+  onChanged,
+}: {
+  rules: AlertRule[]
+  loading: boolean
+  webhooks: MerchantWebhook[]
+  alertEmail: string
+  onChanged: () => void
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-sm font-medium">Alert rules</h2>
+          <p className="max-w-2xl text-sm text-muted-foreground">
+            Threshold alerts run on a slow cadence over your live metrics and push a warning the
+            moment a threshold is crossed — before a rail fines you or churn spikes.
+          </p>
+        </div>
+        <RuleDialog webhooks={webhooks} alertEmail={alertEmail} onDone={onChanged} />
+      </div>
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : rules.length === 0 ? (
+        <Card className="border-dashed">
+          <CardContent className="flex flex-col items-center gap-3 py-10 text-center">
+            <BellIcon className="size-6 text-muted-foreground" />
+            <div>
+              <p className="text-sm font-medium">No alert rules yet</p>
+              <p className="mx-auto mt-1 max-w-md text-sm text-muted-foreground">
+                Alerting watches the metrics that can fine or bankrupt you — chargeback ratio,
+                dunning spikes, credit depletion, expiring cards — and notifies you when a
+                threshold is crossed. Start from a template.
+              </p>
+            </div>
+            <RuleDialog webhooks={webhooks} alertEmail={alertEmail} onDone={onChanged} cta />
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="overflow-x-auto rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Rule</TableHead>
+                <TableHead>Severity</TableHead>
+                <TableHead>Channels</TableHead>
+                <TableHead>State</TableHead>
+                <TableHead>Enabled</TableHead>
+                <TableHead />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rules.map((r) => (
+                <RuleRow
+                  key={r.id}
+                  rule={r}
+                  webhooks={webhooks}
+                  alertEmail={alertEmail}
+                  onChanged={onChanged}
+                />
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function RuleRow({
+  rule,
+  webhooks,
+  alertEmail,
+  onChanged,
+}: {
+  rule: AlertRule
+  webhooks: MerchantWebhook[]
+  alertEmail: string
+  onChanged: () => void
+}) {
+  const [busy, setBusy] = React.useState(false)
+  const [confirmOpen, setConfirmOpen] = React.useState(false)
+  const def = templateDef(rule.template)
+  const firing = ruleIsFiring(rule)
+
+  const run = async (fn: () => Promise<unknown>, action: string, ok: string) => {
+    setBusy(true)
+    try {
+      await fn()
+      toast.success(ok)
+      onChanged()
+    } catch (err) {
+      toastApiError(err, action)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <TableRow className={rule.enabled ? undefined : "opacity-60"}>
+      <TableCell>
+        <span className="font-medium">{def.label}</span>
+        {def.cadenceNote && (
+          <span className="block text-xs text-muted-foreground">{def.cadenceNote}</span>
+        )}
+      </TableCell>
+      <TableCell>
+        <SeverityBadge severity={rule.severity} />
+      </TableCell>
+      <TableCell>
+        <ChannelSummary channels={rule.channels} />
+      </TableCell>
+      <TableCell>
+        {firing ? (
+          <Badge variant="secondary" className="bg-red-500/15 text-red-600 dark:text-red-400">
+            firing
+          </Badge>
+        ) : (
+          <span className="text-xs text-muted-foreground">ok</span>
+        )}
+      </TableCell>
+      <TableCell>
+        <Switch
+          checked={rule.enabled}
+          disabled={busy}
+          aria-label={rule.enabled ? "Disable rule" : "Enable rule"}
+          onCheckedChange={(next) =>
+            run(
+              () => updateAlertRule(rule.id, { enabled: next }),
+              "Update rule",
+              next ? "Rule enabled" : "Rule disabled",
+            )
+          }
+        />
+      </TableCell>
+      <TableCell className="text-right">
+        <div className="flex justify-end gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={busy}
+            onClick={() => run(() => testAlertRule(rule.id), "Send test alert", "Test alert sent")}
+          >
+            <SendIcon className="size-3.5" /> Test
+          </Button>
+          <RuleDialog
+            rule={rule}
+            webhooks={webhooks}
+            alertEmail={alertEmail}
+            onDone={onChanged}
+            trigger={
+              <Button variant="outline" size="sm">
+                Edit
+              </Button>
+            }
+          />
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Delete rule"
+            disabled={busy}
+            onClick={() => setConfirmOpen(true)}
+          >
+            <Trash2Icon className="size-4 text-muted-foreground" />
+          </Button>
+          <TypedConfirmDialog
+            open={confirmOpen}
+            onOpenChange={setConfirmOpen}
+            title={`Delete "${def.label}"?`}
+            description="This alert rule will stop evaluating and its firing state is discarded. This cannot be undone."
+            confirmationWord="DELETE"
+            actionLabel="Delete rule"
+            onConfirm={() => run(() => deleteAlertRule(rule.id), "Delete rule", "Rule deleted")}
+          />
+        </div>
+      </TableCell>
+    </TableRow>
+  )
+}
+
+// --- Rule create/edit dialog ----------------------------------------------
+
+function RuleDialog({
+  rule,
+  webhooks,
+  alertEmail,
+  onDone,
+  trigger,
+  cta,
+}: {
+  rule?: AlertRule
+  webhooks: MerchantWebhook[]
+  alertEmail: string
+  onDone: () => void
+  trigger?: React.ReactNode
+  cta?: boolean
+}) {
+  const editing = !!rule
+  const [open, setOpen] = React.useState(false)
+  const [template, setTemplate] = React.useState<AlertTemplate>(rule?.template ?? "chargeback_rate")
+  const [severity, setSeverity] = React.useState<AlertSeverity>(
+    rule?.severity ?? templateDef(template).defaultSeverity,
+  )
+  const [params, setParams] = React.useState<Record<string, string>>({})
+  const [channels, setChannels] = React.useState<ChannelSelection>({
+    in_app: true,
+    email: false,
+    webhookIds: [],
+  })
+  const [enabled, setEnabled] = React.useState(rule?.enabled ?? true)
+  const [busy, setBusy] = React.useState(false)
+
+  const def = templateDef(template)
+
+  // (Re)initialize form state whenever the dialog opens or the template changes.
+  const initFor = React.useCallback(
+    (tpl: AlertTemplate, r?: AlertRule) => {
+      const d = templateDef(tpl)
+      const p: Record<string, string> = {}
+      for (const spec of d.params) {
+        const existing = r?.params?.[spec.key]
+        p[spec.key] = existing === undefined || existing === null ? spec.default : String(existing)
+      }
+      setParams(p)
+      if (r) {
+        setSeverity(r.severity)
+        setChannels(channelsFromWire(r.channels))
+        setEnabled(r.enabled)
+      } else {
+        setSeverity(d.defaultSeverity)
+        setChannels({ in_app: true, email: d.defaultSeverity === "critical", webhookIds: [] })
+        setEnabled(true)
+      }
+    },
+    [],
+  )
+
+  const handleOpen = (next: boolean) => {
+    setOpen(next)
+    if (next) {
+      const tpl = rule?.template ?? template
+      setTemplate(tpl)
+      initFor(tpl, rule)
+    }
+  }
+
+  const pickTemplate = (tpl: AlertTemplate) => {
+    setTemplate(tpl)
+    initFor(tpl, undefined)
+  }
+
+  const submit = async () => {
+    const p: Record<string, unknown> = {}
+    for (const spec of def.params) {
+      const raw = (params[spec.key] ?? spec.default).trim()
+      p[spec.key] = spec.kind === "number" ? Number(raw) : raw
+    }
+    const body: AlertRuleRequest = {
+      template,
+      params: p,
+      severity,
+      channels: channelsToWire(channels),
+      enabled,
+    }
+    setBusy(true)
+    try {
+      if (editing) await updateAlertRule(rule.id, body)
+      else await createAlertRule(body)
+      toast.success(editing ? "Rule updated" : "Rule created")
+      setOpen(false)
+      onDone()
+    } catch (err) {
+      toastApiError(err, editing ? "Update rule" : "Create rule")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpen}>
+      <DialogTrigger asChild>
+        {trigger ?? (
+          <Button size="sm">
+            <PlusIcon className="size-4" /> {cta ? "Create your first rule" : "New rule"}
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{editing ? "Edit alert rule" : "New alert rule"}</DialogTitle>
+          <DialogDescription>
+            {editing
+              ? def.description
+              : "Pick what to watch, set the threshold, and choose how you want to be told."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4">
+          {!editing && (
+            <div className="grid gap-2">
+              <Label>Template</Label>
+              <div className="grid gap-2">
+                {TEMPLATES.map((t) => (
+                  <button
+                    key={t.key}
+                    type="button"
+                    onClick={() => pickTemplate(t.key)}
+                    aria-pressed={template === t.key}
+                    className={cn(
+                      "rounded-md border p-3 text-left transition-colors",
+                      template === t.key ? "border-primary bg-primary/5" : "hover:bg-muted/50",
+                    )}
+                  >
+                    <p className="text-sm font-medium">{t.label}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">{t.description}</p>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="grid gap-3">
+            {def.params.map((spec) => (
+              <div key={spec.key} className="grid gap-1.5">
+                <Label htmlFor={`p-${spec.key}`}>
+                  {spec.label}
+                  {spec.suffix ? ` (${spec.suffix})` : ""}
+                </Label>
+                <Input
+                  id={`p-${spec.key}`}
+                  type={spec.kind === "number" ? "number" : "text"}
+                  step={spec.step}
+                  min={spec.min}
+                  value={params[spec.key] ?? ""}
+                  onChange={(e) => setParams((prev) => ({ ...prev, [spec.key]: e.target.value }))}
+                />
+                {spec.help && <p className="text-xs text-muted-foreground">{spec.help}</p>}
+              </div>
+            ))}
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label>Severity</Label>
+            <Select value={severity} onValueChange={(v) => setSeverity(v as AlertSeverity)}>
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="warning">Warning — in-app by default</SelectItem>
+                <SelectItem value="critical">Critical — push harder (email + webhooks)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-2">
+            <Label>Channels</Label>
+            <div className="grid gap-2 rounded-md border p-3">
+              <div className="flex items-center justify-between">
+                <span className="inline-flex items-center gap-2 text-sm">
+                  <BellIcon className="size-4" /> In-app
+                </span>
+                <Badge variant="secondary" className="text-[10px]">
+                  always on
+                </Badge>
+              </div>
+
+              <div className="grid gap-1.5">
+                <div className="flex items-center justify-between">
+                  <span className="inline-flex items-center gap-2 text-sm">
+                    <MailIcon className="size-4" /> Email
+                  </span>
+                  <Switch
+                    checked={channels.email}
+                    onCheckedChange={(next) => setChannels((c) => ({ ...c, email: next }))}
+                    aria-label="Toggle email channel"
+                  />
+                </div>
+                {channels.email &&
+                  (alertEmail ? (
+                    <p className="text-xs text-muted-foreground">
+                      Sent to <span className="font-medium text-foreground">{alertEmail}</span>.
+                    </p>
+                  ) : (
+                    <p className="text-xs text-amber-600 dark:text-amber-400">
+                      No alert email set — email won&apos;t send until you set one in “Alert email”
+                      above (the alert still reaches in-app and webhooks).
+                    </p>
+                  ))}
+              </div>
+
+              <div className="grid gap-1.5">
+                <span className="inline-flex items-center gap-2 text-sm">
+                  <WebhookIcon className="size-4" /> Webhooks
+                </span>
+                {webhooks.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    No webhooks configured — add one in the Webhooks section below.
+                  </p>
+                ) : (
+                  <div className="grid gap-1">
+                    {webhooks.map((w) => {
+                      const on = channels.webhookIds.includes(w.id)
+                      return (
+                        <label
+                          key={w.id}
+                          className="flex cursor-pointer items-center justify-between gap-2 rounded-md px-2 py-1 text-sm hover:bg-muted/50"
+                        >
+                          <span className="inline-flex items-center gap-2">
+                            <span>{w.name}</span>
+                            <Badge variant="secondary" className="text-[10px]">
+                              {w.format}
+                            </Badge>
+                          </span>
+                          <Switch
+                            checked={on}
+                            aria-label={`Toggle webhook ${w.name}`}
+                            onCheckedChange={(next) =>
+                              setChannels((c) => ({
+                                ...c,
+                                webhookIds: next
+                                  ? [...c.webhookIds, w.id]
+                                  : c.webhookIds.filter((id) => id !== w.id),
+                              }))
+                            }
+                          />
+                        </label>
+                      )
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button disabled={busy} onClick={submit}>
+            {busy ? "Saving…" : editing ? "Save changes" : "Create rule"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+// --- Webhooks --------------------------------------------------------------
+
+const WEBHOOK_FORMATS: { value: WebhookFormat; label: string }[] = [
+  { value: "generic", label: "Generic (your own receiver)" },
+  { value: "discord", label: "Discord" },
+  { value: "slack", label: "Slack" },
+]
+
+function WebhooksSection({
+  webhooks,
+  loading,
+  onChanged,
+}: {
+  webhooks: MerchantWebhook[]
+  loading: boolean
+  onChanged: () => void
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-sm font-medium">Webhooks</h2>
+          <p className="max-w-2xl text-sm text-muted-foreground">
+            Deliver alerts to a chat channel or your own receiver. Paste a Discord or Slack channel
+            webhook URL — no bot needed — or point “generic” at your own endpoint.
+          </p>
+        </div>
+        <WebhookDialog onDone={onChanged} />
+      </div>
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : webhooks.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No webhooks yet. Add one to route alerts to Discord, Slack, or a custom URL.
+        </p>
+      ) : (
+        <div className="overflow-x-auto rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Format</TableHead>
+                <TableHead>URL</TableHead>
+                <TableHead />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {webhooks.map((w) => (
+                <WebhookRow key={w.id} webhook={w} onChanged={onChanged} />
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function WebhookRow({ webhook, onChanged }: { webhook: MerchantWebhook; onChanged: () => void }) {
+  const [busy, setBusy] = React.useState(false)
+  const [confirmOpen, setConfirmOpen] = React.useState(false)
+  return (
+    <TableRow className={webhook.enabled === false ? "opacity-60" : undefined}>
+      <TableCell className="font-medium">{webhook.name}</TableCell>
+      <TableCell>
+        <Badge variant="secondary">{webhook.format}</Badge>
+      </TableCell>
+      <TableCell className="max-w-[22rem] truncate font-mono text-xs" title={webhook.url}>
+        {webhook.url}
+      </TableCell>
+      <TableCell className="text-right">
+        <div className="flex justify-end gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={busy}
+            onClick={async () => {
+              setBusy(true)
+              try {
+                await testWebhook(webhook.id)
+                toast.success("Test payload sent")
+              } catch (err) {
+                toastApiError(err, "Send test payload")
+              } finally {
+                setBusy(false)
+              }
+            }}
+          >
+            <SendIcon className="size-3.5" /> Test
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Delete webhook"
+            disabled={busy}
+            onClick={() => setConfirmOpen(true)}
+          >
+            <Trash2Icon className="size-4 text-muted-foreground" />
+          </Button>
+          <TypedConfirmDialog
+            open={confirmOpen}
+            onOpenChange={setConfirmOpen}
+            title={`Delete "${webhook.name}"?`}
+            description="Any alert rule routing to this webhook will stop delivering to it. This cannot be undone."
+            confirmationWord="DELETE"
+            actionLabel="Delete webhook"
+            onConfirm={async () => {
+              try {
+                await deleteWebhook(webhook.id)
+                toast.success("Webhook deleted")
+                onChanged()
+              } catch (err) {
+                toastApiError(err, "Delete webhook")
+              }
+            }}
+          />
+        </div>
+      </TableCell>
+    </TableRow>
+  )
+}
+
+function WebhookDialog({ onDone }: { onDone: () => void }) {
+  const [open, setOpen] = React.useState(false)
+  const [name, setName] = React.useState("")
+  const [url, setUrl] = React.useState("")
+  const [format, setFormat] = React.useState<WebhookFormat>("generic")
+  const [busy, setBusy] = React.useState(false)
+
+  const handleOpen = (next: boolean) => {
+    setOpen(next)
+    if (!next) {
+      setName("")
+      setUrl("")
+      setFormat("generic")
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="outline">
+          <PlusIcon className="size-4" /> Add webhook
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add webhook</DialogTitle>
+          <DialogDescription>
+            Paste a Discord or Slack channel webhook URL — no bot needed — or a “generic” URL your
+            own receiver consumes.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-3">
+          <div className="grid gap-1.5">
+            <Label htmlFor="wh-name">Name</Label>
+            <Input
+              id="wh-name"
+              placeholder="e.g. #billing-alerts"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+          <div className="grid gap-1.5">
+            <Label htmlFor="wh-format">Format</Label>
+            <Select value={format} onValueChange={(v) => setFormat(v as WebhookFormat)}>
+              <SelectTrigger id="wh-format" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {WEBHOOK_FORMATS.map((f) => (
+                  <SelectItem key={f.value} value={f.value}>
+                    {f.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="grid gap-1.5">
+            <Label htmlFor="wh-url">Webhook URL</Label>
+            <Input
+              id="wh-url"
+              className="font-mono text-xs"
+              placeholder="https://discord.com/api/webhooks/…"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            disabled={busy || !name.trim() || !url.trim()}
+            onClick={async () => {
+              setBusy(true)
+              try {
+                await createWebhook({ name: name.trim(), url: url.trim(), format })
+                toast.success("Webhook added")
+                handleOpen(false)
+                onDone()
+              } catch (err) {
+                toastApiError(err, "Add webhook")
+              } finally {
+                setBusy(false)
+              }
+            }}
+          >
+            {busy ? "Adding…" : "Add webhook"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/admin/src/pages/settings/alerts.tsx
+++ b/web/admin/src/pages/settings/alerts.tsx
@@ -47,18 +47,20 @@ import {
   deleteWebhook,
   getMerchantSettings,
   listAlertRules,
+  listAlertTemplates,
   listWebhooks,
   putMerchantSettings,
   testAlertRule,
-  testWebhook,
   updateAlertRule,
   type AlertRuleRequest,
 } from "@/lib/api/endpoints"
 import type {
-  AlertChannels,
+  AlertChannelRef,
+  AlertDeliveryResult,
   AlertRule,
   AlertSeverity,
   AlertTemplate,
+  AlertTemplateInfo,
   MerchantSettings,
   MerchantWebhook,
   WebhookFormat,
@@ -66,142 +68,70 @@ import type {
 import { cn } from "@/lib/utils"
 import { toastApiError } from "@/lib/toast"
 
-// --- Template registry (v1 set, per the #736 contract) --------------------
-// Each template maps to a #733 registry query the evaluator runs on the slow
-// tick. Params here are the merchant-tunable knobs with the pinned defaults;
-// their numeric SEMANTICS are owned by the engine (Agent A) — the UI only
-// presents labelled fields and round-trips the values.
+// --- Template copy (v1 set) -------------------------------------------------
+// The param SCHEMA is fetched from GET /merchant/alerts/templates (the create/
+// edit dialog renders its fields from that, never a hardcoded shape). These
+// are just nicer plain-language label/description overrides for the known v1
+// keys — the engine's own copy (display_name/description) is the fallback for
+// any template this map doesn't recognize.
 
-type ParamKind = "number" | "duration"
-
-interface ParamSpec {
-  key: string
-  label: string
-  help?: string
-  kind: ParamKind
-  default: string
-  suffix?: string
-  step?: string
-  min?: string
-}
-
-interface TemplateDef {
-  key: AlertTemplate
-  label: string
-  description: string
-  defaultSeverity: AlertSeverity
-  cadenceNote?: string
-  params: ParamSpec[]
-}
-
-const TEMPLATES: TemplateDef[] = [
-  {
-    key: "chargeback_rate",
-    label: "Chargeback ratio per merchant account",
+const TEMPLATE_COPY: Record<string, { label: string; description: string }> = {
+  chargeback_rate_by_rail_account: {
+    label: "Chargeback ratio per rail account",
     description:
       "Warns before card-network monitoring thresholds. Fires per rail account when its " +
       "chargeback ratio approaches the network limit (VAMP ≈ 0.9%) — the alert that gets a " +
       "high-risk merchant fined.",
-    defaultSeverity: "critical",
-    params: [
-      {
-        key: "threshold",
-        label: "Warn at fraction of the network limit",
-        help: "0.7 = warn at 70% of VAMP (≈ 0.9%), i.e. once chargebacks reach ~0.63%.",
-        kind: "number",
-        default: "0.7",
-        step: "0.05",
-        min: "0",
-      },
-      {
-        key: "window",
-        label: "Measurement window",
-        help: "Trailing window the chargeback ratio is measured over (e.g. 30d).",
-        kind: "duration",
-        default: "30d",
-      },
-    ],
   },
-  {
-    key: "dunning_spike",
+  dunning_spike: {
     label: "Dunning spike",
     description:
       "Fires when the number of subscriptions in dunning (past_due) jumps versus its trailing " +
       "baseline — an early signal that a rail is suddenly declining hard.",
-    defaultSeverity: "critical",
-    params: [
-      {
-        key: "multiplier",
-        label: "Spike multiplier",
-        help: "Fire when the in-dunning count exceeds this multiple of the baseline (2 = doubled).",
-        kind: "number",
-        default: "2",
-        step: "0.5",
-        min: "1",
-      },
-      {
-        key: "window",
-        label: "Baseline window",
-        help: "Trailing window used to compute the baseline (e.g. 7d).",
-        kind: "duration",
-        default: "7d",
-      },
-    ],
   },
-  {
-    key: "payers_at_depletion_risk",
+  payers_at_depletion_risk: {
     label: "Payers approaching credit depletion",
     description:
       "Fires when a batch of prepaid payers are about to run out of credits — the top-up revenue " +
       "moment, and a churn-risk signal for usage-billing platforms.",
-    defaultSeverity: "warning",
-    params: [
-      {
-        key: "min_count",
-        label: "Minimum payers at risk",
-        help: "Only alert when at least this many payers are at risk.",
-        kind: "number",
-        default: "10",
-        min: "1",
-      },
-      {
-        key: "runway_days",
-        label: "Runway",
-        suffix: "days",
-        help: "Count payers whose balance runs out within this many days at their recent burn rate.",
-        kind: "number",
-        default: "7",
-        min: "1",
-      },
-    ],
   },
-  {
-    key: "payment_methods_expiring",
+  payment_methods_expiring: {
     label: "Payment methods expiring (monthly digest)",
     description:
       "A monthly heads-up of cards expiring soon so you can prompt updates before involuntary " +
       "churn hits.",
-    defaultSeverity: "warning",
-    cadenceNote: "Sent monthly.",
-    params: [
-      {
-        key: "days_ahead",
-        label: "Look-ahead",
-        suffix: "days",
-        help: "Include payment methods expiring within this many days.",
-        kind: "number",
-        default: "30",
-        min: "1",
-      },
-    ],
   },
-]
-
-function templateDef(key: AlertTemplate): TemplateDef {
-  return TEMPLATES.find((t) => t.key === key) ?? TEMPLATES[0]
 }
 
-// --- Channel wire adapters (localized reconciliation seam) -----------------
+function templateLabel(t: AlertTemplateInfo): string {
+  return TEMPLATE_COPY[t.key]?.label ?? t.display_name
+}
+
+function templateDescription(t: AlertTemplateInfo): string {
+  return TEMPLATE_COPY[t.key]?.description ?? t.description
+}
+
+function templateByKey(templates: AlertTemplateInfo[], key: string): AlertTemplateInfo | undefined {
+  return templates.find((t) => t.key === key)
+}
+
+// humanizeParam turns a snake_case param name into a label (the schema only
+// carries name/description, not a display label).
+function humanizeParam(name: string): string {
+  return name
+    .split("_")
+    .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : w))
+    .join(" ")
+}
+
+// runway_days is fixed by the #733 engine (only 7 is accepted) — render it
+// read-only/informational rather than let the operator pick a value the
+// server will reject.
+function isFixedParam(templateKey: string, paramName: string): boolean {
+  return templateKey === "payers_at_depletion_risk" && paramName === "runway_days"
+}
+
+// --- Channel wire adapter (array is the ONE true shape) ---------------------
 
 interface ChannelSelection {
   in_app: boolean
@@ -209,46 +139,49 @@ interface ChannelSelection {
   webhookIds: string[]
 }
 
-function channelsFromWire(raw: unknown): ChannelSelection {
-  if (Array.isArray(raw)) {
-    const sel: ChannelSelection = { in_app: false, email: false, webhookIds: [] }
-    for (const c of raw) {
-      if (c === "in_app") sel.in_app = true
-      else if (c === "email") sel.email = true
-      else if (typeof c === "string" && c.startsWith("webhook:")) sel.webhookIds.push(c.slice(8))
-      else if (c && typeof c === "object") {
-        const o = c as Record<string, unknown>
-        if (o.type === "in_app") sel.in_app = true
-        else if (o.type === "email") sel.email = true
-        else if (o.type === "webhook" && typeof o.webhook_id === "string")
-          sel.webhookIds.push(o.webhook_id)
-      }
-    }
-    return sel
+function channelsFromWire(channels: AlertChannelRef[] | undefined): ChannelSelection {
+  const sel: ChannelSelection = { in_app: false, email: false, webhookIds: [] }
+  for (const c of channels ?? []) {
+    if (c.type === "in_app") sel.in_app = true
+    else if (c.type === "email") sel.email = true
+    else if (c.type === "webhook" && c.webhook_id) sel.webhookIds.push(c.webhook_id)
   }
-  const o = (raw ?? {}) as Partial<AlertChannels>
-  return {
-    in_app: o.in_app ?? true,
-    email: o.email ?? false,
-    webhookIds: Array.isArray(o.webhook_ids) ? o.webhook_ids : [],
-  }
+  return sel
 }
 
 // in_app is always on; email/webhooks are the operator's choice.
-function channelsToWire(sel: ChannelSelection): AlertChannels {
-  return { in_app: true, email: sel.email, webhook_ids: sel.webhookIds }
+function channelsToWire(sel: ChannelSelection): AlertChannelRef[] {
+  const out: AlertChannelRef[] = [{ type: "in_app" }]
+  if (sel.email) out.push({ type: "email" })
+  for (const id of sel.webhookIds) out.push({ type: "webhook", webhook_id: id })
+  return out
+}
+
+// summarizeDeliveryResults turns a test-fire response into one toast line.
+function summarizeDeliveryResults(results: AlertDeliveryResult[]): string {
+  if (results.length === 0) return "Test alert sent (rule has no channels)"
+  const failed = results.filter((r) => !r.ok)
+  if (failed.length === 0) {
+    return `Test alert delivered to all ${results.length} channel${results.length > 1 ? "s" : ""}`
+  }
+  const detail = failed.map((f) => f.detail || f.channel).join("; ")
+  return `Test alert: ${results.length - failed.length}/${results.length} channels succeeded (${detail})`
 }
 
 // --- Page ------------------------------------------------------------------
 
 export function AlertsTab() {
   const settings = useApiData(() => getMerchantSettings(), [])
+  const templates = useApiData(() => listAlertTemplates(), [])
   const rules = useApiData(() => listAlertRules(), [])
   const webhooks = useApiData(() => listWebhooks(), [])
 
   React.useEffect(() => {
     if (settings.error) toastApiError(settings.error, "Load settings")
   }, [settings.error])
+  React.useEffect(() => {
+    if (templates.error) toastApiError(templates.error, "Load alert templates")
+  }, [templates.error])
   React.useEffect(() => {
     if (rules.error) toastApiError(rules.error, "Load alert rules")
   }, [rules.error])
@@ -258,6 +191,7 @@ export function AlertsTab() {
 
   const alertEmail = settings.data?.alert_email ?? ""
   const hooks = webhooks.data?.data ?? []
+  const templateList = templates.data?.data ?? []
 
   return (
     <div className="flex max-w-4xl flex-col gap-6">
@@ -270,6 +204,8 @@ export function AlertsTab() {
       <RulesSection
         rules={rules.data?.data ?? []}
         loading={rules.loading}
+        templates={templateList}
+        templatesLoading={templates.loading}
         webhooks={hooks}
         alertEmail={alertEmail}
         onChanged={rules.reload}
@@ -364,7 +300,7 @@ function SeverityBadge({ severity }: { severity: AlertSeverity }) {
   )
 }
 
-function ChannelSummary({ channels }: { channels: AlertChannels }) {
+function ChannelSummary({ channels }: { channels: AlertChannelRef[] }) {
   const sel = channelsFromWire(channels)
   return (
     <span className="flex flex-wrap items-center gap-1 text-xs text-muted-foreground">
@@ -389,16 +325,22 @@ function ChannelSummary({ channels }: { channels: AlertChannels }) {
 function RulesSection({
   rules,
   loading,
+  templates,
+  templatesLoading,
   webhooks,
   alertEmail,
   onChanged,
 }: {
   rules: AlertRule[]
   loading: boolean
+  templates: AlertTemplateInfo[]
+  templatesLoading: boolean
   webhooks: MerchantWebhook[]
   alertEmail: string
   onChanged: () => void
 }) {
+  const canCreate = templates.length > 0
+
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-start justify-between gap-4">
@@ -409,9 +351,15 @@ function RulesSection({
             moment a threshold is crossed — before a rail fines you or churn spikes.
           </p>
         </div>
-        <RuleDialog webhooks={webhooks} alertEmail={alertEmail} onDone={onChanged} />
+        {canCreate ? (
+          <RuleDialog templates={templates} webhooks={webhooks} alertEmail={alertEmail} onDone={onChanged} />
+        ) : (
+          <Button size="sm" disabled>
+            <PlusIcon className="size-4" /> {templatesLoading ? "Loading…" : "New rule"}
+          </Button>
+        )}
       </div>
-      {loading ? (
+      {loading || templatesLoading ? (
         <p className="text-sm text-muted-foreground">Loading…</p>
       ) : rules.length === 0 ? (
         <Card className="border-dashed">
@@ -425,7 +373,15 @@ function RulesSection({
                 threshold is crossed. Start from a template.
               </p>
             </div>
-            <RuleDialog webhooks={webhooks} alertEmail={alertEmail} onDone={onChanged} cta />
+            {canCreate && (
+              <RuleDialog
+                templates={templates}
+                webhooks={webhooks}
+                alertEmail={alertEmail}
+                onDone={onChanged}
+                cta
+              />
+            )}
           </CardContent>
         </Card>
       ) : (
@@ -446,6 +402,7 @@ function RulesSection({
                 <RuleRow
                   key={r.id}
                   rule={r}
+                  templates={templates}
                   webhooks={webhooks}
                   alertEmail={alertEmail}
                   onChanged={onChanged}
@@ -461,18 +418,21 @@ function RulesSection({
 
 function RuleRow({
   rule,
+  templates,
   webhooks,
   alertEmail,
   onChanged,
 }: {
   rule: AlertRule
+  templates: AlertTemplateInfo[]
   webhooks: MerchantWebhook[]
   alertEmail: string
   onChanged: () => void
 }) {
   const [busy, setBusy] = React.useState(false)
   const [confirmOpen, setConfirmOpen] = React.useState(false)
-  const def = templateDef(rule.template)
+  const def = templateByKey(templates, rule.template)
+  const label = rule.name || (def ? templateLabel(def) : rule.template)
   const firing = ruleIsFiring(rule)
 
   const run = async (fn: () => Promise<unknown>, action: string, ok: string) => {
@@ -488,12 +448,24 @@ function RuleRow({
     }
   }
 
+  const runTest = async () => {
+    setBusy(true)
+    try {
+      const { results } = await testAlertRule(rule.id)
+      toast.success(summarizeDeliveryResults(results))
+    } catch (err) {
+      toastApiError(err, "Send test alert")
+    } finally {
+      setBusy(false)
+    }
+  }
+
   return (
     <TableRow className={rule.enabled ? undefined : "opacity-60"}>
       <TableCell>
-        <span className="font-medium">{def.label}</span>
-        {def.cadenceNote && (
-          <span className="block text-xs text-muted-foreground">{def.cadenceNote}</span>
+        <span className="font-medium">{label}</span>
+        {def?.digest && (
+          <span className="block text-xs text-muted-foreground">Digest — periodic, not threshold-triggered</span>
         )}
       </TableCell>
       <TableCell>
@@ -527,16 +499,12 @@ function RuleRow({
       </TableCell>
       <TableCell className="text-right">
         <div className="flex justify-end gap-1">
-          <Button
-            variant="ghost"
-            size="sm"
-            disabled={busy}
-            onClick={() => run(() => testAlertRule(rule.id), "Send test alert", "Test alert sent")}
-          >
+          <Button variant="ghost" size="sm" disabled={busy} onClick={runTest}>
             <SendIcon className="size-3.5" /> Test
           </Button>
           <RuleDialog
             rule={rule}
+            templates={templates}
             webhooks={webhooks}
             alertEmail={alertEmail}
             onDone={onChanged}
@@ -558,7 +526,7 @@ function RuleRow({
           <TypedConfirmDialog
             open={confirmOpen}
             onOpenChange={setConfirmOpen}
-            title={`Delete "${def.label}"?`}
+            title={`Delete "${label}"?`}
             description="This alert rule will stop evaluating and its firing state is discarded. This cannot be undone."
             confirmationWord="DELETE"
             actionLabel="Delete rule"
@@ -574,6 +542,7 @@ function RuleRow({
 
 function RuleDialog({
   rule,
+  templates,
   webhooks,
   alertEmail,
   onDone,
@@ -581,6 +550,7 @@ function RuleDialog({
   cta,
 }: {
   rule?: AlertRule
+  templates: AlertTemplateInfo[]
   webhooks: MerchantWebhook[]
   alertEmail: string
   onDone: () => void
@@ -589,10 +559,8 @@ function RuleDialog({
 }) {
   const editing = !!rule
   const [open, setOpen] = React.useState(false)
-  const [template, setTemplate] = React.useState<AlertTemplate>(rule?.template ?? "chargeback_rate")
-  const [severity, setSeverity] = React.useState<AlertSeverity>(
-    rule?.severity ?? templateDef(template).defaultSeverity,
-  )
+  const [template, setTemplate] = React.useState<AlertTemplate>(rule?.template ?? templates[0]?.key ?? "")
+  const [severity, setSeverity] = React.useState<AlertSeverity>(rule?.severity ?? "warning")
   const [params, setParams] = React.useState<Record<string, string>>({})
   const [channels, setChannels] = React.useState<ChannelSelection>({
     in_app: true,
@@ -602,16 +570,18 @@ function RuleDialog({
   const [enabled, setEnabled] = React.useState(rule?.enabled ?? true)
   const [busy, setBusy] = React.useState(false)
 
-  const def = templateDef(template)
+  const def = templateByKey(templates, template)
 
   // (Re)initialize form state whenever the dialog opens or the template changes.
   const initFor = React.useCallback(
     (tpl: AlertTemplate, r?: AlertRule) => {
-      const d = templateDef(tpl)
+      const d = templateByKey(templates, tpl)
       const p: Record<string, string> = {}
-      for (const spec of d.params) {
-        const existing = r?.params?.[spec.key]
-        p[spec.key] = existing === undefined || existing === null ? spec.default : String(existing)
+      for (const spec of d?.params ?? []) {
+        const existing = r?.params?.[spec.name]
+        if (existing !== undefined && existing !== null) p[spec.name] = String(existing)
+        else if (spec.default !== undefined) p[spec.name] = String(spec.default)
+        else p[spec.name] = ""
       }
       setParams(p)
       if (r) {
@@ -619,12 +589,13 @@ function RuleDialog({
         setChannels(channelsFromWire(r.channels))
         setEnabled(r.enabled)
       } else {
-        setSeverity(d.defaultSeverity)
-        setChannels({ in_app: true, email: d.defaultSeverity === "critical", webhookIds: [] })
+        const sev = d?.default_severity ?? "warning"
+        setSeverity(sev)
+        setChannels({ in_app: true, email: sev === "critical", webhookIds: [] })
         setEnabled(true)
       }
     },
-    [],
+    [templates],
   )
 
   const handleOpen = (next: boolean) => {
@@ -641,11 +612,15 @@ function RuleDialog({
     initFor(tpl, undefined)
   }
 
+  const missingRequired = (def?.params ?? []).some((spec) => spec.required && !params[spec.name]?.trim())
+
   const submit = async () => {
+    if (!def) return
     const p: Record<string, unknown> = {}
     for (const spec of def.params) {
-      const raw = (params[spec.key] ?? spec.default).trim()
-      p[spec.key] = spec.kind === "number" ? Number(raw) : raw
+      const raw = (params[spec.name] ?? "").trim()
+      if (raw === "") continue // omit — the server fills the default or requires it
+      p[spec.name] = spec.type === "window" ? raw : Number(raw)
     }
     const body: AlertRuleRequest = {
       template,
@@ -681,8 +656,8 @@ function RuleDialog({
         <DialogHeader>
           <DialogTitle>{editing ? "Edit alert rule" : "New alert rule"}</DialogTitle>
           <DialogDescription>
-            {editing
-              ? def.description
+            {editing && def
+              ? templateDescription(def)
               : "Pick what to watch, set the threshold, and choose how you want to be told."}
           </DialogDescription>
         </DialogHeader>
@@ -692,7 +667,7 @@ function RuleDialog({
             <div className="grid gap-2">
               <Label>Template</Label>
               <div className="grid gap-2">
-                {TEMPLATES.map((t) => (
+                {templates.map((t) => (
                   <button
                     key={t.key}
                     type="button"
@@ -703,8 +678,8 @@ function RuleDialog({
                       template === t.key ? "border-primary bg-primary/5" : "hover:bg-muted/50",
                     )}
                   >
-                    <p className="text-sm font-medium">{t.label}</p>
-                    <p className="mt-1 text-xs text-muted-foreground">{t.description}</p>
+                    <p className="text-sm font-medium">{templateLabel(t)}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">{templateDescription(t)}</p>
                   </button>
                 ))}
               </div>
@@ -712,23 +687,26 @@ function RuleDialog({
           )}
 
           <div className="grid gap-3">
-            {def.params.map((spec) => (
-              <div key={spec.key} className="grid gap-1.5">
-                <Label htmlFor={`p-${spec.key}`}>
-                  {spec.label}
-                  {spec.suffix ? ` (${spec.suffix})` : ""}
-                </Label>
-                <Input
-                  id={`p-${spec.key}`}
-                  type={spec.kind === "number" ? "number" : "text"}
-                  step={spec.step}
-                  min={spec.min}
-                  value={params[spec.key] ?? ""}
-                  onChange={(e) => setParams((prev) => ({ ...prev, [spec.key]: e.target.value }))}
-                />
-                {spec.help && <p className="text-xs text-muted-foreground">{spec.help}</p>}
-              </div>
-            ))}
+            {(def?.params ?? []).map((spec) => {
+              const readOnly = isFixedParam(template, spec.name)
+              return (
+                <div key={spec.name} className="grid gap-1.5">
+                  <Label htmlFor={`p-${spec.name}`}>{humanizeParam(spec.name)}</Label>
+                  <Input
+                    id={`p-${spec.name}`}
+                    type={spec.type === "window" ? "text" : "number"}
+                    step={spec.type === "integer" ? 1 : spec.type === "number" ? "any" : undefined}
+                    min={spec.min}
+                    max={spec.max}
+                    placeholder={spec.type === "window" ? "e.g. 30d, 12w" : undefined}
+                    disabled={readOnly}
+                    value={params[spec.name] ?? ""}
+                    onChange={(e) => setParams((prev) => ({ ...prev, [spec.name]: e.target.value }))}
+                  />
+                  <p className="text-xs text-muted-foreground">{spec.description}</p>
+                </div>
+              )
+            })}
           </div>
 
           <div className="grid gap-1.5">
@@ -826,7 +804,7 @@ function RuleDialog({
         </div>
 
         <DialogFooter>
-          <Button disabled={busy} onClick={submit}>
+          <Button disabled={busy || !def || missingRequired} onClick={submit}>
             {busy ? "Saving…" : editing ? "Save changes" : "Create rule"}
           </Button>
         </DialogFooter>
@@ -859,7 +837,9 @@ function WebhooksSection({
           <h2 className="text-sm font-medium">Webhooks</h2>
           <p className="max-w-2xl text-sm text-muted-foreground">
             Deliver alerts to a chat channel or your own receiver. Paste a Discord or Slack channel
-            webhook URL — no bot needed — or point “generic” at your own endpoint.
+            webhook URL — no bot needed — or point “generic” at your own endpoint. There is no
+            standalone test for a webhook — add it to a rule&apos;s channels and use that rule&apos;s
+            Test button.
           </p>
         </div>
         <WebhookDialog onDone={onChanged} />
@@ -894,7 +874,6 @@ function WebhooksSection({
 }
 
 function WebhookRow({ webhook, onChanged }: { webhook: MerchantWebhook; onChanged: () => void }) {
-  const [busy, setBusy] = React.useState(false)
   const [confirmOpen, setConfirmOpen] = React.useState(false)
   return (
     <TableRow className={webhook.enabled === false ? "opacity-60" : undefined}>
@@ -909,27 +888,8 @@ function WebhookRow({ webhook, onChanged }: { webhook: MerchantWebhook; onChange
         <div className="flex justify-end gap-1">
           <Button
             variant="ghost"
-            size="sm"
-            disabled={busy}
-            onClick={async () => {
-              setBusy(true)
-              try {
-                await testWebhook(webhook.id)
-                toast.success("Test payload sent")
-              } catch (err) {
-                toastApiError(err, "Send test payload")
-              } finally {
-                setBusy(false)
-              }
-            }}
-          >
-            <SendIcon className="size-3.5" /> Test
-          </Button>
-          <Button
-            variant="ghost"
             size="icon"
             aria-label="Delete webhook"
-            disabled={busy}
             onClick={() => setConfirmOpen(true)}
           >
             <Trash2Icon className="size-4 text-muted-foreground" />

--- a/web/admin/src/pages/settings/index.tsx
+++ b/web/admin/src/pages/settings/index.tsx
@@ -45,6 +45,7 @@ import {
 import type { PaymentProviderConfig } from "@/lib/api/types"
 import { formatDate, formatMicros, microsFromInput } from "@/lib/format"
 import { toastApiError } from "@/lib/toast"
+import { AlertsTab } from "./alerts"
 import { ApiKeysTab } from "./api-keys"
 
 export function SettingsPage() {
@@ -52,12 +53,16 @@ export function SettingsPage() {
     <Tabs defaultValue="merchant" className="flex flex-col gap-4">
       <TabsList>
         <TabsTrigger value="merchant">Merchant</TabsTrigger>
+        <TabsTrigger value="alerts">Alerts</TabsTrigger>
         <TabsTrigger value="providers">Payment providers</TabsTrigger>
         <TabsTrigger value="api-keys">API keys</TabsTrigger>
         <TabsTrigger value="customer-controls">Customer controls</TabsTrigger>
       </TabsList>
       <TabsContent value="merchant">
         <MerchantSettingsTab />
+      </TabsContent>
+      <TabsContent value="alerts">
+        <AlertsTab />
       </TabsContent>
       <TabsContent value="providers">
         <ProvidersTab />


### PR DESCRIPTION
Console UI (Agent B) for **#736 metric threshold alerting**, built against the pinned implementation contract. Agent A builds the engine/API in parallel; **this PR is intentionally left unmerged until A's PR merges**, at which point it rebases onto master and reconciles to the as-built API shapes.

## What's here (UI only — no Go changes)
- **Typed client** (`lib/api/endpoints.ts` + `types.ts`): alert rules CRUD + test-fire, webhooks CRUD + per-webhook test, notifications list/read/unread-count; `alert_email` added to `MerchantSettings`.
- **Settings → Alerts tab** (`pages/settings/alerts.tsx`):
  - Alert-email card (destination for the email channel; fail-soft when empty).
  - Rule list: enable/disable `Switch`, severity + firing badges, channel summary, per-rule **Test**, edit, and typed-confirm delete.
  - Create/edit dialog off the 4 v1 templates (chargeback ratio, dunning spike, payers at depletion risk, expiring cards) — plain-language descriptions, params with the pinned defaults, severity picker, and a channel picker (in-app always-on; email showing the alert_email and prompting when empty; webhook multi-select).
  - Webhook management: add (name + url + `generic|discord|slack` with "paste a Discord/Slack channel webhook URL — no bot needed"), per-webhook **Test**, typed-confirm delete.
  - Pointed empty-states (no rules → what alerting does + CTA; no webhooks; no alert-email prompt).
- **Header notification bell** (`components/notification-bell.tsx`): polled unread badge (30s), dropdown feed (severity icon, title, relative time, unread dot), mark-read on click with in-app deep-link navigation, and mark-all-read (client fan-out — no bulk endpoint pinned).

## Reconciliation seams (pending A's merge)
Localized so the rest of the UI is shape-agnostic:
- **`channels` wire shape** — `channelsFromWire`/`channelsToWire` in `alerts.tsx` (built for the `{in_app, email, webhook_ids}` object form; tolerant of an array form).
- **Per-webhook test endpoint** — `testWebhook` posts to `/merchant/webhooks/{id}/test`, which the required per-webhook Test button implies but the pinned HTTP list does not enumerate. Needs A to expose it (or I adjust the path).
- **`alert_email` placement** — top-level on `MerchantSettings` (move if A nests it under `profile`).

## Verify (all clean vs known baseline)
- `tsc --noEmit`: clean.
- `eslint`: clean except the one pre-existing TanStack `useReactTable` warning in `data-table.tsx` (unrelated).
- `vite build` + `task admin-build`: clean; `web/dist` not committed (#754 asset model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)