### PR TITLE
fix(#767): remove hidden 2s deadline on embedded in-process client

### DIFF
--- a/embed/client.go
+++ b/embed/client.go
@@ -60,6 +60,10 @@ type localClient struct {
 	// currency is the default currency the unified client is built with
 	// (openrails.WithCurrency on the in-process remote).
 	currency string
+	// remoteOpts are host-supplied openrails.RemoteOption values (#767,
+	// WithRemoteOptions) applied to the in-process remote AFTER Runtime.Client's
+	// built-ins, so a host can override any remote knob (e.g. WithTimeout).
+	remoteOpts []openrails.RemoteOption
 }
 
 // merchantCtx replicates the transport's merchant pinning (transport.go) for
@@ -86,6 +90,15 @@ type ClientOption func(*localClient)
 // WithCurrency mirrors openrails.WithCurrency for the embedded client.
 func WithCurrency(currency string) ClientOption {
 	return func(c *localClient) { c.currency = strings.TrimSpace(currency) }
+}
+
+// WithRemoteOptions passes openrails.RemoteOption values straight through to
+// the in-process remote Runtime.Client builds, applied AFTER its built-ins
+// (transport, token provider, currency, timeout) — so a host can override any
+// remote knob (e.g. reinstate a per-call deadline via openrails.WithTimeout)
+// without embed re-exposing each one individually (#767).
+func WithRemoteOptions(opts ...openrails.RemoteOption) ClientOption {
+	return func(c *localClient) { c.remoteOpts = append(c.remoteOpts, opts...) }
 }
 
 // --- shared transcription helpers -----------------------------------------

--- a/embed/client_timeout_integration_test.go
+++ b/embed/client_timeout_integration_test.go
@@ -1,0 +1,81 @@
+//go:build integration
+
+package embed
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails"
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/pkg/embedded"
+)
+
+// TestInProcessClientHasNoHiddenTimeout proves #767: an in-process SDK call
+// through Runtime.Client is bounded ONLY by the caller's ctx, not a hidden 2s
+// per-request deadline. Before the fix, Runtime.Client built the in-process
+// remote without openrails.WithTimeout(0), so every call inherited remote.go's
+// default 2s context deadline regardless of the caller's own ctx.
+//
+// No mocks: a real competing pgx transaction holds a row lock on the
+// merchant's config row (the same row SetMerchantSettings's UPSERT must lock)
+// for ~3s. A generous (10s) caller ctx must let the call block on the real
+// lock and still succeed — which is impossible if a hidden 2s deadline fires
+// first.
+func TestInProcessClientHasNoHiddenTimeout(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+
+	pool, err := pgxpool.New(ctx, dsn)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	dbtest.EnsureTestMerchant(ctx, t, pool)
+
+	cfg := &config.Config{Env: "dev", TestMode: config.CredentialPostureLive, DB: &config.DBConfig{URL: dsn}}
+	rt, err := New(ctx, Options{Options: embedded.Options{Config: cfg}})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rt.Close(context.Background()) })
+	rt.emb.App().Runtime.SetConfiguredMerchant(dbtest.TestMerchantID)
+
+	c := rt.Client()
+
+	// Seed the merchant_configurations row so the competing FOR UPDATE below
+	// has a row to lock, and so the timed call below is an UPDATE (which needs
+	// the row lock) rather than a lock-free first INSERT.
+	require.NoError(t, c.SetMerchantSettings(ctx, openrails.MerchantSettings{}))
+
+	lockTx, err := pool.Begin(ctx)
+	require.NoError(t, err)
+	_, err = lockTx.Exec(ctx,
+		`SELECT 1 FROM openrails.merchant_configurations WHERE merchant_id = $1 FOR UPDATE`,
+		dbtest.TestMerchantID.UUID())
+	require.NoError(t, err)
+
+	const holdFor = 3 * time.Second
+	released := make(chan struct{})
+	go func() {
+		time.Sleep(holdFor)
+		_ = lockTx.Commit(context.Background())
+		close(released)
+	}()
+	t.Cleanup(func() { <-released })
+
+	// Generous caller ctx: comfortably longer than the row-lock hold, and MUCH
+	// longer than the pre-fix hidden 2s deadline this test is guarding against.
+	callCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err = c.SetMerchantSettings(callCtx, openrails.MerchantSettings{})
+	elapsed := time.Since(start)
+
+	require.NoError(t, err, "in-process call must succeed once the real row lock releases, "+
+		"bounded only by the caller ctx (not a hidden per-call deadline)")
+	require.GreaterOrEqual(t, elapsed, holdFor,
+		"call returned before the row lock was released — it did not actually block on the lock")
+}

--- a/embed/embed.go
+++ b/embed/embed.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"io/fs"
 	"net/http"
