### PR TITLE
feat(#734): host-resolved merchant API hosts + per-merchant CORS preflight

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -414,3 +414,48 @@ customer/admin flows while system-origin provider writes stay parked, or
 `PROVIDER_WRITE_MODE=full`. All
 paused work is delayed,
 not lost; missed billing periods are never back-billed.
+
+## Per-merchant API hosts + CORS (#734)
+
+Public multi-merchant deployments (one running engine serving several
+merchants) give each merchant its own canonical API hostname instead of a
+global `Access-Control-Allow-Origin` union — a global union means every
+accepted merchant origin is trusted by every OTHER merchant's preflight
+before any request even carries a JWT. Real API security is always
+JWT signature/issuer/audience/permissions; Origin/Host are browser-transport
+hardening, never authentication.
+
+- **Configuring a merchant's host + origins**: `merchants.Service.SetHostConfig(ctx,
+  merchantID, apiHost, allowedOrigins)` sets `openrails.merchants.api_host` /
+  `.allowed_origins` — a plain row UPDATE, resolved LIVE on the next request.
+  There is no boot-time host map to restart or refresh: a merchant configured
+  on one node resolves immediately on every other node/process sharing the
+  database. Embedding hosts (openrails-saas) reach this through their
+  attached control plane; leave `api_host` unset (the default) for a merchant
+  that should never resolve from any Host.
+- **Local-dev hostnames**: `api_host` compares against the request Host with
+  the port stripped (`merchants.NormalizeAPIHost`), so a merchant configured
+  with `api_host = "api.acme.localhost"` resolves whether the dev server
+  listens on `:80` or `:3000` — point `/etc/hosts` (or your browser's
+  hosts-file equivalent) at `127.0.0.1` for each `*.localhost` name you use.
+- **Reserved names**: `pkg/merchant.ReservedHostedSlugs` is the advisory list
+  a hosted product (openrails-saas) should refuse to let a merchant
+  self-provision as a slug, since a slug commonly becomes part of the
+  hostname scheme (`api.<slug>.<domain>`) — the engine doesn't enforce this
+  (slug MECHANISM vs slug RESERVATION, see reserved.go), the host does.
+- **Interaction with the global `cors_origins` config key**: that key was
+  retired in #519 (`browser CORS belongs to the host app, not OpenRails`) and
+  is ignored wherever still set. Per-merchant `allowed_origins` (#734) is the
+  only OpenRails-owned CORS mechanism, and it is 100% opt-in per merchant: a
+  private single-merchant deployment that never sets `api_host` sees zero
+  CORS grants and zero behavior change, exactly as before this issue.
+- **Webhooks**: the same Host→merchant resolver mounts the Host-routed
+  webhook surface (`pkg/embedded`'s `RegisterHostWebhookRoutes`, saas #15's
+  engine half) at `/v1/webhooks/:provider` — merchant resolved from Host
+  instead of a path segment, then verified with THAT merchant's own signing
+  secret exactly like every other webhook surface.
+- **Consistency with token issuers**: a JWT minted for merchant A's issuer is
+  rejected outright when presented against merchant B's Host, even though the
+  token verifies perfectly — Host-merchant must equal issuer-merchant on every
+  merchant-scoped route. This check is also 100% opt-in: it only fires when a
+  Host actually resolved a merchant for the request.

--- a/internal/controlplane/host_registry.go
+++ b/internal/controlplane/host_registry.go
@@ -1,0 +1,79 @@
+package controlplane
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/open-rails/openrails/internal/merchants"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// ErrHostMerchantUnknown indicates a request Host does not map to any active
+// merchant (#734): unregistered host, a merchant whose host mapping was
+// cleared, an inactive/deleted merchant, or (defensively) an ambiguous match.
+// Every caller fails closed on this error — there is no fallback merchant.
+var ErrHostMerchantUnknown = errors.New("controlplane: host maps to no active merchant")
+
+// merchantForHost resolves the merchant whose openrails.merchants.api_host
+// equals host, sharing merchantDirectoryRow with merchantForIssuer (#734):
+// Host resolution is deliberately the SAME openrails.merchants lookup —
+// same active/deleted filtering, same "ambiguous match" guard — issuer
+// resolution uses, not a parallel authority. Resolved LIVE per call: no
+// boot-time host map exists, so a merchant registered (or re-hosted) on any
+// node resolves on the very next request against every process sharing this
+// database.
+func (c *ControlPlane) merchantForHost(ctx context.Context, host string) (merchant.ID, string, error) {
+	host = merchants.NormalizeAPIHost(host)
+	if host == "" {
+		return merchant.ID{}, "", ErrHostMerchantUnknown
+	}
+	if c == nil || c.pool == nil {
+		return merchant.ID{}, "", errors.New("controlplane: pgx pool unavailable for host resolution")
+	}
+	mid, slug, err := c.merchantDirectoryRow(ctx, `api_host = $1`, host)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) || errors.Is(err, ErrServiceCredentialMerchantUnresolved) {
+			return merchant.ID{}, "", ErrHostMerchantUnknown
+		}
+		return merchant.ID{}, "", err
+	}
+	return mid, slug, nil
+}
+
+// ResolveMerchantByHost is the exported #734 Host->merchant resolver: the
+// single mechanism both per-merchant CORS preflight and the Host-routed
+// webhook mount (pkg/embedded) share. Its signature matches
+// pkg/merchant.HostResolver, so a method value (cp.ResolveMerchantByHost) is
+// directly assignable wherever that type is expected.
+func (c *ControlPlane) ResolveMerchantByHost(ctx context.Context, host string) (merchant.ID, error) {
+	mid, _, err := c.merchantForHost(ctx, host)
+	return mid, err
+}
+
+// AllowedOriginsForHost resolves host -> merchant -> that merchant's stored
+// browser CORS allow-list (#734's preflight half). It fails closed identically
+// to merchantForHost (unknown host, inactive/ambiguous merchant) and ALSO
+// when the merchant is resolved but has configured no allowed_origins — an
+// api_host with no allowed_origins simply grants no browser CORS, matching
+// "no fallback merchant, no implicit allow-list."
+func (c *ControlPlane) AllowedOriginsForHost(ctx context.Context, host string) ([]string, error) {
+	mid, _, err := c.merchantForHost(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	if c.pool == nil {
+		return nil, errors.New("controlplane: pgx pool unavailable for host resolution")
+	}
+	var origins []string
+	if err := c.pool.QueryRow(ctx, `
+		SELECT allowed_origins FROM openrails.merchants WHERE id = $1 AND deleted_at IS NULL
+	`, mid.UUID()).Scan(&origins); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrHostMerchantUnknown
+		}
+		return nil, err
+	}
+	return origins, nil
+}

--- a/internal/controlplane/issuer_registry.go
+++ b/internal/controlplane/issuer_registry.go
@@ -43,8 +43,18 @@ func (c *ControlPlane) ReloadRemoteApplications(ctx context.Context) error {
 // matches (`merchants.permission_group_id`, repurposed under #567 to hold the merchant
 // permission-group's internal id).
 //
+// #734: when a Host resolver has pinned a merchant onto ctx (merchant.WithHostMerchant
+// — set only by the opt-in Host-based resolution middleware/mount, internal/http),
+// the resolved issuer-merchant MUST equal it: a token minted for merchant A
+// presented against merchant B's Host fails closed here, exactly like an
+// unregistered issuer. No Host pin on ctx (the common case: no Host resolver
+// configured) is a pure no-op — this is the SAME sentinel every other
+// unresolvable-issuer case already returns, so every existing caller's error
+// mapping covers it with no changes.
+//
 // Returns ErrDelegatedIssuerUnknown when the issuer is unregistered, is attached
-// to no group, or that group is no active merchant (fail closed). The returned
+// to no group, that group is no active merchant, or (#734) the resolved merchant
+// disagrees with ctx's Host-pinned merchant (fail closed). The returned
 // groupID/groupRef identify the merchant permission-group.
 func (c *ControlPlane) merchantForIssuer(ctx context.Context, issuer string) (merchantID merchant.ID, merchantSlug, groupID, groupRef, remoteApplicationID string, err error) {
 	issuer = strings.TrimSpace(issuer)
@@ -71,6 +81,9 @@ func (c *ControlPlane) merchantForIssuer(ctx context.Context, issuer string) (me
 	}
 	if err != nil {
 		return merchant.ID{}, "", "", "", "", err
+	}
+	if hostMID, ok := merchant.HostMerchant(ctx); ok && hostMID != mid {
+		return merchant.ID{}, "", "", "", "", ErrDelegatedIssuerUnknown
 	}
 	return mid, mslug, groupID, mslug, ra.ID, nil
 }

--- a/internal/http/embedhttp/embedhttp.go
+++ b/internal/http/embedhttp/embedhttp.go
@@ -10,6 +10,7 @@
 package embedhttp
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -30,6 +31,7 @@ import (
 	"github.com/open-rails/openrails/internal/http/routesurface"
 	"github.com/open-rails/openrails/internal/shared/iputil"
 	"github.com/open-rails/openrails/pkg/billingauth"
+	"github.com/open-rails/openrails/pkg/merchant"
 )
 
 // EmbeddedV1Prefix is the canonical API prefix for embedded mode handlers.
@@ -79,6 +81,38 @@ type Assembler struct {
 	// gate on its permissions — the gin-free counterpart of the self surface's
 	// DelegatedPrincipalRequired. nil for standalone (control-plane resolvers).
 	DelegatedAuthenticator billingauth.DelegatedAuthenticator
+	// HostResolve and CORSSource are the #734 Host->merchant mechanism, derived
+	// from the attached control plane (HostMerchantResolverFrom) exactly like
+	// AdminChecker/ServiceCredentialResolver above — nil for embedded hosts
+	// without a control plane, in which case CORS/merchant resolution behave
+	// exactly as before this issue (no behavior change without opting in).
+	HostResolve merchant.HostResolver
+	CORSSource  middleware.CORSOriginSource
+}
+
+// hostMerchantResolver is the #734 neutral capability a *controlplane.ControlPlane
+// satisfies, asserted off App.ControlPlane (held as `any`) so this package stays
+// free of AuthKit (#284) — matching the AdminChecker/ServiceCredentialResolver
+// pattern above.
+type hostMerchantResolver interface {
+	ResolveMerchantByHost(ctx context.Context, host string) (merchant.ID, error)
+	AllowedOriginsForHost(ctx context.Context, host string) ([]string, error)
+}
+
+// HostMerchantResolverFrom derives the #734 Host->merchant resolver + CORS
+// origin source from an app's ControlPlane field (an `any` on app.App).
+// Returns (nil, nil) when no control plane is attached, or it doesn't
+// implement the capability — callers treat that identically to never having
+// called this at all (single-merchant self-hosters see no behavior change
+// without opting in). Exported so pkg/embedded/mount.go (a sibling package,
+// composing the self-service handler) can derive the SAME resolver this
+// package's own FromApp uses, without duplicating the type assertion.
+func HostMerchantResolverFrom(controlPlane any) (merchant.HostResolver, middleware.CORSOriginSource) {
+	c, ok := controlPlane.(hostMerchantResolver)
+	if !ok || c == nil {
+		return nil, nil
+	}
+	return c.ResolveMerchantByHost, c.AllowedOriginsForHost
 }
 
 // FromApp builds an Assembler from the gin-free application graph (the same
@@ -102,6 +136,7 @@ func FromApp(a *app.App) *Assembler {
 	if c, ok := a.ControlPlane.(httphandlers.MerchantAPIKeyManager); ok {
 		apiKeys = c
 	}
+	hostResolve, corsSource := HostMerchantResolverFrom(a.ControlPlane)
 	asm := &Assembler{
 		Cfg:                       a.Config,
 		Runtime:                   a.Runtime,
@@ -110,6 +145,8 @@ func FromApp(a *app.App) *Assembler {
 		APIKeys:                   apiKeys,
 		CaptchaStore:              captcha.NewChallengeStore(a.RedisClient),
 		RDB:                       a.RedisClient,
+		HostResolve:               hostResolve,
+		CORSSource:                corsSource,
 	}
 	if checker != nil || resolver != nil {
 		asm.Gate = httproutes.NewGate(httproutes.GateOptions{
@@ -196,6 +233,16 @@ func (s *Assembler) NewHTTPHandler(opts Options) http.Handler {
 	}
 	if routeSets[RouteSetWebhooks] {
 		httproutes.RegisterMerchantWebhookRoutes(router.NewMux(mux, EmbeddedV1Prefix, s.Runtime), s.Runtime)
+		// #734: the Host-routed webhook mount (saas #15's "api.<slug>.<domain>"
+		// scheme) is additive — it mounts at the canonical no-merchant-segment
+		// path ("/billing/v1/webhooks/:provider"), distinct from the merchant-scoped
+		// path above, and only when a control plane is attached (HostResolve != nil).
+		// A host with no control plane, or one that never configures any
+		// merchant's api_host, is unaffected: the path simply isn't mounted / never
+		// resolves.
+		if s.HostResolve != nil {
+			httproutes.RegisterHostWebhookRoutes(router.NewMux(mux, EmbeddedV1Prefix, s.Runtime), s.Runtime, s.HostResolve)
+		}
 	}
 
 	// Merchant resolution (#223/#336) pins Runtime.ConfiguredMerchant() onto
@@ -216,11 +263,21 @@ func (s *Assembler) NewHTTPHandler(opts Options) http.Handler {
 	if s.Runtime != nil {
 		resolver = s.Runtime.TrustedProxies
 	}
+	// #734: per-merchant CORS when a control plane is attached (CORSSource !=
+	// nil); otherwise the pre-#734 static CORSHTTP(nil) (no browser CORS) —
+	// unchanged for embedded hosts that never attach one.
+	corsMW := middleware.CORSHTTP(nil)
+	if s.CORSSource != nil {
+		corsMW = middleware.CORSFromSourceHTTP(s.CORSSource)
+	}
 	return middleware.ChainHTTP(mux,
 		middleware.SecurityHeadersHTTP(),
-		middleware.CORSHTTP(nil),
+		corsMW,
 		middleware.BodyLimitHTTP(middleware.DefaultMaxBodyBytes),
 		middleware.ResolveMerchantHTTP(s.Runtime.ConfiguredMerchant),
+		// #734: Host-based multi-merchant resolution (a no-op when HostResolve is
+		// nil), sharing the same control-plane directory lookup as corsMW above.
+		middleware.ResolveMerchantFromHostHTTP(s.HostResolve),
 		// Best-effort auth so the rate limiter can key by user, not only IP.
 		middleware.HTTPMiddleware(billingauth.Optional(s.Authenticator)),
 		// OpenRails-native rate-limiting + captcha for embedded hosts.

--- a/internal/http/embedhttp/self.go
+++ b/internal/http/embedhttp/self.go
@@ -14,6 +14,7 @@ import (
 	"github.com/open-rails/openrails/internal/http/routesurface"
 	"github.com/open-rails/openrails/internal/shared/iputil"
 	"github.com/open-rails/openrails/pkg/billingauth"
+	"github.com/open-rails/openrails/pkg/merchant"
 )
 
 // NewSelfHandler assembles the embedded browser-direct SELF-SERVICE surface
@@ -27,7 +28,13 @@ import (
 // CORS, body limit, merchant resolution, rate-limit + captcha), keeping it
 // behaviorally consistent with the base embedded handler. Host-supplied
 // delegated authenticators own their own browser-origin policy.
-func NewSelfHandler(rt *app.Runtime, authn billingauth.DelegatedAuthenticator, providerRouteOverride *routesurface.ProviderRoutes) http.Handler {
+//
+// hostResolve/corsSource are the #734 Host->merchant mechanism (nil for hosts
+// with no control plane attached — HostMerchantResolverFrom derives both, and
+// mount.go's selfHandler is the sole caller), the browser-facing surface
+// self-service checkout apps actually call, so per-merchant CORS matters here
+// at least as much as on the base handler.
+func NewSelfHandler(rt *app.Runtime, authn billingauth.DelegatedAuthenticator, providerRouteOverride *routesurface.ProviderRoutes, hostResolve merchant.HostResolver, corsSource middleware.CORSOriginSource) http.Handler {
 	mux := http.NewServeMux()
 	delegatedMW := middleware.DelegatedPrincipalRequired(authn)
 	providerRoutes := ProviderRoutesForRuntime(rt, providerRouteOverride)
@@ -49,15 +56,21 @@ func NewSelfHandler(rt *app.Runtime, authn billingauth.DelegatedAuthenticator, p
 			captchaCfg = rt.Config.Captcha
 		}
 	}
+	corsMW := middleware.CORSHTTP(nil)
+	if corsSource != nil {
+		corsMW = middleware.CORSFromSourceHTTP(corsSource)
+	}
 	return middleware.ChainHTTP(mux,
 		middleware.RecoverHTTP(),
 		middleware.SecurityHeadersHTTP(),
-		middleware.CORSHTTP(nil),
+		corsMW,
 		middleware.BodyLimitHTTP(middleware.DefaultMaxBodyBytes),
 		// Resolved PER REQUEST off the Runtime (#744) — never a value snapshotted
 		// here at construction time, so a mount that races UpsertMerchantConfig's
 		// post-boot bind still resolves correctly on every request.
 		middleware.ResolveMerchantHTTP(rt.ConfiguredMerchant),
+		// #734: a no-op when hostResolve is nil (no control plane attached).
+		middleware.ResolveMerchantFromHostHTTP(hostResolve),
 		middleware.RateLimitHTTP(rateLimits, captchaCfg, rdb, captcha.NewChallengeStore(rdb), resolver),
 	)
 }

--- a/internal/http/handlers/webhook.go
+++ b/internal/http/handlers/webhook.go
@@ -140,6 +140,33 @@ func MerchantWebhook(r *httprequest.Request) {
 	processResolvedMerchantWebhook(r, provider, route.MerchantID, strings.TrimSpace(r.Param("account_id")))
 }
 
+// HostWebhook returns the Host-routed webhook handler (#734): resolve pins the
+// merchant from the request's Host header — the SAME mechanism per-merchant
+// CORS preflight uses — instead of a URL slug (contrast MerchantWebhook), so
+// the exact same verify/dispatch primitive (processResolvedMerchantWebhook)
+// runs unchanged once the merchant is known. This is the engine half of saas
+// #15's "api.<slug>.<domain>" hostname scheme: the mount is opt-in
+// (pkg/embedded's RegisterHostWebhookRoutes, gated on an attached control
+// plane); an unresolvable Host (unknown/disabled/ambiguous merchant) is a hard
+// 404, never a fall-through to payload-derived resolution.
+func HostWebhook(resolve merchant.HostResolver) func(r *httprequest.Request) {
+	return func(r *httprequest.Request) {
+		if resolve == nil {
+			r.ErrorJSON(http.StatusServiceUnavailable, "Host-routed webhook resolution is not configured")
+			return
+		}
+		provider := webhookutil.CanonicalRail(r.Param("provider"))
+		mid, err := resolve(r.Request.Context(), r.Request.Host)
+		if err != nil || mid.IsZero() {
+			r.ErrorJSON(http.StatusNotFound, "Unknown merchant")
+			return
+		}
+		ctx := merchant.WithID(r.Request.Context(), mid)
+		r.Request = r.Request.WithContext(ctx)
+		processResolvedMerchantWebhook(r, provider, mid, strings.TrimSpace(r.Param("account_id")))
+	}
+}
+
 func processResolvedMerchantWebhook(r *httprequest.Request, provider string, merchantID merchant.ID, accountID string) {
 	if rails.IsNMI(models.Rail(provider)) {
 		if processMerchantNMIWebhook(r, provider, merchantID, accountID) {

--- a/internal/http/middleware/http_base.go
+++ b/internal/http/middleware/http_base.go
@@ -101,11 +101,15 @@ func CORSHTTP(allowedOrigins []string) HTTPMiddleware {
 	}
 }
 
-// CORSOriginSource returns the browser Origin allow-list for the current request.
-type CORSOriginSource func(context.Context) ([]string, error)
+// CORSOriginSource returns the browser Origin allow-list for the current
+// request's Host (#734: per-merchant CORS resolves live from the request Host,
+// e.g. AuthKit remote_application state resolves BY MERCHANT, and merchant is
+// resolved from host). Sources that don't vary by host (a single global
+// allow-list) simply ignore the parameter.
+type CORSOriginSource func(ctx context.Context, host string) ([]string, error)
 
 // CORSFromSourceHTTP grants browser CORS headers only to origins allow-listed by
-// a per-request source (e.g. AuthKit remote_application state). An empty or
+// a per-request source (e.g. a merchant resolved from Host — #734). An empty or
 // failing source grants no browser Origin. OPTIONS is still answered with 204 so
 // denied preflight fails in the browser without invoking handlers.
 func CORSFromSourceHTTP(source CORSOriginSource) HTTPMiddleware {
@@ -114,7 +118,7 @@ func CORSFromSourceHTTP(source CORSOriginSource) HTTPMiddleware {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			origins := []string(nil)
 			if source != nil && strings.TrimSpace(r.Header.Get("Origin")) != "" {
-				if got, err := source(r.Context()); err == nil {
+				if got, err := source(r.Context(), r.Host); err == nil {
 					origins = got
 				}
 			}
@@ -257,4 +261,40 @@ func ResolveMerchantHTTP(resolve func() merchant.ID) HTTPMiddleware {
 // merchant for the lifetime of a test server.
 func StaticMerchant(id merchant.ID) func() merchant.ID {
 	return func() merchant.ID { return id }
+}
+
+// ResolveMerchantFromHostHTTP resolves the merchant owning the request's Host
+// header (#734) and, when resolved, pins it BOTH as the ordinary "configured
+// merchant" (merchant.WithID — the same key ResolveMerchantHTTP sets, so
+// unauthenticated merchant-scoped routes such as public catalog reads work
+// per-Host in a multi-merchant deployment) AND as merchant.WithHostMerchant, a
+// marker the control plane's JWT-issuer resolution (internal/controlplane)
+// reads to enforce Host-merchant == issuer-merchant, fail closed on mismatch.
+//
+// resolve is called ON EVERY REQUEST (live per call, #734: no boot-time host
+// map — a merchant registered after this process started resolves on its very
+// next request, on every process sharing the database). resolve == nil, or an
+// unresolvable Host (unknown/disabled/ambiguous merchant), is a NO-OP: this
+// middleware only ever narrows context, never blocks a request outright, so
+// health/platform routes and Hosts with no configured merchant keep working
+// exactly as before. A deployment that configures no Host resolver never calls
+// this middleware at all — single-merchant self-hosters see no behavior change
+// without opting in.
+func ResolveMerchantFromHostHTTP(resolve merchant.HostResolver) HTTPMiddleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if resolve == nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+			mid, err := resolve(r.Context(), r.Host)
+			if err != nil || mid.IsZero() {
+				next.ServeHTTP(w, r)
+				return
+			}
+			ctx := merchant.WithID(r.Context(), mid)
+			ctx = merchant.WithHostMerchant(ctx, mid)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
 }

--- a/internal/http/middleware/http_base_extra_test.go
+++ b/internal/http/middleware/http_base_extra_test.go
@@ -21,7 +21,7 @@ func TestSecurityHeadersHTTPSetsCSP(t *testing.T) {
 }
 
 func TestCORSFromSourceHTTPGrantsOnlyListedOrigins(t *testing.T) {
-	source := func(context.Context) ([]string, error) {
+	source := func(context.Context, string) ([]string, error) {
 		return []string{"https://app.example"}, nil
 	}
 	h := CORSFromSourceHTTP(source)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/http/routes/routes.go
+++ b/internal/http/routes/routes.go
@@ -357,6 +357,11 @@ func (g legacyGate) Authorize(ctx context.Context, req *http.Request, perm strin
 				return billingauth.Principal{}, billingauth.GateError{Status: http.StatusForbidden, Message: "service_credential_merchant_unresolved"}
 			case errors.Is(err, controlplane.ErrServiceCredentialScopeDenied):
 				return billingauth.Principal{}, billingauth.GateError{Status: http.StatusForbidden, Message: "service_credential_resource_scope_denied"}
+			case errors.Is(err, controlplane.ErrDelegatedIssuerUnknown):
+				// #734: the issuer resolves fine, but its merchant disagrees with the
+				// request's Host-pinned merchant (or, as for any other caller of
+				// merchantForIssuer, the issuer itself is unregistered/disabled).
+				return billingauth.Principal{}, billingauth.GateError{Status: http.StatusForbidden, Message: "host_merchant_mismatch"}
 			default:
 				return billingauth.Principal{}, billingauth.GateError{Status: http.StatusUnauthorized, Message: "service_credential_invalid"}
 			}
@@ -520,12 +525,14 @@ func (g legacyGate) resolveServiceCredential(ctx context.Context, r *http.Reques
 			return resolved, nil, true
 		}
 		// A VERIFIED service JWT that is definitively rejected (cross-merchant
-		// resource scope, or its issuer owns no merchant) must surface as 403 — not
-		// fall through to the delegated/user-session paths, which would mislabel it
-		// 401 access_token_wrong_typ. A wrong-typ (not-a-service-JWT) error still
-		// falls through so delegated/user tokens reach their own resolvers.
+		// resource scope, its issuer owns no merchant, or — #734 — its issuer's
+		// merchant disagrees with the request's Host-pinned merchant) must surface
+		// as 403 — not fall through to the delegated/user-session paths, which
+		// would mislabel it 401 access_token_wrong_typ. A wrong-typ (not-a-service-JWT)
+		// error still falls through so delegated/user tokens reach their own resolvers.
 		if errors.Is(err, controlplane.ErrServiceCredentialScopeDenied) ||
-			errors.Is(err, controlplane.ErrServiceCredentialMerchantUnresolved) {
+			errors.Is(err, controlplane.ErrServiceCredentialMerchantUnresolved) ||
+			errors.Is(err, controlplane.ErrDelegatedIssuerUnknown) {
 			return nil, err, true
 		}
 	}
@@ -715,4 +722,20 @@ func RegisterMerchantWebhookRoutes(rr router.Router, rt *app.Runtime) {
 	// #641: per-account endpoint — account_id in the path selects which account the
 	// event is for (verify with its secret). For multi-account rails like NMI.
 	rr.Handle(http.MethodPost, "/merchants/:merchant/webhooks/:provider/:account_id", h(httphandlers.MerchantWebhook))
+}
+
+// RegisterHostWebhookRoutes mounts the Host-routed webhook surface (#734):
+// POST /webhooks/:provider[/:account_id], merchant resolved from the request's
+// Host header via resolve — the SAME mechanism per-merchant CORS preflight
+// uses — rather than a URL slug (RegisterMerchantWebhookRoutes) or payload
+// account identity (RegisterWebhookRoutes). This is the engine half of saas
+// #15's "api.<slug>.<domain>" hostname scheme: pkg/embedded mounts it
+// alongside the merchant-scoped surface at the SAME canonical path shape the
+// standalone provider-only surface uses, since Host (not a path segment)
+// carries the merchant here. Opt-in: callers only mount this when a resolver
+// is available (an attached control plane).
+func RegisterHostWebhookRoutes(rr router.Router, rt *app.Runtime, resolve merchant.HostResolver) {
+	handler := h(httphandlers.HostWebhook(resolve))
+	rr.Handle(http.MethodPost, "/webhooks/:provider", handler)
+	rr.Handle(http.MethodPost, "/webhooks/:provider/:account_id", handler)
 }

--- a/internal/http/routes_self_test.go
+++ b/internal/http/routes_self_test.go
@@ -100,7 +100,7 @@ func TestRegisterSelfServiceRoutes_HTTPServerRejectsDelegatedOriginMismatch(t *t
 func TestStandaloneCORSUsesConfiguredOriginSource(t *testing.T) {
 	srv := &Server{
 		cfg: &config.Config{},
-		browserCORSOriginSource: func(context.Context) ([]string, error) {
+		browserCORSOriginSource: func(context.Context, string) ([]string, error) {
 			return []string{
 				"https://doujins.com",
 				"https://hentai0.com",

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/open-rails/openrails/internal/shared/iputil"
 	"github.com/open-rails/openrails/pkg/billingauth"
 	"github.com/open-rails/openrails/pkg/cache"
+	"github.com/open-rails/openrails/pkg/merchant"
 )
 
 type Dependencies struct {
@@ -412,7 +413,10 @@ func (s *Server) wrapPublicHandler(mux *http.ServeMux) http.Handler {
 		// CORS is browser transport policy, not API authorization. Preflight has no
 		// JWT issuer. JWT signature/issuer/audience/permissions and merchant ownership
 		// remain the real request security boundary; hosts that need browser CORS wire
-		// an explicit origin source.
+		// an explicit origin source. Per-merchant preflight (#734) is the control
+		// plane's own openrails.merchants directory (api_host/allowed_origins) — a
+		// merchant that never configures an api_host resolves nothing, so this is a
+		// pure no-op for single-merchant self-hosters.
 		middleware.CORSFromSourceHTTP(s.browserCORSOrigins),
 		middleware.BodyLimitHTTP(middleware.DefaultMaxBodyBytes),
 		// Resolve the merchant / billing namespace before authorization and before any
@@ -421,17 +425,45 @@ func (s *Server) wrapPublicHandler(mux *http.ServeMux) http.Handler {
 		// is configured, in which case merchant-owned operations hard-fail (there is
 		// no default merchant).
 		middleware.ResolveMerchantHTTP(s.runtime.ConfiguredMerchant),
+		// #734: Host-based multi-merchant resolution, sharing the SAME control-plane
+		// directory lookup as CORS above and as the JWT-issuer resolution
+		// (internal/controlplane.merchantForIssuer checks the marker this pins).
+		// Runs after the static ResolveMerchantHTTP so a live per-request Host match
+		// is authoritative over any process-wide configured merchant. A Host with no
+		// api_host configured for any merchant is a no-op — behavior is unchanged.
+		middleware.ResolveMerchantFromHostHTTP(s.hostMerchantResolver),
 		// Best-effort auth so the rate limiter can key by user, not only IP.
 		middleware.HTTPMiddleware(billingauth.Optional(s.authenticator)),
 		middleware.RateLimitHTTP(s.cfg.RateLimits, s.cfg.Captcha, s.rdb, s.captchaStore, s.trustedProxies()),
 	)
 }
 
-func (s *Server) browserCORSOrigins(ctx context.Context) ([]string, error) {
-	if s != nil && s.browserCORSOriginSource != nil {
-		return s.browserCORSOriginSource(ctx)
+// browserCORSOrigins is the standalone CORSOriginSource (#734): an explicit
+// browserCORSOriginSource override wins (test seam / a host that wants a
+// different policy); otherwise it resolves the SAME control-plane merchant
+// directory the Host-merchant resolver and JWT-issuer resolution share.
+func (s *Server) browserCORSOrigins(ctx context.Context, host string) ([]string, error) {
+	if s == nil {
+		return nil, nil
+	}
+	if s.browserCORSOriginSource != nil {
+		return s.browserCORSOriginSource(ctx, host)
+	}
+	if s.controlPlane != nil {
+		return s.controlPlane.AllowedOriginsForHost(ctx, host)
 	}
 	return nil, nil
+}
+
+// hostMerchantResolver is the standalone #734 Host->merchant resolver (shared
+// with browserCORSOrigins above) — always the attached control plane in a
+// server built via New() (#469: the control plane is mandatory); nil-safe for
+// hand-built *Server{} unit tests that skip New().
+func (s *Server) hostMerchantResolver(ctx context.Context, host string) (merchant.ID, error) {
+	if s == nil || s.controlPlane == nil {
+		return merchant.ID{}, nil
+	}
+	return s.controlPlane.ResolveMerchantByHost(ctx, host)
 }
 
 // Handler returns the full public HTTP surface: health + user + self/customer

--- a/internal/integrationharness/harness.go
+++ b/internal/integrationharness/harness.go
@@ -582,6 +582,21 @@ func (s *Surface) ProvisionOwnedMerchant(slug string) OwnedMerchant {
 	}
 }
 
+// SetMerchantHostConfig sets a merchant's #734 canonical API host + browser
+// CORS allowed-origins through the REAL merchants.Service the running
+// standalone server itself resolves Host->merchant/CORS from (server.go wires
+// Runtime.Merchants to the exact same *merchants.Service instance) — a live
+// DB write, so the very next request against the new host resolves
+// immediately on this SAME running server, with no restart (the #734
+// multi-node/no-boot-mount proof).
+func (s *Surface) SetMerchantHostConfig(mid merchant.ID, apiHost string, allowedOrigins []string) {
+	h := s.h
+	h.t.Helper()
+	require.NotNil(h.t, s.app, "SetMerchantHostConfig requires the standalone surface")
+	require.NotNil(h.t, s.app.Runtime.Merchants, "merchants service must be armed")
+	require.NoError(h.t, s.app.Runtime.Merchants.SetHostConfig(h.ctx, mid, apiHost, allowedOrigins), "set merchant host config")
+}
+
 // CreateMerchantGroup creates a top-level merchant permission-group through the
 // standalone control plane and returns its slug.
 func (s *Surface) CreateMerchantGroup(slug string) string {

--- a/internal/integrationharness/host_merchant_cors_test.go
+++ b/internal/integrationharness/host_merchant_cors_test.go
@@ -1,0 +1,208 @@
+//go:build integration
+
+package integrationharness
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/controlplane"
+	"github.com/open-rails/openrails/internal/dbtest"
+)
+
+// #734: host-resolved merchant API hosts + per-merchant CORS preflight.
+//
+// A public multi-merchant deployment gets ONE standalone server serving
+// several merchants, each with its own canonical API hostname. These tests
+// prove the engine mechanism: Host resolves to a merchant, CORS preflight
+// answers ONLY that merchant's stored allowed_origins, an unrecognized Host
+// grants nothing, and a token minted for one merchant is rejected on another
+// merchant's Host — all sharing the SAME openrails.merchants directory lookup
+// issuer resolution already uses.
+
+// preflight sends an OPTIONS request to url with the given Host + Origin
+// headers, mirroring a browser CORS preflight.
+func preflightHost(t *testing.T, url, host, origin string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodOptions, url, nil)
+	require.NoError(t, err)
+	req.Host = host
+	req.Header.Set("Origin", origin)
+	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+	req.Header.Set("Access-Control-Request-Headers", "authorization")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	return resp
+}
+
+// requestJSONHost is requestJSON plus an explicit Host header override — a
+// browser-style request against a specific merchant's api_host rather than
+// the httptest server's own bare address.
+func requestJSONHost(t *testing.T, method, url, host, token string, body any) (int, []byte) {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		require.NoError(t, json.NewEncoder(&buf).Encode(body))
+	}
+	req, err := http.NewRequest(method, url, &buf)
+	require.NoError(t, err)
+	if host != "" {
+		req.Host = host
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, raw
+}
+
+func TestHostMerchantCORSPreflightHTTP(t *testing.T) {
+	ctx := context.Background()
+	h := New(t, ctx)
+	surface := h.StartStandalone("usd")
+
+	b := surface.ProvisionOwnedMerchant("host-cors-b-" + strings.ReplaceAll(uuid.NewString(), "-", ""))
+
+	hostA := "api.host-cors-a-" + strings.ReplaceAll(uuid.NewString(), "-", "") + ".test"
+	hostB := "api.host-cors-b-" + strings.ReplaceAll(uuid.NewString(), "-", "") + ".test"
+	originA := "https://storefront-a.example"
+	originB := "https://storefront-b.example"
+
+	surface.SetMerchantHostConfig(dbtest.TestMerchantID, hostA, []string{originA})
+	surface.SetMerchantHostConfig(b.MerchantID, hostB, []string{originB})
+
+	// A's own origin, on A's host: granted.
+	resp := preflightHost(t, surface.BaseURL+"/v1/products", hostA, originA)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.Equal(t, originA, resp.Header.Get("Access-Control-Allow-Origin"))
+	require.Equal(t, "true", resp.Header.Get("Access-Control-Allow-Credentials"))
+
+	// B's origin, presented on A's host: fail closed — no global origin union.
+	resp = preflightHost(t, surface.BaseURL+"/v1/products", hostA, originB)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
+	require.Empty(t, resp.Header.Get("Access-Control-Allow-Credentials"))
+
+	// B's own origin, on B's host: granted.
+	resp = preflightHost(t, surface.BaseURL+"/v1/products", hostB, originB)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.Equal(t, originB, resp.Header.Get("Access-Control-Allow-Origin"))
+
+	// A's origin, presented on B's host: fail closed too (isolation is symmetric).
+	resp = preflightHost(t, surface.BaseURL+"/v1/products", hostB, originA)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
+
+	// A Host that maps to no merchant at all: fail closed.
+	resp = preflightHost(t, surface.BaseURL+"/v1/products", "api.unknown-host.test", originA)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
+
+	// Health checks (merchant-independent) are unaffected by the new Host
+	// resolution/CORS middleware — no merchant resolves, no error.
+	status, _ := requestJSON(t, http.MethodGet, surface.BaseURL+"/health/live", "", nil)
+	require.Equal(t, http.StatusOK, status)
+}
+
+// TestHostMerchantRegisteredAfterBootResolvesHTTP is the #734 multi-node proof:
+// a merchant's Host/CORS config set AFTER the server already booted and started
+// serving requests resolves on the very NEXT request against this SAME running
+// server — there is no boot-time host map to restart or refresh. This is the
+// load-bearing behavior for a multi-node deployment: a merchant registered on
+// node A must resolve on node B without redeploying/restarting node B.
+func TestHostMerchantRegisteredAfterBootResolvesHTTP(t *testing.T) {
+	ctx := context.Background()
+	h := New(t, ctx)
+	surface := h.StartStandalone("usd")
+
+	host := "api.host-late-" + strings.ReplaceAll(uuid.NewString(), "-", "") + ".test"
+	origin := "https://late-storefront.example"
+
+	// Before configuring anything, this host resolves nothing (server already
+	// running).
+	resp := preflightHost(t, surface.BaseURL+"/v1/products", host, origin)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
+
+	// Provision a brand-new merchant and configure its host/origins — entirely
+	// AFTER the server started serving traffic above.
+	late := surface.ProvisionOwnedMerchant("host-late-" + strings.ReplaceAll(uuid.NewString(), "-", ""))
+	surface.SetMerchantHostConfig(late.MerchantID, host, []string{origin})
+
+	// The SAME already-running server now resolves it, no restart.
+	resp = preflightHost(t, surface.BaseURL+"/v1/products", host, origin)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.Equal(t, origin, resp.Header.Get("Access-Control-Allow-Origin"))
+}
+
+// TestHostMerchantVsIssuerMismatchHTTP proves the request-path fail-closed
+// check (#734): a service JWT minted for merchant A's issuer is rejected when
+// presented against merchant B's Host, even though the token itself verifies
+// perfectly (signature/issuer/audience all valid for A) — Host-merchant must
+// equal issuer-merchant on merchant-scoped routes.
+func TestHostMerchantVsIssuerMismatchHTTP(t *testing.T) {
+	ctx := context.Background()
+	h := New(t, ctx)
+	surface := h.StartStandalone("usd")
+
+	b := surface.ProvisionOwnedMerchant("host-mismatch-b-" + strings.ReplaceAll(uuid.NewString(), "-", ""))
+
+	hostA := "api.host-mismatch-a-" + strings.ReplaceAll(uuid.NewString(), "-", "") + ".test"
+	hostB := "api.host-mismatch-b-" + strings.ReplaceAll(uuid.NewString(), "-", "") + ".test"
+	surface.SetMerchantHostConfig(dbtest.TestMerchantID, hostA, nil)
+	surface.SetMerchantHostConfig(b.MerchantID, hostB, nil)
+
+	tokenA := surface.RegisterServiceJWTIssuer(
+		"host-mismatch-issuer-a-"+strings.ReplaceAll(uuid.NewString(), "-", ""),
+		dbtest.TestMerchantSlug,
+		[]string{controlplane.PermMerchantCustomerSettingsRead, controlplane.PermMerchantCustomerSettingsUpdate},
+	)
+
+	payer := uuid.NewString()
+
+	// A's own token, on A's own host: works normally.
+	status, body := requestJSONHost(t, http.MethodPost, surface.BaseURL+"/v1/merchant/credits/deposit", hostA, tokenA.Token, map[string]any{
+		"customer_id": payer,
+		"invoker":     "host-mismatch-invoker",
+		"currency":    "usd",
+		"amount":      1000,
+		"source":      "host-mismatch-test",
+		"source_id":   uuid.NewString(),
+	})
+	require.Equal(t, http.StatusOK, status, string(body))
+
+	// A's own token, presented on B's host: fails closed. The token is a
+	// perfectly valid A credential — Host disagreement alone must reject it.
+	status, body = requestJSONHost(t, http.MethodGet,
+		surface.BaseURL+"/v1/merchant/credits/balance?currency=usd&customer_id="+payer, hostB, tokenA.Token, nil)
+	require.Containsf(t, []int{http.StatusUnauthorized, http.StatusForbidden}, status,
+		"A's token on B's host must fail closed: %s", string(body))
+
+	// Sanity: the SAME token on ITS OWN host still works (the mismatch check
+	// isn't just rejecting everything).
+	status, body = requestJSONHost(t, http.MethodGet,
+		surface.BaseURL+"/v1/merchant/credits/balance?currency=usd&customer_id="+payer, hostA, tokenA.Token, nil)
+	require.Equal(t, http.StatusOK, status, string(body))
+
+	// No Host override at all (the server's own httptest host, unconfigured):
+	// unaffected — single-host deployments see no behavior change.
+	status, body = requestJSON(t, http.MethodGet,
+		surface.BaseURL+"/v1/merchant/credits/balance?currency=usd&customer_id="+payer, tokenA.Token, nil)
+	require.Equal(t, http.StatusOK, status, string(body))
+}

--- a/internal/integrationharness/host_webhook_mount_test.go
+++ b/internal/integrationharness/host_webhook_mount_test.go
@@ -1,0 +1,89 @@
+//go:build integration
+
+package integrationharness
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/pkg/embedded"
+	embcp "github.com/open-rails/openrails/pkg/embedded/controlplane"
+)
+
+// TestHostRoutedWebhookMountHTTP proves the #734 Host-routed webhook mount
+// (pkg/embedded's RegisterHostWebhookRoutes, saas #15's engine half): the SAME
+// Host->merchant resolver CORS preflight uses ALSO pins the merchant for
+// inbound webhooks at the canonical no-merchant-segment path
+// ("/billing/v1/webhooks/:provider"), mounted only when a control plane is
+// attached. An unrecognized Host is a hard 404 (fail closed, never a
+// fall-through to unscoped processing); a recognized Host resolves and reaches
+// the SAME verify/dispatch primitive the path-slug surface uses (proven by an
+// unsupported-provider name reaching the "provider not supported" branch,
+// which only happens AFTER merchant resolution succeeds — the exact same
+// httphandlers.processResolvedMerchantWebhook TestMerchantWebhookRouteHTTPResolvesMerchantBeforeVerifyingStripe
+// exercises for the path-slug surface, so per-merchant secret isolation there
+// covers this mount too).
+func TestHostRoutedWebhookMountHTTP(t *testing.T) {
+	ctx := context.Background()
+	h := New(t, ctx)
+
+	cfg := &config.Config{
+		Env:      "dev",
+		TestMode: config.CredentialPostureSandbox,
+		DB:       &config.DBConfig{URL: h.DSN},
+		Auth:     &config.AuthConfig{Issuer: "https://host-webhook-controlplane.test"},
+	}
+
+	e, err := embedded.New(embedded.Options{Config: cfg, Redis: h.Redis})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = e.Close(context.Background()) })
+
+	require.NoError(t, embcp.AttachWithOptions(ctx, e.App(), cfg, nil, embcp.AttachOptions{}))
+	cp := embcp.Get(e.App())
+	require.NotNil(t, cp, "control plane attached")
+
+	// A bare merchant directory row + api_host is all Host resolution needs
+	// (no AuthKit permission-group linking required for this mechanism).
+	hostA := "api.host-webhook-a-" + strings.ReplaceAll(uuid.NewString(), "-", "") + ".test"
+	insertMerchantWithHost(t, h.sharedPool(), "host-webhook-a-"+strings.ReplaceAll(uuid.NewString(), "-", ""), hostA)
+
+	handler, err := embedded.MountHandler(e, embedded.MountOptions{
+		RouteSets: []embedded.RouteSet{embedded.RouteSetWebhooks},
+	})
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	// Unknown Host: no merchant resolves. Hard 404, never a fall-through.
+	status, body := postHostWebhook(t, srv.URL+"/v1/webhooks/bogus", "api.unknown-webhook-host.test")
+	require.Equal(t, http.StatusNotFound, status, string(body))
+
+	// Known Host, unsupported provider: proves resolution DID succeed (a 400
+	// from inside processResolvedMerchantWebhook, reachable only once the
+	// merchant is pinned) rather than a 404 from unresolved Host.
+	status, body = postHostWebhook(t, srv.URL+"/v1/webhooks/bogus", hostA)
+	require.Equal(t, http.StatusBadRequest, status, string(body))
+}
+
+func postHostWebhook(t *testing.T, url, host string) (int, []byte) {
+	t.Helper()
+	return requestJSONHost(t, http.MethodPost, url, host, "", map[string]any{"id": "evt_1"})
+}
+
+func insertMerchantWithHost(t *testing.T, pool *pgxpool.Pool, slug, apiHost string) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO openrails.merchants (slug, status, api_host)
+		VALUES ($1, 'active', $2)
+	`, slug, apiHost)
+	require.NoError(t, err)
+}

