### PR TITLE
fix(#768): embed localClient pins merchant on single Admit, surfaces error causes

### DIFF
--- a/embed/client.go
+++ b/embed/client.go
@@ -2,6 +2,7 @@ package embed
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -14,6 +15,15 @@ import (
 	"github.com/open-rails/openrails/pkg/merchant"
 	billingservice "github.com/open-rails/openrails/pkg/service"
 )
+
+// SingleAdmitter is the embedded-only single-Admit extra (no /v1/merchant wire
+// counterpart, #666 kept the batch route as the surviving HTTP surface). The
+// value returned by Runtime.Client always implements it via *localClient; hosts
+// that need single-Admit semantics reach it by type-asserting the
+// openrails.Client to SingleAdmitter.
+type SingleAdmitter interface {
+	Admit(ctx context.Context, req openrails.AdmitRequest) (*openrails.AdmitResponse, error)
+}
 
 // localClient is the PERMANENT remainder of the pre-#685 handler-transcribing
 // adapter. Every openrails.Client interface method except one runs through the
@@ -39,7 +49,7 @@ import (
 //     direct engine access by the process owner.
 //   - Embedded-only extra with NO wire counterpart: single Admit (the batch
 //     route is the surviving HTTP surface, #666), reachable via type assertion
-//     by hosts that need it. (SetCreditAccountSettings, ListCreditTransactions,
+//     to SingleAdmitter by hosts that need it. (SetCreditAccountSettings, ListCreditTransactions,
 //     BudgetStatus, AbuseUsage were deleted in the #685 tail — no host used
 //     them.)
 type localClient struct {
@@ -104,8 +114,11 @@ func firstNonEmpty(vals ...string) string {
 	return ""
 }
 
-func internalErr(msg string) error {
-	return openrails.NewStatusError(http.StatusInternalServerError, "", msg)
+// wrapInternalErr wraps a 500 StatusError, appending the underlying cause: these
+// StatusErrors never leave the process (in-process embedded path only), so
+// folding the cause into the message is safe and needed for host debugging.
+func wrapInternalErr(msg string, cause error) error {
+	return openrails.NewStatusError(http.StatusInternalServerError, "", fmt.Sprintf("%s: %v", msg, cause))
 }
 
 // parseCustomer transcribes handlers.parseServiceCustomerID +
@@ -143,7 +156,10 @@ func budgetWindowFromDTO(w billingservice.AdmitBudgetWindowDTO) openrails.Budget
 // Admit carries the single-admit semantics of the retired handlers.ServiceAdmit
 // (#666; the batch /admissions route is the surviving HTTP surface). All verdict
 // outcomes — allowed, abuse (429), money (402), gated (403) — return
-// (resp, nil), like the remote client.
+// (resp, nil), like the remote client. Admit implements SingleAdmitter.
+// Bypasses the in-process transport like the rest of localClient, so it must
+// pin the bound merchant itself (merchantCtx) or every call fails
+// merchant.Require.
 func (c *localClient) Admit(ctx context.Context, req openrails.AdmitRequest) (*openrails.AdmitResponse, error) {
 	if req.EstimatedAmount < 0 {
 		return nil, invalidErr("estimated_amount must be >= 0")
@@ -158,9 +174,9 @@ func (c *localClient) Admit(ctx context.Context, req openrails.AdmitRequest) (*o
 	}
 	req.Currency = currency
 
-	res, err := c.svc.Admit(ctx, admitInputFromSDK(req, payer))
+	res, err := c.svc.Admit(c.merchantCtx(ctx), admitInputFromSDK(req, payer))
 	if err != nil {
-		return nil, internalErr("admission check failed")
+		return nil, wrapInternalErr("admission check failed", err)
 	}
 	return admitResponseFromResult(res), nil
 }
@@ -233,7 +249,7 @@ func (c *localClient) SetCustomerSpendDelegations(ctx context.Context, customerI
 		})
 	}
 	if err := c.svc.ReplaceInvokerSpendLimits(c.merchantCtx(ctx), payer, next); err != nil {
-		return internalErr("set customer spend delegations failed")
+		return wrapInternalErr("set customer spend delegations failed", err)
 	}
 	return nil
 }

--- a/embed/embed.go
+++ b/embed/embed.go
@@ -139,7 +139,9 @@ func New(ctx context.Context, opts Options, options ...Option) (*Runtime, error)
 //
 // One interface method (SetCustomerSpendDelegations) is PERMANENTLY served by
 // the transcribed localClient — see unifiedClient and the localClient doc for
-// the authz reasoning.
+// the authz reasoning. The returned Client also always implements
+// SingleAdmitter (embedded-only single Admit, no wire counterpart) — reach it
+// via a type assertion.
 func (r *Runtime) Client(opts ...ClientOption) openrails.Client {
 	c := &localClient{svc: r.svc, rt: r.emb.App().Runtime}
 	for _, opt := range opts {

--- a/embed/localclient_admit_integration_test.go
+++ b/embed/localclient_admit_integration_test.go
@@ -1,0 +1,123 @@
+//go:build integration
+
+// Regression for #768: the transcribed localClient bypasses the in-process
+// transport (unlike AdmitBatch, which pins the merchant automatically via the
+// transport), so its two methods must pin the bound merchant themselves and
+// must not swallow the underlying cause into a bare constant 500 message.
+package embed_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails"
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/embed"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/pkg/embedded"
+)
+
+// TestLocalClientAdmit covers both bugs in embed/client.go's PERMANENT
+// transcription (localClient): (1) single Admit (SingleAdmitter, reachable via
+// type assertion on Runtime.Client) used to call c.svc.Admit with the raw ctx,
+// while Admitter.Admit starts with merchant.Require(ctx) — every embedded
+// single-Admit call failed "merchant required" surfaced as a bare 500
+// "admission check failed", with AdmitBatch (through the in-process transport)
+// unaffected since the transport pins the merchant itself; (2) both
+// transcribed methods collapsed any service failure into that constant
+// message with the cause dropped, leaving embedded hosts to debug blind.
+func TestLocalClientAdmit(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+	cfg := &config.Config{Env: "dev", TestMode: config.CredentialPostureLive, DB: &config.DBConfig{URL: dsn}}
+
+	t.Run("merchant pinned: verdict + spend delegations", func(t *testing.T) {
+		pool, err := pgxpool.New(ctx, dsn)
+		require.NoError(t, err)
+		t.Cleanup(pool.Close)
+
+		// The admission gate (spendgate) requires Redis; without it Admit fails
+		// before ever reaching merchant.Require, masking the regression this test
+		// targets.
+		rdb, _ := dbtest.SharedRedisClient(t)
+
+		slug := fmt.Sprintf("embed-localclient-admit-%d", time.Now().UnixNano())
+		rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg, Redis: rdb}})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = rt.Close(context.Background()) })
+
+		// Bind the merchant the normal provisioning way (UpsertMerchantConfig),
+		// not a raw ctx/runtime-field pin.
+		_, err = rt.UpsertMerchantConfig(ctx, slug, embed.MerchantConfig{DisplayName: slug})
+		require.NoError(t, err)
+
+		customerID := dbtest.EnsureCustomerIDPgx(ctx, t, pool, "c7c7c7c7-0000-4000-8000-000000000042")
+
+		client := rt.Client()
+		admitter, ok := client.(embed.SingleAdmitter)
+		require.True(t, ok, "Runtime.Client() must implement embed.SingleAdmitter")
+
+		// Money-bearing single Admit. A fresh zero-balance customer is denied on
+		// affordability, but that is a VERDICT (Allowed=false, a DenyCode), never
+		// an error. On the unfixed code this call errors with "admission check
+		// failed" instead (merchant.Require failing on the raw ctx) — this
+		// assertion is the merchant-pin regression check.
+		resp, err := admitter.Admit(ctx, openrails.AdmitRequest{
+			CustomerID:      customerID.String(),
+			Invoker:         "test-invoker",
+			InvokerType:     openrails.InvokerTypePayer,
+			Currency:        "USD",
+			EstimatedAmount: 10_000,
+			Source:          "localclient-admit-test",
+			RequestID:       "localclient-admit-" + customerID.String(),
+		})
+		require.NoError(t, err, "embedded single Admit must pin the bound merchant itself, not error")
+		require.NotNil(t, resp)
+		require.False(t, resp.Allowed, "a fresh zero-balance customer must be a policy deny, not allowed")
+		require.NotEmpty(t, resp.DenyCode, "a deny verdict must carry a DenyCode")
+
+		// SetCustomerSpendDelegations shares the transcription path (also pins via
+		// merchantCtx) through this exact runtime/provisioning setup.
+		err = client.SetCustomerSpendDelegations(ctx, customerID.String(), []openrails.SpendDelegationInput{{
+			Scope:    "invoker",
+			ScopeKey: "test-invoker",
+			Windows:  []openrails.SpendLimitWindow{{Key: "day", WindowSeconds: 86400, Limit: 5_000_000, Currency: "USD"}},
+		}})
+		require.NoError(t, err, "embedded SetCustomerSpendDelegations must pin the bound merchant itself")
+	})
+
+	t.Run("no merchant bound: 500 message names the real cause", func(t *testing.T) {
+		rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg}})
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = rt.Close(context.Background()) })
+		// Deliberately no UpsertMerchantConfig: merchantCtx has nothing to pin, so
+		// c.svc.Admit's merchant.Require(ctx) fails and the wrapped cause must
+		// show up in the message, not just the stable constant prefix.
+
+		client := rt.Client()
+		admitter, ok := client.(embed.SingleAdmitter)
+		require.True(t, ok)
+
+		_, err = admitter.Admit(ctx, openrails.AdmitRequest{
+			CustomerID:      "d8d8d8d8-0000-4000-8000-000000000042",
+			Invoker:         "test-invoker",
+			InvokerType:     openrails.InvokerTypePayer,
+			Currency:        "USD",
+			EstimatedAmount: 10_000,
+			Source:          "localclient-admit-test",
+			RequestID:       "localclient-admit-unbound",
+		})
+		require.Error(t, err)
+		var se *openrails.StatusError
+		require.True(t, errors.As(err, &se), "must be a *openrails.StatusError, got %T: %v", err, err)
+		require.Equal(t, 500, se.Status)
+		require.Contains(t, se.Message, "admission check failed", "stable prefix must be kept")
+		require.NotEqual(t, "admission check failed", se.Message, "the cause must be appended, not just the constant prefix")
+	})
+}


