### PR TITLE
Retire gosec CI baseline: triage all 13 HIGH+ findings

### DIFF
--- a/config/secret_files.go
+++ b/config/secret_files.go
@@ -50,7 +50,7 @@ func SecretFiles() (map[string]string, error) {
 		if e.IsDir() || strings.HasPrefix(name, "..") || !secretFileNameShape.MatchString(name) {
 			continue
 		}
-		raw, err := os.ReadFile(filepath.Join(dir, name))
+		raw, err := os.ReadFile(filepath.Join(dir, name)) // #nosec G304 -- dir is operator-mounted (VAULT_SECRETS_PATH/default), name comes from os.ReadDir on that same dir, filtered to the env-var name shape above
 		if err != nil {
 			return nil, fmt.Errorf("read secret file %s: %w", name, err)
 		}

--- a/config/solana_settings.go
+++ b/config/solana_settings.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -217,8 +218,14 @@ func settingInt(key string, raw any) (int, error) {
 	case int:
 		return v, nil
 	case int64:
+		if v > math.MaxInt || v < math.MinInt {
+			return 0, fmt.Errorf("solana settings: %s exceeds platform int range (got %d)", key, v)
+		}
 		return int(v), nil
 	case uint64:
+		if v > math.MaxInt {
+			return 0, fmt.Errorf("solana settings: %s exceeds platform int range (got %d)", key, v)
+		}
 		return int(v), nil
 	case float64:
 		if v != float64(int(v)) {

--- a/config/solana_settings_test.go
+++ b/config/solana_settings_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -54,6 +55,15 @@ func TestParseSolanaAccountSettings(t *testing.T) {
 		require.True(t, s.IsZero())
 		require.ErrorContains(t, ValidateSolanaAccountSettings(in), "unknown key(s) rpc_provder")
 	})
+}
+
+func TestSettingIntOverflow(t *testing.T) {
+	n, err := settingInt("k", uint64(42))
+	require.NoError(t, err)
+	require.Equal(t, 42, n)
+
+	_, err = settingInt("k", uint64(math.MaxInt64)+1)
+	require.ErrorContains(t, err, "exceeds platform int range")
 }
 
 func TestSolanaAccountSettingsApplyTo(t *testing.T) {

--- a/internal/bootstrap/serverboot/serverboot.go
+++ b/internal/bootstrap/serverboot/serverboot.go
@@ -147,7 +147,7 @@ func reconcileBootMerchantManifest(ctx context.Context, cfg *config.Config, appl
 	if !explicit {
 		path = bootstrap.DefaultMerchantConfigManifestPath
 	}
-	raw, err := os.ReadFile(path)
+	raw, err := os.ReadFile(path) // #nosec G304 -- path is a boot-time CLI/config value, not request input
 	if os.IsNotExist(err) {
 		if explicit {
 			return fmt.Errorf("merchant manifest %s: %w (merchant_source=manifest declared this file as truth, #723)", path, err)

--- a/internal/db/models/genmap.go
+++ b/internal/db/models/genmap.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/google/uuid"
@@ -68,12 +69,22 @@ func DerefUUID(u *uuid.UUID) uuid.UUID {
 	return *u
 }
 
-// IntPtrTo32 converts a models *int to a generated *int32.
+// IntPtrTo32 converts a models *int to a generated *int32, clamping instead
+// of wrapping if a caller ever hands it a value outside int32's range (none
+// of today's callers — retry counts, duration hours — can, but the helper is
+// shared and should never truncate silently).
 func IntPtrTo32(v *int) *int32 {
 	if v == nil {
 		return nil
 	}
-	i := int32(*v)
+	n := *v
+	switch {
+	case n > math.MaxInt32:
+		n = math.MaxInt32
+	case n < math.MinInt32:
+		n = math.MinInt32
+	}
+	i := int32(n)
 	return &i
 }
 

--- a/internal/db/models/genmap_test.go
+++ b/internal/db/models/genmap_test.go
@@ -1,0 +1,26 @@
+package models
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntPtrTo32(t *testing.T) {
+	require.Nil(t, IntPtrTo32(nil))
+
+	n := 5
+	got := IntPtrTo32(&n)
+	require.NotNil(t, got)
+	require.Equal(t, int32(5), *got)
+
+	// Clamp rather than wrap on out-of-range values.
+	over := math.MaxInt32 + 1
+	got = IntPtrTo32(&over)
+	require.Equal(t, int32(math.MaxInt32), *got)
+
+	under := math.MinInt32 - 1
+	got = IntPtrTo32(&under)
+	require.Equal(t, int32(math.MinInt32), *got)
+}

--- a/internal/integrations/vault/auth.go
+++ b/internal/integrations/vault/auth.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"os"
 	"strings"
@@ -139,7 +139,7 @@ func login(ctx context.Context, client *vaultapi.Client, cfg Config) (*vaultapi.
 		// re-login (#751) pick up a rotated service-account token instead of
 		// replaying whatever was on disk at process boot.
 		jwtPath := firstNonEmpty(cfg.K8sJWTPath, defaultK8sJWTPath)
-		jwt, err := os.ReadFile(jwtPath)
+		jwt, err := os.ReadFile(jwtPath) // #nosec G304 -- jwtPath is operator config or the fixed k8s service-account token convention path
 		if err != nil {
 			return nil, fmt.Errorf("vault: read k8s service-account token: %w", err)
 		}
@@ -373,7 +373,7 @@ func (s *Supervisor) reauthWithBackoff(ctx context.Context) (*vaultapi.Secret, b
 		log.WithError(err).WithField("attempt", attempt).
 			Error("vault: RE-AUTHENTICATION FAILED — merchant secret / signing operations are degraded until this clears; retrying with backoff")
 
-		wait := backoff/2 + time.Duration(rand.Int63n(int64(backoff/2)+1))
+		wait := backoff/2 + time.Duration(rand.Int64N(int64(backoff/2)+1)) // #nosec G404 -- retry backoff jitter timing, not security-sensitive
 		select {
 		case <-ctx.Done():
 			return nil, false

--- a/internal/modules/alerting/store.go
+++ b/internal/modules/alerting/store.go
@@ -209,7 +209,7 @@ func (s *store) createNotification(ctx context.Context, n Notification) (Notific
 
 func (s *store) listNotifications(ctx context.Context, unreadOnly bool, limit int) ([]Notification, error) {
 	rows, err := s.db.Gen(ctx).ListMerchantNotifications(ctx, gen.ListMerchantNotificationsParams{
-		UnreadOnly: unreadOnly, RowLimit: int32(limit),
+		UnreadOnly: unreadOnly, RowLimit: int32(limit), // #nosec G115 -- only caller passes the hardcoded notificationListLimit const (100); no HTTP param feeds limit
 	})
 	if err != nil {
 		return nil, err
@@ -232,7 +232,7 @@ func (s *store) unreadCount(ctx context.Context) (int64, error) {
 // countPaymentMethodsExpiring implements templateEvalDeps for the digest.
 func (s *store) countPaymentMethodsExpiring(ctx context.Context, now time.Time, daysAhead int) (int64, error) {
 	return s.db.Gen(ctx).CountPaymentMethodsExpiringWithin(ctx, gen.CountPaymentMethodsExpiringWithinParams{
-		Now: now, DaysAhead: int32(daysAhead),
+		Now: now, DaysAhead: int32(daysAhead), // #nosec G115 -- days_ahead is validated to [1,120] by paramReader.integer before a rule can persist (templates.go)
 	})
 }
 

--- a/internal/reconcile/solana.go
+++ b/internal/reconcile/solana.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"hash/fnv"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -1185,6 +1186,32 @@ func assetName(mint string) string {
 	return mint
 }
 
+// u64ToI64 converts a uint64 balance/amount to int64, refusing values above
+// math.MaxInt64 rather than silently wrapping to negative. Real Solana
+// balances never approach this (total SOL supply and any sane SPL mint sit
+// many orders of magnitude below it), so a rejection here means the data is
+// bogus — safer to treat the transfer as unusable than trust a wrapped delta.
+func u64ToI64(u uint64) (int64, bool) {
+	if u > math.MaxInt64 {
+		return 0, false
+	}
+	return int64(u), true
+}
+
+// i64Delta converts a pre/post uint64 pair to int64 in one call, propagating
+// failure if either side overflows.
+func i64Delta(post, pre uint64) (int64, int64, bool) {
+	p, ok := u64ToI64(post)
+	if !ok {
+		return 0, 0, false
+	}
+	q, ok := u64ToI64(pre)
+	if !ok {
+		return 0, 0, false
+	}
+	return p, q, true
+}
+
 // walletTransferMoney extracts the ONE asset a transaction moved into the
 // wallet from the balance metas (the transfer IS the money truth — never the
 // memo). ok=false with a note when nothing moved in, several assets did, or
@@ -1217,11 +1244,19 @@ func walletTransferMoney(meta *solrpc.TransactionMeta, tx *solanago.Transaction,
 	post := readTokenBalances(meta.PostTokenBalances)
 	deltas := map[string]int64{}
 	for idx, p := range post {
-		deltas[p.mint] += int64(p.amount) - int64(pre[idx].amount)
+		postAmt, preAmt, ok := i64Delta(p.amount, pre[idx].amount)
+		if !ok {
+			return walletTransfer{}, false, "token amount exceeds representable range"
+		}
+		deltas[p.mint] += postAmt - preAmt
 	}
 	for idx, p := range pre {
 		if _, ok := post[idx]; !ok {
-			deltas[p.mint] -= int64(p.amount) // account emptied/closed
+			amt, ok := u64ToI64(p.amount)
+			if !ok {
+				return walletTransfer{}, false, "token amount exceeds representable range"
+			}
+			deltas[p.mint] -= amt // account emptied/closed
 		}
 	}
 
@@ -1239,7 +1274,11 @@ func walletTransferMoney(meta *solrpc.TransactionMeta, tx *solanago.Transaction,
 				continue
 			}
 			if i < len(meta.PreBalances) && i < len(meta.PostBalances) {
-				if delta := int64(meta.PostBalances[i]) - int64(meta.PreBalances[i]); delta > 0 {
+				postLamports, preLamports, ok := i64Delta(meta.PostBalances[i], meta.PreBalances[i])
+				if !ok {
+					return walletTransfer{}, false, "lamport balance exceeds representable range"
+				}
+				if delta := postLamports - preLamports; delta > 0 {
 					received = append(received, walletTransfer{Mint: "", BaseUnits: uint64(delta)})
 				}
 			}
@@ -1308,5 +1347,5 @@ func solanaFiatCents(mint string, baseUnits uint64) (int64, bool) {
 	if _, ok := microUSDMints[mint]; !ok || baseUnits%10_000 != 0 {
 		return 0, false
 	}
-	return int64(baseUnits / 10_000), true
+	return int64(baseUnits / 10_000), true // #nosec G115 -- uint64/10_000 always fits int64 (max ~1.8e15 < MaxInt64)
 }

--- a/internal/reconcile/solana_test.go
+++ b/internal/reconcile/solana_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -834,6 +835,14 @@ func TestWalletTransferMoney(t *testing.T) {
 	// No meta: unusable.
 	_, ok, _ = walletTransferMoney(nil, nil, wallet)
 	require.False(t, ok)
+
+	// A token balance beyond int64 range is refused, never wrapped into a
+	// bogus negative/small delta.
+	_, ok, note = walletTransferMoney(&solrpc.TransactionMeta{
+		PostTokenBalances: []solrpc.TokenBalance{tb(1, wallet, usdcMint, math.MaxInt64+1)},
+	}, nil, wallet)
+	require.False(t, ok)
+	require.Contains(t, note, "exceeds representable range")
 }
 
 // TestDiffSolanaDiscoveryRouting pins the #714 finding routes: clean+priced

--- a/internal/reconcile/unknown_orchestration.go
+++ b/internal/reconcile/unknown_orchestration.go
@@ -90,7 +90,8 @@ func ReconcileUnknownCohort(ctx context.Context, database *db.DB, lc *subscripti
 		prober := probers[provider]
 		railArg := rail
 		rows, err := q.ListUnknownSubscriptions(ctx, gen.ListUnknownSubscriptionsParams{
-			MerchantID: merchantID.UUID(), Rail: &railArg, MaxRows: int32(opts.MaxPerRail),
+			MerchantID: merchantID.UUID(), Rail: &railArg,
+			MaxRows: int32(opts.MaxPerRail), // #nosec G115 -- withDefaults() clamps to 500 when <=0; only caller is the internal River worker, no HTTP path sets this
 		})
 		if err != nil {
 			return res, fmt.Errorf("reconcile unknown: list %s cohort: %w", rail, err)

--- a/pkg/adminconsole/adminconsole.go
+++ b/pkg/adminconsole/adminconsole.go
@@ -86,6 +86,9 @@ func Handler(cfg Config, assets fs.FS) http.Handler {
 					// Vite emits content-hashed filenames under assets/.
 					w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
 				}
+				// #nosec G703 -- fs.ValidPath (stdlib-recommended fs.FS traversal
+				// guard) already rejected "..", empty, and rooted elements above;
+				// gosec's default taint sanitizer list doesn't know this stdlib func.
 				http.ServeFileFS(w, r, assets, rel)
 				return
 			}

--- a/pkg/catalog/load.go
+++ b/pkg/catalog/load.go
@@ -67,7 +67,7 @@ var stablecoinCurrencies = map[string]struct{}{
 // manifests (bad version, duplicate slugs, duplicate prices by financial terms,
 // provider-eligibility violations). It never touches the database or any chain.
 func Load(path string) (*Manifest, error) {
-	raw, err := os.ReadFile(path)
+	raw, err := os.ReadFile(path) // #nosec G304 -- path is caller-supplied (CLI/operator invocation), same trust boundary as os.ReadFile itself
 	if err != nil {
 		return nil, fmt.Errorf("read catalog manifest: %w", err)
 	}

--- a/pkg/embedded/catalog_push.go
+++ b/pkg/embedded/catalog_push.go
@@ -154,7 +154,7 @@ func loadCatalogPushTargets(opts CatalogPushOptions) ([]catalogPushTarget, error
 			return nil, fmt.Errorf("catalog manifest file or manifest bytes are required")
 		}
 		var err error
-		raw, err = os.ReadFile(path)
+		raw, err = os.ReadFile(path) // #nosec G304 -- path is opts.File, an operator CLI flag, not request input
 		if err != nil {
 			return nil, fmt.Errorf("read catalog manifest: %w", err)
 		}

--- a/pkg/embedded/pull_provider.go
+++ b/pkg/embedded/pull_provider.go
@@ -378,7 +378,7 @@ func pullProviderManifestPlane(ctx context.Context, cfg *config.Config, database
 		if !explicit {
 			path = boot.DefaultMerchantConfigManifestPath
 		}
-		raw, err := os.ReadFile(path)
+		raw, err := os.ReadFile(path) // #nosec G304 -- path is opts.MerchantManifestPath (operator CLI flag) or a fixed conventional default
 		if os.IsNotExist(err) && !explicit {
 			log.Warn("pull-provider: merchant_source=manifest but no merchant manifest was supplied or found; pulls arm from boot-config rails only (#723)")
 			return nil, nil
@@ -537,11 +537,11 @@ func writePullProviderLog(logDir string, run reconcile.RunRecord, res *reconcile
 	if strings.TrimSpace(logDir) == "" {
 		logDir = "."
 	}
-	if err := os.MkdirAll(logDir, 0o755); err != nil {
+	if err := os.MkdirAll(logDir, 0o750); err != nil {
 		return "", fmt.Errorf("create pull-provider log dir: %w", err)
 	}
 	path := filepath.Join(logDir, fmt.Sprintf("pull-provider-%s.log", run.ID))
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600) // #nosec G304 -- logDir is an operator CLI flag, not request input
 	if err != nil {
 		return "", fmt.Errorf("open pull-provider log: %w", err)
 	}


### PR DESCRIPTION
## Summary

The `gosec` job (`.github/workflows/security.yaml`, `gosec -severity high -confidence medium -exclude-dir=.agents ./...`) has failed on every master push with the same 13 findings. This triages each on the merits and makes the job pass — no blanket excludes added to the workflow.

## Triage table

| Rule | Location | Verdict | Action |
|---|---|---|---|
| G115 | `internal/reconcile/solana.go:1220,1224,1242` (x2 each) | Real (defense-in-depth) | Added `u64ToI64`/`i64Delta` helpers; refuse uint64->int64 conversions that would overflow instead of silently wrapping the wallet-transfer money delta |
| G115 | `internal/reconcile/solana.go:1311` (`solanaFiatCents`) | False positive | `baseUnits/10_000` is mathematically bounded well under `MaxInt64`; annotated, not guarded (no dead defensive code) |
| G115 | `config/solana_settings.go:222` (`settingInt`, uint64 case) | Real | Added bounds check rejecting values outside platform `int` range instead of truncating on 32-bit |
| G115 | `internal/reconcile/unknown_orchestration.go:93` (`MaxRows`) | False positive | Verified: `MaxPerRail` is `withDefaults()`-clamped (500), only set by an internal River worker, no HTTP path reaches it — annotated |
| G115 | `internal/modules/alerting/store.go:212` (`RowLimit`) | False positive | Verified: only caller passes the hardcoded `notificationListLimit` const (100) — annotated |
| G115 | `internal/modules/alerting/store.go:235` (`DaysAhead`) | False positive | Verified: `days_ahead` is validated to `[1,120]` by `paramReader.integer` before an alert rule can persist — annotated |
| G115 | `internal/db/models/genmap.go:76` (`IntPtrTo32`) | Real (defense-in-depth) | Shared helper now clamps to int32 range instead of truncating, for any future caller |
| G404 | `internal/integrations/vault/auth.go:376` (backoff jitter) | False positive, but swapped anyway | Swapped `math/rand` -> `math/rand/v2` (free upgrade); still non-crypto by nature (retry timing jitter) so annotated too — gosec flags v2 identically |
| G703 | `pkg/adminconsole/adminconsole.go:89` (`http.ServeFileFS`) | False positive (the "pre-existing G703") | `fs.ValidPath(rel)` already rejects `..`/empty/rooted path elements before the sink — the exact stdlib-recommended guard; gosec's default G703 sanitizer list just doesn't include `fs.ValidPath`. Annotated. |

Also triaged and fixed the non-blocking MEDIUM-severity warn step's 8 findings while in there:

| Rule | Location | Verdict | Action |
|---|---|---|---|
| G304 | `pkg/embedded/pull_provider.go:381,544`, `catalog_push.go:157`, `pkg/catalog/load.go:70`, `vault/auth.go:142`, `serverboot.go:150`, `config/secret_files.go:53` | False positive | All paths are operator config / CLI flags / fixed conventional locations (k8s service-account token, `/vault/secrets` mount) — never HTTP request input. Annotated at each site with the specific provenance. |
| G301 | `pkg/embedded/pull_provider.go:540` (log dir) | Real | `os.MkdirAll(logDir, 0o755)` -> `0o750` |

## Test plan
- [x] `gosec -severity high -confidence medium -exclude-dir=.agents ./...` — 0 issues (was 13)
- [x] `gosec -severity medium -confidence medium -exclude-dir=.agents ./...` — 0 issues (was 8 more)
- [x] Same, clean under `-tags integration` and `-tags console_assets`
- [x] `go build` / `go vet` clean on default, `integration`, `console_assets` tag sets
- [x] `go test ./...` green
- [x] `scripts/test_integration.sh` green on every touched package (reconcile, alerting, vault, catalog, embedded/controlplane, config, db/models, adminconsole)
- [x] Added unit tests pinning the new overflow-guard behavior (`TestWalletTransferMoney`, `TestSettingIntOverflow`, `TestIntPtrTo32`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)