--- a/internal/merchants/host_config.go
+++ b/internal/merchants/host_config.go
@@ -1,0 +1,113 @@
+package merchants
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// ErrAPIHostTaken indicates apiHost is already assigned to a different active
+// merchant (#734: api_host is globally unique).
+var ErrAPIHostTaken = errors.New("merchants: api host already assigned to another merchant")
+
+// NormalizeAPIHost canonicalizes a Host-header value for #734 resolution:
+// lowercased, whitespace-trimmed, and stripped of a ":port" suffix (Go's
+// net/http leaves the port on Request.Host for non-default ports, and local-dev
+// deployments commonly run on a non-443/80 port). Empty in, empty out.
+func NormalizeAPIHost(host string) string {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return ""
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	return strings.ToLower(host)
+}
+
+// SetHostConfig sets a merchant's canonical API host + browser CORS
+// allowed-origins (#734): the ONE per-merchant Host->CORS/webhook-routing
+// config, engine-owned (never AuthKit's remote_application — CORS is browser
+// transport policy, not federation identity). apiHost empty clears the
+// mapping (the merchant no longer resolves from any Host). This is a plain
+// UPDATE on the live directory row: the very next request against the new
+// Host resolves immediately, on every process sharing this database (#734's
+// multi-node requirement) — there is no boot-time host map to refresh.
+func (s *Service) SetHostConfig(ctx context.Context, id merchant.ID, apiHost string, allowedOrigins []string) error {
+	if id.IsZero() {
+		return errors.New("merchants: merchant id is required")
+	}
+	host := NormalizeAPIHost(apiHost)
+	origins := normalizeOrigins(allowedOrigins)
+
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE openrails.merchants
+		   SET api_host = NULLIF($2, ''), allowed_origins = $3, updated_at = current_timestamp
+		 WHERE id = $1::uuid AND deleted_at IS NULL
+	`, id.UUID(), host, origins)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return fmt.Errorf("merchants: set host config for %s host %q: %w", id, host, ErrAPIHostTaken)
+		}
+		return fmt.Errorf("merchants: set host config: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrMerchantNotFound
+	}
+	return nil
+}
+
+// HostConfig is a merchant's #734 Host/CORS configuration.
+type HostConfig struct {
+	APIHost        string
+	AllowedOrigins []string
+}
+
+// GetHostConfig returns id's current #734 Host/CORS configuration.
+func (s *Service) GetHostConfig(ctx context.Context, id merchant.ID) (*HostConfig, error) {
+	if id.IsZero() {
+		return nil, errors.New("merchants: merchant id is required")
+	}
+	var apiHost *string
+	var origins []string
+	err := s.pool.QueryRow(ctx, `
+		SELECT api_host, allowed_origins
+		  FROM openrails.merchants
+		 WHERE id = $1::uuid AND deleted_at IS NULL
+	`, id.UUID()).Scan(&apiHost, &origins)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrMerchantNotFound
+		}
+		return nil, fmt.Errorf("merchants: get host config: %w", err)
+	}
+	cfg := &HostConfig{AllowedOrigins: origins}
+	if apiHost != nil {
+		cfg.APIHost = *apiHost
+	}
+	return cfg, nil
+}
+
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}
+
+func normalizeOrigins(origins []string) []string {
+	out := make([]string, 0, len(origins))
+	for _, o := range origins {
+		o = strings.TrimSpace(o)
+		if o == "" {
+			continue
+		}
+		out = append(out, o)
+	}
+	return out
+}

--- a/migrations/postgres/0006_merchant_host_cors.up.sql
+++ b/migrations/postgres/0006_merchant_host_cors.up.sql
@@ -1,0 +1,24 @@
+-- #734: per-merchant API host + browser CORS allow-list, engine-owned.
+--
+-- Both columns live on the GLOBAL merchant directory (same table
+-- merchantForIssuer's authority chain already reads), never AuthKit's
+-- remote_application (CORS is browser transport policy, not federation
+-- identity) and never a boot-time engine-config list (a merchant registered
+-- or reconfigured on any node must resolve immediately on every other node
+-- sharing this database).
+--
+-- api_host is the canonical Host-header value ("api.example.com", no
+-- scheme/port) a request resolves this merchant from — the ONE mechanism
+-- shared by per-merchant CORS preflight and the Host-routed webhook mount
+-- (pkg/embedded). NULL = this merchant does not resolve from any Host (the
+-- default; single-merchant self-hosters see no behavior change without
+-- opting in). Globally unique when set.
+ALTER TABLE openrails.merchants
+    ADD COLUMN api_host text,
+    ADD COLUMN allowed_origins text[] DEFAULT ARRAY[]::text[] NOT NULL;
+
+COMMENT ON COLUMN openrails.merchants.api_host IS 'Canonical Host-header value this merchant resolves from (#734), e.g. "api.acme.example". NULL = no Host resolution for this merchant. Lowercase, no scheme/port.';
+
+COMMENT ON COLUMN openrails.merchants.allowed_origins IS 'Browser CORS allow-list answered ONLY for preflight against this merchant''s resolved Host (#734). Empty = no browser CORS for this merchant, even if api_host is set.';
+
+CREATE UNIQUE INDEX uq_merchants_api_host ON openrails.merchants (api_host) WHERE api_host IS NOT NULL AND deleted_at IS NULL;

--- a/pkg/embedded/README.md
+++ b/pkg/embedded/README.md
@@ -86,6 +86,19 @@ two ways over one source of truth:
   — public, cached, hand-written (not OpenAPI; nothing is generated).
 - **Go** (in-process host code): `rt.ActiveRouteSets()` returns the same selection.
 
+### Per-merchant CORS + Host-routed webhooks (#734)
+
+A host serving multiple merchants behind distinct hostnames (e.g. openrails-saas's
+`api.<slug>.<domain>` scheme) gets per-merchant browser CORS and Host-routed
+webhooks for free, with NO extra `MountOptions`/`Options` field to set:
+attaching a control plane (`pkg/embedded/controlplane.AttachWithOptions`)
+BEFORE calling `MountHandler`/`NewHTTPHandler` is the only step — CORS
+preflight, the Host->merchant resolver, and the `/v1/webhooks/:provider` mount
+under `RouteSetWebhooks` all derive from whatever control plane is attached
+(`embedhttp.HostMerchantResolverFrom`). A host with no control plane attached,
+or one that never sets a merchant's `api_host` (see docs/operations.md), is
+completely unaffected — CORS stays the pre-#734 `CORSHTTP(nil)` default.
+
 ## Payment Providers
 
 Embedded hosts have two credential planes; `config.yaml` carries neither:

--- a/pkg/embedded/mount.go
+++ b/pkg/embedded/mount.go
@@ -7,8 +7,10 @@ import (
 
 	"github.com/open-rails/openrails/internal/app"
 	"github.com/open-rails/openrails/internal/http/embedhttp"
+	"github.com/open-rails/openrails/internal/http/middleware"
 	"github.com/open-rails/openrails/internal/http/routesurface"
 	"github.com/open-rails/openrails/pkg/billingauth"
+	"github.com/open-rails/openrails/pkg/merchant"
 )
 
 // MountOptions configures the combined embedded surface (MountHandler).
@@ -97,13 +99,18 @@ func selfHandler(e *Embedded, authn billingauth.DelegatedAuthenticator, provider
 	if authn == nil {
 		return nil, fmt.Errorf("embedded billing: self surface requires MountOptions.DelegatedAuthenticator")
 	}
-	return newSelfHandler(a.Runtime, authn, providerRouteOverride), nil
+	// #734: derive the SAME Host->merchant resolver + CORS source the base
+	// handler uses (embedhttp.FromApp) from whatever control plane is attached
+	// — nil/nil when none is, in which case this surface behaves exactly as
+	// before this issue.
+	hostResolve, corsSource := embedhttp.HostMerchantResolverFrom(a.ControlPlane)
+	return newSelfHandler(a.Runtime, authn, providerRouteOverride, hostResolve, corsSource), nil
 }
 
 // newSelfHandler delegates to the neutral assembly; kept as the unit-testable
 // seam (no live app graph required).
-func newSelfHandler(rt *app.Runtime, authn billingauth.DelegatedAuthenticator, providerRouteOverride *routesurface.ProviderRoutes) http.Handler {
-	return embedhttp.NewSelfHandler(rt, authn, providerRouteOverride)
+func newSelfHandler(rt *app.Runtime, authn billingauth.DelegatedAuthenticator, providerRouteOverride *routesurface.ProviderRoutes, hostResolve merchant.HostResolver, corsSource middleware.CORSOriginSource) http.Handler {
+	return embedhttp.NewSelfHandler(rt, authn, providerRouteOverride, hostResolve, corsSource)
 }
 
 func providerRoutesFromMountOptions(opt *ProviderRoutes) *routesurface.ProviderRoutes {

--- a/pkg/embedded/self_test.go
+++ b/pkg/embedded/self_test.go
@@ -55,7 +55,7 @@ func doSelf(h http.Handler, method, path string) *httptest.ResponseRecorder {
 func TestSelfHandler_EmbeddedPathsMountedWithoutSelfPermissions(t *testing.T) {
 	self := newSelfHandler(nil, stubSelfAuthenticator{
 		principal: selfPrincipal(),
-	}, nil)
+	}, nil, nil, nil)
 
 	w := doSelf(self, http.MethodGet, "/billing/v1/me/balance")
 	require.NotEqual(t, http.StatusNotFound, w.Code, w.Body.String())
@@ -79,7 +79,7 @@ func TestSelfHandler_EmbeddedPathsMountedWithoutSelfPermissions(t *testing.T) {
 // Host authenticator rejection and invalid principals map to 401 (fail closed),
 // exactly like the standalone host-pluggable mode.
 func TestSelfHandler_FailClosed(t *testing.T) {
-	h := newSelfHandler(nil, stubSelfAuthenticator{err: billingauth.ErrUnauthenticated}, nil)
+	h := newSelfHandler(nil, stubSelfAuthenticator{err: billingauth.ErrUnauthenticated}, nil, nil, nil)
 	w := doSelf(h, http.MethodGet, "/billing/v1/me/balance?currency=usd")
 	require.Equal(t, http.StatusUnauthorized, w.Code, w.Body.String())
 
@@ -88,7 +88,7 @@ func TestSelfHandler_FailClosed(t *testing.T) {
 		principal: &billingauth.DelegatedPrincipal{
 			SubjectID: "user-1",
 		},
-	}, nil)
+	}, nil, nil, nil)
 	w = doSelf(h, http.MethodGet, "/billing/v1/me/balance?currency=usd")
 	require.Equal(t, http.StatusUnauthorized, w.Code, w.Body.String())
 	require.Contains(t, w.Body.String(), "delegated_principal_invalid")
@@ -96,7 +96,7 @@ func TestSelfHandler_FailClosed(t *testing.T) {
 	// Merchant-admin routes live on the base embedded handler, not SelfHandler.
 	h = newSelfHandler(nil, stubSelfAuthenticator{
 		principal: selfPrincipal("platform:metrics:read"),
-	}, nil)
+	}, nil, nil, nil)
 	w = doSelf(h, http.MethodGet, "/billing/v1/merchant/metrics")
 	require.Equal(t, http.StatusNotFound, w.Code, w.Body.String())
 }

--- a/pkg/merchant/host.go
+++ b/pkg/merchant/host.go
@@ -1,0 +1,48 @@
+package merchant
+
+import "context"
+
+// HostResolver resolves the merchant that owns an inbound request Host header
+// (#734) — the ONE mechanism shared by per-merchant browser CORS preflight and
+// the Host-routed webhook mount (pkg/embedded). Implementations MUST resolve
+// LIVE per call: OpenRails never builds a boot-time host->merchant map, so a
+// merchant registered (or reconfigured) on any node resolves immediately on
+// every other node/process sharing the same database — no restart, no cache
+// refresh required. Returns a zero ID and a non-nil error when host maps to no
+// active merchant (unknown/disabled/ambiguous host) — callers MUST fail closed
+// on error, never fall back to a default merchant.
+type HostResolver func(ctx context.Context, host string) (ID, error)
+
+// hostMerchantCtxKey is the unexported context key for the Host-pinned
+// merchant. Deliberately distinct from the general "configured merchant"
+// WithID/FromContext key: HTTP Host resolution sets both together, but only
+// THIS key lets the JWT-issuer resolution path (internal/controlplane)
+// positively detect "a Host resolver ran and pinned merchant X for this
+// request" so it can enforce X == the token's own issuer-resolved merchant.
+type hostMerchantCtxKey struct{}
+
+// WithHostMerchant pins the merchant a HostResolver resolved from the
+// request's Host header. A deployment that never configures Host resolution
+// never sets this key, so any check gated on HostMerchant is a pure no-op —
+// single-merchant self-hosters see no behavior change without opting in
+// (#734).
+func WithHostMerchant(ctx context.Context, id ID) context.Context {
+	return context.WithValue(ctx, hostMerchantCtxKey{}, id)
+}
+
+// HostMerchant returns the Host-pinned merchant set by WithHostMerchant, if
+// any.
+func HostMerchant(ctx context.Context) (ID, bool) {
+	if ctx == nil {
+		return ID{}, false
+	}
+	v := ctx.Value(hostMerchantCtxKey{})
+	if v == nil {
+		return ID{}, false
+	}
+	id, ok := v.(ID)
+	if !ok || id.IsZero() {
+		return ID{}, false
+	}
+	return id, true
+}


### PR DESCRIPTION
## Summary

Public multi-merchant deployments get per-merchant API hosts instead of a global CORS origin union: each merchant gets a canonical `api_host` + `allowed_origins` on `openrails.merchants`, resolved live per request from the SAME `merchantDirectoryRow` lookup issuer resolution already uses (`internal/controlplane/host_registry.go`). This is the engine mechanism behind openrails-saas #14 (per-merchant hostnames) and #15 (host-routed webhooks).

**Design-invalidating finding recorded on the tracker issue**: the spec assumed `remote_application.allowed_origins` in AuthKit, but that field was removed pre-#480 (confirmed via a stray pseudo-version in the module cache showing the old global-union `RemoteApplicationCORS` this issue explicitly diagnoses as insecure, plus an explicit regression test in `internal/bootstrap/merchant_manifest_test.go` rejecting it as a removed field). `allowed_origins`/`api_host` now live on OpenRails' own `openrails.merchants` directory row instead — engine-owned, sharing the issuer-resolution authority chain rather than a parallel table.

- `internal/controlplane/host_registry.go`: `merchantForHost` / `ResolveMerchantByHost` / `AllowedOriginsForHost`, sharing `merchantDirectoryRow` with `merchantForIssuer`. `merchantForIssuer` now fails closed (`ErrDelegatedIssuerUnknown`, no new sentinel) when the issuer's resolved merchant disagrees with a Host-pinned merchant on ctx.
- `pkg/merchant/host.go`: `HostResolver` type + `WithHostMerchant`/`HostMerchant` context markers.
- `internal/http/middleware`: `CORSOriginSource` gained a `host` parameter (this seam was dead/unwired since #749); new opt-in `ResolveMerchantFromHostHTTP` middleware.
- Standalone (`internal/http/server.go`) and embedded (`embedhttp`, `pkg/embedded`) both auto-derive the resolver from whatever control plane is attached — **no new `Dependencies`/`MountOptions` fields**, so a merchant that never configures `api_host` sees zero behavior change.
- Host-routed webhook mount (saas #15's engine half): `httphandlers.HostWebhook` + `routes.RegisterHostWebhookRoutes`, mounted by `embedhttp` alongside the existing merchant-scoped webhook path (pkg/embedded only — standalone already occupies that path shape with its two existing webhook surfaces).
- `migrations/postgres/0006_merchant_host_cors.up.sql`: `api_host` (globally unique) + `allowed_origins` columns.
- `internal/merchants/host_config.go`: `SetHostConfig`/`GetHostConfig` service methods.
- Docs: `docs/operations.md` new section (local-dev hostnames, `merchant.ReservedHostedSlugs` pointer, `cors_origins` interaction); `pkg/embedded/README.md` addendum.

## Fail-closed matrix

Unknown host / disabled merchant / ambiguous host all collapse to one sentinel per side (`ErrHostMerchantUnknown` for Host resolution, reused `ErrDelegatedIssuerUnknown` for the issuer-consistency check) — deliberately uniform: every one of these means "no fallback merchant, reject."

## Test plan

Real Postgres/Redis via testcontainers, real standalone server / real embedded+control-plane, no mocks (`internal/integrationharness`):
- [x] `TestHostMerchantCORSPreflightHTTP` — two merchants/two hosts: allowed origin granted, cross-merchant origin denied both directions, unknown host denied, health checks unaffected.
- [x] `TestHostMerchantRegisteredAfterBootResolvesHTTP` — the multi-node proof: a merchant provisioned + host-configured AFTER the server already started resolves on the very next request, no restart.
- [x] `TestHostMerchantVsIssuerMismatchHTTP` — a real service-JWT minted for merchant A's issuer works on A's host, 403s on B's host, still works on A's host afterward, unaffected with no Host override.
- [x] `TestHostRoutedWebhookMountHTTP` — embedded + attached control plane: unknown host 404s, known host reaches the shared verify/dispatch primitive.
- [x] `gofmt`/`go vet`/`go build` clean (with and without `-tags integration`).
- [x] `go test ./...` green.
- [x] `go test -tags integration ./internal/... ./pkg/...` — 72 packages green, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)