### PR TITLE
Staging posture: sandbox everywhere, embedded RLS gate, openrails_app grants (#762, #763, #764)

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,8 @@ or your own tooling instead — admin routes without a permission checker fail c
 - **Sandbox vs live:** `TEST_MODE=sandbox` routes every rail to its test/sandbox
   environment and enforces sandbox credentials so you can't accidentally charge a real
   card. It defaults to sandbox in development, must be explicit (`live`) for live local
-  runs, and is rejected outside development (see Operating modes below).
+  runs, and is allowed in every environment — including staging and production (see
+  Operating modes below).
 
 ## Configuration
 
@@ -478,8 +479,13 @@ crash-looping supervisor pays one declined auth total, not one per restart — a
 `simulated` verdict skips the probe, and a rotated key or stale verdict always
 re-probes (cache failures degrade to probing); CCBill uses
 `sandbox-api.ccbill.com`; Solana derives devnet structurally. `test_mode=sandbox` is
-**rejected outside `env=development`** — sandbox money is dev-only. The old `mode=test`
-is exactly `TEST_MODE=sandbox` + `PROVIDER_WRITE_MODE=full`.
+**allowed in every environment** (#762) — posture and environment strictness are
+independent axes, so a staging (or even production) deployment can run sandbox rails
+under full non-dev hard gates. Nothing about `env=production` special-cases this field;
+what keeps it honest is rail-credential validation — every configured rail account's
+declared `environment` is cross-checked against `test_mode` (`ExpectedProviderEnvironment`),
+and a live secret key is refused outright whenever `test_mode=sandbox`, in any
+environment. The old `mode=test` is exactly `TEST_MODE=sandbox` + `PROVIDER_WRITE_MODE=full`.
 
 At a glance — what each provider write mode permits (the `test_mode` axis applies orthogonally: with
 `TEST_MODE=sandbox` the same matrix holds against sandbox rails, so no real money can

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,7 +7,7 @@
 
 env: development
 provider_write_mode: full # full | limited | readonly; UNSET fail-closes to readonly (no provider writes) — set full/limited explicitly; required outside development
-test_mode: sandbox        # sandbox | live; sandbox is development-only
+test_mode: sandbox        # sandbox | live; allowed in every environment (#762) — rail-credential validation, not env, keeps it honest
 
 host: 0.0.0.0
 port: 3053

--- a/config/config.go
+++ b/config/config.go
@@ -108,9 +108,18 @@ type Config struct {
 	// — so a local boot is sandbox by default and a prod boot is live by
 	// default. embedded.New never runs Load's defaulting and refuses to
 	// construct with it unset — an embedded host must declare its posture,
-	// never guess (supersedes #711's warn-only). test_mode=sandbox is
-	// rejected outside env=development — sandbox money is dev-only. Set
-	// test_mode=live explicitly to run live credentials locally.
+	// never guess (supersedes #711's warn-only).
+	//
+	// Posture (this field) and environment strictness (Env/IsDev) are
+	// INDEPENDENT axes (#762): sandbox is allowed in every environment,
+	// including production — a staging (or production) deployment running
+	// sandbox rails under full non-dev hard gates is a legitimate, common
+	// shape, not a footgun. Nothing here special-cases env=production; the
+	// credential guarantees this field attaches (live-key refusal above,
+	// ExpectedProviderEnvironment's cross-check against each configured rail
+	// account's declared Environment) are what keep a sandbox posture honest
+	// regardless of Env. Set test_mode=live explicitly to run live credentials
+	// locally in development.
 	TestMode CredentialPosture `koanf:"test_mode,omitempty"`
 
 	// APIURL is the base URL where billing's versioned routes are mounted.
@@ -1036,11 +1045,26 @@ func Validate(cfg *Config) error {
 
 	isDev := cfg.Env == "development" || cfg.Env == "dev" || cfg.Env == ""
 	if !isDev {
-		// Sandbox credentials are dev-only (#355): a production deployment
-		// must never boot pointed at sandbox rails.
-		if cfg.TestMode == CredentialPostureSandbox {
-			return fmt.Errorf("test_mode=sandbox is not allowed outside development")
-		}
+		// #762: posture (TestMode: sandbox|live) and environment strictness
+		// (isDev vs non-dev hard gates) are INDEPENDENT axes — sandbox is
+		// legitimate outside development (a staging environment running
+		// sandbox rails under full production-grade gates is exactly the
+		// point), so there is no environment-based rejection of
+		// test_mode=sandbox here. The #355-era "sandbox is dev-only" rule
+		// this superseded conflated the two axes; that left staging with no
+		// honest posture (it had to lie as env=development to unlock sandbox,
+		// disabling every other hard gate, or lie as live with no rail
+		// credentials). What actually prevents a sandbox posture from being
+		// misused in a genuinely-live deployment is rail-credential
+		// validation, not the environment string: ExpectedProviderEnvironment
+		// cross-checks every configured rail account's declared Environment
+		// against TestMode (ValidateRailSet/validateRails below), and
+		// validateStripeKeyForTestMode hard-rejects a live secret key
+		// (sk_live_/rk_live_) whenever TestMode is sandbox, in every
+		// environment including production. A deployment that declares
+		// env=production and test_mode=sandbox simply runs a fully-gated
+		// sandbox deployment — self-consistent, not a security hole.
+		//
 		// Outside development the operating mode must be declared explicitly —
 		// "I forgot to set it" must never silently pick a behavior. Checked on
 		// the RAW value: GetProviderWriteMode fail-closes unset to readonly,
@@ -1601,8 +1625,9 @@ func (cfg *Config) GetProviderWriteMode() string {
 // live, matching the historical bool zero value; standalone Load() always
 // resolves TestMode explicitly before this is read, and embedded.New refuses
 // to construct with it unset (#745), so "unset" in practice only reaches this
-// accessor via a direct Config{} literal in a test. Validate rejects
-// test_mode=sandbox outside development.
+// accessor via a direct Config{} literal in a test. Sandbox is allowed in
+// every environment (#762) — Validate no longer rejects test_mode=sandbox
+// outside development.
 func (cfg *Config) IsTestMode() bool {
 	return cfg.TestMode == CredentialPostureSandbox
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -364,14 +364,31 @@ func TestRequiresRLS(t *testing.T) {
 }
 
 func TestProductionTestModeValidation(t *testing.T) {
-	t.Run("prod env rejects test_mode=sandbox", func(t *testing.T) {
+	t.Run("prod env allows test_mode=sandbox (#762: posture and environment strictness are independent axes)", func(t *testing.T) {
 		cfg := GetDefaultBillingConfig()
 		cfg.Env = "prod"
 		cfg.ProviderWriteMode = ProviderWriteModeFull
 		cfg.TestMode = CredentialPostureSandbox
+		cfg.DB.Username = "billing_app"
+		cfg.DB.Password = "production-db-password"
 		assembleDBURL(cfg)
 		assert.False(t, cfg.IsDev(), "env=prod should not be dev")
-		assert.ErrorContains(t, Validate(cfg), "test_mode=sandbox is not allowed outside development")
+		assert.NoError(t, Validate(cfg), "sandbox posture must boot outside development — rail-credential validation, not the environment string, is what keeps it honest")
+	})
+
+	t.Run("staging env + sandbox + full non-dev gates boots (#762 staging-shaped acceptance test)", func(t *testing.T) {
+		cfg := GetDefaultBillingConfig()
+		cfg.Env = "staging"
+		cfg.ProviderWriteMode = ProviderWriteModeFull
+		cfg.TestMode = CredentialPostureSandbox
+		cfg.DB.Username = "billing_app"
+		cfg.DB.Password = "staging-db-password"
+		assembleDBURL(cfg)
+		cfg.Auth.Issuer = "https://auth.staging.example.com"
+		require.NotNil(t, cfg.RateLimits, "GetDefaultBillingConfig seeds rate limits")
+		assert.False(t, cfg.IsDev(), "env=staging should not be dev")
+		assert.True(t, cfg.RequiresRLS(), "env=staging requires RLS enforcement")
+		assert.NoError(t, Validate(cfg), "env=staging + sandbox + every other non-dev gate satisfied must boot")
 	})
 
 	t.Run("prod env rejects a plaintext-http auth issuer", func(t *testing.T) {

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -406,7 +406,10 @@ what backfills those missed provider events from the durable watermark.
   verdict refuses the boot from cache without re-probing (a crash loop costs
   one declined auth total), a fresh `simulated` verdict skips the probe, a
   rotated key or stale verdict re-probes, and cache failures degrade to
-  probing. Dev-only.
+  probing. Allowed in every environment (#762) — posture and environment
+  strictness are independent axes; rail-credential validation (the live-key
+  refusal above, plus each account's declared `environment` cross-checked
+  against `test_mode`) is what keeps it honest, not the environment string.
 **Cutover posture** (migration/reconciliation against production
 credentials): use `PROVIDER_WRITE_MODE=limited` when OpenRails should keep serving reactive
 customer/admin flows while system-origin provider writes stay parked, or

--- a/internal/app/build_runtime.go
+++ b/internal/app/build_runtime.go
@@ -244,6 +244,19 @@ func buildRuntimeWithOverrides(cfg *config.Config, overrides *runtimeOverrides) 
 		}
 	}
 
+	// Surface (and, outside development, enforce) the Row Level Security
+	// posture of the connected role (issue #227/#763): RLS policies only
+	// constrain a non-superuser, non-BYPASSRLS role. This ONE call covers BOTH
+	// construction paths above — a config-built standalone pool (createDatabase)
+	// AND a host-injected embedded pool (overrides.DB) — so an embedded host
+	// connecting as a privileged/BYPASSRLS role outside development fails boot
+	// exactly like standalone does, with no separate gate to keep in sync.
+	// Previously this ran only inside createDatabase, so embedded construction
+	// (which always supplies overrides.DB) never hit it at all.
+	if err := database.EnforceRLSPosture(context.Background(), cfg.RequiresRLS()); err != nil {
+		return nil, err
+	}
+
 	if overrides != nil && overrides.Redis != nil {
 		redisClient = overrides.Redis
 	} else {
@@ -254,8 +267,7 @@ func buildRuntimeWithOverrides(cfg *config.Config, overrides *runtimeOverrides) 
 	}
 
 	// Webhook-dedup posture (#678). Embedded hosts are identified by the injected
-	// DB pool — the same signal that scopes createDatabase's RLS gate to the
-	// config-built (standalone) path.
+	// DB pool.
 	if err := enforceWebhookDedupPosture(cfg, redisClient != nil, overrides != nil && overrides.DB != nil); err != nil {
 		return nil, err
 	}
@@ -532,15 +544,8 @@ func createDatabase(cfg *config.Config) (*db.DB, error) {
 	if err := validateDatabase(cfg, database); err != nil {
 		return nil, err
 	}
-
-	// Surface (and, outside development, enforce) the Row Level Security
-	// posture of the connected role (issue #227): RLS policies only constrain a
-	// non-superuser, non-BYPASSRLS role. Non-development boots fail if the app
-	// would connect as a privileged role that silently bypasses every per-merchant
-	// policy.
-	if err := database.EnforceRLSPosture(context.Background(), cfg.RequiresRLS()); err != nil {
-		return nil, err
-	}
+	// RLS posture (issue #227/#763) is enforced once, in buildRuntimeWithOverrides,
+	// for both this path and the overrides.DB (embedded) path — see there.
 	return database, nil
 }
 

--- a/internal/dbtest/rls.go
+++ b/internal/dbtest/rls.go
@@ -51,8 +51,15 @@ func SharedRLSPostgres(t *testing.T) (superDSN, appDSN string) {
 }
 
 // enableAppRoleLogin grants the openrails_app role LOGIN + a password so tests can
-// connect as it. Migration 050 creates the role NOLOGIN; production attaches login
+// connect as it. Migration 001 creates the role NOLOGIN; production attaches login
 // credentials out of band. The role keeps NOBYPASSRLS so RLS still enforces.
+//
+// Grants on public (River) / profiles (AuthKit) / public.migrations used to be
+// re-derived here in test-only code (#764) — that shape is now migration
+// 0007_openrails_app_grants, applied by migrate.RunPostgres like any other
+// migration (SharedPostgresDSN runs the full migration set before this is
+// ever called), so there is nothing left for this helper to grant beyond the
+// test-only login credential.
 func enableAppRoleLogin(ctx context.Context, superDSN string) error {
 	sqlDB, err := sql.Open("pgx", superDSN)
 	if err != nil {
@@ -61,23 +68,6 @@ func enableAppRoleLogin(ctx context.Context, superDSN string) error {
 	defer func() { _ = sqlDB.Close() }()
 	if _, err := sqlDB.ExecContext(ctx, `ALTER ROLE `+appRole+` WITH LOGIN PASSWORD '`+appPassword+`'`); err != nil {
 		return fmt.Errorf("grant %s login: %w", appRole, err)
-	}
-	// Full-app integration tests (the StartStandalone harness) run the whole server as openrails_app,
-	// which shares one pool with AuthKit's profiles.* schema and reads public.migrations
-	// at boot. Grant those (prod-faithful — the prod app role holds both); the role
-	// stays NOBYPASSRLS, so openrails.* RLS still enforces. Guarded on schema existence.
-	const grantProfiles = `
-DO $$
-BEGIN
-  IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'profiles') THEN
-    GRANT USAGE ON SCHEMA profiles TO openrails_app;
-    GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA profiles TO openrails_app;
-    GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA profiles TO openrails_app;
-  END IF;
-END $$;
-GRANT SELECT ON public.migrations TO openrails_app;`
-	if _, err := sqlDB.ExecContext(ctx, grantProfiles); err != nil {
-		return fmt.Errorf("grant %s profiles access: %w", appRole, err)
 	}
 	return nil
 }

--- a/internal/integrationharness/openrails_app_river_grants_integration_test.go
+++ b/internal/integrationharness/openrails_app_river_grants_integration_test.go
@@ -1,0 +1,81 @@
+//go:build integration
+
+package integrationharness
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/controlplane"
+	"github.com/open-rails/openrails/internal/dbtest"
+	riverjobs "github.com/open-rails/openrails/internal/river"
+)
+
+// TestFullStackServesAndDrainsRiverAsOpenrailsApp proves #764: migration
+// 0007_openrails_app_grants must give the openrails_app role everything the
+// runtime actually needs on `public` (River) and `profiles` (AuthKit), not
+// just the `openrails` schema migration 0001 already covers.
+//
+// StartStandalone already connects as openrails_app (dbtest.SharedRLSPostgres's
+// app DSN) — that part is old news. WithWorkers is the new ingredient: no
+// existing test starts the real in-process River workers against that role.
+// The one pre-existing WithWorkers() caller (tests/testcontainer_suite.go)
+// deliberately boots over the SUPER/BYPASSRLS DSN instead, so River's own
+// tables have never been exercised end to end under the role production
+// actually connects as. river.Client.Start alone does leader election + queue
+// registration (writes to river_leader/river_queue) before any job is ever
+// enqueued; enqueuing and draining one job exercises river_job end to end
+// (INSERT to enqueue, SELECT+UPDATE to claim and finalize). AuthKit/profiles
+// access is exercised by the same boot for free: minting the API key below
+// (and StartStandalone's own bootstrap) round-trips through the real control
+// plane's AuthKit core, which lives entirely in the `profiles` schema.
+func TestFullStackServesAndDrainsRiverAsOpenrailsApp(t *testing.T) {
+	ctx := context.Background()
+	h := New(t, ctx)
+	surface := h.StartStandalone("usd", WithWorkers())
+
+	// AuthKit/profiles: minting a real API key round-trips through AuthKit
+	// core's profiles-schema tables (actors, permission groups, API keys).
+	token := surface.MintAPIKey(dbtest.TestMerchantSlug, "river-grants-"+uuid.NewString(),
+		[]string{controlplane.PermMerchantSubscriptionsRead})
+	require.NotEmpty(t, token)
+
+	// "serves": the standalone HTTP surface, connected strictly as
+	// openrails_app, answers a real request.
+	status, body := requestJSON(t, http.MethodGet, surface.BaseURL+"/v1/merchant/subscriptions", token, nil)
+	require.Equal(t, http.StatusOK, status, string(body))
+
+	// River: enqueue a resume job for a subscription id that does not exist.
+	// The worker's own not-found handling (jobs_subscription_manage.go) treats
+	// this as a graceful no-op success, so this needs no product/price/
+	// customer/subscription fixtures at all — the only thing under test is
+	// whether river_job/river_queue/river_leader are actually usable by
+	// openrails_app end to end. If any of those grants were missing, either
+	// the Insert below fails outright (a real Postgres permission-denied
+	// error) or no worker ever claims the job and the Eventually poll times
+	// out — both are unambiguous failures of this test.
+	producer := surface.App().Runtime.RiverProducer
+	require.NotNil(t, producer, "River producer must be initialized")
+	_, err := producer.Insert(ctx, riverjobs.ResumeSubscriptionArgs{
+		UserID:         uuid.NewString(),
+		SubscriptionID: uuid.New(),
+	}, &river.InsertOpts{Queue: riverjobs.QueueBilling})
+	require.NoError(t, err, "enqueueing a River job as openrails_app must succeed (INSERT on river_job)")
+
+	require.Eventually(t, func() bool {
+		var state string
+		err := h.sharedPool().QueryRow(ctx,
+			"SELECT state FROM "+config.RiverSchema+".river_job WHERE kind = $1 ORDER BY id DESC LIMIT 1",
+			riverjobs.KindSubscriptionResume,
+		).Scan(&state)
+		return err == nil && state == "completed"
+	}, 15*time.Second, 100*time.Millisecond,
+		"the openrails_app-connected worker pool must claim and complete the enqueued River job")
+}

--- a/migrations/postgres/0007_openrails_app_grants.up.sql
+++ b/migrations/postgres/0007_openrails_app_grants.up.sql
@@ -1,0 +1,74 @@
+-- #764: openrails_app's grants (migration 0001) stop at the `openrails`
+-- schema. A production-shaped boot also needs:
+--   - River's job-queue tables (`public`, config.RiverSchema) — every
+--     enqueue/dequeue/work-loop iteration runs as openrails_app.
+--   - AuthKit's `profiles` schema — the control plane's identity/session
+--     tables, likewise queried as openrails_app.
+--
+-- This runs as step 3 of internal/migrate.RunPostgres, AFTER step 1 (AuthKit
+-- migrations, creates `profiles`) and step 2 (River migrations, creates the
+-- tables below) — see internal/migrate/migrator.go's fixed ordering comment —
+-- so every object granted here already exists.
+--
+-- Previously this shape existed ONLY in test-only code
+-- (internal/dbtest/rls.go's enableAppRoleLogin) and, for openrails-saas, a
+-- hand-rolled scripts/staging/db-bootstrap.sql the host had to ship on top of
+-- openrails' own migrations. This migration is now the single source of
+-- truth; both workarounds are removed once a host is on this version.
+
+-- ---------------------------------------------------------------------------
+-- River (public schema). Least-privilege: name the actual tables the runtime
+-- client touches (per riverpgxv5's dbsqlc query set) rather than blanket ALL
+-- TABLES IN SCHEMA public. river_migration is deliberately excluded — only
+-- River's own migrator (running as the admin/migrate role) ever reads or
+-- writes it; the runtime client never touches it.
+--
+-- Guarded on existence: internal/migrate.RunPostgres (the one production
+-- path) always creates these before this migration ever runs, but a
+-- from-scratch or test-only harness that applies OpenRails' own migrations
+-- without also running River's separate migrator must not fail here — the
+-- ALTER DEFAULT PRIVILEGES below still covers those tables the moment they
+-- (or a later River version's new tables) DO get created by this same role.
+GRANT USAGE ON SCHEMA public TO openrails_app;
+DO $$
+BEGIN
+  IF to_regclass('public.river_job') IS NOT NULL THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.river_job TO openrails_app;
+  END IF;
+  IF to_regclass('public.river_job_id_seq') IS NOT NULL THEN
+    GRANT USAGE, SELECT, UPDATE ON SEQUENCE public.river_job_id_seq TO openrails_app;
+  END IF;
+  IF to_regclass('public.river_queue') IS NOT NULL THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.river_queue TO openrails_app;
+  END IF;
+  IF to_regclass('public.river_leader') IS NOT NULL THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.river_leader TO openrails_app;
+  END IF;
+END $$;
+
+-- The migratekit ledger table (public.migrations) predates this migration on
+-- every deployment (created at the bootstrap step, before AuthKit/River/
+-- OpenRails migrations run), so the default privileges below don't reach it
+-- retroactively. The runtime reads it once at boot to confirm migrations are
+-- applied (internal/app/build_runtime.go validateDatabase) — read-only, no
+-- write path needs it.
+GRANT SELECT ON TABLE public.migrations TO openrails_app;
+
+-- A later River version bump's NEW tables must inherit the same grant
+-- automatically — both migrators (River's and OpenRails') run as the SAME
+-- admin/migrate role that applies this migration, so ALTER DEFAULT PRIVILEGES
+-- (scoped to that role, implicitly) covers them without a follow-up migration.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO openrails_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO openrails_app;
+
+-- ---------------------------------------------------------------------------
+-- AuthKit (profiles schema) — a sibling-owned, independently-versioned
+-- schema (github.com/open-rails/authkit's own migrations). Unlike River,
+-- granted at the SCHEMA boundary rather than by table name: this repo does
+-- not own or want to track AuthKit's internal table shape, exactly as
+-- openrails.* is granted at the openrails schema boundary in migration 0001.
+GRANT USAGE ON SCHEMA profiles TO openrails_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA profiles TO openrails_app;
+GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA profiles TO openrails_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA profiles GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO openrails_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA profiles GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO openrails_app;

--- a/pkg/embedded/rls_posture_integration_test.go
+++ b/pkg/embedded/rls_posture_integration_test.go
@@ -1,0 +1,81 @@
+//go:build integration
+
+package embedded
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/dbtest"
+)
+
+// #763: embedded construction never enforced the RLS posture gate
+// (db.EnforceRLSPosture, issue #227) — only the standalone boot path did.
+// internal/app.buildRuntimeWithOverrides now runs the check for BOTH
+// construction paths from one call site, so embedded.New (the entry point
+// every real embedding host uses) inherits it automatically. These tests
+// drive that through the actual public entry point, not the internal
+// function directly, so a future refactor that re-splits the two paths would
+// be caught here.
+
+// TestNew_EmbeddedBootRefusesBypassRLSRoleOutsideDev proves the non-dev fail
+// case: an embedded host whose injected PGXPool connects as a
+// superuser/BYPASSRLS role must NOT boot outside development.
+func TestNew_EmbeddedBootRefusesBypassRLSRoleOutsideDev(t *testing.T) {
+	superDSN, _ := dbtest.SharedRLSPostgres(t)
+	pool, err := pgxpool.New(context.Background(), superDSN)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	cfg := &config.Config{
+		Env:               "staging",
+		TestMode:          config.CredentialPostureLive,
+		ProviderWriteMode: config.ProviderWriteModeReadOnly,
+		DB:                &config.DBConfig{URL: superDSN},
+	}
+	_, err = New(Options{Config: cfg, PGXPool: pool})
+	require.Error(t, err, "an embedded host connected as a BYPASSRLS role must refuse to boot outside development")
+	require.ErrorContains(t, err, "bypasses RLS")
+	require.ErrorContains(t, err, "openrails_app")
+}
+
+// TestNew_EmbeddedBootWarnsOnBypassRLSRoleInDev proves development stays a
+// warn, not a boot failure, exactly like the standalone path.
+func TestNew_EmbeddedBootWarnsOnBypassRLSRoleInDev(t *testing.T) {
+	superDSN, _ := dbtest.SharedRLSPostgres(t)
+	pool, err := pgxpool.New(context.Background(), superDSN)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	cfg := &config.Config{
+		Env:      "development",
+		TestMode: config.CredentialPostureSandbox,
+		DB:       &config.DBConfig{URL: superDSN},
+	}
+	e, err := New(Options{Config: cfg, PGXPool: pool})
+	require.NoError(t, err, "development must only warn, never fail, on a bypass-RLS role")
+	t.Cleanup(func() { _ = e.Close(context.Background()) })
+}
+
+// TestNew_EmbeddedBootSucceedsAsAppRoleOutsideDev proves the positive case: a
+// properly RLS-enforcing role boots cleanly outside development.
+func TestNew_EmbeddedBootSucceedsAsAppRoleOutsideDev(t *testing.T) {
+	_, appDSN := dbtest.SharedRLSPostgres(t)
+	pool, err := pgxpool.New(context.Background(), appDSN)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	cfg := &config.Config{
+		Env:               "staging",
+		TestMode:          config.CredentialPostureLive,
+		ProviderWriteMode: config.ProviderWriteModeReadOnly,
+		DB:                &config.DBConfig{URL: appDSN},
+	}
+	e, err := New(Options{Config: cfg, PGXPool: pool})
+	require.NoError(t, err, "an RLS-enforcing role must boot outside development")
+	t.Cleanup(func() { _ = e.Close(context.Background()) })
+}


### PR DESCRIPTION
## Summary

Three staging-posture gaps found by the openrails-saas #10 staging build (see openrails tracker #762/#763/#764).

- **#762** — `config.Validate` no longer rejects `test_mode=sandbox` outside development. Posture (`TestMode`) and environment strictness (`Env`/`IsDev`) are independent axes. Decision: sandbox is allowed in *every* environment, including production — rail-credential validation (`ExpectedProviderEnvironment`'s environment cross-check, `validateStripeKeyForTestMode`'s live-key refusal) is what actually keeps it honest, not the environment string. Documented in `config.go`'s `TestMode` field comment, README, docs/operations.md, config.example.yaml.
- **#763** — `internal/app.buildRuntimeWithOverrides` now calls `EnforceRLSPosture` exactly once, after resolving the DB pool from either construction path (standalone `createDatabase`, embedded `overrides.DB`). Previously the check lived inside `createDatabase`, which embedded construction never calls (it always injects a pool), so an embedded host connecting as a BYPASSRLS role outside development booted silently. One shared gate now, not a copy.
- **#764** — new migration `0007_openrails_app_grants` gives `openrails_app` what the runtime actually needs on `public` (River: `river_job`/`river_queue`/`river_leader` + `river_job`'s sequence — scoped to what the riverpgxv5 client actually queries; `river_migration` deliberately excluded, only River's own migrator touches it) and `profiles` (AuthKit, granted at the schema boundary, matching how `openrails.*` is granted at its own schema boundary). `ALTER DEFAULT PRIVILEGES` covers future River/AuthKit version bumps automatically. Deletes the harness-only re-grant in `internal/dbtest/rls.go` — the migration is now the single source of truth.

Cross-repo follow-ups (openrails-saas's staging compose flip to sandbox, its `internal/app/rls.go` host-side RLS workaround, and `scripts/staging/db-bootstrap.sql`) are tracked separately in the tracker and deliberately NOT touched here — they ride the next openrails version bump in that repo.

## Test plan

- [x] `gofmt`/`go vet`/`go vet -tags=integration`/`go build ./...` clean
- [x] `go test ./...` green
- [x] `go test -tags=integration -count=1 ./config/... ./internal/db/... ./pkg/embedded/... ./internal/app/... ./internal/integrationharness/...` green
- [x] Wider sweep of every other package touching `dbtest.SharedRLSPostgres` (alerting, catalog, grants, money/ledger, solana/recurring, reconcile, reconcile/converge, pkg/service) green — confirms the `internal/dbtest/rls.go` change regresses nothing
- [x] Verified the new River-grants test is meaningful: temporarily removed migration 0007 and reran — boot fails with `permission denied for table migrations`; restored the migration and it passes again