+	"sync"
 
 	"github.com/open-rails/openrails"
 	"github.com/open-rails/openrails/pkg/embedded"
@@ -95,6 +96,13 @@ type Runtime struct {
 
 	workersCancel context.CancelFunc
 	workersDone   chan error
+
+	// handlerOnce/handler memoize the in-process route mux (#767): it depends
+	// only on r.emb's *app.Runtime, never on per-Client() options, so building
+	// it once and reusing it across every Client() call avoids re-running
+	// RegisterServiceRoutes/RegisterImportRoutes on every call.
+	handlerOnce sync.Once
+	handler     http.Handler
 }
 
 // New builds the embedded runtime: the gin-free app graph (pkg/embedded.New),
@@ -142,6 +150,11 @@ func New(ctx context.Context, opts Options, options ...Option) (*Runtime, error)
 // the authz reasoning. The returned Client also always implements
 // SingleAdmitter (embedded-only single Admit, no wire counterpart) — reach it
 // via a type assertion.
+//
+// Built-in RemoteOptions (transport, token provider, currency, timeout) are
+// applied first; any host-supplied opts carrying WithRemoteOptions are applied
+// LAST, so a host can override any one of them (e.g. opt back into a deadline)
+// without embed re-exposing each knob individually.
 func (r *Runtime) Client(opts ...ClientOption) openrails.Client {
 	c := &localClient{svc: r.svc, rt: r.emb.App().Runtime}
 	for _, opt := range opts {
@@ -150,16 +163,21 @@ func (r *Runtime) Client(opts ...ClientOption) openrails.Client {
 		}
 	}
 	rt := r.emb.App().Runtime
-	transport := &inprocessTransport{handler: newServiceHandler(rt), rt: rt}
-	remote := openrails.NewRemote(inprocessBaseURL,
-		// No Timeout on the client: in-process calls are bounded by the caller's
-		// ctx, matching the old localClient behavior.
+	r.handlerOnce.Do(func() { r.handler = newServiceHandler(rt) })
+	transport := &inprocessTransport{handler: r.handler, rt: rt}
+	builtins := []openrails.RemoteOption{
 		openrails.WithHTTPClient(&http.Client{Transport: transport}),
 		// The credential is the context-attached host principal; the bearer is a
 		// placeholder the in-process gate never consults.
 		openrails.WithTokenProvider(func(context.Context) (string, error) { return "in-process-host", nil }),
 		openrails.WithCurrency(c.currency),
-	)
+		// In-process calls have no network hop to bound: disable the remote's
+		// default 2s per-call context deadline so calls are bounded ONLY by the
+		// caller's own ctx (#767 — the deadline previously fired regardless of
+		// the injected http.Client, silently truncating every embedded call).
+		openrails.WithTimeout(0),
+	}
+	remote := openrails.NewRemote(inprocessBaseURL, append(builtins, c.remoteOpts...)...)
 	return &unifiedClient{Client: remote, localClient: c}
 }
 


### PR DESCRIPTION
## Summary
- `Runtime.Client()` (embed/embed.go) built the in-process `openrails.NewRemote` without `openrails.WithTimeout(0)`. `NewRemote` defaults to a 2s timeout, enforced by `doRaw` as a per-request **context deadline** regardless of the injected `http.Client` — so every embedded in-process SDK call carried a hidden 2s deadline, contradicting the comment claiming calls were "bounded by the caller's ctx". Fixed by passing `WithTimeout(0)` and correcting the comment.
- `Runtime.Client` now accepts host-supplied `openrails.RemoteOption`s via a new `embed.WithRemoteOptions(...)` `ClientOption`, applied AFTER the built-ins (transport, token provider, currency, timeout) — hosts can override any remote knob (e.g. reinstate a deadline) without embed re-exposing each one. `embed.WithCurrency` keeps working unchanged (still lands on both `localClient.currency` and the remote via `openrails.WithCurrency`).
- Memoized the in-process route mux construction (`sync.Once` on `Runtime.handler`) so repeated `Client()` calls no longer rebuild the whole `RegisterServiceRoutes`/`RegisterImportRoutes` mux each time. Per-call `ClientOption`s (currency, remote options) are unaffected since they only affect the remote, not the handler.
- Added `embed/client_timeout_integration_test.go` (build tag `integration`, no mocks): a competing pgx transaction holds a `FOR UPDATE` lock on the merchant's config row for ~3s while a `SetMerchantSettings` call (10s caller ctx) blocks on the real row lock and must still succeed. Verified this test fails at ~2s against the old (unfixed) code and passes against the fix.

Fixes #767.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./embed/ .`
- [x] `go test -tags integration ./embed/... -timeout 15m` (full embed integration suite, green)
- [x] Manually reintroduced the old `WithTimeout(2*time.Second)` default and confirmed the new test fails (500 from the truncated in-flight DB query); reverted and confirmed green with the fix.