### PR DESCRIPTION
## Summary
Fixes #768: two bugs in `embed/client.go`'s permanent transcription (the pre-#685 tail).

- `localClient.Admit` called `c.svc.Admit(ctx, ...)` with the raw ctx while `Admitter.Admit` starts with `merchant.Require(ctx)`. Every embedded single-Admit call (`SingleAdmitter`, reachable via type assertion on `Runtime.Client()`) failed "merchant required" unless the host manually pinned via `openrails.WithMerchant` — `AdmitBatch` was unaffected since the in-process transport pins the merchant itself. `Admit` now uses `c.merchantCtx(ctx)` like `SetCustomerSpendDelegations` already does.
- Both transcribed methods (`Admit`, `SetCustomerSpendDelegations`) collapsed any service failure into a constant `internalErr("...failed")` 500 with the cause dropped. These errors never leave the process (in-process embedded path only), so the cause is now folded into the message (`wrapInternalErr`).
- Exported `embed.SingleAdmitter` (one-method interface) so the existing doc phrase "reachable via type assertion" has something concrete to assert to; referenced from `Runtime.Client`'s doc comment and the `localClient`/`Admit` doc comments.

## Test plan
- [x] New integration test `embed/localclient_admit_integration_test.go` (`-tags integration`), no mocks: builds the runtime through `embed.New` + `UpsertMerchantConfig` (normal provisioning), gets `rt.Client()`, type-asserts to `embed.SingleAdmitter`, issues a money-bearing single `Admit` (`EstimatedAmount: 10_000`, real customer UUID, `InvokerType: payer`) and asserts a policy-deny verdict (not an error) for a fresh zero-balance customer; also exercises `SetCustomerSpendDelegations` through the client.
- [x] A second subtest drives `Admit` with no merchant bound and asserts the 500 message names the real cause (not just the stable prefix) — pins the error-wrapping fix.
- [x] Verified RED on the pre-fix code: reverting just the `merchantCtx` line reproduces `openrails: status=500 admission check failed: merchant: no merchant resolved on context`.
- [x] Verified GREEN with the fix: `go test -tags integration ./embed/ -run 'TestLocalClientAdmit|TestConformance' -v` — both pass, conformance suite unaffected.
- [x] `go build ./...`, `go vet ./embed/...`, `gofmt -l` all clean.
- [x] Full `go test -tags integration ./embed/...` green.