### PR TITLE
pkg/embedded/controlplane: export SetMerchantAPIHost/GetMerchantAPIHost (#734, saas #14)

### DIFF
--- a/pkg/embedded/controlplane/host.go
+++ b/pkg/embedded/controlplane/host.go
@@ -1,0 +1,53 @@
+package controlplane
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-rails/openrails/internal/app"
+	"github.com/open-rails/openrails/internal/merchants"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// SetMerchantAPIHost sets id's canonical #734 API host through the attached
+// control plane (openrails-saas #14: hosted products provision a merchant's
+// api_host right after ProvisionMerchant succeeds, using the MerchantID that
+// call already returned). apiHost empty clears the mapping. Mirrors
+// ProvisionMerchant's shape: resolve the attached control plane, build the
+// directory-only merchants.Service (merchants.NewDirectoryService), and
+// forward to its SetHostConfig — the exact seam ProvisionMerchant already
+// uses for the directory row itself. Safe to call multiple times (a plain
+// UPDATE); returns merchants.ErrAPIHostTaken (errors.Is-able) when apiHost is
+// already assigned to a different active merchant.
+func SetMerchantAPIHost(ctx context.Context, a *app.App, id merchant.ID, apiHost string) error {
+	cp := Get(a)
+	if cp == nil {
+		return fmt.Errorf("control plane set host: no control plane attached (call Attach first)")
+	}
+	dir, err := merchants.NewDirectoryService(cp.Pool())
+	if err != nil {
+		return fmt.Errorf("control plane set host: build merchant directory service: %w", err)
+	}
+	if err := dir.SetHostConfig(ctx, id, apiHost); err != nil {
+		return fmt.Errorf("control plane set host: %w", err)
+	}
+	return nil
+}
+
+// GetMerchantAPIHost returns id's current #734 API host (empty when unset)
+// through the attached control plane.
+func GetMerchantAPIHost(ctx context.Context, a *app.App, id merchant.ID) (string, error) {
+	cp := Get(a)
+	if cp == nil {
+		return "", fmt.Errorf("control plane get host: no control plane attached (call Attach first)")
+	}
+	dir, err := merchants.NewDirectoryService(cp.Pool())
+	if err != nil {
+		return "", fmt.Errorf("control plane get host: build merchant directory service: %w", err)
+	}
+	cfg, err := dir.GetHostConfig(ctx, id)
+	if err != nil {
+		return "", fmt.Errorf("control plane get host: %w", err)
+	}
+	return cfg.APIHost, nil
+}

--- a/pkg/embedded/controlplane/host_integration_test.go
+++ b/pkg/embedded/controlplane/host_integration_test.go
@@ -1,0 +1,85 @@
+//go:build integration
+
+package controlplane_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/internal/merchants"
+	embcp "github.com/open-rails/openrails/pkg/embedded/controlplane"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// TestSetGetMerchantAPIHost proves the openrails-saas #14 seam end to end: a
+// host provisions a merchant, sets its api_host through the exported
+// SetMerchantAPIHost/GetMerchantAPIHost pair, and the SAME control plane's
+// #734 ResolveMerchantByHost resolves it immediately — i.e. this seam writes
+// through the identical authority ProvisionMerchant and Host resolution
+// already share, not a parallel table.
+func TestSetGetMerchantAPIHost(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+	cfg := hostedTestConfig(dsn, "https://hosts.openrails.test")
+	e := newHostApp(t, cfg)
+	require.NoError(t, embcp.Attach(ctx, e.App(), cfg, nil))
+
+	sfx := strings.ToLower(uuid.NewString()[:8])
+	slug := "hostset-" + sfx
+	res, err := embcp.ProvisionMerchant(ctx, e.App(), embcp.ProvisionMerchantRequest{Slug: slug})
+	require.NoError(t, err)
+
+	// Unset by default.
+	host, err := embcp.GetMerchantAPIHost(ctx, e.App(), res.MerchantID)
+	require.NoError(t, err)
+	require.Empty(t, host)
+
+	apiHost := "api." + slug + ".localtest.me"
+	require.NoError(t, embcp.SetMerchantAPIHost(ctx, e.App(), res.MerchantID, apiHost))
+
+	got, err := embcp.GetMerchantAPIHost(ctx, e.App(), res.MerchantID)
+	require.NoError(t, err)
+	require.Equal(t, apiHost, got)
+
+	// The #734 Host resolver (ResolveMerchantByHost) is the SAME authority:
+	// setting the host here must make it resolve immediately, live, with no
+	// restart — proving this seam is not a parallel mapping.
+	cp := embcp.Get(e.App())
+	require.NotNil(t, cp)
+	resolved, err := cp.ResolveMerchantByHost(ctx, apiHost)
+	require.NoError(t, err)
+	require.Equal(t, res.MerchantID, resolved)
+
+	// A different, never-configured host resolves to nothing (fail closed).
+	_, err = cp.ResolveMerchantByHost(ctx, "api.never-configured."+sfx+".localtest.me")
+	require.Error(t, err)
+
+	// Clearing (empty apiHost) removes the mapping.
+	require.NoError(t, embcp.SetMerchantAPIHost(ctx, e.App(), res.MerchantID, ""))
+	cleared, err := embcp.GetMerchantAPIHost(ctx, e.App(), res.MerchantID)
+	require.NoError(t, err)
+	require.Empty(t, cleared)
+	_, err = cp.ResolveMerchantByHost(ctx, apiHost)
+	require.Error(t, err)
+
+	// A second merchant cannot steal an already-assigned host.
+	res2, err := embcp.ProvisionMerchant(ctx, e.App(), embcp.ProvisionMerchantRequest{Slug: "hostset2-" + sfx})
+	require.NoError(t, err)
+	require.NoError(t, embcp.SetMerchantAPIHost(ctx, e.App(), res2.MerchantID, apiHost))
+	res3, err := embcp.ProvisionMerchant(ctx, e.App(), embcp.ProvisionMerchantRequest{Slug: "hostset3-" + sfx})
+	require.NoError(t, err)
+	err = embcp.SetMerchantAPIHost(ctx, e.App(), res3.MerchantID, apiHost)
+	require.Error(t, err)
+	require.ErrorIs(t, err, merchants.ErrAPIHostTaken)
+
+	// Without an attached control plane, both calls are a wiring error.
+	bare := newHostApp(t, hostedTestConfig(dsn, "https://hostset-bare.openrails.test"))
+	err = embcp.SetMerchantAPIHost(ctx, bare.App(), merchant.ID{}, apiHost)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no control plane attached")
+}

--- a/pkg/embedded/merchant_conn.go
+++ b/pkg/embedded/merchant_conn.go
@@ -1,0 +1,27 @@
+package embedded
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// RunInMerchantConn pins ctx to a merchant-scoped DB connection for the
+// duration of fn — the exported analogue of internal/db.DB.RunInMerchantConn
+// for a host calling *service.Service (or any other merchant-owned engine Go
+// API) DIRECTLY, outside of an HTTP request (which gets this for free via
+// middleware.ResolveMerchantHTTP) or a River job (which gets it via the
+// worker wiring). Every merchant-owned table's RLS policy requires the
+// `app.merchant_id` GUC this pins (issue #227): a caller that skips it does
+// not fail gracefully — reads silently see zero rows and writes are rejected
+// by the table's RLS policy, for EVERY merchant, indistinguishable from a
+// generic permission error. A host doing boot-time catalog seeding or other
+// one-off Go-native merchant work (as opposed to a bulk manifest operation
+// already covered by ConvergeMerchant/PushMerchantCatalog/dump) needs this.
+func (e *Embedded) RunInMerchantConn(ctx context.Context, id merchant.ID, fn func(context.Context) error) error {
+	if e == nil || e.app == nil || e.app.Runtime == nil || e.app.Runtime.DB == nil {
+		return fmt.Errorf("embedded billing: not initialized")
+	}
+	return e.app.Runtime.DB.RunInMerchantConn(merchant.WithID(ctx, id), fn)
+}

--- a/pkg/embedded/merchant_conn_integration_test.go
+++ b/pkg/embedded/merchant_conn_integration_test.go
@@ -1,0 +1,92 @@
+//go:build integration
+
+package embedded
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/dbtest"
+	embcp "github.com/open-rails/openrails/pkg/embedded/controlplane"
+	"github.com/open-rails/openrails/pkg/merchant"
+	billingservice "github.com/open-rails/openrails/pkg/service"
+)
+
+// TestEmbedded_RunInMerchantConn proves the exact failure this seam exists
+// to close: a host calling *service.Service directly (outside any HTTP
+// request or River job) MUST pin a merchant-scoped connection, or the
+// RLS-enforcing openrails_app role rejects the write outright (issue #227),
+// with no distinguishing error from a real permission problem. Found via
+// openrails-saas's own staging build (#10/#26): internal/platform.Bootstrap
+// calls svc.CreateProduct directly at boot and failed exactly this way under
+// the RLS-enforcing role.
+func TestEmbedded_RunInMerchantConn(t *testing.T) {
+	_, appDSN := dbtest.SharedRLSPostgres(t)
+	pool, err := pgxpool.New(context.Background(), appDSN)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	sfx := strings.ToLower(uuid.NewString()[:8])
+	cfg := &config.Config{
+		// development sidesteps MerchantSourceAPI's non-dev secret-backend
+		// requirement (unrelated to this test); the openrails_app role
+		// connected below enforces RLS at the Postgres engine level
+		// unconditionally, independent of cfg.Env — the #763 app-level gate
+		// (development-vs-not) is a different, orthogonal check from the one
+		// this test exercises.
+		Env:               "development",
+		TestMode:          config.CredentialPostureSandbox,
+		ProviderWriteMode: config.ProviderWriteModeReadOnly,
+		MerchantSource:    config.MerchantSourceAPI,
+		DB:                &config.DBConfig{URL: appDSN},
+		Auth:              &config.AuthConfig{Issuer: "https://merchant-conn-" + sfx + ".openrails.test"},
+	}
+	e, err := New(Options{Config: cfg, PGXPool: pool})
+	require.NoError(t, err, "boot as the openrails_app role")
+	t.Cleanup(func() { _ = e.Close(context.Background()) })
+
+	ctx := context.Background()
+	require.NoError(t, embcp.Attach(ctx, e.App(), cfg, pool))
+	res, err := embcp.ProvisionMerchant(ctx, e.App(), embcp.ProvisionMerchantRequest{Slug: "conn-" + sfx})
+	require.NoError(t, err)
+
+	svc, err := e.Service()
+	require.NoError(t, err)
+
+	// Without a pinned merchant connection, a direct write fails closed under
+	// RLS — merchant.WithID alone satisfies merchant.Require but never touches
+	// the app.merchant_id session GUC the table's RLS policy checks.
+	_, err = svc.CreateProduct(merchant.WithID(ctx, res.MerchantID), billingservice.CreateProductRequest{
+		Key: "unpinned-" + sfx, DisplayName: "Unpinned",
+	})
+	require.Error(t, err, "a merchant-owned write without a pinned connection must be rejected by RLS")
+
+	// The SAME call, wrapped in RunInMerchantConn, succeeds.
+	var created *billingservice.CatalogProduct
+	err = e.RunInMerchantConn(ctx, res.MerchantID, func(mctx context.Context) error {
+		created, err = svc.CreateProduct(mctx, billingservice.CreateProductRequest{
+			Key: "pinned-" + sfx, DisplayName: "Pinned",
+		})
+		return err
+	})
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	require.Equal(t, "pinned-"+sfx, created.Key)
+
+	// A read is scoped the same way: querying by key inside the pinned
+	// connection finds it; the same query without any pin sees nothing (RLS
+	// filters every row, not just writes).
+	err = e.RunInMerchantConn(ctx, res.MerchantID, func(mctx context.Context) error {
+		got, gerr := svc.GetProductByKey(mctx, "pinned-"+sfx)
+		require.NoError(t, gerr)
+		require.Equal(t, created.ID, got.ID)
+		return nil
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- openrails-saas #14 (per-merchant API hostnames) needs a way to set a merchant's `api_host` right after `ProvisionMerchant` succeeds, using the `MerchantID` that call already returns.
- `merchants.Service.SetHostConfig`/`GetHostConfig` (#734) already do the work but `internal/merchants` is unimportable outside this module — no externally-nameable seam existed, the same gap `ProvisionMerchant` (#738) closed for the directory row itself.
- Adds `embcp.SetMerchantAPIHost(ctx, app, id, apiHost)` / `embcp.GetMerchantAPIHost(ctx, app, id)`, following `ProvisionMerchant`'s own shape: resolve the attached control plane, build the directory-only `merchants.Service` (`merchants.NewDirectoryService(cp.Pool())`), forward to `SetHostConfig`/`GetHostConfig`.

## Test plan
- [x] `gofmt -l` clean on new files
- [x] `go build ./...` / `go vet ./...` / `go vet -tags integration ./...` clean
- [x] `go test ./...` green
- [x] `go test -tags=integration ./pkg/embedded/controlplane/...` green, including new `TestSetGetMerchantAPIHost` (roundtrip, clears, `ErrAPIHostTaken` on collision, live-resolves through the same `ResolveMerchantByHost` authority, no-control-plane wiring error)