### PR TITLE
fix(#766): assert Host-pinned merchant matches user-session membership merchant

### DIFF
--- a/internal/http/routes/routes.go
+++ b/internal/http/routes/routes.go
@@ -462,17 +462,60 @@ func (g legacyGate) Authorize(ctx context.Context, req *http.Request, perm strin
 	}
 	mid, ok := merchant.FromContext(ctx)
 	if !ok {
-		resolver, ok := g.AdminPermissionChecker.(merchantGroupResolver)
-		if !ok {
-			return billingauth.Principal{}, billingauth.GateError{Status: http.StatusInternalServerError, Message: "merchant resolver unavailable"}
+		var rerr error
+		mid, rerr = g.resolveMerchantForGroup(ctx, uc.Merchant)
+		if rerr != nil {
+			return billingauth.Principal{}, resolveMerchantForGroupGateError(rerr)
 		}
-		var err error
-		mid, _, err = resolver.ResolveMerchantForGroup(ctx, uc.Merchant)
-		if err != nil {
-			return billingauth.Principal{}, billingauth.GateError{Status: http.StatusForbidden, Message: "merchant_unresolved"}
+	}
+	// #766: uc.Merchant was resolved from the USER'S group membership, but mid
+	// may instead be the Host-pinned merchant (merchant.WithHostMerchant, set by
+	// ResolveMerchantFromHostHTTP alongside merchant.WithID — #734). Without this
+	// assertion a user with permission on merchant A, whose request lands on
+	// merchant B's Host, would get a Principal scoped to B on authority checked
+	// against A. Mirrors merchantForIssuer's identical Host-pin check
+	// (internal/controlplane/issuer_registry.go) for the service-JWT/API-key/
+	// delegated paths; HostMerchant (not the plain FromContext merchant) is the
+	// right signal because it is a no-op unless a Host resolver actually ran, so
+	// single-merchant self-hosters are unaffected.
+	if hostMID, ok := merchant.HostMerchant(ctx); ok {
+		membershipMID, rerr := g.resolveMerchantForGroup(ctx, uc.Merchant)
+		if rerr != nil {
+			return billingauth.Principal{}, resolveMerchantForGroupGateError(rerr)
+		}
+		if hostMID != membershipMID {
+			return billingauth.Principal{}, billingauth.GateError{Status: http.StatusForbidden, Message: "host_merchant_mismatch"}
 		}
 	}
 	return billingauth.Principal{MerchantID: mid, UserContext: uc}, nil
+}
+
+// errMerchantGroupResolverUnavailable distinguishes "AdminPermissionChecker
+// doesn't implement merchantGroupResolver" (a server misconfiguration, 500)
+// from "the merchant ref itself didn't resolve" (403, fail closed) in
+// resolveMerchantForGroup's callers.
+var errMerchantGroupResolverUnavailable = errors.New("merchant resolver unavailable")
+
+// resolveMerchantForGroup resolves the merchant.ID that owns merchantRef (a
+// merchant-group ref, e.g. from user-membership resolution) via the
+// AdminPermissionChecker's merchantGroupResolver facet.
+func (g legacyGate) resolveMerchantForGroup(ctx context.Context, merchantRef string) (merchant.ID, error) {
+	resolver, ok := g.AdminPermissionChecker.(merchantGroupResolver)
+	if !ok {
+		return merchant.ID{}, errMerchantGroupResolverUnavailable
+	}
+	mid, _, err := resolver.ResolveMerchantForGroup(ctx, merchantRef)
+	if err != nil {
+		return merchant.ID{}, err
+	}
+	return mid, nil
+}
+
+func resolveMerchantForGroupGateError(err error) billingauth.GateError {
+	if errors.Is(err, errMerchantGroupResolverUnavailable) {
+		return billingauth.GateError{Status: http.StatusInternalServerError, Message: "merchant resolver unavailable"}
+	}
+	return billingauth.GateError{Status: http.StatusForbidden, Message: "merchant_unresolved"}
 }
 
 func (opts Options) authenticateUser(r *httprequest.Request) (billingauth.UserContext, bool) {

--- a/internal/integrationharness/host_merchant_test.go
+++ b/internal/integrationharness/host_merchant_test.go
@@ -12,10 +12,12 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	authcore "github.com/open-rails/authkit/embedded"
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-rails/openrails/internal/controlplane"
 	"github.com/open-rails/openrails/internal/dbtest"
+	embcp "github.com/open-rails/openrails/pkg/embedded/controlplane"
 )
 
 // #734: host-resolved merchant API hosts (browser CORS was cut in #765 — see
@@ -172,5 +174,66 @@ func TestHostMerchantVsIssuerMismatchHTTP(t *testing.T) {
 	// unaffected — single-host deployments see no behavior change.
 	status, body = requestJSON(t, http.MethodGet,
 		surface.BaseURL+"/v1/merchant/credits/balance?currency=usd&customer_id="+payer, tokenA.Token, nil)
+	require.Equal(t, http.StatusOK, status, string(body))
+}
+
+// TestHostMerchantVsUserSessionMembershipMismatchHTTP is the #766 user-session
+// analogue of TestHostMerchantVsIssuerMismatchHTTP: a plain user access token
+// (no service JWT / API key / delegated credential in play) whose ONLY
+// merchant-group membership is merchant A must be rejected when the request's
+// Host resolves to a DIFFERENT merchant B — even though the user genuinely has
+// owner permissions on A, and even though the permission check alone (against
+// A) would pass. Before the #766 fix, legacyGate.Authorize resolved the
+// principal's MerchantID from ctx (Host-pinned B) without ever asserting it
+// matched the membership-resolved merchant (A), so this request would have
+// reached B's money-moving handlers on authority checked against A.
+func TestHostMerchantVsUserSessionMembershipMismatchHTTP(t *testing.T) {
+	ctx := context.Background()
+	h := New(t, ctx)
+	surface := h.StartStandalone("usd")
+
+	b := surface.ProvisionOwnedMerchant("host-user-mismatch-b-" + strings.ReplaceAll(uuid.NewString(), "-", ""))
+
+	hostA := "api.host-user-mismatch-a-" + strings.ReplaceAll(uuid.NewString(), "-", "") + ".test"
+	hostB := "api.host-user-mismatch-b-" + strings.ReplaceAll(uuid.NewString(), "-", "") + ".test"
+	surface.SetMerchantHostConfig(dbtest.TestMerchantID, hostA)
+	surface.SetMerchantHostConfig(b.MerchantID, hostB)
+
+	cp := embcp.Get(surface.app)
+	require.NotNil(t, cp, "control plane attached")
+	core := cp.Core()
+	require.NotNil(t, core, "authkit core")
+
+	username := "host-user-mismatch-" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	email := username + "@example.com"
+	user, err := core.CreateUser(ctx, email, username)
+	require.NoError(t, err, "create user")
+	// Owner of merchant A ONLY — no membership in B whatsoever.
+	require.NoError(t, core.Genesis().AssignGroupRole(
+		ctx, controlplane.MerchantType, dbtest.TestMerchantSlug, user.ID, authcore.SubjectKindUser, controlplane.MerchantRoleOwner,
+	), "assign merchant A owner role")
+	token, _, err := core.MintAccessToken(ctx, user.ID, nil)
+	require.NoError(t, err, "issue user access token")
+
+	payer := uuid.NewString()
+
+	// A owner's user session, on A's own host: works normally (membership ==
+	// Host-pinned merchant).
+	status, body := requestJSONHost(t, http.MethodGet,
+		surface.BaseURL+"/v1/merchant/credits/balance?currency=usd&customer_id="+payer, hostA, token, nil)
+	require.Equal(t, http.StatusOK, status, string(body))
+
+	// The SAME user session, presented on B's host: fails closed. HasAdminPermission
+	// alone would pass (checked against A, where the user IS owner) — only the
+	// #766 Host-vs-membership assertion catches this.
+	status, body = requestJSONHost(t, http.MethodGet,
+		surface.BaseURL+"/v1/merchant/credits/balance?currency=usd&customer_id="+payer, hostB, token, nil)
+	require.Equalf(t, http.StatusForbidden, status,
+		"user session with membership only in A must fail closed on B's host: %s", string(body))
+
+	// No Host override at all (unconfigured host): unaffected — single-merchant
+	// self-hosters see no behavior change (regression check, #766).
+	status, body = requestJSON(t, http.MethodGet,
+		surface.BaseURL+"/v1/merchant/credits/balance?currency=usd&customer_id="+payer, token, nil)
 	require.Equal(t, http.StatusOK, status, string(body))
 }

--- a/pkg/billingauth/authenticator.go
+++ b/pkg/billingauth/authenticator.go
@@ -20,6 +20,12 @@ import (
 // valid credential. OpenRails maps that to 401 on required routes and to
 // anonymous access on optional routes. A returned error's message is surfaced on
 // required routes, so it should be safe to expose to clients.
+//
+// UserContext.UserID MUST be a UUID (see its doc, #364/#766): a host whose
+// native subject ids are not UUIDs must map them to a stable UUID here. A
+// non-UUID UserID fails [UserContext.ValidateSubject] on every request — 401
+// on required routes, but a SILENT downgrade to anonymous on optional routes
+// (no error surfaced) — so this is easy to miss during embedding.
 type Authenticator interface {
 	Authenticate(ctx context.Context, r *http.Request) (UserContext, error)
 }

--- a/pkg/billingauth/user_context.go
+++ b/pkg/billingauth/user_context.go
@@ -23,7 +23,16 @@ import (
 // populates whichever fields apply to its identity model and OpenRails treats
 // everything beyond UserID as optional.
 type UserContext struct {
-	// UserID is the unique identifier for the principal/payer (required).
+	// UserID is the unique identifier for the principal/payer (required). It
+	// MUST be a UUID (#364/#766): OpenRails uses it directly as the payable
+	// customer_id, and ValidateSubject enforces this at every auth middleware.
+	// A host whose native subject ids are NOT UUIDs (e.g. sequential integers,
+	// external-provider opaque strings) must map them to a stable UUID before
+	// returning UserContext from its Authenticator — otherwise EVERY request
+	// from that host fails this gate: required routes 401 ("subject ... is not
+	// a UUID"), optional routes silently downgrade to anonymous (no error
+	// surfaced), a correctness footgun that looks like "auth isn't working" if
+	// undocumented.
 	UserID string
 
 	// Email is the user's email address (optional).


### PR DESCRIPTION
## Summary
- Closes the HIGH cross-merchant authz seam in #766: the user-session branch of `legacyGate.Authorize` (internal/http/routes/routes.go) resolved the acting merchant from group membership for the permission check, but returned a `Principal` scoped to whatever `merchant.FromContext` held (the Host-pinned merchant, in Host-routed multi-merchant deployments) with no assertion the two agreed. A user with permission on merchant A whose request landed on merchant B's Host got full merchant-scoped authority on B, checked against A.
- Fix, at the shared gate (covers every route through it, not per-handler): when `merchant.HostMerchant(ctx)` is set (a Host resolver actually ran — #734), assert it equals the membership-resolved merchant before returning the principal; 403 (`host_merchant_mismatch`) on disagreement. Mirrors the existing `merchantForIssuer` Host-pin check already protecting the service-JWT/API-key/delegated paths (`internal/controlplane/issuer_registry.go`). Single-merchant self-hosters are unaffected — `HostMerchant` is a no-op unless Host-based routing is configured.
- LOW item: documented the UUID-only `UserContext.UserID` contract at the actual embedding seam (`billingauth.Authenticator` interface doc + `UserContext.UserID` field doc), since the requirement was previously only documented on the internal `ValidateSubject` enforcement, not where a host implementer would read it.

## Test plan
- [x] New integration test `TestHostMerchantVsUserSessionMembershipMismatchHTTP` (internal/integrationharness/host_merchant_test.go): a user who is owner of merchant A only gets 200 on A's Host, 403 on B's Host, and 200 with no Host override (self-host regression guard). Verified meaningful — fails (200 instead of 403) when reverting the routes.go fix, passes with it.
- [x] `go build ./...`, `go vet ./...`, `go vet -tags=integration ./...` clean.
- [x] `go test ./...` green (full repo).
- [x] `go test -tags=integration -count=1 ./internal/integrationharness/... ./internal/http/... ./internal/controlplane/... ./pkg/embedded/... ./pkg/merchant/... ./embed/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)