### PR TITLE
fix(#769): normalize embedded MountPrefix + boundary-check combinedMount

### DIFF
--- a/pkg/embedded/mount.go
+++ b/pkg/embedded/mount.go
@@ -36,6 +36,11 @@ type MountOptions struct {
 // framework-neutral net/http handler. The host mounts this once (a gin host
 // uses gin.WrapH) and rewrites nothing.
 func MountHandler(e *Embedded, opts MountOptions) (http.Handler, error) {
+	mountPrefix, err := normalizeMountPrefix(opts.MountPrefix)
+	if err != nil {
+		return nil, err
+	}
+
 	// Resolve + record the full selection (incl. customer); the combined mount
 	// serves customer via the self handler, so it is part of the advertised set.
 	active := e.MountRouteSets(opts.RouteSets)
@@ -64,7 +69,22 @@ func MountHandler(e *Embedded, opts MountOptions) (http.Handler, error) {
 	// base is the canonical embedded mount ("/billing"); both handlers serve at
 	// base + "/v1/...".
 	base := strings.TrimSuffix(embedhttp.EmbeddedV1Prefix, "/v1")
-	return combinedMount(opts.MountPrefix, base, self, user), nil
+	return combinedMount(mountPrefix, base, self, user), nil
+}
+
+// normalizeMountPrefix trims trailing slashes (so "/billing/" and "/billing//"
+// both mean the canonical "/billing") and requires a leading "/" when
+// non-empty — a prefix silently missing its leading slash is far more likely
+// a caller bug than an intentional relative mount, so it fails loudly here at
+// boot time instead of silently 404ing every request.
+func normalizeMountPrefix(prefix string) (string, error) {
+	for strings.HasSuffix(prefix, "/") {
+		prefix = strings.TrimSuffix(prefix, "/")
+	}
+	if prefix != "" && !strings.HasPrefix(prefix, "/") {
+		return "", fmt.Errorf("embedded billing: MountPrefix %q must start with \"/\"", prefix)
+	}
+	return prefix, nil
 }
 
 // SelfHandler returns the mountable browser-direct SELF-SERVICE surface for an
@@ -149,17 +169,25 @@ func routeSetsWithoutCustomer(routeSets []RouteSet) []RouteSet {
 
 // combinedMount strips mountPrefix, rewrites to the canonical base, and routes
 // selected customer subtrees to the self handler; everything else to the user
-// handler.
+// handler. Paths not under mountPrefix (including prefix-boundary near-misses
+// like "/billingfoo" against "/billing") get a clean 404 instead of a garbage
+// rewrite.
 func combinedMount(mountPrefix, base string, self, user http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		rest := strings.TrimPrefix(r.URL.Path, mountPrefix)
-		if rest == "" {
-			rest = "/"
+		rest, ok := stripMountPrefix(r.URL.Path, mountPrefix)
+		if !ok {
+			http.NotFound(w, r)
+			return
 		}
 		r2 := r.Clone(r.Context())
 		r2.URL.Path = base + rest
 		if r2.URL.RawPath != "" {
-			r2.URL.RawPath = base + strings.TrimPrefix(r.URL.RawPath, mountPrefix)
+			rawRest, ok := stripMountPrefix(r.URL.RawPath, mountPrefix)
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
+			r2.URL.RawPath = base + rawRest
 		}
 		if self != nil && (rest == "/v1/me" || rest == "/v1/customers" ||
 			strings.HasPrefix(rest, "/v1/me/") || strings.HasPrefix(rest, "/v1/customers/")) {
@@ -168,4 +196,23 @@ func combinedMount(mountPrefix, base string, self, user http.Handler) http.Handl
 		}
 		user.ServeHTTP(w, r2)
 	})
+}
+
+// stripMountPrefix removes mountPrefix from path at a "/" boundary (path
+// equals mountPrefix exactly, or continues with "/"). Returns ok=false when
+// path is not under mountPrefix at all.
+func stripMountPrefix(path, mountPrefix string) (rest string, ok bool) {
+	if mountPrefix == "" {
+		if path == "" {
+			return "/", true
+		}
+		return path, true
+	}
+	if path == mountPrefix {
+		return "/", true
+	}
+	if strings.HasPrefix(path, mountPrefix+"/") {
+		return path[len(mountPrefix):], true
+	}
+	return "", false
 }

--- a/pkg/embedded/mount_test.go
+++ b/pkg/embedded/mount_test.go
@@ -39,6 +39,84 @@ func TestCombinedMountRoutesAndRewrites(t *testing.T) {
 	}
 }
 
+// TestCombinedMountPrefixNormalizationAndBoundary covers #769: a trailing
+// slash on mountPrefix must not corrupt every rewrite, prefix matching must
+// respect a "/" boundary (not just a byte prefix), and paths outside the
+// mount must 404 cleanly instead of getting a garbage rewrite.
+func TestCombinedMountPrefixNormalizationAndBoundary(t *testing.T) {
+	ok := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Path", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}
+	user := http.HandlerFunc(ok)
+
+	cases := []struct {
+		name        string
+		mountPrefix string
+		path        string
+		wantStatus  int
+		wantPath    string // only checked when wantStatus == 200
+	}{
+		{
+			name:        "trailing slash prefix serves identically to canonical",
+			mountPrefix: "/billing/",
+			path:        "/billing/v1/products",
+			wantStatus:  http.StatusOK,
+			wantPath:    "/base/v1/products",
+		},
+		{
+			name:        "double trailing slash prefix also normalizes",
+			mountPrefix: "/billing//",
+			path:        "/billing/v1/products",
+			wantStatus:  http.StatusOK,
+			wantPath:    "/base/v1/products",
+		},
+		{
+			name:        "canonical no-trailing-slash prefix unaffected",
+			mountPrefix: "/billing",
+			path:        "/billing/v1/products",
+			wantStatus:  http.StatusOK,
+			wantPath:    "/base/v1/products",
+		},
+		{
+			name:        "non-matching path 404s cleanly",
+			mountPrefix: "/billing",
+			path:        "/other/v1/products",
+			wantStatus:  http.StatusNotFound,
+		},
+		{
+			name:        "prefix-boundary near-miss 404s",
+			mountPrefix: "/billing",
+			path:        "/billingfoo/v1/products",
+			wantStatus:  http.StatusNotFound,
+		},
+		{
+			name:        "empty prefix unchanged",
+			mountPrefix: "",
+			path:        "/v1/products",
+			wantStatus:  http.StatusOK,
+			wantPath:    "/base/v1/products",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mountPrefix, err := normalizeMountPrefix(tc.mountPrefix)
+			if err != nil {
+				t.Fatalf("normalizeMountPrefix(%q): %v", tc.mountPrefix, err)
+			}
+			mount := combinedMount(mountPrefix, "/base", nil, user)
+			rec := httptest.NewRecorder()
+			mount.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, tc.path, nil))
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+			if tc.wantStatus == http.StatusOK && rec.Header().Get("X-Path") != tc.wantPath {
+				t.Fatalf("rewritten path = %q, want %q", rec.Header().Get("X-Path"), tc.wantPath)
+			}
+		})
+	}
+}
+
 func TestRouteSetSelectedCustomer(t *testing.T) {
 	if !routeSetSelected(nil, RouteSetCustomer) {
 		t.Fatal("default embedded route sets should include customer routes")


### PR DESCRIPTION
## Summary
Fixes #769. `combinedMount` in `pkg/embedded/mount.go` used a naive `strings.TrimPrefix(r.URL.Path, mountPrefix)`:

- `MountPrefix: "/billing/"` (trailing slash) stripped the remainder to a path missing its leading slash, rewriting every request to e.g. `/billingv1/...` — silent total 404 breakage from one character, with no boot-time error.
- No path-boundary check: `/billingfoo` matched prefix `/billing`.
- Paths outside the mount were passed through with `base` prepended instead of a clean 404.
- `RawPath` got the same naive treatment.

## Changes
- `MountHandler` now normalizes `MountPrefix` via `normalizeMountPrefix`: trims trailing slashes (repeatedly), and errors at boot if a non-empty prefix lacks a leading `/`.
- `combinedMount` now uses `stripMountPrefix`, which requires a `/` boundary (exact match or `prefix + "/"`) for both `URL.Path` and `URL.RawPath`; non-matching paths get a clean `http.NotFound` instead of a garbage rewrite.

## Test plan
- [x] Extended `pkg/embedded/mount_test.go` with a table-driven `TestCombinedMountPrefixNormalizationAndBoundary` covering: trailing-slash prefix parity with canonical, double-trailing-slash, canonical unaffected, non-matching path 404, `/billingfoo` boundary near-miss 404, empty prefix unchanged.
- [x] `go test ./pkg/embedded/... -v` all green.
- [x] `go build ./...` and `go vet ./pkg/embedded/` clean.
- [x] Verified new cases are load-bearing: reverting `combinedMount`/`stripMountPrefix` to the old logic makes the boundary-check subtests fail (confirmed locally, not part of the diff).