### PR TITLE
Retire the 3 baseline-red CCBill refund integration tests (post-1d3cffb4 contract)

### DIFF
--- a/internal/http/handlers/admin_findings_ccbill_integration_test.go
+++ b/internal/http/handlers/admin_findings_ccbill_integration_test.go
@@ -21,10 +21,11 @@ import (
 )
 
 // fakeCCBillSMS scripts DataLink's subscriptionManagement.cgi for the admin
-// cancel drain: view answers "rebilling", cancel answers success.
+// cancel + refund drain: view answers "rebilling", cancel/refund answer success.
 type fakeCCBillSMS struct {
 	viewCalls   atomic.Int64
 	cancelCalls atomic.Int64
+	refundCalls atomic.Int64
 	status      atomic.Value // string
 }
 
@@ -41,6 +42,9 @@ func newFakeCCBillSMS(t *testing.T) (*fakeCCBillSMS, *ccbill.DataLinkClient) {
 		case "cancelSubscription":
 			f.cancelCalls.Add(1)
 			f.status.Store("1")
+			fmt.Fprint(w, `<results>1</results>`)
+		case "voidOrRefundTransaction":
+			f.refundCalls.Add(1)
 			fmt.Fprint(w, `<results>1</results>`)
 		default:
 			w.WriteHeader(http.StatusBadRequest)
@@ -68,8 +72,9 @@ func (fx *findingsFixture) seedActiveCCBillSubscription(psid string) uuid.UUID {
 // #696 admin path: approving a cancel_and_refund on a CCBill subscription
 // executes the local cancel and queues the durable ccbill_cancel intent
 // (admin-origin); the executor drains it through the fake DataLink server. The
-// refund leg stays not-supported with a clear manual-portal error that leaves
-// the finding OPEN with the completed cancel documented.
+// refund leg (#696 follow-up) now rides the same intent ledger — it queues a
+// ccbill_refund intent instead of bouncing to the manual admin portal — and
+// the executor drains that too against the fake DataLink server.
 func TestFindingsQueueApproveCCBillCancelAndRefund(t *testing.T) {
 	fx := newFindingsFixture(t)
 	psid := "ccsub-" + uuid.NewString()[:8]
@@ -107,10 +112,13 @@ func TestFindingsQueueApproveCCBillCancelAndRefund(t *testing.T) {
 	// Drain through the choke point against the fake DataLink server.
 	fake, client := newFakeCCBillSMS(t)
 	runner := &intents.Runner{
-		Store:    intents.NewStore(fx.dbi),
-		Registry: intents.NewRegistry(intents.NewCCBillCancelHandler(fx.dbi, client, nil)),
-		Config:   fx.rt.Config,
-		Breaker:  intents.NewVolumeBreaker(fx.dbi),
+		Store: intents.NewStore(fx.dbi),
+		Registry: intents.NewRegistry(
+			intents.NewCCBillCancelHandler(fx.dbi, client, nil),
+			intents.NewCCBillRefundHandler(fx.dbi, client, nil),
+		),
+		Config:  fx.rt.Config,
+		Breaker: intents.NewVolumeBreaker(fx.dbi),
 	}
 	_, err := runner.RunExecuteOnce(fx.ctx)
 	require.NoError(t, err)
@@ -119,12 +127,13 @@ func TestFindingsQueueApproveCCBillCancelAndRefund(t *testing.T) {
 	assert.Equal(t, intents.StatusSucceeded, intentStatus)
 	assert.EqualValues(t, 1, fake.cancelCalls.Load())
 
-	// --- refund leg: not supported for ccbill, clear manual-portal error ---
+	// --- refund leg: rides the ccbill_refund intent ledger (queue-always #679) ---
 	payID := uuid.New()
+	txnID := "cctxn-" + uuid.NewString()[:8]
 	fx.exec(`INSERT INTO openrails.payments
 	          (id, price_id, rail, transaction_id, amount, list_amount, currency, status, subscription_id, customer_id, merchant_id)
 	        VALUES ($1, $2, 'ccbill', $3, 10000000, 10000000, 'usd', 'completed', $4, $5, $6)`,
-		payID, fx.price, "cctxn-"+uuid.NewString()[:8], subID, fx.customer, fx.merchant)
+		payID, fx.price, txnID, subID, fx.customer, fx.merchant)
 	refundFinding := fx.seedFinding("consistency.duplicate.ownership", "cc-refund-"+uuid.NewString()[:8], "critical",
 		"refund the duplicate ccbill charge", &recommend.Recommendation{
 			Action: recommend.ActionCancelAndRefund,
@@ -132,12 +141,45 @@ func TestFindingsQueueApproveCCBillCancelAndRefund(t *testing.T) {
 		})
 	rec = fx.do(AdminResolveFinding, http.MethodPost, "/findings/"+refundFinding.String()+"/resolve",
 		map[string]any{"outcome": "approve", "notes": "dup charge"}, refundFinding.String())
-	require.Equal(t, http.StatusBadRequest, rec.Code, rec.Body.String())
-	assert.Contains(t, rec.Body.String(), "CCBill admin portal", "error names the manual path")
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resolved))
+	assert.Equal(t, "noop_already_cancelled", resolved.Execution["cancel"])
+	assert.Equal(t, "queued", resolved.Execution["refund"], "the runtime's intent registry has no CCBill DataLink client wired -> parks, queued not inline (mirrors cancel_intent)")
+	assert.Equal(t, "fixed", resolved.Finding.Status)
+
+	var refundIntentID uuid.UUID
+	var refundIntentStatus, refundOrigin string
+	require.NoError(t, fx.dbi.Pool().QueryRow(fx.ctx,
+		`SELECT id, status, origin FROM openrails.rail_intents
+		 WHERE merchant_id = $1 AND intent_type = $2 AND payment_id = $3`,
+		fx.merchant, intents.TypeCCBillRefund, payID).Scan(&refundIntentID, &refundIntentStatus, &refundOrigin))
+	assert.Equal(t, intents.StatusPending, refundIntentStatus, "remote refund rides the ledger (queue-always #679)")
+	assert.Equal(t, string(intents.OriginAdmin), refundOrigin)
+
+	// The inline attempt during resolve already parked this intent 5m out
+	// (ParkRetryInterval) since the runtime's registry has no client wired;
+	// force it due so the test's runner (real client) drains it now.
+	fx.exec(`UPDATE openrails.rail_intents SET next_attempt_at = now() WHERE id = $1`, refundIntentID)
+
+	// Drain the refund through the same choke point against the fake DataLink server.
+	_, err = runner.RunExecuteOnce(fx.ctx)
+	require.NoError(t, err)
+	require.NoError(t, fx.dbi.Pool().QueryRow(fx.ctx,
+		`SELECT status FROM openrails.rail_intents WHERE id = $1`, refundIntentID).Scan(&refundIntentStatus))
+	assert.Equal(t, intents.StatusSucceeded, refundIntentStatus)
+	assert.EqualValues(t, 1, fake.refundCalls.Load())
+
+	var refundAmount int64
+	var refundStatus, refundTxn string
+	require.NoError(t, fx.dbi.Pool().QueryRow(fx.ctx,
+		`SELECT amount, status, transaction_id FROM openrails.payments WHERE refunded_payment_id = $1`, payID).
+		Scan(&refundAmount, &refundStatus, &refundTxn))
+	assert.EqualValues(t, -10000000, refundAmount)
+	assert.Equal(t, "completed", refundStatus)
+	// CCBill has no discrete provider refund id; the recorded ref composes the
+	// subscription + original transaction (ccbillRefundProviderRef).
+	assert.Equal(t, "ccbill_refund:"+psid+":"+txnID, refundTxn)
 
 	row := fx.findingRow(refundFinding)
-	assert.Equal(t, "requires_review", row.Status, "unsupported refund leaves the finding OPEN")
-	require.NotNil(t, row.OperatorNotes)
-	assert.Contains(t, *row.OperatorNotes, "CCBill admin portal")
-	assert.Contains(t, *row.OperatorNotes, `"cancel":"noop_already_cancelled"`, "compensation state documented")
+	assert.Equal(t, "fixed", row.Status)
 }

--- a/internal/http/handlers/admin_payments.go
+++ b/internal/http/handlers/admin_payments.go
@@ -241,12 +241,13 @@ func prepareAdminRefund(ctx context.Context, r *httprequest.Request, txDB *db.DB
 	var ccbillSubscriptionID, ccbillTransactionID string
 	switch {
 	case payment.Rail == models.RailCCBill:
-		// #696: refund through OUR admin via the DataLink SMS choke point instead
-		// of routing the operator to CCBill's portal. The refund action keys off
-		// the CCBill subscriptionId (carried on the subscription row) + the
-		// payment's transaction id; the provider mutation rides the intent ledger.
+		// #696: refund through OUR admin via the DataLink SMS choke point. The
+		// refund action keys off the CCBill subscriptionId (carried on the
+		// subscription row) + the payment's transaction id; the provider mutation
+		// rides the intent ledger. (API refunds also require CCBill's
+		// account-level refund feature; a -7 denial surfaces from the executor.)
 		if payment.SubscriptionID == nil {
-			return nil, adminRefundHTTPError(http.StatusBadRequest, "payment cannot be refunded: ccbill payment has no linked subscription")
+			return nil, ccbillManualRefundError("CCBill refunds are keyed off the linked subscription's CCBill subscription id, and this payment has no linked subscription")
 		}
 		sub, err := subscriptions.NewSubscriptionRepo(txDB).GetByID(ctx, *payment.SubscriptionID)
 		if err != nil {
@@ -254,7 +255,7 @@ func prepareAdminRefund(ctx context.Context, r *httprequest.Request, txDB *db.DB
 		}
 		subID, txnID, err := ccbillRefundTarget(payment, sub)
 		if err != nil {
-			return nil, adminRefundHTTPError(http.StatusBadRequest, "payment cannot be refunded: "+err.Error())
+			return nil, ccbillManualRefundError(err.Error())
 		}
 		ccbillSubscriptionID = subID
 		ccbillTransactionID = txnID
@@ -286,6 +287,14 @@ func prepareAdminRefund(ctx context.Context, r *httprequest.Request, txDB *db.DB
 	}
 	prepared.reservation = reservation
 	return prepared, nil
+}
+
+// ccbillManualRefundError: this specific payment can't resolve its CCBill
+// refund coordinates, so the API path is out — direct the operator to the
+// manual fallback instead of a dead end.
+func ccbillManualRefundError(why string) error {
+	return adminRefundHTTPError(http.StatusBadRequest,
+		"payment cannot be refunded via the API: "+why+" — refund it manually in the CCBill admin portal")
 }
 
 // ccbillRefundTarget derives the CCBill refund coordinates from a CCBill payment

--- a/tests/admin_payments_test.go
+++ b/tests/admin_payments_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -21,6 +22,7 @@ import (
 	"github.com/open-rails/openrails/config"
 	"github.com/open-rails/openrails/internal/controlplane"
 	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/integrations/ccbill"
 	"github.com/open-rails/openrails/internal/integrations/nmi"
 	"github.com/open-rails/openrails/pkg/api"
 )
@@ -600,7 +602,11 @@ func TestAdminRefundPayment(t *testing.T) {
 		assert.Contains(t, message, "charge/payment_intent")
 	})
 
-	t.Run("returns 400 for CCBill payments with helpful message", func(t *testing.T) {
+	t.Run("returns 400 for CCBill payments without a linked subscription", func(t *testing.T) {
+		// #696: CCBill refunds ride the DataLink intent path keyed off the linked
+		// subscription's CCBill subscription id. Without that link the API path
+		// can't resolve its refund coordinates — the 400 must say why and direct
+		// the operator to the manual fallback.
 		payment := suite.CreateTestPaymentWithOptions(PaymentOptions{
 			UserID:  userID,
 			PriceID: priceID,
@@ -616,7 +622,7 @@ func TestAdminRefundPayment(t *testing.T) {
 		req.Header.Set("X-Idempotency-Key", "refund-ccbill-"+uuid.NewString())
 		admin.ServeHTTP(w, req)
 
-		assert.Equal(t, http.StatusBadRequest, w.Code, "Should return 400 for CCBill")
+		assert.Equal(t, http.StatusBadRequest, w.Code, "Should return 400 for a CCBill payment with no subscription link")
 
 		var response map[string]interface{}
 		err := json.Unmarshal(w.Body.Bytes(), &response)
@@ -625,14 +631,16 @@ func TestAdminRefundPayment(t *testing.T) {
 		errorObj := response["error"].(map[string]interface{})
 		message := errorObj["message"].(string)
 		assert.Contains(t, message, "CCBill", "Error should mention CCBill")
-		assert.Contains(t, message, "admin portal", "Error should direct to admin portal")
+		assert.Contains(t, message, "no linked subscription", "Error should explain the subscription-link requirement")
+		assert.Contains(t, message, "admin portal", "Error should direct to the manual fallback")
 	})
 }
 
 // TestAdminRefundReachesAnyUserInMerchant confirms a merchant admin holding
 // payments:write can drive a refund against ANY user's payment within its
-// merchant — the operator is merchant-scoped, not user-scoped. (CCBill returns a
-// rail error, which proves the request reached the handler, not an auth gate.)
+// merchant — the operator is merchant-scoped, not user-scoped. (The unlinked
+// CCBill payments draw the no-subscription-link rail 400, which proves the
+// request reached the handler, not an auth gate.)
 func TestAdminRefundReachesAnyUserInMerchant(t *testing.T) {
 	suite := getSharedTestSuite(t)
 	admin := adminPaymentsWriter(t, suite)
@@ -753,4 +761,138 @@ func TestAdminRefundPaymentThroughIntentLedger(t *testing.T) {
 	w = refundReq("ledger-key-2")
 	assert.Equal(t, http.StatusConflict, w.Code, "identical refund content must conflict: %s", w.Body.String())
 	assert.EqualValues(t, 1, refundCalls.Load(), "the gateway never sees a duplicate refund")
+}
+
+// seedCCBillRefundablePayment: an active CCBill subscription (carrying the
+// CCBill subscription id) + a completed charge linked to it — the shape the
+// #696 refund path resolves its DataLink coordinates from.
+func seedCCBillRefundablePayment(suite *TestContainerSuite, priceID uuid.UUID) (payment *models.Payment, psid, txnID string) {
+	userID := uuid.New().String()
+	psid = "ccsub-" + uuid.NewString()[:8]
+	sub := suite.CreateTestSubscriptionWithOptions(SubscriptionOptions{
+		UserID:    userID,
+		PriceID:   priceID,
+		Status:    models.StatusActive,
+		Rail:      models.RailCCBill,
+		RailSubID: psid,
+	})
+	txnID = "cctxn-" + uuid.NewString()[:8]
+	payment = suite.CreateTestPaymentWithOptions(PaymentOptions{
+		UserID:         userID,
+		PriceID:        priceID,
+		SubscriptionID: &sub.ID,
+		Rail:           models.RailCCBill,
+		TransactionID:  txnID,
+		Amount:         10_000_000, // $10 in micros
+	})
+	return payment, psid, txnID
+}
+
+func ccbillAdminRefundReq(t *testing.T, admin http.Handler, paymentID uuid.UUID, idempotencyKey string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", fmt.Sprintf("/v1/merchant/payments/%s/refunds", paymentID.String()),
+		strings.NewReader(`{"amount": 5000000}`)) // $5 in micros
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+merchantDelegatedTestToken)
+	req.Header.Set("X-Idempotency-Key", idempotencyKey)
+	admin.ServeHTTP(w, req)
+	return w
+}
+
+// TestAdminRefundCCBillThroughIntentLedger drives the post-#696 CCBill refund
+// contract: a CCBill payment WITH a linked subscription refunds through the
+// durable ccbill_refund intent against the DataLink SMS choke point
+// (voidOrRefundTransaction keyed off the CCBill subscription id, narrowed to
+// the original transaction id), with the same content-addressed
+// effectively-once semantics as the NMI ledger path.
+func TestAdminRefundCCBillThroughIntentLedger(t *testing.T) {
+	suite := getSharedTestSuite(t)
+	admin := adminPaymentsWriter(t, suite)
+	products := suite.SeedProducts()
+	payment, psid, txnID := seedCCBillRefundablePayment(suite, products[0].Prices[0].ID)
+
+	// Fake DataLink SMS endpoint approving the refund; records the wire form so
+	// subscription/transaction/amount are pinned.
+	var refundCalls atomic.Int64
+	var refundForm atomic.Value
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		if r.PostForm.Get("action") == "voidOrRefundTransaction" {
+			refundCalls.Add(1)
+			refundForm.Store(r.PostForm)
+			fmt.Fprint(w, `<results>1</results>`)
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	t.Cleanup(srv.Close)
+	prevClient := suite.App.Runtime.CCBillDataLink
+	suite.App.Runtime.CCBillDataLink = &ccbill.DataLinkClient{
+		BaseURL: srv.URL, ClientAccNum: "900100", ClientSubAcc: "0000",
+		Username: "u", Password: "p", HTTPClient: srv.Client(),
+	}
+	t.Cleanup(func() { suite.App.Runtime.CCBillDataLink = prevClient })
+
+	w := ccbillAdminRefundReq(t, admin, payment.ID, "ccbill-ledger-key-1")
+	require.Equal(t, http.StatusCreated, w.Code, "synchronous ledger execution completes inline: %s", w.Body.String())
+	require.EqualValues(t, 1, refundCalls.Load())
+	form := refundForm.Load().(url.Values)
+	assert.Equal(t, psid, form.Get("subscriptionId"), "refund keys off the CCBill subscription id")
+	assert.Equal(t, txnID, form.Get("transactionId"), "the original transaction id narrows the refund")
+	// #671: 5,000,000 micros crosses the CCBill wire as decimal dollars.
+	assert.Equal(t, "5.00", form.Get("amount"), "provider must see the exact decimal amount")
+
+	var intentStatus string
+	require.NoError(t, suite.App.Runtime.DB.Pool().QueryRow(context.Background(),
+		"SELECT status FROM openrails.rail_intents WHERE intent_type = 'ccbill_refund' AND payment_id = $1",
+		payment.ID).Scan(&intentStatus))
+	assert.Equal(t, "succeeded", intentStatus)
+
+	// The finalized refund lands on the payments ledger against the original.
+	// CCBill answers no refund id, so the recorded ref composes
+	// subscription+transaction (ccbillRefundProviderRef).
+	var refundAmount int64
+	var refundStatus, refundTxn string
+	require.NoError(t, suite.App.Runtime.DB.Pool().QueryRow(context.Background(),
+		"SELECT amount, status, transaction_id FROM openrails.payments WHERE refunded_payment_id = $1",
+		payment.ID).Scan(&refundAmount, &refundStatus, &refundTxn))
+	assert.EqualValues(t, -5_000_000, refundAmount)
+	assert.Equal(t, "completed", refundStatus)
+	assert.Equal(t, "ccbill_refund:"+psid+":"+txnID, refundTxn)
+
+	// Admin-key replay returns the recorded refund without a second send.
+	w = ccbillAdminRefundReq(t, admin, payment.ID, "ccbill-ledger-key-1")
+	assert.Equal(t, http.StatusCreated, w.Code, "admin-key replay returns the recorded refund: %s", w.Body.String())
+	assert.EqualValues(t, 1, refundCalls.Load(), "replay never re-refunds")
+
+	// The SAME refund content under a DIFFERENT admin key conflicts on the
+	// content-addressed intent identity — no second money movement.
+	w = ccbillAdminRefundReq(t, admin, payment.ID, "ccbill-ledger-key-2")
+	assert.Equal(t, http.StatusConflict, w.Code, "identical refund content must conflict: %s", w.Body.String())
+	assert.EqualValues(t, 1, refundCalls.Load(), "CCBill never sees a duplicate refund")
+}
+
+// TestAdminRefundCCBillQueuedWhenDataLinkUnconfigured pins the pending
+// semantics: with no DataLink client armed the inline attempt parks, the
+// admin gets 202 with the pending reservation, and the durable intent stays
+// on the ledger for the scheduled executor (queue-always #679).
+func TestAdminRefundCCBillQueuedWhenDataLinkUnconfigured(t *testing.T) {
+	suite := getSharedTestSuite(t)
+	admin := adminPaymentsWriter(t, suite)
+	products := suite.SeedProducts()
+	payment, _, _ := seedCCBillRefundablePayment(suite, products[0].Prices[0].ID)
+
+	prevClient := suite.App.Runtime.CCBillDataLink
+	suite.App.Runtime.CCBillDataLink = nil
+	t.Cleanup(func() { suite.App.Runtime.CCBillDataLink = prevClient })
+
+	w := ccbillAdminRefundReq(t, admin, payment.ID, "ccbill-queued-key-1")
+	require.Equal(t, http.StatusAccepted, w.Code, "parked intent reports 202 with the pending reservation: %s", w.Body.String())
+
+	var intentStatus string
+	require.NoError(t, suite.App.Runtime.DB.Pool().QueryRow(context.Background(),
+		"SELECT status FROM openrails.rail_intents WHERE intent_type = 'ccbill_refund' AND payment_id = $1",
+		payment.ID).Scan(&intentStatus))
+	assert.Equal(t, "pending", intentStatus, "the durable intent waits for the scheduled executor")
 }


### PR DESCRIPTION
Retires the three documented "baseline red" integration tests. Integration should be FULLY green after this; gosec's standing baseline findings remain the only known red.

## Root cause

Commit `1d3cffb4` changed the CCBill refund contract — refunds now execute through the durable `ccbill_refund` rail intent (DataLink `voidOrRefundTransaction`, keyed off the linked subscription's CCBill subscription id + the original transaction id) — but three tests still pinned the obsolete pre-`1d3cffb4` contract ("CCBill refunds unsupported via API; go to the admin portal"):

1. `TestAdminRefundPayment/returns_400_for_CCBill_payments_with_helpful_message` — asserted the old portal-only 400 text; the new no-sub-link branch answers a terse "ccbill payment has no linked subscription".
2. `TestAdminRefundReachesAnyUserInMerchant` — same assertion drift (its CCBill payments are unlinked, so they hit the same branch).
3. `TestFindingsQueueApproveCCBillCancelAndRefund` — the findings-queue refund leg now succeeds (200, `refund: queued` on the intent ledger) where the test demanded a 400 manual-portal error leaving the finding open. Same root cause, distinct surface: `refundPaymentForFinding` routes through the same admin refund producer.

CCBill *does* support API cancels/refunds (account-level feature, enabled on our account) — the intent path is the product direction, so the tests move to it; no "unsupported" framing is reintroduced.

## Contract pinned

- **CCBill payment WITH linked subscription** → refund proceeds through the rail-intent ledger. New `TestAdminRefundCCBillThroughIntentLedger` pins: 201 inline execution against a fake DataLink SMS endpoint, the exact wire (`subscriptionId`=CCBill sub id, `transactionId`=original charge, `amount`="5.00" decimal dollars for 5,000,000 micros), intent `succeeded`, finalized ledger refund row (−5,000,000, `completed`, ref `ccbill_refund:<sub>:<txn>`), admin-key replay without a resend, and the content-addressed 409 across different admin keys. New `TestAdminRefundCCBillQueuedWhenDataLinkUnconfigured` pins the pending semantics: no DataLink client → 202 + intent stays `pending` for the scheduled executor (queue-always #679).
- **CCBill payment WITHOUT linked subscription** → helpful 400 (new message):
  > `payment cannot be refunded via the API: CCBill refunds are keyed off the linked subscription's CCBill subscription id, and this payment has no linked subscription — refund it manually in the CCBill admin portal`

  The same portal-fallback wrapper now also covers the resolvable-but-broken coordinates case (linked sub missing its CCBill subscription id / payment missing its transaction id). A code comment notes API refunds also require CCBill's account-level refund feature; a `-7` denial surfaces verbatim from the intent executor rather than being masked.
- **Findings queue** — approve on a CCBill `cancel_and_refund` queues the `ccbill_refund` intent (`refund: queued`, finding `fixed`) and the executor drains it through the DataLink choke point; asserted end-to-end including the finalized refund row.

## Preserved branch vs fresh

`wip-ccbill-billingimport-preserved` (4a8f3c30) was used as intent reference:

- **Adopted verbatim**: the `admin_findings_ccbill_integration_test.go` rewrite (its base file is byte-identical to master's, and its asserted behavior matches what master actually does today — verified by running the old test and comparing output).
- **Superseded / rewritten**: its `tests/admin_payments_test.go` change merely re-pinned the terse "no linked subscription" message. Per the contract decision, the handler message was improved instead (tests assert CCBill + the why + the portal fallback), and the linked-subscription success/pending intent-path coverage was written fresh.
- **Left on the branch for its original author** (unrelated #737 billingimport WIP, still unlanded): `internal/billingimport/billingimport.go` (`markerOnlyDeferredDelete` scheduler), `internal/dbtest/rls.go`, `pkg/embedded/billing_import_integration_test.go`, go.mod/go.sum (gomega). Its `embed/mount_order_integration_test.go` TestMode fix already landed on master in another form (`CredentialPostureSandbox`).

## Verification

- `go build` / `go vet` clean on default + integration tag sets.
- `scripts/test_integration.sh ./tests ./internal/http/...` fully green (all 9 packages ok), including the three retired tests and the two new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
