### PR TITLE
LLM provider: OpenAI (+ OpenAI-compatible base_url) alongside Anthropic (#761)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -89,9 +89,13 @@ admin_console:
 # and metrics Q&A (#756). FAIL-CLOSED: no api_key = the generate/ask endpoints
 # answer 501 and the console hides the NL box; the dashboard works without it.
 # llm:
-#   provider: anthropic      # default (only supported value)
-#   model: claude-haiku-4-5-20251001   # default (cheapest capable; schema does the heavy lifting)
+#   provider: anthropic      # anthropic (default) | openai
+#   model: ""                # default per provider (anthropic: claude-haiku-4-5-20251001,
+#                            # openai: gpt-5.4-nano — cheapest capable; schema does the heavy lifting)
 #   api_key: ""              # SECRET — set env LLM_API_KEY or a mounted secret file
+#   base_url: ""             # optional endpoint override (env LLM_BASE_URL) — with provider=openai
+#                            # this serves any OpenAI-compatible backend, base INCLUDES /v1
+#                            # (e.g. https://api.groq.com/openai/v1, dev-only http://localhost:11434/v1)
 #   ask_enabled: false       # #756 consent: /metrics/ask sends aggregate query RESULTS to the
 #                            # LLM provider (widget generation sends only the schema) — opt in
 #                            # explicitly; env LLM_ASK_ENABLED

--- a/config/config.go
+++ b/config/config.go
@@ -153,8 +153,8 @@ type Config struct {
 	// natural-language widget generator. FAIL-CLOSED: no api_key → the
 	// generate endpoint answers 501 and the admin console hides the NL box;
 	// the dashboard itself never depends on an LLM. Env: LLM_PROVIDER,
-	// LLM_MODEL, LLM_API_KEY (secret — mounted secret files work like any
-	// other secret env name).
+	// LLM_MODEL, LLM_BASE_URL, LLM_API_KEY (secret — mounted secret files
+	// work like any other secret env name).
 	LLM *LLMConfig `koanf:"llm,omitempty"`
 
 	// SecretBackend declares WHERE merchant secrets physically live: "db" (the
@@ -319,24 +319,41 @@ type AdminConsoleConfig struct {
 // IsEnabled reports whether the admin console SPA should be served.
 func (c *AdminConsoleConfig) IsEnabled() bool { return c != nil && c.Enabled }
 
-// LLM provider names (#741). Anthropic is the only wired provider; the knob
-// exists so adding one later is config, not code archaeology.
-const LLMProviderAnthropic = "anthropic"
+// LLM provider names (#741/#761). The provider selects the API dialect;
+// unknown values refuse to boot.
+const (
+	LLMProviderAnthropic = "anthropic"
+	LLMProviderOpenAI    = "openai"
+)
 
-// LLMDefaultModel is used when llm.model is unset.
+// Per-provider default models when llm.model is unset.
 // Cheapest-capable-first (Paul): query generation is designed to need no model
 // cleverness — /schema + corrective errors carry the intelligence. Configure a
 // bigger model only if generation quality measurably demands it.
-const LLMDefaultModel = "claude-haiku-4-5-20251001"
+const (
+	LLMDefaultModelAnthropic = "claude-haiku-4-5-20251001"
+	// gpt-5.4-nano is the cheapest current-generation tool-capable OpenAI
+	// model ($0.20/M in, $1.25/M out as of 2026-07). gpt-4.1-nano is nominally
+	// cheaper but the 4.1 family is mid-retirement — a default must not 404.
+	LLMDefaultModelOpenAI = "gpt-5.4-nano"
+)
 
 // LLMConfig configures the #741 natural-language widget generator and the
 // #756 metrics Q&A endpoint.
 type LLMConfig struct {
-	// Provider selects the API dialect. Empty = "anthropic" (the only
-	// supported value today); unknown values refuse to boot.
+	// Provider selects the API dialect: "anthropic" (default) or "openai";
+	// unknown values refuse to boot.
 	Provider string `koanf:"provider,omitempty"`
-	// Model is the provider model id. Empty = LLMDefaultModel.
+	// Model is the provider model id. Empty = the provider's default
+	// (LLMDefaultModelAnthropic / LLMDefaultModelOpenAI).
 	Model string `koanf:"model,omitempty"`
+	// BaseURL overrides the provider's public API endpoint — with
+	// provider=openai this is the door to every OpenAI-compatible endpoint
+	// (Groq, Together, Ollama, vLLM). Convention per dialect: openai INCLUDES
+	// the version segment (e.g. http://localhost:11434/v1), anthropic is the
+	// origin (e.g. https://api.anthropic.com). Must be an absolute URL; https
+	// required outside development. Env: LLM_BASE_URL.
+	BaseURL string `koanf:"base_url,omitempty"`
 	// APIKey is the provider credential (SECRET — env LLM_API_KEY or a
 	// mounted secret file, never committed config). Empty = feature off.
 	APIKey string `koanf:"api_key,omitempty"`
@@ -364,12 +381,15 @@ func (c *LLMConfig) ResolvedProvider() string {
 	return strings.ToLower(strings.TrimSpace(c.Provider))
 }
 
-// ResolvedModel returns the effective model id.
+// ResolvedModel returns the effective model id (per-provider default).
 func (c *LLMConfig) ResolvedModel() string {
-	if c == nil || strings.TrimSpace(c.Model) == "" {
-		return LLMDefaultModel
+	if c != nil && strings.TrimSpace(c.Model) != "" {
+		return strings.TrimSpace(c.Model)
 	}
-	return strings.TrimSpace(c.Model)
+	if c.ResolvedProvider() == LLMProviderOpenAI {
+		return LLMDefaultModelOpenAI
+	}
+	return LLMDefaultModelAnthropic
 }
 
 // DBConfig holds database configuration.
@@ -1058,10 +1078,26 @@ func Validate(cfg *Config) error {
 		return fmt.Errorf("captcha config validation failed: %w", err)
 	}
 
-	// #741: an unknown llm.provider must never silently boot with the
-	// anthropic dialect pointed at another vendor's key.
-	if cfg.LLM != nil && cfg.LLM.ResolvedProvider() != LLMProviderAnthropic {
-		return fmt.Errorf("invalid llm.provider %q: only %q is supported", cfg.LLM.Provider, LLMProviderAnthropic)
+	// #741/#761: an unknown llm.provider must never silently boot with one
+	// vendor's dialect pointed at another vendor's key.
+	if cfg.LLM != nil {
+		switch cfg.LLM.ResolvedProvider() {
+		case LLMProviderAnthropic, LLMProviderOpenAI:
+		default:
+			return fmt.Errorf("invalid llm.provider %q: must be %q or %q", cfg.LLM.Provider, LLMProviderAnthropic, LLMProviderOpenAI)
+		}
+		// Same root-of-trust posture as the auth issuer: plaintext HTTP to
+		// the model endpoint (prompts + aggregate results in flight) is
+		// dev-only.
+		if base := strings.TrimSpace(cfg.LLM.BaseURL); base != "" {
+			u, err := url.Parse(base)
+			if err != nil || !u.IsAbs() || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+				return fmt.Errorf("invalid llm.base_url %q: must be an absolute http(s) URL", base)
+			}
+			if !isDev && u.Scheme != "https" {
+				return fmt.Errorf("llm.base_url %q must use https outside development", base)
+			}
+		}
 	}
 
 	// Always validate database configuration

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1023,3 +1023,57 @@ func TestValidateEncryption(t *testing.T) {
 		})
 	}
 }
+
+// #741/#761: llm.provider enum + llm.base_url validation + per-provider model
+// defaults.
+func TestValidateLLM(t *testing.T) {
+	devCfg := func(llm *LLMConfig) *Config {
+		cfg := GetDefaultBillingConfig()
+		cfg.Env = "dev"
+		cfg.LLM = llm
+		assembleDBURL(cfg)
+		return cfg
+	}
+	prodCfg := func(llm *LLMConfig) *Config {
+		cfg := GetDefaultBillingConfig()
+		cfg.Env = "prod"
+		cfg.ProviderWriteMode = ProviderWriteModeFull
+		cfg.DB.Username = "billing_app"
+		cfg.DB.Password = "production-db-password"
+		cfg.LLM = llm
+		assembleDBURL(cfg)
+		return cfg
+	}
+
+	t.Run("anthropic, openai and empty providers boot", func(t *testing.T) {
+		assert.NoError(t, Validate(devCfg(&LLMConfig{Provider: "anthropic", APIKey: "k"})))
+		assert.NoError(t, Validate(devCfg(&LLMConfig{Provider: "openai", APIKey: "k"})))
+		assert.NoError(t, Validate(devCfg(&LLMConfig{APIKey: "k"})))
+	})
+
+	t.Run("unknown provider refuses boot", func(t *testing.T) {
+		assert.ErrorContains(t, Validate(devCfg(&LLMConfig{Provider: "gemini"})),
+			`invalid llm.provider "gemini"`)
+	})
+
+	t.Run("base_url must be an absolute http(s) URL", func(t *testing.T) {
+		for _, bad := range []string{"api.openai.com/v1", "/v1", "ftp://host/v1", "://nope"} {
+			assert.ErrorContains(t, Validate(devCfg(&LLMConfig{Provider: "openai", BaseURL: bad})),
+				"invalid llm.base_url", "base_url %q", bad)
+		}
+	})
+
+	t.Run("http base_url is development-only", func(t *testing.T) {
+		llm := &LLMConfig{Provider: "openai", BaseURL: "http://localhost:11434/v1"}
+		assert.NoError(t, Validate(devCfg(llm)))
+		assert.ErrorContains(t, Validate(prodCfg(llm)), "must use https outside development")
+		assert.NoError(t, Validate(prodCfg(&LLMConfig{Provider: "openai", BaseURL: "https://api.groq.com/openai/v1"})))
+	})
+
+	t.Run("per-provider model defaults", func(t *testing.T) {
+		assert.Equal(t, LLMDefaultModelAnthropic, (&LLMConfig{}).ResolvedModel())
+		assert.Equal(t, LLMDefaultModelAnthropic, (&LLMConfig{Provider: "anthropic"}).ResolvedModel())
+		assert.Equal(t, LLMDefaultModelOpenAI, (&LLMConfig{Provider: "openai"}).ResolvedModel())
+		assert.Equal(t, "custom-model", (&LLMConfig{Provider: "openai", Model: " custom-model "}).ResolvedModel())
+	})
+}

--- a/docs/admin-console.md
+++ b/docs/admin-console.md
@@ -187,13 +187,37 @@ refining queries needs the key.
 
 ```yaml
 llm:
-  # provider: anthropic      # default (only supported value)
-  # model: claude-haiku-4-5-20251001   # default — cheapest capable model on purpose: the
-  # /schema examples + all-at-once corrective errors are designed so query generation needs
+  # provider: anthropic      # anthropic (default) | openai — unknown values refuse boot
+  # model: ...               # default per provider (see matrix) — cheapest capable on purpose:
+  # the /schema examples + all-at-once corrective errors are designed so query generation needs
   # no model cleverness; configure a bigger model only if generation quality demands it
   api_key: "..."             # SECRET — prefer env LLM_API_KEY or a mounted secret file
+  # base_url: ...            # override the provider endpoint (OpenAI-compatible backends);
+  #                          # absolute URL, https outside development; env LLM_BASE_URL
   # ask_enabled: true        # #756 metrics Q&A consent — see below; env LLM_ASK_ENABLED
 ```
+
+Provider matrix (#761):
+
+| `provider` | default `model` | `base_url` |
+|---|---|---|
+| `anthropic` (default) | `claude-haiku-4-5-20251001` | optional; origin form, e.g. `https://api.anthropic.com` |
+| `openai` | `gpt-5.4-nano` | optional; version-inclusive form, e.g. `https://api.openai.com/v1` |
+| OpenAI-compatible (Groq, Together, Ollama, vLLM) | none — set `model` to the backend's id | `provider: openai` + required `base_url`, e.g. Ollama `http://localhost:11434/v1` (http = development only) |
+
+Defaults are the cheapest tool-capable model per provider (`gpt-5.4-nano`: $0.20/M in,
+$1.25/M out — the current-generation floor). Example — local Ollama in development:
+
+```yaml
+llm:
+  provider: openai
+  base_url: http://localhost:11434/v1
+  model: qwen3:8b            # any tool-capable local model
+  api_key: ollama            # compatible backends still require a bearer value
+```
+
+The provider is invisible to the frontend: the fail-closed gates
+(`nl_widgets_enabled` / `ask_enabled`) and every endpoint behave identically.
 
 ## Ask your metrics (#756)
 

--- a/internal/app/build_runtime.go
+++ b/internal/app/build_runtime.go
@@ -836,7 +836,13 @@ func createServices(database *db.DB, cfg *config.Config, railSet config.RailMerc
 	// per merchant (Redis-backed when available, in-process fallback).
 	var dashboardLLM dashboard.LLM
 	if cfg.LLM.IsConfigured() {
-		dashboardLLM = dashboard.NewAnthropicLLM(cfg.LLM.APIKey, cfg.LLM.ResolvedModel(), "")
+		llmBaseURL := strings.TrimSpace(cfg.LLM.BaseURL)
+		switch cfg.LLM.ResolvedProvider() {
+		case config.LLMProviderOpenAI:
+			dashboardLLM = dashboard.NewOpenAILLM(cfg.LLM.APIKey, cfg.LLM.ResolvedModel(), llmBaseURL)
+		default: // anthropic — unknown providers refuse boot in config.Validate
+			dashboardLLM = dashboard.NewAnthropicLLM(cfg.LLM.APIKey, cfg.LLM.ResolvedModel(), llmBaseURL)
+		}
 	}
 	var askLimiter dashboard.AskLimiter
 	if redisClient != nil {

--- a/internal/modules/dashboard/llm.go
+++ b/internal/modules/dashboard/llm.go
@@ -57,8 +57,8 @@ type ToolTurn struct {
 
 // LLM is the provider seam for the dashboard module's model calls: text
 // completion (widget generation, #741) and tool-use turns (metrics Q&A, #756).
-// The production implementation is AnthropicLLM; tests inject deterministic
-// stubs via Service.SetLLM.
+// Production implementations: AnthropicLLM and OpenAILLM (#761); tests inject
+// deterministic stubs via Service.SetLLM.
 type LLM interface {
 	Complete(ctx context.Context, system string, msgs []LLMMessage) (string, error)
 	CompleteTools(ctx context.Context, system string, tools []ToolDef, msgs []ToolMessage, maxTokens int) (*ToolTurn, error)

--- a/internal/modules/dashboard/llm_openai.go
+++ b/internal/modules/dashboard/llm_openai.go
@@ -1,0 +1,217 @@
+package dashboard
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	// openaiBaseURL includes the version segment — the OpenAI-compatible
+	// ecosystem convention (OPENAI_BASE_URL), so llm.base_url plugs straight
+	// into Groq/Together/Ollama/vLLM docs values (e.g. http://localhost:11434/v1).
+	openaiBaseURL   = "https://api.openai.com/v1"
+	openaiMaxTokens = anthropicMaxTokens
+)
+
+// OpenAILLM calls the OpenAI Chat Completions API over plain HTTP (no SDK dep
+// — one endpoint, one request shape; #761). A custom baseURL serves any
+// OpenAI-compatible endpoint. Credentials come from deployment config; this
+// package never reads the environment.
+type OpenAILLM struct {
+	apiKey  string
+	model   string
+	baseURL string
+	client  *http.Client
+}
+
+// NewOpenAILLM builds the production client. baseURL "" = the public API;
+// non-empty values must include the version segment (…/v1).
+func NewOpenAILLM(apiKey, model, baseURL string) *OpenAILLM {
+	if baseURL == "" {
+		baseURL = openaiBaseURL
+	}
+	return &OpenAILLM{
+		apiKey:  apiKey,
+		model:   model,
+		baseURL: strings.TrimRight(baseURL, "/"),
+		client:  &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+// openaiRequest is the /chat/completions body. MaxCompletionTokens, not the
+// legacy max_tokens: reasoning-capable models reject max_tokens outright.
+// No temperature — parity with the Anthropic client (provider default), and
+// current OpenAI reasoning models reject non-default values anyway.
+type openaiRequest struct {
+	Model               string          `json:"model"`
+	MaxCompletionTokens int             `json:"max_completion_tokens"`
+	Messages            []openaiMessage `json:"messages"`
+	Tools               []openaiTool    `json:"tools,omitempty"`
+}
+
+// openaiMessage is one chat turn: system/user/assistant text, an assistant
+// turn's tool calls, or (role "tool") one tool result keyed by tool_call_id.
+type openaiMessage struct {
+	Role       string           `json:"role"`
+	Content    string           `json:"content,omitempty"`
+	ToolCalls  []openaiToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string           `json:"tool_call_id,omitempty"`
+}
+
+type openaiTool struct {
+	Type     string            `json:"type"` // always "function"
+	Function openaiFunctionDef `json:"function"`
+}
+
+type openaiFunctionDef struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Parameters  json.RawMessage `json:"parameters"`
+}
+
+type openaiToolCall struct {
+	ID       string             `json:"id"`
+	Type     string             `json:"type"` // always "function"
+	Function openaiFunctionCall `json:"function"`
+}
+
+type openaiFunctionCall struct {
+	Name string `json:"name"`
+	// Arguments is a JSON-ENCODED STRING (not an object) on the OpenAI wire.
+	Arguments string `json:"arguments"`
+}
+
+type openaiResponse struct {
+	Choices []struct {
+		Message struct {
+			Content   string           `json:"content"`
+			ToolCalls []openaiToolCall `json:"tool_calls"`
+		} `json:"message"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Error *struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// send posts one chat-completions request body and parses the response envelope.
+func (o *OpenAILLM) send(ctx context.Context, reqBody any) (*openaiResponse, error) {
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("dashboard llm: marshal request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, o.baseURL+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("dashboard llm: build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+o.apiKey)
+
+	resp, err := o.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("dashboard llm: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("dashboard llm: read response: %w", err)
+	}
+	var out openaiResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("dashboard llm: non-JSON response (status %d)", resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		msg := "unknown error"
+		if out.Error != nil {
+			msg = fmt.Sprintf("%s: %s", out.Error.Type, out.Error.Message)
+		}
+		return nil, fmt.Errorf("dashboard llm: openai API error (status %d): %s", resp.StatusCode, msg)
+	}
+	if len(out.Choices) == 0 {
+		return nil, fmt.Errorf("dashboard llm: response has no choices")
+	}
+	return &out, nil
+}
+
+// Complete sends one chat turn and returns the assistant text.
+func (o *OpenAILLM) Complete(ctx context.Context, system string, msgs []LLMMessage) (string, error) {
+	req := openaiRequest{Model: o.model, MaxCompletionTokens: openaiMaxTokens}
+	if system != "" {
+		req.Messages = append(req.Messages, openaiMessage{Role: "system", Content: system})
+	}
+	for _, m := range msgs {
+		req.Messages = append(req.Messages, openaiMessage{Role: m.Role, Content: m.Content})
+	}
+	out, err := o.send(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	text := strings.TrimSpace(out.Choices[0].Message.Content)
+	if text == "" {
+		return "", fmt.Errorf("dashboard llm: empty response (finish_reason %q)", out.Choices[0].FinishReason)
+	}
+	return text, nil
+}
+
+// CompleteTools sends one tool-use turn. Mapping notes vs the Anthropic wire:
+// tool results are individual role:"tool" messages (not blocks in a user
+// turn), tool-call arguments travel as a JSON-encoded string, and there is no
+// is_error flag — error results carry an explicit "ERROR: " marker in the
+// body so corrective feedback stays unambiguous.
+func (o *OpenAILLM) CompleteTools(ctx context.Context, system string, tools []ToolDef, msgs []ToolMessage, maxTokens int) (*ToolTurn, error) {
+	if maxTokens <= 0 {
+		maxTokens = openaiMaxTokens
+	}
+	req := openaiRequest{Model: o.model, MaxCompletionTokens: maxTokens}
+	if system != "" {
+		req.Messages = append(req.Messages, openaiMessage{Role: "system", Content: system})
+	}
+	for _, t := range tools {
+		req.Tools = append(req.Tools, openaiTool{Type: "function", Function: openaiFunctionDef{
+			Name: t.Name, Description: t.Description, Parameters: t.InputSchema,
+		}})
+	}
+	for _, m := range msgs {
+		// Results first, then prose — same order the Anthropic client emits
+		// blocks.
+		for _, tr := range m.ToolResults {
+			content := tr.Content
+			if tr.IsError {
+				content = "ERROR: " + content
+			}
+			req.Messages = append(req.Messages, openaiMessage{Role: "tool", ToolCallID: tr.ToolUseID, Content: content})
+		}
+		if m.Text == "" && len(m.ToolCalls) == 0 {
+			continue
+		}
+		msg := openaiMessage{Role: m.Role, Content: m.Text}
+		for _, tc := range m.ToolCalls {
+			msg.ToolCalls = append(msg.ToolCalls, openaiToolCall{
+				ID: tc.ID, Type: "function",
+				Function: openaiFunctionCall{Name: tc.Name, Arguments: string(tc.Input)},
+			})
+		}
+		req.Messages = append(req.Messages, msg)
+	}
+	out, err := o.send(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	choice := out.Choices[0]
+	turn := &ToolTurn{Text: strings.TrimSpace(choice.Message.Content), StopReason: choice.FinishReason}
+	for _, tc := range choice.Message.ToolCalls {
+		input := strings.TrimSpace(tc.Function.Arguments)
+		if input == "" {
+			input = "{}"
+		}
+		turn.ToolCalls = append(turn.ToolCalls, ToolCall{ID: tc.ID, Name: tc.Function.Name, Input: json.RawMessage(input)})
+	}
+	return turn, nil
+}

--- a/internal/modules/dashboard/llm_openai_test.go
+++ b/internal/modules/dashboard/llm_openai_test.go
@@ -1,0 +1,263 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/modules/metrics"
+)
+
+// openaiStub records every request body and plays canned response bodies in
+// order (last repeats). No network — the wire shape is the contract (#761).
+type openaiStub struct {
+	t         *testing.T
+	responses []string
+	requests  []map[string]any
+	raw       [][]byte
+	paths     []string
+	auths     []string
+	status    int
+}
+
+func (s *openaiStub) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(s.t, err)
+		var decoded map[string]any
+		require.NoError(s.t, json.Unmarshal(body, &decoded))
+		s.requests = append(s.requests, decoded)
+		s.raw = append(s.raw, body)
+		s.paths = append(s.paths, r.URL.Path)
+		s.auths = append(s.auths, r.Header.Get("Authorization"))
+		i := len(s.requests) - 1
+		if i >= len(s.responses) {
+			i = len(s.responses) - 1
+		}
+		if s.status != 0 {
+			w.WriteHeader(s.status)
+		}
+		_, _ = w.Write([]byte(s.responses[i]))
+	})
+}
+
+func openaiTextResponse(text string) string {
+	b, _ := json.Marshal(map[string]any{
+		"choices": []map[string]any{{
+			"message":       map[string]any{"role": "assistant", "content": text},
+			"finish_reason": "stop",
+		}},
+	})
+	return string(b)
+}
+
+func openaiToolCallResponse(text string, calls ...[3]string) string {
+	tcs := make([]map[string]any, 0, len(calls))
+	for _, c := range calls {
+		tcs = append(tcs, map[string]any{
+			"id": c[0], "type": "function",
+			"function": map[string]any{"name": c[1], "arguments": c[2]},
+		})
+	}
+	msg := map[string]any{"role": "assistant", "tool_calls": tcs}
+	if text != "" {
+		msg["content"] = text
+	} else {
+		msg["content"] = nil
+	}
+	b, _ := json.Marshal(map[string]any{
+		"choices": []map[string]any{{"message": msg, "finish_reason": "tool_calls"}},
+	})
+	return string(b)
+}
+
+func newStubLLM(t *testing.T, stub *openaiStub) (*OpenAILLM, *httptest.Server) {
+	stub.t = t
+	srv := httptest.NewServer(stub.handler())
+	t.Cleanup(srv.Close)
+	return NewOpenAILLM("sk-test", "gpt-test", srv.URL+"/v1"), srv
+}
+
+func TestOpenAIComplete_WireShapeAndExtraction(t *testing.T) {
+	stub := &openaiStub{responses: []string{openaiTextResponse("  {\"query\":{}}  ")}}
+	llm, _ := newStubLLM(t, stub)
+
+	got, err := llm.Complete(context.Background(), "SYSTEM PROMPT", []LLMMessage{
+		{Role: "user", Content: "make a widget"},
+		{Role: "assistant", Content: "bad json"},
+		{Role: "user", Content: "fix it"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, `{"query":{}}`, got, "text extracted and trimmed")
+
+	require.Equal(t, []string{"/v1/chat/completions"}, stub.paths, "joins /chat/completions onto the /v1 base")
+	require.Equal(t, []string{"Bearer sk-test"}, stub.auths)
+
+	req := stub.requests[0]
+	require.Equal(t, "gpt-test", req["model"])
+	require.EqualValues(t, openaiMaxTokens, req["max_completion_tokens"])
+	require.NotContains(t, req, "max_tokens", "reasoning models reject legacy max_tokens")
+	require.NotContains(t, req, "temperature", "provider default — parity with the Anthropic client")
+	require.JSONEq(t, `[
+		{"role":"system","content":"SYSTEM PROMPT"},
+		{"role":"user","content":"make a widget"},
+		{"role":"assistant","content":"bad json"},
+		{"role":"user","content":"fix it"}
+	]`, mustJSON(t, req["messages"]))
+}
+
+func TestOpenAIComplete_EmptyResponseErrors(t *testing.T) {
+	stub := &openaiStub{responses: []string{openaiTextResponse("   ")}}
+	llm, _ := newStubLLM(t, stub)
+	_, err := llm.Complete(context.Background(), "s", []LLMMessage{{Role: "user", Content: "q"}})
+	require.ErrorContains(t, err, "empty response")
+	require.ErrorContains(t, err, "stop")
+}
+
+func TestOpenAI_APIErrorSurfaced(t *testing.T) {
+	stub := &openaiStub{
+		status:    http.StatusBadRequest,
+		responses: []string{`{"error":{"type":"invalid_request_error","message":"model does not exist"}}`},
+	}
+	llm, _ := newStubLLM(t, stub)
+	_, err := llm.Complete(context.Background(), "s", []LLMMessage{{Role: "user", Content: "q"}})
+	require.ErrorContains(t, err, "status 400")
+	require.ErrorContains(t, err, "invalid_request_error: model does not exist")
+
+	_, err = llm.CompleteTools(context.Background(), "s", nil, []ToolMessage{{Role: "user", Text: "q"}}, 0)
+	require.ErrorContains(t, err, "status 400")
+}
+
+func TestOpenAI_BaseURLJoining(t *testing.T) {
+	require.Equal(t, "https://api.openai.com/v1", NewOpenAILLM("k", "m", "").baseURL, "empty = public API")
+	require.Equal(t, "http://localhost:11434/v1", NewOpenAILLM("k", "m", "http://localhost:11434/v1/").baseURL, "trailing slash trimmed — no double slash in the join")
+
+	stub := &openaiStub{responses: []string{openaiTextResponse("ok")}}
+	stub.t = t
+	srv := httptest.NewServer(stub.handler())
+	t.Cleanup(srv.Close)
+	llm := NewOpenAILLM("k", "m", srv.URL+"/openai/v1") // Groq-style nested base path
+	_, err := llm.Complete(context.Background(), "", []LLMMessage{{Role: "user", Content: "q"}})
+	require.NoError(t, err)
+	require.Equal(t, []string{"/openai/v1/chat/completions"}, stub.paths)
+	require.NotContains(t, stub.requests[0], "messages_system")
+	require.JSONEq(t, `[{"role":"user","content":"q"}]`, mustJSON(t, stub.requests[0]["messages"]), "empty system prompt sends no system message")
+}
+
+func TestOpenAICompleteTools_RequestShape(t *testing.T) {
+	stub := &openaiStub{responses: []string{openaiTextResponse("final answer")}}
+	llm, _ := newStubLLM(t, stub)
+
+	msgs := []ToolMessage{
+		{Role: "user", Text: "how much revenue?"},
+		{Role: "assistant", Text: "let me check", ToolCalls: []ToolCall{
+			{ID: "call_1", Name: askToolName, Input: json.RawMessage(`{"measures":["bogus"],"range":{"last":"7d"}}`)},
+		}},
+		{Role: "user", ToolResults: []ToolResult{
+			{ToolUseID: "call_1", Content: "query failed validation. Fix ALL of these errors", IsError: true},
+		}},
+		{Role: "assistant", ToolCalls: []ToolCall{
+			{ID: "call_2", Name: askToolName, Input: json.RawMessage(`{"measures":["net_revenue"],"range":{"last":"7d"}}`)},
+		}},
+		{Role: "user", ToolResults: []ToolResult{
+			{ToolUseID: "call_2", Content: `{"rows":[[42]]}`},
+		}},
+	}
+	turn, err := llm.CompleteTools(context.Background(), "SYS", []ToolDef{askToolDef()}, msgs, 512)
+	require.NoError(t, err)
+	require.Equal(t, "final answer", turn.Text)
+	require.Empty(t, turn.ToolCalls)
+	require.Equal(t, "stop", turn.StopReason)
+
+	req := stub.requests[0]
+	require.EqualValues(t, 512, req["max_completion_tokens"], "explicit cap rides the wire")
+
+	// Tool definition: nested {type:"function", function:{name,description,parameters}}.
+	require.JSONEq(t, mustJSON(t, []map[string]any{{
+		"type": "function",
+		"function": map[string]any{
+			"name":        askToolName,
+			"description": askToolDef().Description,
+			"parameters":  json.RawMessage(askToolInputSchema),
+		},
+	}}), mustJSON(t, req["tools"]))
+
+	// Conversation: system first; assistant tool calls replay arguments as a
+	// JSON-encoded STRING; each tool result is its own role:"tool" message
+	// keyed by tool_call_id; is_error becomes an explicit ERROR marker.
+	require.JSONEq(t, `[
+		{"role":"system","content":"SYS"},
+		{"role":"user","content":"how much revenue?"},
+		{"role":"assistant","content":"let me check","tool_calls":[
+			{"id":"call_1","type":"function","function":{"name":"run_metrics_query","arguments":"{\"measures\":[\"bogus\"],\"range\":{\"last\":\"7d\"}}"}}
+		]},
+		{"role":"tool","tool_call_id":"call_1","content":"ERROR: query failed validation. Fix ALL of these errors"},
+		{"role":"assistant","tool_calls":[
+			{"id":"call_2","type":"function","function":{"name":"run_metrics_query","arguments":"{\"measures\":[\"net_revenue\"],\"range\":{\"last\":\"7d\"}}"}}
+		]},
+		{"role":"tool","tool_call_id":"call_2","content":"{\"rows\":[[42]]}"}
+	]`, mustJSON(t, req["messages"]))
+}
+
+func TestOpenAICompleteTools_ToolCallExtractionAndDefaultCap(t *testing.T) {
+	stub := &openaiStub{responses: []string{openaiToolCallResponse("",
+		[3]string{"call_a", askToolName, `{"measures":["net_revenue"],"range":{"last":"7d"}}`},
+		[3]string{"call_b", askToolName, ""}, // empty arguments normalize to {}
+	)}}
+	llm, _ := newStubLLM(t, stub)
+
+	turn, err := llm.CompleteTools(context.Background(), "SYS", []ToolDef{askToolDef()}, []ToolMessage{{Role: "user", Text: "q"}}, 0)
+	require.NoError(t, err)
+	require.Equal(t, "", turn.Text, "null content decodes to empty text")
+	require.Equal(t, "tool_calls", turn.StopReason)
+	require.Len(t, turn.ToolCalls, 2)
+	require.Equal(t, "call_a", turn.ToolCalls[0].ID)
+	require.Equal(t, askToolName, turn.ToolCalls[0].Name)
+	require.JSONEq(t, `{"measures":["net_revenue"],"range":{"last":"7d"}}`, string(turn.ToolCalls[0].Input))
+	require.JSONEq(t, `{}`, string(turn.ToolCalls[1].Input))
+
+	require.EqualValues(t, openaiMaxTokens, stub.requests[0]["max_completion_tokens"], "maxTokens<=0 falls back to the default cap")
+}
+
+// TestAsk_OpenAIWireRoundTrip drives the whole #756 ask loop through the real
+// OpenAI client against a scripted server: invalid tool call → corrective
+// errors fed back on the wire (ERROR-marked tool message) → corrected call →
+// final answer, with evidence intact.
+func TestAsk_OpenAIWireRoundTrip(t *testing.T) {
+	stub := &openaiStub{responses: []string{
+		openaiToolCallResponse("", [3]string{"call_1", askToolName, `{"measures":["no_such_measure"],"range":{"last":"7d"}}`}),
+		openaiToolCallResponse("", [3]string{"call_2", askToolName, askQ1}),
+		openaiTextResponse("Net revenue was 42 micros."),
+	}}
+	llm, _ := newStubLLM(t, stub)
+
+	exec := &fakeExecutor{results: []*metrics.Result{cannedResult("net_revenue", 42)}}
+	svc := askService(llm, exec)
+	res, err := svc.Ask(context.Background(), "how much revenue?")
+	require.NoError(t, err)
+	require.Equal(t, "Net revenue was 42 micros.", res.Answer)
+	require.Len(t, res.Evidence, 1, "only the executed query becomes evidence")
+
+	require.Len(t, stub.requests, 3)
+	// Turn 2 carries the corrective validation errors as an ERROR-marked tool message.
+	msgs2 := mustJSON(t, stub.requests[1]["messages"])
+	require.Contains(t, msgs2, `"tool_call_id":"call_1"`)
+	require.Contains(t, msgs2, "ERROR: query failed validation")
+	require.Contains(t, msgs2, "no_such_measure")
+	// Turn 3 carries the executed result verbatim for call_2.
+	msgs3 := mustJSON(t, stub.requests[2]["messages"])
+	require.Contains(t, msgs3, `"tool_call_id":"call_2"`)
+	require.Contains(t, msgs3, "net_revenue")
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}


### PR DESCRIPTION
Implements #761: the dashboard LLM features (#741 widget generation, #756 ask tool-loop) gain an OpenAI provider, and — via `llm.base_url` — every OpenAI-compatible endpoint (Groq, Together, Ollama, vLLM).

## What
- **`OpenAILLM`** (`internal/modules/dashboard/llm_openai.go`): implements the existing `LLM` seam (`Complete` + `CompleteTools`) over the Chat Completions API with plain net/http, matching the Anthropic client's style (no SDK). Mapping notes:
  - tools → `{type:"function", function:{name,description,parameters}}`; tool-call `arguments` travel as JSON-encoded strings both directions.
  - tool results → individual `role:"tool"` messages keyed by `tool_call_id`; there is no `is_error` on the OpenAI wire, so error results carry an explicit `ERROR: ` marker (corrective-feedback parity with #756).
  - `max_completion_tokens` (reasoning models reject legacy `max_tokens`); no temperature — provider default, parity with the Anthropic client. Same 2048 default cap; explicit `maxTokens` honored.
- **Config**: `llm.provider` gains `openai` (unknown still refuses boot); new `llm.base_url` (env `LLM_BASE_URL`; absolute URL required, https required outside development — same posture as the auth issuer); per-provider model defaults.
- **Default model: `gpt-5.4-nano`** — cheapest current-generation tool-capable OpenAI model ($0.20/M in, $1.25/M out per OpenAI's pricing page; function calling confirmed on its model page). `gpt-4.1-nano` is nominally cheaper but the 4.1 family is mid-retirement in 2026 — a default must not 404. Cheapest-capable-first per #741 doctrine.
- **Docs**: admin-console.md provider matrix + Ollama example; config.example.yaml.

## Tests
- Existing fake-LLM suites untouched and green (they inject via `SetLLM`).
- New wire-shape unit tests against a local httptest stub (no network): request shape (tools, system+messages), tool-call round trip incl. ERROR-marked corrective feedback, extraction, base_url joining (Groq-style nested path, trailing slash), cap parity, error envelope — plus a full `Service.Ask` loop driven through the real client (invalid query → corrective errors on the wire → corrected call → answer + evidence).
- Config tests: provider enum, base_url absolute/https-outside-dev, per-provider defaults.
- go build/vet clean on default, `integration`, `console_assets` tag sets; full unit suite green; `scripts/test_integration.sh ./internal/modules/dashboard ./internal/http ./internal/integrationharness` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)