### PR TITLE
feat(#297 Phase A): CIT/MIT stored-credential framework + rail-agnostic charge seam

### DIFF
--- a/internal/db/gen/models.go
+++ b/internal/db/gen/models.go
@@ -717,6 +717,10 @@ type OpenrailsPaymentMethod struct {
 	// Instrument-scope rail handle (e.g. NMI billing_id, Stripe pm_, Spreedly/HyperSwitch token).
 	RailMethodRef string
 	RebillDriver  string
+	// Rail-scoped stored-credential replay reference for the RECURRING card-network agreement (NMI: gateway transactionid of the initial recurring CIT, replayed as initial_transaction_id on recurring MITs). Empty = not captured yet.
+	StoredCredentialRecurringRef string
+	// Rail-scoped stored-credential replay reference for the UNSCHEDULED card-network agreement (NMI: gateway transactionid of the initial unscheduled CIT, replayed as initial_transaction_id on unscheduled MITs). Empty = not captured yet.
+	StoredCredentialUnscheduledRef string
 }
 
 // Pricing tiers for products with rail-specific identifiers

--- a/internal/db/gen/payment_methods.sql.go
+++ b/internal/db/gen/payment_methods.sql.go
@@ -12,6 +12,90 @@ import (
 	"github.com/google/uuid"
 )
 
+const captureStoredCredentialRef = `-- name: CaptureStoredCredentialRef :execrows
+UPDATE openrails.payment_methods SET
+    stored_credential_recurring_ref = CASE
+        WHEN $1::text = 'recurring' THEN $2::text
+        ELSE stored_credential_recurring_ref END,
+    stored_credential_unscheduled_ref = CASE
+        WHEN $1::text = 'unscheduled' THEN $2::text
+        ELSE stored_credential_unscheduled_ref END,
+    updated_at = now()
+WHERE merchant_id = $3
+  AND id = $4
+  AND (($1::text = 'recurring' AND stored_credential_recurring_ref = '')
+    OR ($1::text = 'unscheduled' AND stored_credential_unscheduled_ref = ''))
+`
+
+type CaptureStoredCredentialRefParams struct {
+	Agreement  string
+	Ref        string
+	MerchantID uuid.UUID
+	ID         uuid.UUID
+}
+
+// #297: persist the rail-scoped stored-credential replay reference captured by
+// a successful charge, WRITE-ONCE per agreement type — an existing non-empty
+// reference is never overwritten (the sequence anchors on its first capture).
+func (q *Queries) CaptureStoredCredentialRef(ctx context.Context, arg CaptureStoredCredentialRefParams) (int64, error) {
+	result, err := q.db.Exec(ctx, captureStoredCredentialRef,
+		arg.Agreement,
+		arg.Ref,
+		arg.MerchantID,
+		arg.ID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const captureStoredCredentialRefByRailInstrument = `-- name: CaptureStoredCredentialRefByRailInstrument :execrows
+UPDATE openrails.payment_methods SET
+    stored_credential_recurring_ref = CASE
+        WHEN $1::text = 'recurring' THEN $2::text
+        ELSE stored_credential_recurring_ref END,
+    stored_credential_unscheduled_ref = CASE
+        WHEN $1::text = 'unscheduled' THEN $2::text
+        ELSE stored_credential_unscheduled_ref END,
+    updated_at = now()
+WHERE merchant_id = $3
+  AND rail = $4
+  AND rail_customer_ref = $5
+  AND (rail_method_ref = $6
+       OR $6::text = ''
+       OR rail_method_ref = '')
+  AND (($1::text = 'recurring' AND stored_credential_recurring_ref = '')
+    OR ($1::text = 'unscheduled' AND stored_credential_unscheduled_ref = ''))
+`
+
+type CaptureStoredCredentialRefByRailInstrumentParams struct {
+	Agreement       string
+	Ref             string
+	MerchantID      uuid.UUID
+	Rail            string
+	RailCustomerRef string
+	RailMethodRef   string
+}
+
+// #297: instrument-handle variant of CaptureStoredCredentialRef for charge
+// sites that never load the local row (checkout sale/subscription intents).
+// Same write-once semantics.
+func (q *Queries) CaptureStoredCredentialRefByRailInstrument(ctx context.Context, arg CaptureStoredCredentialRefByRailInstrumentParams) (int64, error) {
+	result, err := q.db.Exec(ctx, captureStoredCredentialRefByRailInstrument,
+		arg.Agreement,
+		arg.Ref,
+		arg.MerchantID,
+		arg.Rail,
+		arg.RailCustomerRef,
+		arg.RailMethodRef,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const countPaymentMethodForUser = `-- name: CountPaymentMethodForUser :one
 SELECT count(*) FROM openrails.payment_methods pm
 WHERE pm.id = $1 AND pm.customer_id = $2
@@ -138,7 +222,7 @@ func (q *Queries) DeletePaymentMethod(ctx context.Context, id uuid.UUID) (int64,
 }
 
 const getPaymentMethodByID = `-- name: GetPaymentMethodByID :one
-SELECT id, rail, initial_transaction_id, last_four, card_type, expiry_date, metadata, created_at, updated_at, merchant_id, customer_id, rail_merchant_account_id, rail_customer_ref, rail_method_ref, rebill_driver FROM openrails.payment_methods WHERE id = $1
+SELECT id, rail, initial_transaction_id, last_four, card_type, expiry_date, metadata, created_at, updated_at, merchant_id, customer_id, rail_merchant_account_id, rail_customer_ref, rail_method_ref, rebill_driver, stored_credential_recurring_ref, stored_credential_unscheduled_ref FROM openrails.payment_methods WHERE id = $1
 `
 
 func (q *Queries) GetPaymentMethodByID(ctx context.Context, id uuid.UUID) (OpenrailsPaymentMethod, error) {
@@ -160,12 +244,68 @@ func (q *Queries) GetPaymentMethodByID(ctx context.Context, id uuid.UUID) (Openr
 		&i.RailCustomerRef,
 		&i.RailMethodRef,
 		&i.RebillDriver,
+		&i.StoredCredentialRecurringRef,
+		&i.StoredCredentialUnscheduledRef,
+	)
+	return i, err
+}
+
+const getPaymentMethodByRailInstrument = `-- name: GetPaymentMethodByRailInstrument :one
+SELECT id, rail, initial_transaction_id, last_four, card_type, expiry_date, metadata, created_at, updated_at, merchant_id, customer_id, rail_merchant_account_id, rail_customer_ref, rail_method_ref, rebill_driver, stored_credential_recurring_ref, stored_credential_unscheduled_ref FROM openrails.payment_methods pm
+WHERE pm.merchant_id = $1
+  AND pm.rail = $2
+  AND pm.rail_customer_ref = $3
+  AND (pm.rail_method_ref = $4
+       OR $4::text = ''
+       OR pm.rail_method_ref = '')
+ORDER BY pm.created_at
+LIMIT 1
+`
+
+type GetPaymentMethodByRailInstrumentParams struct {
+	MerchantID      uuid.UUID
+	Rail            string
+	RailCustomerRef string
+	RailMethodRef   string
+}
+
+// #297: resolve the stored instrument for a charge that only knows the rail
+// handles (checkout intents carry vault/billing ids, not the local row id).
+// One-vault-per-card minting (#682) makes rail_customer_ref alone decisive for
+// NMI; the method-ref predicate narrows within shared (imported) vaults and is
+// skipped when either side has no billing id.
+func (q *Queries) GetPaymentMethodByRailInstrument(ctx context.Context, arg GetPaymentMethodByRailInstrumentParams) (OpenrailsPaymentMethod, error) {
+	row := q.db.QueryRow(ctx, getPaymentMethodByRailInstrument,
+		arg.MerchantID,
+		arg.Rail,
+		arg.RailCustomerRef,
+		arg.RailMethodRef,
+	)
+	var i OpenrailsPaymentMethod
+	err := row.Scan(
+		&i.ID,
+		&i.Rail,
+		&i.InitialTransactionID,
+		&i.LastFour,
+		&i.CardType,
+		&i.ExpiryDate,
+		&i.Metadata,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.MerchantID,
+		&i.CustomerID,
+		&i.RailMerchantAccountID,
+		&i.RailCustomerRef,
+		&i.RailMethodRef,
+		&i.RebillDriver,
+		&i.StoredCredentialRecurringRef,
+		&i.StoredCredentialUnscheduledRef,
 	)
 	return i, err
 }
 
 const getPaymentMethodByRailMethodRef = `-- name: GetPaymentMethodByRailMethodRef :one
-SELECT id, rail, initial_transaction_id, last_four, card_type, expiry_date, metadata, created_at, updated_at, merchant_id, customer_id, rail_merchant_account_id, rail_customer_ref, rail_method_ref, rebill_driver FROM openrails.payment_methods pm
+SELECT id, rail, initial_transaction_id, last_four, card_type, expiry_date, metadata, created_at, updated_at, merchant_id, customer_id, rail_merchant_account_id, rail_customer_ref, rail_method_ref, rebill_driver, stored_credential_recurring_ref, stored_credential_unscheduled_ref FROM openrails.payment_methods pm
 WHERE pm.rail = $1 AND pm.rail_method_ref = $2
 LIMIT 1
 `
@@ -194,6 +334,8 @@ func (q *Queries) GetPaymentMethodByRailMethodRef(ctx context.Context, arg GetPa
 		&i.RailCustomerRef,
 		&i.RailMethodRef,
 		&i.RebillDriver,
+		&i.StoredCredentialRecurringRef,
+		&i.StoredCredentialUnscheduledRef,
 	)
 	return i, err
 }
@@ -240,7 +382,7 @@ func (q *Queries) ListLatestChargeByPaymentMethodIDs(ctx context.Context, ids []
 }
 
 const listPaymentMethodsByCustomer = `-- name: ListPaymentMethodsByCustomer :many
-SELECT id, rail, initial_transaction_id, last_four, card_type, expiry_date, metadata, created_at, updated_at, merchant_id, customer_id, rail_merchant_account_id, rail_customer_ref, rail_method_ref, rebill_driver FROM openrails.payment_methods pm
+SELECT id, rail, initial_transaction_id, last_four, card_type, expiry_date, metadata, created_at, updated_at, merchant_id, customer_id, rail_merchant_account_id, rail_customer_ref, rail_method_ref, rebill_driver, stored_credential_recurring_ref, stored_credential_unscheduled_ref FROM openrails.payment_methods pm
 WHERE pm.customer_id = $1
 ORDER BY pm.created_at DESC
 `
@@ -270,6 +412,8 @@ func (q *Queries) ListPaymentMethodsByCustomer(ctx context.Context, customerID u
 			&i.RailCustomerRef,
 			&i.RailMethodRef,
 			&i.RebillDriver,
+			&i.StoredCredentialRecurringRef,
+			&i.StoredCredentialUnscheduledRef,
 		); err != nil {
 			return nil, err
 		}
@@ -282,7 +426,7 @@ func (q *Queries) ListPaymentMethodsByCustomer(ctx context.Context, customerID u
 }
 
 const listPaymentMethodsByCustomerPaged = `-- name: ListPaymentMethodsByCustomerPaged :many
-SELECT id, rail, initial_transaction_id, last_four, card_type, expiry_date, metadata, created_at, updated_at, merchant_id, customer_id, rail_merchant_account_id, rail_customer_ref, rail_method_ref, rebill_driver FROM openrails.payment_methods pm
+SELECT id, rail, initial_transaction_id, last_four, card_type, expiry_date, metadata, created_at, updated_at, merchant_id, customer_id, rail_merchant_account_id, rail_customer_ref, rail_method_ref, rebill_driver, stored_credential_recurring_ref, stored_credential_unscheduled_ref FROM openrails.payment_methods pm
 WHERE pm.customer_id = $1
 ORDER BY pm.created_at DESC
 LIMIT NULLIF($3::int, 0) OFFSET $2::int
@@ -319,6 +463,8 @@ func (q *Queries) ListPaymentMethodsByCustomerPaged(ctx context.Context, arg Lis
 			&i.RailCustomerRef,
 			&i.RailMethodRef,
 			&i.RebillDriver,
+			&i.StoredCredentialRecurringRef,
+			&i.StoredCredentialUnscheduledRef,
 		); err != nil {
 			return nil, err
 		}
@@ -331,7 +477,7 @@ func (q *Queries) ListPaymentMethodsByCustomerPaged(ctx context.Context, arg Lis
 }
 
 const listPaymentMethodsByCustomerRails = `-- name: ListPaymentMethodsByCustomerRails :many
-SELECT id, rail, initial_transaction_id, last_four, card_type, expiry_date, metadata, created_at, updated_at, merchant_id, customer_id, rail_merchant_account_id, rail_customer_ref, rail_method_ref, rebill_driver FROM openrails.payment_methods pm
+SELECT id, rail, initial_transaction_id, last_four, card_type, expiry_date, metadata, created_at, updated_at, merchant_id, customer_id, rail_merchant_account_id, rail_customer_ref, rail_method_ref, rebill_driver, stored_credential_recurring_ref, stored_credential_unscheduled_ref FROM openrails.payment_methods pm
 WHERE pm.customer_id = $1
   AND pm.rail = ANY($2::text[])
 ORDER BY pm.created_at DESC
@@ -367,6 +513,8 @@ func (q *Queries) ListPaymentMethodsByCustomerRails(ctx context.Context, arg Lis
 			&i.RailCustomerRef,
 			&i.RailMethodRef,
 			&i.RebillDriver,
+			&i.StoredCredentialRecurringRef,
+			&i.StoredCredentialUnscheduledRef,
 		); err != nil {
 			return nil, err
 		}
@@ -379,7 +527,7 @@ func (q *Queries) ListPaymentMethodsByCustomerRails(ctx context.Context, arg Lis
 }
 
 const listPaymentMethodsByIDs = `-- name: ListPaymentMethodsByIDs :many
-SELECT id, rail, initial_transaction_id, last_four, card_type, expiry_date, metadata, created_at, updated_at, merchant_id, customer_id, rail_merchant_account_id, rail_customer_ref, rail_method_ref, rebill_driver FROM openrails.payment_methods WHERE id = ANY($1::uuid[])
+SELECT id, rail, initial_transaction_id, last_four, card_type, expiry_date, metadata, created_at, updated_at, merchant_id, customer_id, rail_merchant_account_id, rail_customer_ref, rail_method_ref, rebill_driver, stored_credential_recurring_ref, stored_credential_unscheduled_ref FROM openrails.payment_methods WHERE id = ANY($1::uuid[])
 `
 
 func (q *Queries) ListPaymentMethodsByIDs(ctx context.Context, ids []uuid.UUID) ([]OpenrailsPaymentMethod, error) {
@@ -407,6 +555,8 @@ func (q *Queries) ListPaymentMethodsByIDs(ctx context.Context, ids []uuid.UUID) 
 			&i.RailCustomerRef,
 			&i.RailMethodRef,
 			&i.RebillDriver,
+			&i.StoredCredentialRecurringRef,
+			&i.StoredCredentialUnscheduledRef,
 		); err != nil {
 			return nil, err
 		}
@@ -419,7 +569,7 @@ func (q *Queries) ListPaymentMethodsByIDs(ctx context.Context, ids []uuid.UUID) 
 }
 
 const listPaymentMethodsByRail = `-- name: ListPaymentMethodsByRail :many
-SELECT id, rail, initial_transaction_id, last_four, card_type, expiry_date, metadata, created_at, updated_at, merchant_id, customer_id, rail_merchant_account_id, rail_customer_ref, rail_method_ref, rebill_driver FROM openrails.payment_methods pm
+SELECT id, rail, initial_transaction_id, last_four, card_type, expiry_date, metadata, created_at, updated_at, merchant_id, customer_id, rail_merchant_account_id, rail_customer_ref, rail_method_ref, rebill_driver, stored_credential_recurring_ref, stored_credential_unscheduled_ref FROM openrails.payment_methods pm
 WHERE pm.rail = $1
 ORDER BY pm.created_at DESC
 `
@@ -449,6 +599,8 @@ func (q *Queries) ListPaymentMethodsByRail(ctx context.Context, rail string) ([]
 			&i.RailCustomerRef,
 			&i.RailMethodRef,
 			&i.RebillDriver,
+			&i.StoredCredentialRecurringRef,
+			&i.StoredCredentialUnscheduledRef,
 		); err != nil {
 			return nil, err
 		}
@@ -461,7 +613,7 @@ func (q *Queries) ListPaymentMethodsByRail(ctx context.Context, rail string) ([]
 }
 
 const listPaymentMethodsByRails = `-- name: ListPaymentMethodsByRails :many
-SELECT id, rail, initial_transaction_id, last_four, card_type, expiry_date, metadata, created_at, updated_at, merchant_id, customer_id, rail_merchant_account_id, rail_customer_ref, rail_method_ref, rebill_driver FROM openrails.payment_methods pm
+SELECT id, rail, initial_transaction_id, last_four, card_type, expiry_date, metadata, created_at, updated_at, merchant_id, customer_id, rail_merchant_account_id, rail_customer_ref, rail_method_ref, rebill_driver, stored_credential_recurring_ref, stored_credential_unscheduled_ref FROM openrails.payment_methods pm
 WHERE pm.rail = ANY($1::text[])
 ORDER BY pm.created_at DESC
 `
@@ -491,6 +643,8 @@ func (q *Queries) ListPaymentMethodsByRails(ctx context.Context, rails []string)
 			&i.RailCustomerRef,
 			&i.RailMethodRef,
 			&i.RebillDriver,
+			&i.StoredCredentialRecurringRef,
+			&i.StoredCredentialUnscheduledRef,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/models/genmap.go
+++ b/internal/db/models/genmap.go
@@ -260,6 +260,9 @@ func PaymentMethodFromGen(p gen.OpenrailsPaymentMethod) (*PaymentMethod, error) 
 		ExpiryDate:            p.ExpiryDate,
 		CreatedAt:             p.CreatedAt,
 		UpdatedAt:             p.UpdatedAt,
+
+		StoredCredentialRecurringRef:   p.StoredCredentialRecurringRef,
+		StoredCredentialUnscheduledRef: p.StoredCredentialUnscheduledRef,
 	}
 	if err := FromJSONB(p.Metadata, &m.Metadata, "payment_methods.metadata"); err != nil {
 		return nil, err

--- a/internal/db/models/payment_method.go
+++ b/internal/db/models/payment_method.go
@@ -37,6 +37,16 @@ type PaymentMethod struct {
 	// which made an identity field load-bearing as a behavior flag.
 	RebillDriver string `json:"-"`
 
+	// Stored-credential (CIT/MIT) replay references (#297), one per card-network
+	// agreement type — the networks track separate credential-on-file sequences
+	// for recurring vs unscheduled charges and the references are not
+	// interchangeable. Rail-scoped value (NMI: the gateway transactionid of the
+	// sequence's initial CIT, replayed as initial_transaction_id on MITs).
+	// "" = not captured yet (legacy instrument, or no charge on that agreement
+	// type); captures are write-once (CaptureStoredCredentialRef).
+	StoredCredentialRecurringRef   string `json:"-"`
+	StoredCredentialUnscheduledRef string `json:"-"`
+
 	// Payment method metadata
 	LastFour   *string        `json:"last_four"`   // Last 4 digits of card
 	CardType   *string        `json:"card_type"`   // "Visa", "MasterCard", etc.

--- a/internal/db/queries/payment_methods.sql
+++ b/internal/db/queries/payment_methods.sql
@@ -101,3 +101,57 @@ WHERE rail = $1
   AND rail_customer_ref = sqlc.arg(rail_customer_ref)
   AND rail_customer_ref <> ''
   AND id <> sqlc.arg(exclude_id);
+
+-- name: GetPaymentMethodByRailInstrument :one
+-- #297: resolve the stored instrument for a charge that only knows the rail
+-- handles (checkout intents carry vault/billing ids, not the local row id).
+-- One-vault-per-card minting (#682) makes rail_customer_ref alone decisive for
+-- NMI; the method-ref predicate narrows within shared (imported) vaults and is
+-- skipped when either side has no billing id.
+SELECT * FROM openrails.payment_methods pm
+WHERE pm.merchant_id = sqlc.arg(merchant_id)
+  AND pm.rail = sqlc.arg(rail)
+  AND pm.rail_customer_ref = sqlc.arg(rail_customer_ref)
+  AND (pm.rail_method_ref = sqlc.arg(rail_method_ref)
+       OR sqlc.arg(rail_method_ref)::text = ''
+       OR pm.rail_method_ref = '')
+ORDER BY pm.created_at
+LIMIT 1;
+
+-- name: CaptureStoredCredentialRef :execrows
+-- #297: persist the rail-scoped stored-credential replay reference captured by
+-- a successful charge, WRITE-ONCE per agreement type — an existing non-empty
+-- reference is never overwritten (the sequence anchors on its first capture).
+UPDATE openrails.payment_methods SET
+    stored_credential_recurring_ref = CASE
+        WHEN sqlc.arg(agreement)::text = 'recurring' THEN sqlc.arg(ref)::text
+        ELSE stored_credential_recurring_ref END,
+    stored_credential_unscheduled_ref = CASE
+        WHEN sqlc.arg(agreement)::text = 'unscheduled' THEN sqlc.arg(ref)::text
+        ELSE stored_credential_unscheduled_ref END,
+    updated_at = now()
+WHERE merchant_id = sqlc.arg(merchant_id)
+  AND id = sqlc.arg(id)
+  AND ((sqlc.arg(agreement)::text = 'recurring' AND stored_credential_recurring_ref = '')
+    OR (sqlc.arg(agreement)::text = 'unscheduled' AND stored_credential_unscheduled_ref = ''));
+
+-- name: CaptureStoredCredentialRefByRailInstrument :execrows
+-- #297: instrument-handle variant of CaptureStoredCredentialRef for charge
+-- sites that never load the local row (checkout sale/subscription intents).
+-- Same write-once semantics.
+UPDATE openrails.payment_methods SET
+    stored_credential_recurring_ref = CASE
+        WHEN sqlc.arg(agreement)::text = 'recurring' THEN sqlc.arg(ref)::text
+        ELSE stored_credential_recurring_ref END,
+    stored_credential_unscheduled_ref = CASE
+        WHEN sqlc.arg(agreement)::text = 'unscheduled' THEN sqlc.arg(ref)::text
+        ELSE stored_credential_unscheduled_ref END,
+    updated_at = now()
+WHERE merchant_id = sqlc.arg(merchant_id)
+  AND rail = sqlc.arg(rail)
+  AND rail_customer_ref = sqlc.arg(rail_customer_ref)
+  AND (rail_method_ref = sqlc.arg(rail_method_ref)
+       OR sqlc.arg(rail_method_ref)::text = ''
+       OR rail_method_ref = '')
+  AND ((sqlc.arg(agreement)::text = 'recurring' AND stored_credential_recurring_ref = '')
+    OR (sqlc.arg(agreement)::text = 'unscheduled' AND stored_credential_unscheduled_ref = ''));

--- a/internal/integrations/nmi/payments.go
+++ b/internal/integrations/nmi/payments.go
@@ -22,6 +22,10 @@ type SaleParams struct {
 	Currency         string
 	OrderDescription string
 	OrderID          string
+	// StoredCredential carries the CIT/MIT credential-on-file fields (#297).
+	// Non-nil routes the sale through classic Direct Post — the lane the NMI
+	// portal documents the fields on. nil preserves the legacy shape.
+	StoredCredential *StoredCredential
 }
 
 type SaleResponse struct {
@@ -76,9 +80,17 @@ func (c *NMIClient) RunSale(params SaleParams) (*SaleResponse, error) {
 	if len(params.OrderID) > 50 {
 		return nil, fmt.Errorf("order id %q exceeds NMI's 50-character limit", params.OrderID)
 	}
+	if err := params.StoredCredential.validate(); err != nil {
+		return nil, err
+	}
 
-	if billingID := strings.TrimSpace(params.BillingID); billingID != "" {
-		return c.runClassicTargetedSale(params, currency, orderDesc, billingID)
+	// Stored-credential (CIT/MIT) sales go classic DELIBERATELY (#297): the
+	// integration portal documents initiated_by / stored_credential_indicator /
+	// initial_transaction_id on the Direct Post variables (v5 nests them under
+	// cit_mit, but the classic vault-sale lane is the one already live-verified
+	// here — billing-targeted sales and dunning rebills ride it today).
+	if billingID := strings.TrimSpace(params.BillingID); billingID != "" || params.StoredCredential != nil {
+		return c.runClassicSale(params, currency, orderDesc, billingID)
 	}
 
 	req := v5PaymentRequest{
@@ -103,22 +115,26 @@ func (c *NMIClient) RunSale(params SaleParams) (*SaleResponse, error) {
 	}, nil
 }
 
-// runClassicTargetedSale charges ONE specific billing entry of a vault via
-// classic Direct Post (type=sale + customer_vault_id + billing_id) — see the
-// RunSale doc for why v5 cannot do this.
-func (c *NMIClient) runClassicTargetedSale(params SaleParams, currency, orderDesc, billingID string) (*SaleResponse, error) {
+// runClassicSale charges a vault via classic Direct Post (type=sale +
+// customer_vault_id): billingID targets ONE specific billing entry (see the
+// RunSale doc for why v5 cannot do this); "" charges the priority-1 entry.
+// Stored-credential fields ride this lane (#297).
+func (c *NMIClient) runClassicSale(params SaleParams, currency, orderDesc, billingID string) (*SaleResponse, error) {
 	values := url.Values{
 		"type":              {"sale"},
 		"security_key":      {c.SecurityKey},
 		"customer_vault_id": {params.CustomerVaultID},
-		"billing_id":        {billingID},
 		"amount":            {string(centsJSONAmount(params.Amount))},
 		"currency":          {currency},
 		"order_description": {orderDesc},
 	}
+	if billingID != "" {
+		values.Set("billing_id", billingID)
+	}
 	if params.OrderID != "" {
 		values.Set("orderid", params.OrderID)
 	}
+	params.StoredCredential.applyToForm(values)
 
 	response, err := c.sendDirectRequest(values)
 	if err != nil {

--- a/internal/integrations/nmi/stored_credential.go
+++ b/internal/integrations/nmi/stored_credential.go
@@ -1,0 +1,75 @@
+package nmi
+
+import (
+	"errors"
+	"net/url"
+)
+
+// StoredCredential carries NMI's credential-on-file (CIT/MIT) wire fields,
+// verified verbatim against the NMI integration portal ("Credential on File
+// Information", 2026-07-06):
+//
+//	initiated_by                customer | merchant
+//	stored_credential_indicator stored | used        (SINGULAR "credential")
+//	initial_transaction_id      the gateway transactionid of the sequence's
+//	                            initial CIT — NMI's own id, which the gateway
+//	                            maps to the network transaction identifier
+//	                            internally; never a raw network NTID
+//	billing_method              recurring — sent on recurring-agreement charges
+//	                            only; unscheduled CoF sends NO billing_method
+//
+// The portal's canonical combinations:
+//
+//	recurring initial CIT:  billing_method=recurring initiated_by=customer stored_credential_indicator=stored
+//	recurring MIT:          billing_method=recurring initiated_by=merchant stored_credential_indicator=used initial_transaction_id=…
+//	unscheduled initial CIT:                         initiated_by=customer stored_credential_indicator=stored
+//	unscheduled CIT reuse:                           initiated_by=customer stored_credential_indicator=used
+//	unscheduled MIT:                                 initiated_by=merchant stored_credential_indicator=used initial_transaction_id=…
+//
+// References do NOT cross agreement types ("This transaction ID cannot be
+// used for 'unscheduled' … credential-on-file transactions").
+type StoredCredential struct {
+	InitiatedBy          string // "customer" | "merchant"
+	Indicator            string // "stored" | "used"
+	InitialTransactionID string // "" on initial transactions and legacy reference-less charges
+	// Recurring: stamp billing_method=recurring (recurring-agreement charge).
+	// False = unscheduled credential-on-file: no billing_method on the wire.
+	Recurring bool
+}
+
+// StoredCredential wire values.
+const (
+	InitiatedByCustomer = "customer"
+	InitiatedByMerchant = "merchant"
+	IndicatorStored     = "stored"
+	IndicatorUsed       = "used"
+)
+
+func (sc *StoredCredential) validate() error {
+	if sc == nil {
+		return nil
+	}
+	if sc.InitiatedBy != InitiatedByCustomer && sc.InitiatedBy != InitiatedByMerchant {
+		return errors.New("stored credential initiated_by must be customer or merchant")
+	}
+	if sc.Indicator != IndicatorStored && sc.Indicator != IndicatorUsed {
+		return errors.New("stored credential indicator must be stored or used")
+	}
+	return nil
+}
+
+// applyToForm stamps the credential-on-file fields onto a classic Direct Post
+// form. nil = caller sends no stored-credential data (legacy shape).
+func (sc *StoredCredential) applyToForm(values url.Values) {
+	if sc == nil {
+		return
+	}
+	values.Set("initiated_by", sc.InitiatedBy)
+	values.Set("stored_credential_indicator", sc.Indicator)
+	if sc.InitialTransactionID != "" {
+		values.Set("initial_transaction_id", sc.InitialTransactionID)
+	}
+	if sc.Recurring {
+		values.Set("billing_method", "recurring")
+	}
+}

--- a/internal/integrations/nmi/stored_credential_sandbox_integration_test.go
+++ b/internal/integrations/nmi/stored_credential_sandbox_integration_test.go
@@ -1,0 +1,98 @@
+//go:build integration
+
+package nmi
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/shared/moneyutil"
+)
+
+// TestLiveSandboxStoredCredentialCITThenMIT is the #297 live proof against the
+// REAL NMI sandbox (opt-in via NMI_SANDBOX_SECURITY_KEY; skips otherwise):
+//
+//  1. the initial cardholder-initiated charge carries the portal's unscheduled
+//     initial-CIT fields (initiated_by=customer +
+//     stored_credential_indicator=stored) and the gateway APPROVES it,
+//     returning the transactionid that becomes the sequence anchor;
+//  2. a merchant-initiated charge replaying that anchor
+//     (initiated_by=merchant + stored_credential_indicator=used +
+//     initial_transaction_id=<CIT txn>) is APPROVED — the gateway accepts
+//     NMI's own transaction id as the stored-credential reference, exactly as
+//     the docs specify (no raw network NTID anywhere).
+func TestLiveSandboxStoredCredentialCITThenMIT(t *testing.T) {
+	key := strings.TrimSpace(os.Getenv("NMI_SANDBOX_SECURITY_KEY"))
+	if key == "" {
+		t.Skip("NMI_SANDBOX_SECURITY_KEY not set; skipping live sandbox stored-credential proof (#297)")
+	}
+
+	client, err := NewClient("live-sandbox", &config.NMIProviderSettings{SecurityKey: key}, true)
+	require.NoError(t, err)
+	require.Equal(t, DefaultDirectPostURL, client.DirectPostURL, "must hit the real gateway, not a stub")
+
+	// Vault the standard test card (raw-PAN classic shortcut — production
+	// vaulting takes a Collect.js token; see TestLiveSandboxClientSurface).
+	form := url.Values{
+		"security_key":   {key},
+		"customer_vault": {"add_customer"},
+		"ccnumber":       {"4111111111111111"},
+		"ccexp":          {"1029"},
+		"first_name":     {"StoredCred"},
+		"last_name":      {"Probe297"},
+	}
+	resp, err := http.PostForm(client.DirectPostURL, form)
+	require.NoError(t, err)
+	body := make([]byte, 4096)
+	n, _ := resp.Body.Read(body)
+	_ = resp.Body.Close()
+	vals, err := url.ParseQuery(string(body[:n]))
+	require.NoError(t, err)
+	vaultID := vals.Get("customer_vault_id")
+	require.NotEmpty(t, vaultID, "sandbox vault create failed: %s", string(body[:n]))
+	t.Cleanup(func() {
+		_ = client.DeleteCustomerVault(DeleteCustomerVaultData{CustomerVaultID: vaultID})
+	})
+
+	// Randomize inside the simulator's approving band (>= $1.00) so repeated
+	// runs dodge duplicate-transaction detection.
+	amount := moneyutil.Cents(110 + time.Now().UnixNano()%80)
+
+	// Leg 1 — initial CIT (unscheduled sequence anchor).
+	cit, err := client.RunSale(SaleParams{
+		CustomerVaultID:  vaultID,
+		Amount:           amount,
+		Currency:         "USD",
+		OrderDescription: "openrails #297 CIT probe",
+		StoredCredential: &StoredCredential{
+			InitiatedBy: InitiatedByCustomer,
+			Indicator:   IndicatorStored,
+		},
+	})
+	require.NoError(t, err, "sandbox must approve the initial CIT carrying stored-credential fields")
+	require.NotEmpty(t, cit.TransactionID)
+	t.Logf("CIT approved: transactionid=%s (the stored-credential anchor)", cit.TransactionID)
+
+	// Leg 2 — MIT replaying the anchor as initial_transaction_id.
+	mit, err := client.RunSale(SaleParams{
+		CustomerVaultID:  vaultID,
+		Amount:           amount + 1,
+		Currency:         "USD",
+		OrderDescription: "openrails #297 MIT probe",
+		StoredCredential: &StoredCredential{
+			InitiatedBy:          InitiatedByMerchant,
+			Indicator:            IndicatorUsed,
+			InitialTransactionID: cit.TransactionID,
+		},
+	})
+	require.NoError(t, err, "sandbox must approve the MIT replaying the CIT transactionid as initial_transaction_id")
+	require.NotEmpty(t, mit.TransactionID)
+	t.Logf("MIT approved: transactionid=%s (anchored on %s)", mit.TransactionID, cit.TransactionID)
+}

--- a/internal/integrations/nmi/stored_credential_wire_test.go
+++ b/internal/integrations/nmi/stored_credential_wire_test.go
@@ -1,0 +1,203 @@
+package nmi
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/open-rails/openrails/internal/shared/moneyutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Wire-pinning tests for the #297 stored-credential (CIT/MIT) fields: a
+// charge.Context-derived StoredCredential in ⇒ EXACTLY the portal-documented
+// classic Direct Post fields out (initiated_by / stored_credential_indicator /
+// initial_transaction_id / billing_method).
+
+// classicFormServer records every classic Direct Post form and answers an
+// approved sale.
+func classicFormServer(t *testing.T) (*httptest.Server, *[]url.Values) {
+	t.Helper()
+	forms := &[]url.Values{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		*forms = append(*forms, r.Form)
+		fmt.Fprint(w, "response=1&responsetext=SUCCESS&authcode=OK&transactionid=txn-wire-1&response_code=100")
+	}))
+	t.Cleanup(server.Close)
+	return server, forms
+}
+
+func lastForm(t *testing.T, forms *[]url.Values) url.Values {
+	t.Helper()
+	require.NotEmpty(t, *forms)
+	return (*forms)[len(*forms)-1]
+}
+
+func TestRunSale_StoredCredentialRoutesClassicWithCITFields(t *testing.T) {
+	server, forms := classicFormServer(t)
+	client := newTestClient(t, server.URL)
+
+	// Unscheduled initial CIT: indicator=stored, no reference, NO billing_method.
+	_, err := client.RunSale(SaleParams{
+		CustomerVaultID: "v1",
+		Amount:          moneyutil.Cents(1999),
+		Currency:        "USD",
+		OrderID:         "o1",
+		StoredCredential: &StoredCredential{
+			InitiatedBy: InitiatedByCustomer,
+			Indicator:   IndicatorStored,
+		},
+	})
+	require.NoError(t, err)
+	form := lastForm(t, forms)
+	assert.Equal(t, "sale", form.Get("type"), "stored-credential sales ride classic Direct Post")
+	assert.Equal(t, "v1", form.Get("customer_vault_id"))
+	assert.Equal(t, "customer", form.Get("initiated_by"))
+	assert.Equal(t, "stored", form.Get("stored_credential_indicator"))
+	_, hasInitial := form["initial_transaction_id"]
+	assert.False(t, hasInitial, "initial CIT carries no initial_transaction_id")
+	_, hasBillingMethod := form["billing_method"]
+	assert.False(t, hasBillingMethod, "unscheduled CoF sends no billing_method")
+	assert.Equal(t, "19.99", form.Get("amount"))
+}
+
+func TestRunSale_StoredCredentialMITCarriesReference(t *testing.T) {
+	server, forms := classicFormServer(t)
+	client := newTestClient(t, server.URL)
+
+	// Unscheduled MIT: merchant + used + the sequence anchor.
+	_, err := client.RunSale(SaleParams{
+		CustomerVaultID: "v1",
+		BillingID:       "b1",
+		Amount:          moneyutil.Cents(500),
+		Currency:        "USD",
+		OrderID:         "o2",
+		StoredCredential: &StoredCredential{
+			InitiatedBy:          InitiatedByMerchant,
+			Indicator:            IndicatorUsed,
+			InitialTransactionID: "1234567890",
+		},
+	})
+	require.NoError(t, err)
+	form := lastForm(t, forms)
+	assert.Equal(t, "merchant", form.Get("initiated_by"))
+	assert.Equal(t, "used", form.Get("stored_credential_indicator"))
+	assert.Equal(t, "1234567890", form.Get("initial_transaction_id"))
+	assert.Equal(t, "b1", form.Get("billing_id"), "targeted MIT still scopes the exact card")
+	_, hasBillingMethod := form["billing_method"]
+	assert.False(t, hasBillingMethod, "unscheduled MIT sends no billing_method")
+}
+
+func TestRunSale_StoredCredentialValidation(t *testing.T) {
+	server, _ := classicFormServer(t)
+	client := newTestClient(t, server.URL)
+
+	_, err := client.RunSale(SaleParams{
+		CustomerVaultID:  "v1",
+		Amount:           moneyutil.Cents(100),
+		Currency:         "USD",
+		StoredCredential: &StoredCredential{InitiatedBy: "robot", Indicator: IndicatorUsed},
+	})
+	require.ErrorContains(t, err, "initiated_by")
+
+	_, err = client.RunSale(SaleParams{
+		CustomerVaultID:  "v1",
+		Amount:           moneyutil.Cents(100),
+		Currency:         "USD",
+		StoredCredential: &StoredCredential{InitiatedBy: InitiatedByCustomer, Indicator: "maybe"},
+	})
+	require.ErrorContains(t, err, "indicator")
+}
+
+func TestAddRecurringSubscription_StoredCredentialRecurringCIT(t *testing.T) {
+	var form url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		form = r.Form
+		fmt.Fprint(w, "response=1&responsetext=SUCCESS&subscription_id=sub1&transactionid=t3")
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	_, err := client.AddRecurringSubscription(RecurringPaymentData{
+		PlanID:          "plan1",
+		CustomerVaultID: "v1",
+		Currency:        "USD",
+		Amount:          moneyutil.MajorUnits(19.99),
+		StoredCredential: &StoredCredential{
+			InitiatedBy: InitiatedByCustomer,
+			Indicator:   IndicatorStored,
+			Recurring:   true,
+		},
+	})
+	require.NoError(t, err)
+	// The portal's recurring initial CIT MUST-INCLUDE trio:
+	assert.Equal(t, "recurring", form.Get("billing_method"))
+	assert.Equal(t, "customer", form.Get("initiated_by"))
+	assert.Equal(t, "stored", form.Get("stored_credential_indicator"))
+	_, hasInitial := form["initial_transaction_id"]
+	assert.False(t, hasInitial)
+}
+
+func TestAttemptManualRebill_StoredCredentialRecurringMIT(t *testing.T) {
+	var form url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		form = r.Form
+		fmt.Fprint(w, "response=1&transactionid=t4")
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	resp, err := client.AttemptManualRebill(ManualRebillParams{
+		VaultID:        "v1",
+		BillingID:      "b1",
+		SubscriptionID: "sub1",
+		OrderID:        "ord1",
+		StoredCredential: &StoredCredential{
+			InitiatedBy:          InitiatedByMerchant,
+			Indicator:            IndicatorUsed,
+			InitialTransactionID: "9876543210",
+			Recurring:            true,
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, resp.Success)
+	// The portal's recurring MIT combination:
+	assert.Equal(t, "rebill_subscription", form.Get("recurring"))
+	assert.Equal(t, "recurring", form.Get("billing_method"))
+	assert.Equal(t, "merchant", form.Get("initiated_by"))
+	assert.Equal(t, "used", form.Get("stored_credential_indicator"))
+	assert.Equal(t, "9876543210", form.Get("initial_transaction_id"))
+}
+
+func TestAttemptManualRebill_LegacyReferenceLessMITOmitsInitialTransactionID(t *testing.T) {
+	var form url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		form = r.Form
+		fmt.Fprint(w, "response=1&transactionid=t5")
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	_, err := client.AttemptManualRebill(ManualRebillParams{
+		VaultID:        "v1",
+		BillingID:      "b1",
+		SubscriptionID: "sub1",
+		StoredCredential: &StoredCredential{
+			InitiatedBy: InitiatedByMerchant,
+			Indicator:   IndicatorUsed,
+			Recurring:   true,
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "merchant", form.Get("initiated_by"))
+	assert.Equal(t, "used", form.Get("stored_credential_indicator"))
+	_, hasInitial := form["initial_transaction_id"]
+	assert.False(t, hasInitial, "legacy instrument charges reference-less; the key is omitted, never sent empty")
+}

--- a/internal/integrations/nmi/subscriptions.go
+++ b/internal/integrations/nmi/subscriptions.go
@@ -39,6 +39,12 @@ type RecurringPaymentData struct {
 	PONumber   string
 	CustomerID string
 	StartDate  string
+	// StoredCredential carries the CIT credential-on-file fields (#297) for the
+	// enrollment charge — the portal's recurring initial CIT "MUST INCLUDE"
+	// billing_method=recurring + initiated_by=customer +
+	// stored_credential_indicator=stored (billing_method is already always sent
+	// by this lane). nil preserves the legacy shape.
+	StoredCredential *StoredCredential
 }
 
 type QueryFilter struct {
@@ -67,6 +73,11 @@ type ManualRebillParams struct {
 	SubscriptionID string
 	OrderID        string
 	PONumber       string
+	// StoredCredential carries the recurring-MIT credential-on-file fields
+	// (#297): initiated_by=merchant + stored_credential_indicator=used +
+	// initial_transaction_id=<recurring sequence anchor> + billing_method=
+	// recurring. nil preserves the legacy shape.
+	StoredCredential *StoredCredential
 }
 
 type ManualRebillResponse struct {
@@ -94,6 +105,9 @@ func (c *NMIClient) AddRecurringSubscription(data RecurringPaymentData) (*AddSub
 	}
 	if data.CustomerVaultID == "" && data.PaymentToken == "" {
 		return nil, errors.New("either customer vault or payment token is required")
+	}
+	if err := data.StoredCredential.validate(); err != nil {
+		return nil, err
 	}
 
 	amtStr := strconv.FormatFloat(float64(data.Amount), 'f', 2, 64)
@@ -137,6 +151,9 @@ func (c *NMIClient) AddRecurringSubscription(data RecurringPaymentData) (*AddSub
 	if trimmed := strings.TrimSpace(data.StartDate); trimmed != "" {
 		values.Set("start_date", trimmed)
 	}
+	// billing_method=recurring is already stamped above; applyToForm re-setting
+	// it for a recurring-agreement StoredCredential is idempotent.
+	data.StoredCredential.applyToForm(values)
 
 	response, err := c.sendDirectRequest(values)
 	if err != nil {
@@ -265,6 +282,9 @@ func (c *NMIClient) AttemptManualRebill(params ManualRebillParams) (*ManualRebil
 		err := errors.New("vault ID, billing ID, and subscription ID are required")
 		return &ManualRebillResponse{Success: false, ErrorMessage: err.Error()}, err
 	}
+	if err := params.StoredCredential.validate(); err != nil {
+		return &ManualRebillResponse{Success: false, ErrorMessage: err.Error()}, err
+	}
 
 	values := url.Values{
 		"type":              {"sale"},
@@ -281,6 +301,7 @@ func (c *NMIClient) AttemptManualRebill(params ManualRebillParams) (*ManualRebil
 	if trimmed := strings.TrimSpace(params.PONumber); trimmed != "" {
 		values.Set("ponumber", trimmed)
 	}
+	params.StoredCredential.applyToForm(values)
 
 	response, err := c.sendDirectRequest(values)
 	if err != nil {

--- a/internal/intents/enforcement_guard_test.go
+++ b/internal/intents/enforcement_guard_test.go
@@ -29,9 +29,9 @@ func TestProviderWritesStayBehindIntents(t *testing.T) {
 	// with WHY they are allowed.
 	allowed := map[string]map[string]string{
 		".RunSale(": {
-			"internal/modules/checkout/nmi_sale_intent.go": "nmi_sale intent handler (the sanctioned executor)",
-			"internal/modules/checkout/service.go":         "upgrade proration: order id content-derived + pre/post verify (#674); full intent migration deferred",
-			"internal/modules/money/nmi_collection.go":     "CollectionAdapter choke: reached via the topup_charge intent handler and the arrears/invoice worker (attempt-count keys, #672/#673)",
+			"internal/modules/checkout/nmi_sale_intent.go":         "nmi_sale intent handler (the sanctioned executor)",
+			"internal/modules/checkout/service.go":                 "upgrade proration: order id content-derived + pre/post verify (#674); full intent migration deferred",
+			"internal/modules/payments/rails/nmidirect/charger.go": "#297 charge-seam implementation: the ONE seam wire call, reached only via the money CollectionAdapter choke (topup_charge intent handler + arrears/invoice worker attempt-count keys, #672/#673)",
 		},
 		".AddRecurringSubscription(": {
 			"internal/modules/checkout/nmi_subscription_intent.go": "nmi_subscription_create intent handler",

--- a/internal/intents/manual_rebill.go
+++ b/internal/intents/manual_rebill.go
@@ -21,6 +21,8 @@ import (
 	"github.com/open-rails/openrails/internal/modules/entitlements"
 	"github.com/open-rails/openrails/internal/modules/money"
 	"github.com/open-rails/openrails/internal/modules/payments"
+	"github.com/open-rails/openrails/internal/modules/payments/charge"
+	"github.com/open-rails/openrails/internal/modules/payments/rails/nmidirect"
 	"github.com/open-rails/openrails/internal/modules/subscriptions"
 )
 
@@ -183,7 +185,7 @@ func (h *ManualRebillHandler) Execute(ctx context.Context, intent gen.OpenrailsR
 			return Ambiguous("pre-send verification read failed: " + verr.Error())
 		}
 		if found {
-			if err := h.finalizeSuccess(ctx, p, txnID); err != nil {
+			if err := h.finalizeSuccess(ctx, intent.MerchantID, p, txnID); err != nil {
 				return Ambiguous("charge verified at provider, but local lifecycle repair failed: " + err.Error())
 			}
 			return Succeeded(map[string]any{"transaction_id": txnID, "verified_existing": true})
@@ -203,12 +205,25 @@ func (h *ManualRebillHandler) Execute(ctx context.Context, intent gen.OpenrailsR
 		return TerminalWithEvidence("payment method unavailable for rebill", map[string]any{"declined": false})
 	}
 
+	// #297: a dunning retry is a merchant-initiated RECURRING charge — carry
+	// the credential-on-file indicators plus the recurring sequence anchor.
+	// Legacy instrument without an anchor: charge reference-less (networks
+	// tolerate it on legacy credentials) and back-fill from the success.
+	priorRef := strings.TrimSpace(pm.StoredCredentialRecurringRef)
+	if priorRef == "" {
+		log.WithContext(ctx).WithFields(log.Fields{
+			"payment_method_id": pm.ID,
+			"subscription_id":   sub.ID,
+		}).Warn("manual rebill: instrument has no stored-credential reference; charging reference-less MIT and back-filling on success (#297)")
+	}
+
 	rebillResp, err := client.AttemptManualRebill(nmi.ManualRebillParams{
-		VaultID:        pm.RailCustomerRef,
-		BillingID:      pm.RailMethodRef,
-		SubscriptionID: sub.RailSubscriptionID,
-		OrderID:        p.OrderReference,
-		PONumber:       p.OrderReference,
+		VaultID:          pm.RailCustomerRef,
+		BillingID:        pm.RailMethodRef,
+		SubscriptionID:   sub.RailSubscriptionID,
+		OrderID:          p.OrderReference,
+		PONumber:         p.OrderReference,
+		StoredCredential: nmidirect.StoredCredentialFor(charge.RecurringMIT(priorRef)),
 	})
 	if err != nil {
 		if errors.Is(err, nmi.ErrProviderReadOnly) {
@@ -233,7 +248,7 @@ func (h *ManualRebillHandler) Execute(ctx context.Context, intent gen.OpenrailsR
 		})
 	}
 
-	if err := h.finalizeSuccess(ctx, p, rebillResp.TransactionID); err != nil {
+	if err := h.finalizeSuccess(ctx, intent.MerchantID, p, rebillResp.TransactionID); err != nil {
 		// The charge DID happen; route through the verifier so the lifecycle
 		// repair is retried (its read re-finds the sale by order reference).
 		return Ambiguous("rebill charged, but local lifecycle update failed: " + err.Error())
@@ -262,7 +277,7 @@ func (h *ManualRebillHandler) Verify(ctx context.Context, intent gen.OpenrailsRa
 	if !found {
 		return Retryable("no successful sale found for order reference; charge verified not executed")
 	}
-	if err := h.finalizeSuccess(ctx, p, txnID); err != nil {
+	if err := h.finalizeSuccess(ctx, intent.MerchantID, p, txnID); err != nil {
 		return Ambiguous("charge verified at provider, but local lifecycle repair failed: " + err.Error())
 	}
 	return Succeeded(map[string]any{"transaction_id": txnID, "verified_existing": true})
@@ -282,12 +297,29 @@ func (h *ManualRebillHandler) findSuccessfulSale(client *nmi.NMIClient, p Manual
 // notifications) and grant per-renewal credits. Idempotent — a subscription
 // that already left past_due (the renewal applied, or a racing worker
 // repaired it) is left alone.
-func (h *ManualRebillHandler) finalizeSuccess(ctx context.Context, p ManualRebillPayload, transactionID string) error {
+func (h *ManualRebillHandler) finalizeSuccess(ctx context.Context, merchantID uuid.UUID, p ManualRebillPayload, transactionID string) error {
 	subRepo := subscriptions.NewSubscriptionRepo(h.DB)
 	sub, err := subRepo.GetByID(ctx, p.SubscriptionID)
 	if err != nil {
 		return fmt.Errorf("load subscription: %w", err)
 	}
+
+	// #297: a successful rebill on an instrument with no recurring
+	// stored-credential anchor establishes one — persist write-once,
+	// best-effort, BEFORE the past_due gate (a verified-existing success that
+	// already renewed still anchors the sequence).
+	if pm := sub.PaymentMethod; pm != nil && strings.TrimSpace(pm.StoredCredentialRecurringRef) == "" && strings.TrimSpace(transactionID) != "" {
+		if _, cerr := h.DB.Gen(ctx).CaptureStoredCredentialRef(ctx, gen.CaptureStoredCredentialRefParams{
+			MerchantID: merchantID,
+			ID:         pm.ID,
+			Agreement:  string(charge.AgreementRecurring),
+			Ref:        strings.TrimSpace(transactionID),
+		}); cerr != nil {
+			log.WithContext(ctx).WithError(cerr).WithField("payment_method_id", pm.ID).
+				Warn("manual rebill: failed to persist captured stored-credential reference (#297); next rebill re-captures")
+		}
+	}
+
 	if sub.Status != models.StatusPastDue ||
 		sub.CurrentPeriodEndsAt == nil || sub.CurrentPeriodEndsAt.UTC().Unix() != p.PeriodEnd.UTC().Unix() {
 		return nil

--- a/internal/intents/manual_rebill_integration_test.go
+++ b/internal/intents/manual_rebill_integration_test.go
@@ -32,6 +32,7 @@ type fakeNMIRebillGateway struct {
 	saleCalls   atomic.Int64
 	queryCalls  atomic.Int64
 	saleAuthKey atomic.Value // security_key the last sale authenticated with (#730)
+	saleForm    atomic.Value // url.Values: full form of the last sale (#297 wire assertions)
 	txnID       string
 }
 
@@ -58,6 +59,7 @@ func newFakeNMIRebillGateway(t *testing.T) (*fakeNMIRebillGateway, *nmi.NMIClien
 		if r.Form.Get("type") == "sale" {
 			f.saleCalls.Add(1)
 			f.saleAuthKey.Store(r.Form.Get("security_key"))
+			f.saleForm.Store(r.Form)
 			if st := f.saleStatus.Load(); st != 0 {
 				w.WriteHeader(int(st))
 				return

--- a/internal/intents/stored_credential_rebill_integration_test.go
+++ b/internal/intents/stored_credential_rebill_integration_test.go
@@ -1,0 +1,76 @@
+//go:build integration
+
+package intents
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #297 dunning proof: every manual rebill is a merchant-initiated RECURRING
+// credential-on-file charge. An anchored instrument replays its recurring
+// reference as initial_transaction_id; a legacy (unanchored) instrument
+// charges reference-less — the deliberate fail-open policy — and the success
+// back-fills the anchor for every later retry.
+
+func (fx rebillFixture) recurringRef(t *testing.T) string {
+	t.Helper()
+	var ref string
+	require.NoError(t, fx.db.Pool().QueryRow(context.Background(),
+		`SELECT pm.stored_credential_recurring_ref
+		 FROM openrails.payment_methods pm
+		 JOIN openrails.subscriptions s ON s.payment_method_id = pm.id
+		 WHERE s.id = $1`, fx.subID).Scan(&ref))
+	return ref
+}
+
+func (fx rebillFixture) setRecurringRef(t *testing.T, ref string) {
+	t.Helper()
+	_, err := fx.db.Pool().Exec(context.Background(),
+		`UPDATE openrails.payment_methods pm SET stored_credential_recurring_ref = $2
+		 FROM openrails.subscriptions s
+		 WHERE s.payment_method_id = pm.id AND s.id = $1`, fx.subID, ref)
+	require.NoError(t, err)
+}
+
+func TestManualRebill_AnchoredInstrumentSendsRecurringMIT(t *testing.T) {
+	fx := seedPastDueSubscription(t)
+	fx.setRecurringRef(t, "anchor-297-rec")
+	fake, client := newFakeNMIRebillGateway(t)
+
+	row, err := fx.rebillRunner(client, fullModeConfig()).EnqueueAndExecute(context.Background(), fx.enqueueParams(1))
+	require.NoError(t, err)
+	require.Equal(t, StatusSucceeded, row.Status)
+
+	form := fake.saleForm.Load().(url.Values)
+	assert.Equal(t, "rebill_subscription", form.Get("recurring"))
+	assert.Equal(t, "merchant", form.Get("initiated_by"))
+	assert.Equal(t, "used", form.Get("stored_credential_indicator"))
+	assert.Equal(t, "recurring", form.Get("billing_method"))
+	assert.Equal(t, "anchor-297-rec", form.Get("initial_transaction_id"))
+
+	assert.Equal(t, "anchor-297-rec", fx.recurringRef(t), "existing anchor is never overwritten")
+}
+
+func TestManualRebill_LegacyInstrumentChargesReferenceLessAndBackfills(t *testing.T) {
+	fx := seedPastDueSubscription(t)
+	fake, client := newFakeNMIRebillGateway(t)
+
+	require.Empty(t, fx.recurringRef(t), "legacy instrument starts unanchored")
+
+	row, err := fx.rebillRunner(client, fullModeConfig()).EnqueueAndExecute(context.Background(), fx.enqueueParams(1))
+	require.NoError(t, err)
+	require.Equal(t, StatusSucceeded, row.Status)
+
+	form := fake.saleForm.Load().(url.Values)
+	assert.Equal(t, "merchant", form.Get("initiated_by"))
+	assert.Equal(t, "used", form.Get("stored_credential_indicator"))
+	_, hasInitial := form["initial_transaction_id"]
+	assert.False(t, hasInitial, "legacy instrument charges reference-less (fail-open policy)")
+
+	assert.Equal(t, fake.txnID, fx.recurringRef(t), "success back-fills the recurring anchor")
+}

--- a/internal/modules/checkout/nmi_sale_intent.go
+++ b/internal/modules/checkout/nmi_sale_intent.go
@@ -9,11 +9,14 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/open-rails/openrails/internal/db/gen"
 	"github.com/open-rails/openrails/internal/integrations/nmi"
 	"github.com/open-rails/openrails/internal/intents"
 	"github.com/open-rails/openrails/internal/modules/payments"
+	"github.com/open-rails/openrails/internal/modules/payments/charge"
+	"github.com/open-rails/openrails/internal/modules/payments/rails/nmidirect"
 	"github.com/open-rails/openrails/internal/shared/moneyutil"
 )
 
@@ -46,7 +49,12 @@ type NMISalePayload struct {
 	Description  string    `json:"description"`
 	UserID       string    `json:"user_id"`
 	PriceID      uuid.UUID `json:"price_id"`
-	E2ERunID     string    `json:"e2e_run_id,omitempty"`
+	// StoredCredentialRef is the instrument's unscheduled-sequence
+	// stored-credential anchor at enqueue (#297). "" = this charge is the
+	// sequence's initial CIT (indicator=stored) and finalize captures the
+	// returned transaction id as the anchor (write-once).
+	StoredCredentialRef string `json:"stored_credential_ref,omitempty"`
+	E2ERunID            string `json:"e2e_run_id,omitempty"`
 }
 
 // Evidence keys the producer reads back off a succeeded intent.
@@ -134,13 +142,20 @@ func (h *NMISaleIntentHandler) Execute(ctx context.Context, intent gen.Openrails
 			return intents.Ambiguous("pre-send verification read failed: " + verr.Error())
 		}
 		if found {
-			return h.finalize(ctx, p, orderID, txnID, true)
+			return h.finalize(ctx, intent.MerchantID, p, orderID, txnID, true)
 		}
 	}
 
 	amountCents, err := moneyutil.MicrosToCentsExact(p.AmountMicros)
 	if err != nil {
 		return intents.Terminal("sale amount must be representable in whole cents: " + err.Error())
+	}
+	// #297: a checkout sale is a cardholder-initiated unscheduled CoF charge —
+	// the sequence's initial CIT when the instrument has no anchor yet, a
+	// reuse (indicator=used + initial_transaction_id) when it does.
+	citContext := charge.InitialOneTime()
+	if p.StoredCredentialRef != "" {
+		citContext = charge.OneTimeReuse(p.StoredCredentialRef)
 	}
 	saleResp, err := client.RunSale(nmi.SaleParams{
 		CustomerVaultID:  p.CustomerVaultID,
@@ -149,6 +164,7 @@ func (h *NMISaleIntentHandler) Execute(ctx context.Context, intent gen.Openrails
 		Currency:         p.Currency,
 		OrderDescription: p.Description,
 		OrderID:          orderID,
+		StoredCredential: nmidirect.StoredCredentialFor(citContext),
 	})
 	if err != nil {
 		if errors.Is(err, nmi.ErrProviderReadOnly) {
@@ -169,7 +185,7 @@ func (h *NMISaleIntentHandler) Execute(ctx context.Context, intent gen.Openrails
 		// Request-level rejection (validation, config): nothing was charged.
 		return intents.Terminal("sale request rejected: " + err.Error())
 	}
-	return h.finalize(ctx, p, orderID, saleResp.TransactionID, false)
+	return h.finalize(ctx, intent.MerchantID, p, orderID, saleResp.TransactionID, false)
 }
 
 // Verify resolves an ambiguous sale via the Query API: a successful sale for
@@ -193,13 +209,20 @@ func (h *NMISaleIntentHandler) Verify(ctx context.Context, intent gen.OpenrailsR
 	if !found {
 		return intents.Retryable("no successful sale found for order id; charge verified not executed")
 	}
-	return h.finalize(ctx, p, orderID, txnID, true)
+	return h.finalize(ctx, intent.MerchantID, p, orderID, txnID, true)
 }
 
 // finalize registers the confirmed charge locally (payment row, entitlements,
 // credits — RegisterPurchase is idempotent on (rail, transaction_id)) and
 // returns the evidence the producer builds its response from.
-func (h *NMISaleIntentHandler) finalize(ctx context.Context, p NMISalePayload, orderID, transactionID string, verified bool) intents.Outcome {
+func (h *NMISaleIntentHandler) finalize(ctx context.Context, merchantID uuid.UUID, p NMISalePayload, orderID, transactionID string, verified bool) intents.Outcome {
+	// #297: an initial CIT anchors the instrument's unscheduled sequence —
+	// persist the returned transaction id write-once. Best-effort: the charge
+	// happened and registration must never fail on this.
+	if p.StoredCredentialRef == "" && strings.TrimSpace(transactionID) != "" {
+		h.captureStoredCredentialRef(ctx, merchantID, p, strings.TrimSpace(transactionID))
+	}
+
 	var metadata map[string]any
 	if p.E2ERunID != "" {
 		metadata = map[string]any{"e2e_run_id": p.E2ERunID, "order_id": orderID}
@@ -230,4 +253,26 @@ func (h *NMISaleIntentHandler) finalize(ctx context.Context, p NMISalePayload, o
 		evidence["verified_existing"] = true
 	}
 	return intents.Succeeded(evidence)
+}
+
+// captureStoredCredentialRef persists the unscheduled-sequence anchor for the
+// charged instrument (#297), keyed by the rail handles the payload carries.
+// Best-effort by design: a miss just means the next successful charge
+// re-captures (the query is write-once either way).
+func (h *NMISaleIntentHandler) captureStoredCredentialRef(ctx context.Context, merchantID uuid.UUID, p NMISalePayload, transactionID string) {
+	if h.Sale == nil || h.Sale.VaultService == nil || h.Sale.VaultService.DB == nil {
+		log.WithContext(ctx).Warn("nmi sale finalize: no DB handle to persist stored-credential reference (#297)")
+		return
+	}
+	if _, err := h.Sale.VaultService.DB.Gen(ctx).CaptureStoredCredentialRefByRailInstrument(ctx, gen.CaptureStoredCredentialRefByRailInstrumentParams{
+		MerchantID:      merchantID,
+		Rail:            strings.ToLower(strings.TrimSpace(p.Provider)),
+		RailCustomerRef: strings.TrimSpace(p.CustomerVaultID),
+		RailMethodRef:   strings.TrimSpace(p.BillingID),
+		Agreement:       string(charge.AgreementUnscheduled),
+		Ref:             transactionID,
+	}); err != nil {
+		log.WithContext(ctx).WithError(err).WithField("customer_vault_id", p.CustomerVaultID).
+			Warn("nmi sale finalize: failed to persist stored-credential reference (#297); next charge re-captures")
+	}
 }

--- a/internal/modules/checkout/nmi_sale_intent_integration_test.go
+++ b/internal/modules/checkout/nmi_sale_intent_integration_test.go
@@ -26,19 +26,24 @@ import (
 	"github.com/open-rails/openrails/internal/intents"
 	"github.com/open-rails/openrails/internal/modules/catalog"
 	"github.com/open-rails/openrails/internal/modules/entitlements"
+	"github.com/open-rails/openrails/internal/modules/paymentmethods"
 	"github.com/open-rails/openrails/internal/modules/payments"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
 
-// fakeNMISaleGateway scripts the v5 sale endpoint + the classic query API the
-// verify leg reads: saleMode controls the sale outcome, charged whether the
-// query reports a landed sale for the searched order id.
+// fakeNMISaleGateway scripts the sale lanes (classic Direct Post — the #297
+// stored-credential lane every checkout sale rides now — plus the legacy v5
+// endpoint) and the classic query API the verify leg reads: saleMode controls
+// the sale outcome, charged whether the query reports a landed sale for the
+// searched order id. saleForm records the last classic sale's full form for
+// stored-credential wire assertions.
 type fakeNMISaleGateway struct {
 	saleCalls  atomic.Int64
 	queryCalls atomic.Int64
 	saleMode   atomic.Value // "approve" | "decline" | "ambiguous500"
 	charged    atomic.Bool
 	lastOrder  atomic.Value // string: order id of the last sale attempt
+	saleForm   atomic.Value // url.Values: last classic sale form
 	txnID      string
 }
 
@@ -71,8 +76,26 @@ func newFakeNMISaleGateway(t *testing.T) (*fakeNMISaleGateway, *nmi.NMIClient) {
 			}
 			return
 		}
-		// classic query.php transaction search
 		_ = r.ParseForm()
+		if r.Form.Get("type") == "sale" {
+			// Classic Direct Post sale — the #297 stored-credential lane.
+			f.saleCalls.Add(1)
+			f.saleForm.Store(r.Form)
+			f.lastOrder.Store(r.Form.Get("orderid"))
+			switch f.saleMode.Load().(string) {
+			case "decline":
+				fmt.Fprint(w, "response=2&responsetext=DECLINED&response_code=200")
+			case "ambiguous500":
+				// The charge LANDED but the response was lost (5xx).
+				f.charged.Store(true)
+				w.WriteHeader(http.StatusBadGateway)
+			default:
+				f.charged.Store(true)
+				fmt.Fprintf(w, "response=1&responsetext=SUCCESS&authcode=OK&transactionid=%s&response_code=100", f.txnID)
+			}
+			return
+		}
+		// classic query.php transaction search
 		f.queryCalls.Add(1)
 		orderID := r.Form.Get("order_id")
 		if f.charged.Load() {
@@ -146,6 +169,9 @@ func newSaleIntentFixture(t *testing.T) *saleIntentFixture {
 			clock,
 		),
 		NMIClients: map[string]*nmi.NMIClient{"mobius": client},
+		// VaultService carries the DB handle finalize persists the #297
+		// stored-credential anchor through.
+		VaultService: &paymentmethods.VaultService{DB: dbi},
 	}
 	runner := &intents.Runner{
 		Store:    intents.NewStore(dbi),

--- a/internal/modules/checkout/nmi_sale_service.go
+++ b/internal/modules/checkout/nmi_sale_service.go
@@ -117,10 +117,17 @@ func (s *CheckoutNMISaleService) Process(ctx context.Context, req *CheckoutReque
 		}
 	}
 
-	customerVaultID, vaultBillingID, createdPaymentMethod, err := s.VaultResolver.ResolveVault(ctx, req, user, provider)
+	customerVaultID, vaultBillingID, resolvedMethod, createdVault, err := s.VaultResolver.ResolveVault(ctx, req, user, provider)
 	if err != nil {
 		_ = s.IdempotencyStore.Fail(ctx, idempOp, idempotencyKey, err)
 		return nil, err
+	}
+	// #297: the instrument's unscheduled-sequence anchor. "" (fresh vault or
+	// legacy instrument) makes this charge the sequence's initial CIT
+	// (indicator=stored) and finalize captures the returned transaction id.
+	storedCredentialRef := ""
+	if resolvedMethod != nil {
+		storedCredentialRef = strings.TrimSpace(resolvedMethod.StoredCredentialUnscheduledRef)
 	}
 
 	tid, err := merchant.Require(ctx)
@@ -134,15 +141,16 @@ func (s *CheckoutNMISaleService) Process(ctx context.Context, req *CheckoutReque
 		IntentType: TypeNMISale,
 		PriceID:    &price.ID,
 		Payload: NMISalePayload{
-			Provider:        provider,
-			CustomerVaultID: customerVaultID,
-			BillingID:       vaultBillingID,
-			AmountMicros:    price.Amount,
-			Currency:        price.Currency,
-			Description:     fmt.Sprintf("Purchase: %s", product.DisplayName),
-			UserID:          user.ID,
-			PriceID:         price.ID,
-			E2ERunID:        strings.TrimSpace(req.Metadata["e2e_run_id"]),
+			Provider:            provider,
+			CustomerVaultID:     customerVaultID,
+			BillingID:           vaultBillingID,
+			AmountMicros:        price.Amount,
+			Currency:            price.Currency,
+			Description:         fmt.Sprintf("Purchase: %s", product.DisplayName),
+			UserID:              user.ID,
+			PriceID:             price.ID,
+			StoredCredentialRef: storedCredentialRef,
+			E2ERunID:            strings.TrimSpace(req.Metadata["e2e_run_id"]),
 		},
 		IdempotencyKey: NMISaleIdempotencyKey(idempotencyKey),
 		NextAttemptAt:  time.Now().UTC(),
@@ -167,8 +175,8 @@ func (s *CheckoutNMISaleService) Process(ctx context.Context, req *CheckoutReque
 		// Verified-clean decline/rejection: no money moved. Direct best-effort
 		// cleanup, NOT an intent (#674 tail): the vault was created for THIS
 		// declined attempt and is referenced nowhere — harmless if lost.
-		if createdPaymentMethod != nil && s.VaultService != nil {
-			_ = s.VaultService.CleanupVaultBestEffort(ctx, createdPaymentMethod)
+		if createdVault && resolvedMethod != nil && s.VaultService != nil {
+			_ = s.VaultService.CleanupVaultBestEffort(ctx, resolvedMethod)
 		}
 		reason := "payment failed"
 		if intent.LastFailureReason != nil && *intent.LastFailureReason != "" {

--- a/internal/modules/checkout/nmi_subscription_intent.go
+++ b/internal/modules/checkout/nmi_subscription_intent.go
@@ -9,12 +9,15 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/open-rails/openrails/internal/db"
 	"github.com/open-rails/openrails/internal/db/gen"
 	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/integrations/nmi"
 	"github.com/open-rails/openrails/internal/intents"
+	"github.com/open-rails/openrails/internal/modules/payments/charge"
+	"github.com/open-rails/openrails/internal/modules/payments/rails/nmidirect"
 	"github.com/open-rails/openrails/internal/shared/moneyutil"
 )
 
@@ -54,7 +57,13 @@ type NMISubscriptionCreatePayload struct {
 	// nmiSubscriptionStartDate's coverage-derived delayed start.
 	StartDate    string     `json:"start_date,omitempty"`
 	DelayedStart *time.Time `json:"delayed_start,omitempty"`
-	E2ERunID     string     `json:"e2e_run_id,omitempty"`
+	// StoredCredentialRef is the instrument's RECURRING-sequence
+	// stored-credential anchor at enqueue (#297). "" = this enrollment is the
+	// sequence's initial CIT (indicator=stored) and finalize captures the
+	// first-charge transaction id as the anchor (delayed starts produce no
+	// first charge — the anchor then back-fills from the first dunning MIT).
+	StoredCredentialRef string `json:"stored_credential_ref,omitempty"`
+	E2ERunID            string `json:"e2e_run_id,omitempty"`
 	// CheckoutIdempotencyKey lets finalize complete the request-level
 	// idempotency record so a client replay gets the cached response.
 	CheckoutIdempotencyKey string `json:"checkout_idempotency_key"`
@@ -141,11 +150,19 @@ func (h *NMISubscriptionCreateIntentHandler) Execute(ctx context.Context, intent
 
 	// Money mover + remote-resource creator: re-executions verify first.
 	if intent.Attempts > 1 {
-		if outcome, resolved := h.verifyAtProvider(ctx, client, p, orderID); resolved {
+		if outcome, resolved := h.verifyAtProvider(ctx, intent.MerchantID, client, p, orderID); resolved {
 			return outcome
 		}
 	}
 
+	// #297: subscription enrollment is the cardholder-initiated RECURRING
+	// credential-on-file charge — the sequence's initial CIT when the
+	// instrument has no recurring anchor, a reuse when it does (a second
+	// subscription on an already-anchored card).
+	citContext := charge.InitialRecurring()
+	if p.StoredCredentialRef != "" {
+		citContext = charge.RecurringReuse(p.StoredCredentialRef)
+	}
 	resp, err := client.AddRecurringSubscription(nmi.RecurringPaymentData{
 		BillingID: p.BillingID,
 		CardUserData: nmi.CardUserData{
@@ -157,15 +174,16 @@ func (h *NMISubscriptionCreateIntentHandler) Execute(ctx context.Context, intent
 			Zip:       p.Zip,
 			Country:   p.Country,
 		},
-		PlanID:          p.PlanID,
-		CustomerVaultID: p.CustomerVaultID,
-		Amount:          moneyutil.MajorUnits(moneyutil.MicrosToMajorUnits(p.AmountMicros)),
-		Currency:        p.Currency,
-		Email:           p.Email,
-		OrderID:         orderID,
-		PONumber:        orderID,
-		CustomerID:      p.UserID,
-		StartDate:       p.StartDate,
+		PlanID:           p.PlanID,
+		CustomerVaultID:  p.CustomerVaultID,
+		Amount:           moneyutil.MajorUnits(moneyutil.MicrosToMajorUnits(p.AmountMicros)),
+		Currency:         p.Currency,
+		Email:            p.Email,
+		OrderID:          orderID,
+		PONumber:         orderID,
+		CustomerID:       p.UserID,
+		StartDate:        p.StartDate,
+		StoredCredential: nmidirect.StoredCredentialFor(citContext),
 	})
 	if err != nil {
 		if errors.Is(err, nmi.ErrProviderReadOnly) {
@@ -185,7 +203,7 @@ func (h *NMISubscriptionCreateIntentHandler) Execute(ctx context.Context, intent
 		}
 		return intents.Terminal("subscription create request rejected: " + err.Error())
 	}
-	return h.finalize(ctx, p, orderID, resp.SubscriptionID, resp.TransactionID, false)
+	return h.finalize(ctx, intent.MerchantID, p, orderID, resp.SubscriptionID, resp.TransactionID, false)
 }
 
 // Verify resolves an ambiguous create via provider READS.
@@ -199,7 +217,7 @@ func (h *NMISubscriptionCreateIntentHandler) Verify(ctx context.Context, intent 
 		return intents.Ambiguous(fmt.Sprintf("nmi client not configured for provider %q; cannot verify", intent.Rail))
 	}
 	orderID := nmiSaleIntentOrderID(intent.ID, p.E2ERunID)
-	if outcome, resolved := h.verifyAtProvider(ctx, client, p, orderID); resolved {
+	if outcome, resolved := h.verifyAtProvider(ctx, intent.MerchantID, client, p, orderID); resolved {
 		return outcome
 	}
 	return intents.Retryable("no remote subscription or sale found for this intent; create verified not executed")
@@ -214,7 +232,7 @@ func (h *NMISubscriptionCreateIntentHandler) Verify(ctx context.Context, intent 
 //     crashed midway; re-finalize).
 //
 // resolved=false means "verified not executed" — the caller may (re)send.
-func (h *NMISubscriptionCreateIntentHandler) verifyAtProvider(ctx context.Context, client *nmi.NMIClient, p NMISubscriptionCreatePayload, orderID string) (intents.Outcome, bool) {
+func (h *NMISubscriptionCreateIntentHandler) verifyAtProvider(ctx context.Context, merchantID uuid.UUID, client *nmi.NMIClient, p NMISubscriptionCreatePayload, orderID string) (intents.Outcome, bool) {
 	txnID, txnFound, err := client.FindSuccessfulSaleByOrderID(orderID)
 	if err != nil {
 		return intents.Ambiguous("pre-send verification read failed: " + err.Error()), true
@@ -227,7 +245,7 @@ func (h *NMISubscriptionCreateIntentHandler) verifyAtProvider(ctx context.Contex
 
 	switch {
 	case len(candidates) == 1:
-		return h.finalize(ctx, p, orderID, candidates[0], txnID, true), true
+		return h.finalize(ctx, merchantID, p, orderID, candidates[0], txnID, true), true
 	case len(candidates) > 1:
 		return intents.Ambiguous(fmt.Sprintf("%d unregistered remote subscriptions match vault %s plan %s; operator attention required",
 			len(candidates), p.CustomerVaultID, p.PlanID)), true
@@ -309,9 +327,17 @@ func subscriptionMetadataString(raw json.RawMessage, key string) string {
 // standard registration path (idempotent: existing rows are activated /
 // answered, not duplicated) and completes the request-level idempotency
 // record so client replays get the cached response.
-func (h *NMISubscriptionCreateIntentHandler) finalize(ctx context.Context, p NMISubscriptionCreatePayload, orderID, providerSubscriptionID, transactionID string, verified bool) intents.Outcome {
+func (h *NMISubscriptionCreateIntentHandler) finalize(ctx context.Context, merchantID uuid.UUID, p NMISubscriptionCreatePayload, orderID, providerSubscriptionID, transactionID string, verified bool) intents.Outcome {
 	if strings.TrimSpace(providerSubscriptionID) == "" {
 		return intents.Ambiguous("remote subscription id unavailable; cannot register locally")
+	}
+
+	// #297: an initial recurring CIT anchors the instrument's recurring
+	// sequence with its first-charge transaction id. Delayed starts have no
+	// first charge (transactionID "") — the anchor then back-fills from the
+	// first successful dunning MIT instead. Best-effort, write-once.
+	if p.StoredCredentialRef == "" && strings.TrimSpace(transactionID) != "" {
+		h.captureStoredCredentialRef(ctx, merchantID, p, strings.TrimSpace(transactionID))
 	}
 	price, err := h.Checkout.PriceService.GetByID(ctx, p.PriceID)
 	if err != nil {
@@ -354,4 +380,25 @@ func (h *NMISubscriptionCreateIntentHandler) finalize(ctx context.Context, p NMI
 		evidence["verified_existing"] = true
 	}
 	return intents.Succeeded(evidence)
+}
+
+// captureStoredCredentialRef persists the recurring-sequence anchor for the
+// enrolled instrument (#297), keyed by the rail handles the payload carries.
+// Best-effort: a miss means the next successful recurring charge re-captures.
+func (h *NMISubscriptionCreateIntentHandler) captureStoredCredentialRef(ctx context.Context, merchantID uuid.UUID, p NMISubscriptionCreatePayload, transactionID string) {
+	if h.Checkout == nil || h.Checkout.VaultService == nil || h.Checkout.VaultService.DB == nil {
+		log.WithContext(ctx).Warn("nmi subscription finalize: no DB handle to persist stored-credential reference (#297)")
+		return
+	}
+	if _, err := h.Checkout.VaultService.DB.Gen(ctx).CaptureStoredCredentialRefByRailInstrument(ctx, gen.CaptureStoredCredentialRefByRailInstrumentParams{
+		MerchantID:      merchantID,
+		Rail:            strings.ToLower(strings.TrimSpace(p.Provider)),
+		RailCustomerRef: strings.TrimSpace(p.CustomerVaultID),
+		RailMethodRef:   strings.TrimSpace(p.BillingID),
+		Agreement:       string(charge.AgreementRecurring),
+		Ref:             transactionID,
+	}); err != nil {
+		log.WithContext(ctx).WithError(err).WithField("customer_vault_id", p.CustomerVaultID).
+			Warn("nmi subscription finalize: failed to persist stored-credential reference (#297); next recurring charge re-captures")
+	}
 }

--- a/internal/modules/checkout/nmi_subscription_intent_integration_test.go
+++ b/internal/modules/checkout/nmi_subscription_intent_integration_test.go
@@ -50,6 +50,7 @@ func (s *stubIdemStore) Complete(context.Context, string, string, json.RawMessag
 type fakeNMISubGateway struct {
 	createCalls atomic.Int64
 	createMode  atomic.Value // "approve" | "ambiguous500"
+	createForm  atomic.Value // url.Values: full form of the last create (#297 wire assertions)
 	// remote state
 	subExists atomic.Bool
 	vaultID   string
@@ -82,6 +83,7 @@ func newFakeNMISubGateway(t *testing.T, vaultID, planID string) (*fakeNMISubGate
 		_ = r.ParseForm()
 		if r.Form.Get("recurring") == "add_subscription" {
 			f.createCalls.Add(1)
+			f.createForm.Store(r.Form)
 			switch f.createMode.Load().(string) {
 			case "ambiguous500":
 				// The create LANDED but the response was lost.

--- a/internal/modules/checkout/service.go
+++ b/internal/modules/checkout/service.go
@@ -29,7 +29,9 @@ import (
 	"github.com/open-rails/openrails/internal/modules/entitlements"
 	"github.com/open-rails/openrails/internal/modules/paymentmethods"
 	"github.com/open-rails/openrails/internal/modules/payments"
+	"github.com/open-rails/openrails/internal/modules/payments/charge"
 	"github.com/open-rails/openrails/internal/modules/payments/rails"
+	"github.com/open-rails/openrails/internal/modules/payments/rails/nmidirect"
 	"github.com/open-rails/openrails/internal/modules/subscriptions"
 	"github.com/open-rails/openrails/internal/shared/moneyutil"
 	"github.com/open-rails/openrails/internal/shared/normalize"
@@ -663,10 +665,17 @@ func (s *CheckoutService) processNMISubscription(
 	}
 
 	// Get or create vault (payment method)
-	customerVaultID, vaultBillingID, createdPaymentMethod, err := s.VaultResolver.ResolveVault(ctx, req, user, provider)
+	customerVaultID, vaultBillingID, resolvedMethod, createdVault, err := s.VaultResolver.ResolveVault(ctx, req, user, provider)
 	if err != nil {
 		_ = s.IdempotencyService.Fail(ctx, idempOp, idempotencyKey, err)
 		return nil, err
+	}
+	// #297: the instrument's recurring-sequence stored-credential anchor. ""
+	// (fresh vault or legacy instrument) makes this enrollment the sequence's
+	// initial CIT; the intent's finalize captures the first-charge txn id.
+	storedCredentialRef := ""
+	if resolvedMethod != nil {
+		storedCredentialRef = strings.TrimSpace(resolvedMethod.StoredCredentialRecurringRef)
 	}
 
 	// Determine start date for delayed start
@@ -678,14 +687,8 @@ func (s *CheckoutService) processNMISubscription(
 	// subscription id) wins — enqueue conflicts never overwrite the payload.
 	subscriptionID := uuidutil.NewV7()
 	var paymentMethodID *uuid.UUID
-	if createdPaymentMethod != nil {
-		paymentMethodID = &createdPaymentMethod.ID
-	} else if req.PaymentMethodID != "" {
-		if pmID, err := api.ParsePaymentMethodID(req.PaymentMethodID); err == nil {
-			paymentMethodID = &pmID
-		} else {
-			log.WithError(err).Warn("failed to parse payment_method_id while preparing subscription attempt")
-		}
+	if resolvedMethod != nil {
+		paymentMethodID = &resolvedMethod.ID
 	}
 
 	if _, err := customerIDFromUser(user.ID); err != nil {
@@ -724,6 +727,7 @@ func (s *CheckoutService) processNMISubscription(
 			PaymentMethodID:        paymentMethodID,
 			StartDate:              startDate,
 			DelayedStart:           delayedStart,
+			StoredCredentialRef:    storedCredentialRef,
 			E2ERunID:               strings.TrimSpace(req.Metadata["e2e_run_id"]),
 			CheckoutIdempotencyKey: idempotencyKey,
 			FirstName:              ResolveCheckoutFirstName(req, user),
@@ -752,8 +756,8 @@ func (s *CheckoutService) processNMISubscription(
 		// Verified-clean decline/rejection. Direct best-effort cleanup of the
 		// vault created for THIS attempt, NOT an intent (#674 tail): it is
 		// referenced nowhere — harmless if lost.
-		if createdPaymentMethod != nil && s.VaultService != nil {
-			if cleanupErr := s.VaultService.CleanupVaultBestEffort(ctx, createdPaymentMethod); cleanupErr != nil {
+		if createdVault && resolvedMethod != nil && s.VaultService != nil {
+			if cleanupErr := s.VaultService.CleanupVaultBestEffort(ctx, resolvedMethod); cleanupErr != nil {
 				log.WithError(cleanupErr).WithField("vault_id", customerVaultID).Warn("failed to cleanup payment method after subscription error")
 			}
 		}
@@ -1804,10 +1808,25 @@ func (s *CheckoutService) processUpgrade(
 	}
 
 	// Get or create vault
-	customerVaultID, vaultBillingID, createdPaymentMethod, err := s.VaultResolver.ResolveVault(ctx, req, user, provider)
+	customerVaultID, vaultBillingID, resolvedMethod, createdVault, err := s.VaultResolver.ResolveVault(ctx, req, user, provider)
 	if err != nil {
 		_ = s.IdempotencyService.Fail(ctx, idempOp, idempotencyKey, err)
 		return nil, err
+	}
+
+	// #297 CIT contexts for the two upgrade charges: the successor enrollment
+	// rides the RECURRING sequence, the proration sale the UNSCHEDULED one.
+	// An instrument without an anchor makes the charge that sequence's initial
+	// CIT; anchors are captured after success below.
+	recurringCtx := charge.InitialRecurring()
+	unscheduledCtx := charge.InitialOneTime()
+	if resolvedMethod != nil {
+		if ref := strings.TrimSpace(resolvedMethod.StoredCredentialRecurringRef); ref != "" {
+			recurringCtx = charge.RecurringReuse(ref)
+		}
+		if ref := strings.TrimSpace(resolvedMethod.StoredCredentialUnscheduledRef); ref != "" {
+			unscheduledCtx = charge.OneTimeReuse(ref)
+		}
 	}
 
 	// Step 1: Create the successor subscription at NMI before charging/cancelling.
@@ -1854,7 +1873,8 @@ func (s *CheckoutService) processUpgrade(
 			PONumber:        successorOrderID,
 			CustomerID:      user.ID,
 			// Start date uses day precision and must be strictly in the future for NMI.
-			StartDate: startDate,
+			StartDate:        startDate,
+			StoredCredential: nmidirect.StoredCredentialFor(recurringCtx),
 		}
 
 		created, err := client.AddRecurringSubscription(params)
@@ -1927,6 +1947,7 @@ func (s *CheckoutService) processUpgrade(
 				Currency:         newPrice.Currency,
 				OrderDescription: fmt.Sprintf("Upgrade proration: %s", newProduct.DisplayName),
 				OrderID:          prorationOrderID,
+				StoredCredential: nmidirect.StoredCredentialFor(unscheduledCtx),
 			})
 			switch {
 			case err == nil:
@@ -1949,8 +1970,8 @@ func (s *CheckoutService) processUpgrade(
 				// best-effort cleanup of the vault created for THIS attempt,
 				// NOT an intent (#674 tail): referenced nowhere, harmless if lost.
 				rollbackNewSubscription()
-				if createdPaymentMethod != nil && s.VaultService != nil {
-					_ = s.VaultService.CleanupVaultBestEffort(ctx, createdPaymentMethod)
+				if createdVault && resolvedMethod != nil && s.VaultService != nil {
+					_ = s.VaultService.CleanupVaultBestEffort(ctx, resolvedMethod)
 				}
 				prorationErr := fmt.Errorf("failed to charge proration: %w", err)
 				_ = s.IdempotencyService.Fail(ctx, idempOp, idempotencyKey, prorationErr)
@@ -1965,6 +1986,13 @@ func (s *CheckoutService) processUpgrade(
 			"rail":           provider,
 		}).Info("charged upgrade proration")
 	}
+
+	// #297: anchor captures (write-once, best-effort). The proration sale
+	// anchors the unscheduled sequence; the successor's first-charge txn (""
+	// under the delayed start used here — then the first dunning MIT anchors
+	// instead) the recurring one.
+	s.captureStoredCredentialRef(ctx, resolvedMethod, charge.AgreementUnscheduled, prorationTransactionID)
+	s.captureStoredCredentialRef(ctx, resolvedMethod, charge.AgreementRecurring, resp.TransactionID)
 
 	// Step 3: Update local database.
 	//
@@ -1997,14 +2025,8 @@ func (s *CheckoutService) processUpgrade(
 		CurrentPeriodEndsAt:   &newPeriodEnd,
 	}
 
-	if createdPaymentMethod != nil {
-		newSubscription.PaymentMethodID = &createdPaymentMethod.ID
-	} else if req.PaymentMethodID != "" {
-		if pmID, err := api.ParsePaymentMethodID(req.PaymentMethodID); err == nil {
-			newSubscription.PaymentMethodID = &pmID
-		} else {
-			log.WithError(err).Warn("failed to parse payment_method_id while scheduling upgrade subscription")
-		}
+	if resolvedMethod != nil {
+		newSubscription.PaymentMethodID = &resolvedMethod.ID
 	}
 
 	// Persist the swap ATOMICALLY: the partial unique index
@@ -2973,4 +2995,32 @@ func requireNMIPlanForRail(price *models.Price, provider string) (string, error)
 		return "", fmt.Errorf("price %s is missing NMI plan configuration for rail %s", price.ID, provider)
 	}
 	return planID, nil
+}
+
+// captureStoredCredentialRef persists a stored-credential sequence anchor for
+// an instrument (#297), write-once and best-effort — a miss just means the
+// next successful charge on that agreement type re-captures.
+func (s *CheckoutService) captureStoredCredentialRef(ctx context.Context, pm *models.PaymentMethod, agreement charge.Agreement, ref string) {
+	ref = strings.TrimSpace(ref)
+	if pm == nil || ref == "" {
+		return
+	}
+	if s.VaultService == nil || s.VaultService.DB == nil {
+		log.WithContext(ctx).Warn("checkout: no DB handle to persist stored-credential reference (#297)")
+		return
+	}
+	tid, err := merchant.Require(ctx)
+	if err != nil {
+		log.WithContext(ctx).WithError(err).Warn("checkout: no merchant context to persist stored-credential reference (#297)")
+		return
+	}
+	if _, err := s.VaultService.DB.Gen(ctx).CaptureStoredCredentialRef(ctx, gen.CaptureStoredCredentialRefParams{
+		MerchantID: tid.UUID(),
+		ID:         pm.ID,
+		Agreement:  string(agreement),
+		Ref:        ref,
+	}); err != nil {
+		log.WithContext(ctx).WithError(err).WithField("payment_method_id", pm.ID).
+			Warn("checkout: failed to persist stored-credential reference (#297); next charge re-captures")
+	}
 }

--- a/internal/modules/checkout/stored_credential_intent_integration_test.go
+++ b/internal/modules/checkout/stored_credential_intent_integration_test.go
@@ -1,0 +1,144 @@
+//go:build integration
+
+package checkout
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/internal/intents"
+	"github.com/open-rails/openrails/internal/modules/paymentmethods"
+)
+
+// #297 checkout proof: the initial cardholder-present sale is the unscheduled
+// sequence's initial CIT (indicator=stored, no reference) and finalize
+// persists the returned transaction id as the instrument's anchor; a checkout
+// on an already-anchored instrument sends indicator=used + the anchor.
+
+// seedSaleInstrument stores a payment_methods row matching the fixture
+// payload's rail handles, with the given unscheduled anchor ("" = legacy/new).
+func (fx *saleIntentFixture) seedSaleInstrument(t *testing.T, unscheduledRef string) uuid.UUID {
+	t.Helper()
+	pool := fx.db.Pool()
+	customerID := dbtest.EnsureCustomerIDPgx(fx.ctx, t, pool, fx.userID)
+	pmID := uuid.New()
+	_, err := pool.Exec(fx.ctx,
+		`INSERT INTO openrails.payment_methods
+		   (id, merchant_id, customer_id, rail, rail_customer_ref, rail_method_ref,
+		    initial_transaction_id, stored_credential_unscheduled_ref)
+		 VALUES ($1, $2, $3, 'mobius', $4, '', '', $5)`,
+		pmID, dbtest.TestMerchantID.UUID(), customerID, fx.payload.CustomerVaultID, unscheduledRef)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(fx.ctx, "DELETE FROM openrails.payment_methods WHERE id = $1", pmID)
+	})
+	return pmID
+}
+
+func (fx *saleIntentFixture) unscheduledRef(t *testing.T, pmID uuid.UUID) string {
+	t.Helper()
+	var ref string
+	require.NoError(t, fx.db.Pool().QueryRow(fx.ctx,
+		"SELECT stored_credential_unscheduled_ref FROM openrails.payment_methods WHERE id = $1", pmID).Scan(&ref))
+	return ref
+}
+
+func TestNMISaleIntent_InitialCITAnchorsInstrument(t *testing.T) {
+	fx := newSaleIntentFixture(t)
+	pmID := fx.seedSaleInstrument(t, "")
+
+	intent := fx.enqueueAndExecute(t, "sale-297-"+uuid.NewString()[:8])
+	require.Equal(t, intents.StatusSucceeded, intent.Status)
+
+	form := fx.gateway.saleForm.Load().(url.Values)
+	assert.Equal(t, "customer", form.Get("initiated_by"))
+	assert.Equal(t, "stored", form.Get("stored_credential_indicator"), "first charge on an unanchored card is the sequence's initial CIT")
+	_, hasInitial := form["initial_transaction_id"]
+	assert.False(t, hasInitial)
+	_, hasBillingMethod := form["billing_method"]
+	assert.False(t, hasBillingMethod, "one-time checkout is unscheduled CoF: no billing_method")
+
+	assert.Equal(t, fx.gateway.txnID, fx.unscheduledRef(t, pmID), "finalize persists the CIT transaction id as the anchor")
+}
+
+func TestNMISaleIntent_AnchoredInstrumentSendsUsedWithReference(t *testing.T) {
+	fx := newSaleIntentFixture(t)
+	pmID := fx.seedSaleInstrument(t, "anchor-297-uns")
+	fx.payload.StoredCredentialRef = "anchor-297-uns"
+
+	intent := fx.enqueueAndExecute(t, "sale-297-"+uuid.NewString()[:8])
+	require.Equal(t, intents.StatusSucceeded, intent.Status)
+
+	form := fx.gateway.saleForm.Load().(url.Values)
+	assert.Equal(t, "customer", form.Get("initiated_by"))
+	assert.Equal(t, "used", form.Get("stored_credential_indicator"))
+	assert.Equal(t, "anchor-297-uns", form.Get("initial_transaction_id"))
+
+	assert.Equal(t, "anchor-297-uns", fx.unscheduledRef(t, pmID), "existing anchor is never overwritten")
+}
+
+// #297 enrollment proof: the subscription create is the RECURRING sequence's
+// initial CIT (billing_method=recurring + initiated_by=customer +
+// stored_credential_indicator=stored — the portal's MUST-INCLUDE trio) and
+// finalize persists the first-charge transaction id as the recurring anchor.
+
+func (fx *subIntentFixture) seedSubInstrument(t *testing.T, recurringRef string) uuid.UUID {
+	t.Helper()
+	pool := fx.db.Pool()
+	customerID := dbtest.EnsureCustomerIDPgx(fx.ctx, t, pool, fx.payload.UserID)
+	pmID := uuid.New()
+	_, err := pool.Exec(fx.ctx,
+		`INSERT INTO openrails.payment_methods
+		   (id, merchant_id, customer_id, rail, rail_customer_ref, rail_method_ref,
+		    initial_transaction_id, stored_credential_recurring_ref)
+		 VALUES ($1, $2, $3, 'mobius', $4, '', '', $5)`,
+		pmID, dbtest.TestMerchantID.UUID(), customerID, fx.payload.CustomerVaultID, recurringRef)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(fx.ctx, "DELETE FROM openrails.payment_methods WHERE id = $1", pmID)
+	})
+	return pmID
+}
+
+func TestNMISubscriptionIntent_InitialRecurringCITAnchorsInstrument(t *testing.T) {
+	fx := newSubIntentFixture(t)
+	// Wire the DB handle finalize persists the anchor through.
+	fx.svc.VaultService = &paymentmethods.VaultService{DB: fx.db}
+	pmID := fx.seedSubInstrument(t, "")
+
+	intent := fx.enqueueAndExecute(t)
+	require.Equal(t, intents.StatusSucceeded, intent.Status)
+
+	form := fx.gateway.createForm.Load().(url.Values)
+	assert.Equal(t, "recurring", form.Get("billing_method"))
+	assert.Equal(t, "customer", form.Get("initiated_by"))
+	assert.Equal(t, "stored", form.Get("stored_credential_indicator"))
+	_, hasInitial := form["initial_transaction_id"]
+	assert.False(t, hasInitial)
+
+	var ref string
+	require.NoError(t, fx.db.Pool().QueryRow(fx.ctx,
+		"SELECT stored_credential_recurring_ref FROM openrails.payment_methods WHERE id = $1", pmID).Scan(&ref))
+	assert.Equal(t, fx.gateway.txnID, ref, "finalize persists the enrollment charge as the recurring anchor")
+}
+
+func TestNMISubscriptionIntent_AnchoredInstrumentSendsUsedWithReference(t *testing.T) {
+	fx := newSubIntentFixture(t)
+	fx.svc.VaultService = &paymentmethods.VaultService{DB: fx.db}
+	fx.seedSubInstrument(t, "anchor-297-sub")
+	fx.payload.StoredCredentialRef = "anchor-297-sub"
+
+	intent := fx.enqueueAndExecute(t)
+	require.Equal(t, intents.StatusSucceeded, intent.Status)
+
+	form := fx.gateway.createForm.Load().(url.Values)
+	assert.Equal(t, "recurring", form.Get("billing_method"))
+	assert.Equal(t, "customer", form.Get("initiated_by"))
+	assert.Equal(t, "used", form.Get("stored_credential_indicator"))
+	assert.Equal(t, "anchor-297-sub", form.Get("initial_transaction_id"))
+}

--- a/internal/modules/checkout/vault_service.go
+++ b/internal/modules/checkout/vault_service.go
@@ -25,41 +25,43 @@ func NewCheckoutVaultService(paymentMethodService *paymentmethods.PaymentMethodS
 }
 
 // ResolveVault returns the vault handle pair (customer-scope vault id +
-// instrument-scope billing id, #682) and the created payment method when a
-// fresh token was vaulted. The billing id is "" for pre-#682 rows that never
-// recorded one.
-func (s *CheckoutVaultService) ResolveVault(ctx context.Context, req *CheckoutRequest, user *UserIdentity, provider string) (string, string, *models.PaymentMethod, error) {
+// instrument-scope billing id, #682), the resolved payment method row (#297:
+// carries the stored-credential replay references), and whether it was freshly
+// vaulted from a token in THIS request (created=true — the caller may
+// best-effort clean it up on a verified-clean decline). The billing id is ""
+// for pre-#682 rows that never recorded one.
+func (s *CheckoutVaultService) ResolveVault(ctx context.Context, req *CheckoutRequest, user *UserIdentity, provider string) (vaultID, billingID string, pm *models.PaymentMethod, created bool, err error) {
 	if req.PaymentMethodID != "" {
 		pmID, err := api.ParsePaymentMethodID(req.PaymentMethodID)
 		if err != nil {
-			return "", "", nil, fmt.Errorf("invalid payment_method_id: %w", err)
+			return "", "", nil, false, fmt.Errorf("invalid payment_method_id: %w", err)
 		}
 
 		pm, err := s.PaymentMethodService.ValidatePaymentMethodOperation(ctx, pmID, user.ID)
 		if err != nil {
-			return "", "", nil, fmt.Errorf("invalid payment method: %w", err)
+			return "", "", nil, false, fmt.Errorf("invalid payment method: %w", err)
 		}
 
 		if !rails.IsNMI(pm.Rail) {
-			return "", "", nil, errors.New("payment method is not compatible with card payments")
+			return "", "", nil, false, errors.New("payment method is not compatible with card payments")
 		}
 		if !rails.SameRail(pm.Rail, models.Rail(provider)) {
-			return "", "", nil, errors.New("payment method belongs to a different payment provider")
+			return "", "", nil, false, errors.New("payment method belongs to a different payment provider")
 		}
 
 		// NMI-backed only (checked above): vault id = customer-scope handle,
 		// billing id = instrument-scope handle (targets the exact card, #682).
-		return pm.RailCustomerRef, pm.RailMethodRef, nil, nil
+		return pm.RailCustomerRef, pm.RailMethodRef, pm, false, nil
 	}
 
 	if req.PaymentToken == "" {
-		return "", "", nil, errors.New("payment_method_id or payment_token is required")
+		return "", "", nil, false, errors.New("payment_method_id or payment_token is required")
 	}
 	if s.VaultService == nil {
-		return "", "", nil, errors.New("vault service unavailable")
+		return "", "", nil, false, errors.New("vault service unavailable")
 	}
 
-	pm, err := s.VaultService.CreateVault(ctx, user.ID, &paymentmethods.CreateVaultRequest{
+	pmNew, err := s.VaultService.CreateVault(ctx, user.ID, &paymentmethods.CreateVaultRequest{
 		PaymentToken: req.PaymentToken,
 		Provider:     provider,
 		FirstName:    ResolveCheckoutFirstName(req, user),
@@ -89,10 +91,10 @@ func (s *CheckoutVaultService) ResolveVault(ctx context.Context, req *CheckoutRe
 		}(),
 	})
 	if err != nil {
-		return "", "", nil, err
+		return "", "", nil, false, err
 	}
 
-	return pm.RailCustomerRef, pm.RailMethodRef, pm, nil
+	return pmNew.RailCustomerRef, pmNew.RailMethodRef, pmNew, true, nil
 }
 
 func ResolveCheckoutFirstName(req *CheckoutRequest, user *UserIdentity) string {

--- a/internal/modules/money/collection.go
+++ b/internal/modules/money/collection.go
@@ -10,8 +10,10 @@ import (
 	"github.com/open-rails/openrails/internal/db"
 	"github.com/open-rails/openrails/internal/db/gen"
 	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/modules/payments/charge"
 	"github.com/open-rails/openrails/internal/modules/payments/rails"
 	"github.com/open-rails/openrails/pkg/merchant"
+	log "github.com/sirupsen/logrus"
 )
 
 // CollectionAdapter charges a rail-specific saved payment method.
@@ -110,6 +112,20 @@ func (c *ScopedCharger) ChargeSavedMethod(ctx context.Context, req ChargeRequest
 	}
 	if strings.TrimSpace(res.Rail) == "" {
 		res.Rail = rail
+	}
+	// #297: a successful charge on an instrument with no stored-credential
+	// replay reference anchors its unscheduled sequence — persist write-once.
+	// Best-effort: the charge itself succeeded and must never fail on this.
+	if ref := strings.TrimSpace(res.CapturedStoredCredentialRef); ref != "" && !res.Declined {
+		if _, cerr := c.db.Gen(ctx).CaptureStoredCredentialRef(ctx, gen.CaptureStoredCredentialRefParams{
+			MerchantID: merchantID,
+			ID:         method.ID,
+			Agreement:  string(charge.AgreementUnscheduled),
+			Ref:        ref,
+		}); cerr != nil {
+			log.WithContext(ctx).WithError(cerr).WithField("payment_method_id", method.ID).
+				Warn("failed to persist captured stored-credential reference (#297); next charge re-captures")
+		}
 	}
 	return res, nil
 }

--- a/internal/modules/money/merchant_store_collection_integration_test.go
+++ b/internal/modules/money/merchant_store_collection_integration_test.go
@@ -4,7 +4,6 @@ package money_test
 
 import (
 	"context"
-	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -130,26 +129,23 @@ func TestChargeOutstanding_StoreOnlyNMICredentials_ChargesThroughStore(t *testin
 	invID := seedArrearsInvoice(t, svc, ctx, payer, pm)
 
 	seen := make(chan struct{}, 1)
+	// #297: store-armed collections are merchant-initiated stored-credential
+	// charges and ride classic Direct Post.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/payments/sale", r.URL.Path)
-		// The store-armed client authenticates with the STORE key (v5: the bare
-		// key is the whole Authorization header).
-		require.Equal(t, "store-only-security-key-"+sfx, r.Header.Get("Authorization"))
-		var req struct {
-			Amount        json.Number `json:"amount"`
-			CustomerVault struct {
-				ID string `json:"id"`
-			} `json:"customer_vault"`
-		}
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-		require.Equal(t, "vault_"+pm.String(), req.CustomerVault.ID)
-		require.Equal(t, "0.05", req.Amount.String())
+		require.NoError(t, r.ParseForm())
+		require.Equal(t, "sale", r.Form.Get("type"))
+		// The store-armed client authenticates with the STORE key.
+		require.Equal(t, "store-only-security-key-"+sfx, r.Form.Get("security_key"))
+		require.Equal(t, "vault_"+pm.String(), r.Form.Get("customer_vault_id"))
+		require.Equal(t, "0.05", r.Form.Get("amount"))
+		require.Equal(t, "merchant", r.Form.Get("initiated_by"))
+		require.Equal(t, "used", r.Form.Get("stored_credential_indicator"))
 		seen <- struct{}{}
-		_, _ = w.Write([]byte(`{"object":"transaction","id":"txn_store_only_nmi","response":"1","response_text":"SUCCESS","response_code":"100"}`))
+		_, _ = w.Write([]byte("response=1&responsetext=SUCCESS&authcode=OK&transactionid=txn_store_only_nmi&response_code=100"))
 	}))
 	t.Cleanup(server.Close)
 
-	ch := storeArmedCharger(dbi, msvc, nil, money.CollectionEndpoints{NMIV5BaseURL: server.URL})
+	ch := storeArmedCharger(dbi, msvc, nil, money.CollectionEndpoints{NMIDirectPostURL: server.URL})
 
 	n, err := svc.ChargeOutstanding(ctx, ch, 0)
 	require.NoError(t, err)

--- a/internal/modules/money/money_in.go
+++ b/internal/modules/money/money_in.go
@@ -45,6 +45,11 @@ type ChargeResult struct {
 	Declined          bool // true = hard decline (don't keep retrying); false+err = transient
 	FailureCode       *string
 	FailureMessage    *string
+	// CapturedStoredCredentialRef is the rail-scoped stored-credential replay
+	// reference this charge established for the instrument's UNSCHEDULED
+	// agreement sequence (#297) — set when the instrument had none (first use
+	// or legacy). ScopedCharger persists it write-once; "" = nothing captured.
+	CapturedStoredCredentialRef string
 }
 
 // Alerter delivers a low-balance notification. Implemented by the notification

--- a/internal/modules/money/money_in_integration_test.go
+++ b/internal/modules/money/money_in_integration_test.go
@@ -4,7 +4,6 @@ package money_test
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -553,35 +552,28 @@ func TestScopedCharger_NMIAdapterCollectsThroughGateway(t *testing.T) {
 	_, dbi, pool, payer, _, ctx := moneyInEnvWithDB(t)
 	pm := seedPaymentMethod(t, pool, ctx, payer, string(models.RailNMI))
 	seen := make(chan struct{}, 1)
+	// #297: collections are merchant-initiated stored-credential charges and
+	// ride classic Direct Post (the portal-documented CoF lane), not v5.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodPost, r.Method)
-		require.Equal(t, "/payments/sale", r.URL.Path)
-		require.Equal(t, "test-security-key", r.Header.Get("Authorization"))
-		var req struct {
-			Amount        json.Number `json:"amount"`
-			Currency      string      `json:"currency"`
-			CustomerVault struct {
-				ID string `json:"id"`
-			} `json:"customer_vault"`
-			OrderDetails struct {
-				ID               string `json:"id"`
-				OrderDescription string `json:"order_description"`
-			} `json:"order_details"`
-		}
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-		require.Equal(t, "vault_"+pm.String(), req.CustomerVault.ID)
-		require.Equal(t, "1.23", req.Amount.String())
-		require.Equal(t, money.DefaultCurrency, req.Currency)
-		require.Equal(t, "nmi-scope-ok", req.OrderDetails.ID)
-		require.Equal(t, "invoice", req.OrderDetails.OrderDescription)
+		require.NoError(t, r.ParseForm())
+		require.Equal(t, "sale", r.Form.Get("type"))
+		require.Equal(t, "test-security-key", r.Form.Get("security_key"))
+		require.Equal(t, "vault_"+pm.String(), r.Form.Get("customer_vault_id"))
+		require.Equal(t, "1.23", r.Form.Get("amount"))
+		require.Equal(t, money.DefaultCurrency, r.Form.Get("currency"))
+		require.Equal(t, "nmi-scope-ok", r.Form.Get("orderid"))
+		require.Equal(t, "invoice", r.Form.Get("order_description"))
+		require.Equal(t, "merchant", r.Form.Get("initiated_by"))
+		require.Equal(t, "used", r.Form.Get("stored_credential_indicator"))
 		seen <- struct{}{}
-		_, _ = w.Write([]byte(`{"object":"transaction","id":"txn_nmi_invoice_123","response":"1","response_text":"SUCCESS","response_code":"100"}`))
+		_, _ = w.Write([]byte("response=1&responsetext=SUCCESS&authcode=OK&transactionid=txn_nmi_invoice_123&response_code=100"))
 	}))
 	t.Cleanup(server.Close)
 
 	client, err := nmi.NewClient(string(models.RailNMI), &config.NMIProviderSettings{SecurityKey: "test-security-key"}, false)
 	require.NoError(t, err)
-	client.V5BaseURL = server.URL
+	client.DirectPostURL = server.URL
 	ch := money.NewScopedCharger(dbi, money.NewNMICollectionAdapters(map[string]*nmi.NMIClient{
 		string(models.RailNMI): client,
 	}))
@@ -610,13 +602,13 @@ func TestScopedCharger_NMIAdapterDeclineReturnsStructuredFailure(t *testing.T) {
 	_, dbi, pool, payer, _, ctx := moneyInEnvWithDB(t)
 	pm := seedPaymentMethod(t, pool, ctx, payer, string(models.RailNMI))
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"object":"transaction","id":"txn_declined","response":"2","response_text":"Do not honor","response_code":"201"}`))
+		_, _ = w.Write([]byte("response=2&responsetext=Do not honor&response_code=201"))
 	}))
 	t.Cleanup(server.Close)
 
 	client, err := nmi.NewClient(string(models.RailNMI), &config.NMIProviderSettings{SecurityKey: "test-security-key"}, false)
 	require.NoError(t, err)
-	client.V5BaseURL = server.URL
+	client.DirectPostURL = server.URL
 	ch := money.NewScopedCharger(dbi, money.NewNMICollectionAdapters(map[string]*nmi.NMIClient{
 		string(models.RailNMI): client,
 	}))
@@ -658,29 +650,24 @@ func TestChargeOutstanding_WithNMIAdapter_SettlesInvoiceThroughGateway(t *testin
 	require.NoError(t, err)
 
 	seen := make(chan struct{}, 1)
+	// #297: the invoice collection is a merchant-initiated stored-credential
+	// charge on classic Direct Post.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/payments/sale", r.URL.Path)
-		var req struct {
-			Amount        json.Number `json:"amount"`
-			CustomerVault struct {
-				ID string `json:"id"`
-			} `json:"customer_vault"`
-			OrderDetails struct {
-				ID string `json:"id"`
-			} `json:"order_details"`
-		}
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-		require.Equal(t, "vault_"+pm.String(), req.CustomerVault.ID)
-		require.Equal(t, "0.05", req.Amount.String())
-		require.Equal(t, "inv:"+inv.ID.String()+":a0", req.OrderDetails.ID)
+		require.NoError(t, r.ParseForm())
+		require.Equal(t, "sale", r.Form.Get("type"))
+		require.Equal(t, "vault_"+pm.String(), r.Form.Get("customer_vault_id"))
+		require.Equal(t, "0.05", r.Form.Get("amount"))
+		require.Equal(t, "inv:"+inv.ID.String()+":a0", r.Form.Get("orderid"))
+		require.Equal(t, "merchant", r.Form.Get("initiated_by"))
+		require.Equal(t, "used", r.Form.Get("stored_credential_indicator"))
 		seen <- struct{}{}
-		_, _ = w.Write([]byte(`{"object":"transaction","id":"txn_nmi_invoice_settled","response":"1","response_text":"SUCCESS","response_code":"100"}`))
+		_, _ = w.Write([]byte("response=1&responsetext=SUCCESS&authcode=OK&transactionid=txn_nmi_invoice_settled&response_code=100"))
 	}))
 	t.Cleanup(server.Close)
 
 	client, err := nmi.NewClient(string(models.RailNMI), &config.NMIProviderSettings{SecurityKey: "test-security-key"}, false)
 	require.NoError(t, err)
-	client.V5BaseURL = server.URL
+	client.DirectPostURL = server.URL
 	ch := money.NewScopedCharger(dbi, money.NewNMICollectionAdapters(map[string]*nmi.NMIClient{
 		string(models.RailNMI): client,
 	}))

--- a/internal/modules/money/nmi_collection.go
+++ b/internal/modules/money/nmi_collection.go
@@ -2,22 +2,26 @@ package money
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/open-rails/openrails/internal/db/gen"
 	"github.com/open-rails/openrails/internal/integrations/nmi"
+	"github.com/open-rails/openrails/internal/modules/payments/charge"
+	"github.com/open-rails/openrails/internal/modules/payments/rails/nmidirect"
+	log "github.com/sirupsen/logrus"
 )
 
 // NMICollectionAdapter collects invoices and top-ups from NMI customer
-// vault payment methods.
+// vault payment methods through the #297 charge seam: every collection is a
+// merchant-initiated unscheduled credential-on-file charge carrying the
+// instrument's stored-credential replay reference.
 type NMICollectionAdapter struct {
-	Client *nmi.NMIClient
+	Charger *nmidirect.Charger
 }
 
 func NewNMICollectionAdapter(client *nmi.NMIClient) *NMICollectionAdapter {
-	return &NMICollectionAdapter{Client: client}
+	return &NMICollectionAdapter{Charger: nmidirect.New(client)}
 }
 
 func NewNMICollectionAdapters(clients map[string]*nmi.NMIClient) map[string]CollectionAdapter {
@@ -32,12 +36,11 @@ func NewNMICollectionAdapters(clients map[string]*nmi.NMIClient) map[string]Coll
 	return adapters
 }
 
-func (a *NMICollectionAdapter) ChargeSavedMethod(_ context.Context, method gen.OpenrailsPaymentMethod, req ChargeRequest) (ChargeResult, error) {
-	if a == nil || a.Client == nil {
+func (a *NMICollectionAdapter) ChargeSavedMethod(ctx context.Context, method gen.OpenrailsPaymentMethod, req ChargeRequest) (ChargeResult, error) {
+	if a == nil || a.Charger == nil {
 		return ChargeResult{}, fmt.Errorf("nmi collection adapter not initialized")
 	}
-	vaultID := strings.TrimSpace(method.RailCustomerRef)
-	if vaultID == "" {
+	if strings.TrimSpace(method.RailCustomerRef) == "" {
 		return ChargeResult{}, fmt.Errorf("nmi payment method missing customer vault id")
 	}
 	if req.AmountCents <= 0 {
@@ -53,31 +56,43 @@ func (a *NMICollectionAdapter) ChargeSavedMethod(_ context.Context, method gen.O
 		description = "OpenRails invoice collection"
 	}
 
-	sale, err := a.Client.RunSale(nmi.SaleParams{
-		CustomerVaultID:  vaultID,
-		BillingID:        strings.TrimSpace(method.RailMethodRef),
-		Amount:           req.AmountCents,
-		Currency:         currency,
-		OrderDescription: description,
-		OrderID:          nmiWireOrderRef(req.IdempotencyKey),
+	// Legacy-instrument policy (#297): a stored card with no unscheduled
+	// replay reference charges reference-less (initiated_by=merchant +
+	// stored_credential_indicator=used, no initial_transaction_id) — the
+	// networks tolerate missing references on legacy credentials, and refusing
+	// would break collection for every pre-migration card. The success anchors
+	// the sequence: ScopedCharger persists Result.CapturedRef write-once.
+	priorRef := strings.TrimSpace(method.StoredCredentialUnscheduledRef)
+	if priorRef == "" {
+		log.WithContext(ctx).WithFields(log.Fields{
+			"payment_method_id": method.ID,
+			"rail":              rail,
+		}).Warn("nmi collection: instrument has no stored-credential reference; charging reference-less MIT and back-filling on success (#297)")
+	}
+
+	res, err := a.Charger.Charge(ctx, charge.Request{
+		Instrument: charge.Instrument{
+			PaymentMethodID: method.ID,
+			Rail:            rail,
+			CustomerRef:     strings.TrimSpace(method.RailCustomerRef),
+			MethodRef:       strings.TrimSpace(method.RailMethodRef),
+		},
+		AmountMinor: req.AmountCents,
+		Currency:    currency,
+		Description: description,
+		OrderRef:    nmiWireOrderRef(req.IdempotencyKey),
+		Context:     charge.UnscheduledMIT(priorRef),
 	})
 	if err != nil {
-		var vaultErr *nmi.CustomerVaultError
-		if errors.As(err, &vaultErr) && nmiCollectionHardDecline(vaultErr.ResponseCode) {
-			code := nmiFailureCode(vaultErr)
-			message := vaultErr.Error()
-			return ChargeResult{
-				Rail:           rail,
-				Declined:       true,
-				FailureCode:    &code,
-				FailureMessage: &message,
-			}, nil
-		}
 		return ChargeResult{}, err
 	}
 	return ChargeResult{
-		Rail:          rail,
-		TransactionID: strings.TrimSpace(sale.TransactionID),
+		Rail:                        rail,
+		TransactionID:               res.TransactionID,
+		Declined:                    res.Declined,
+		FailureCode:                 res.FailureCode,
+		FailureMessage:              res.FailureMessage,
+		CapturedStoredCredentialRef: res.CapturedRef,
 	}, nil
 }
 
@@ -86,26 +101,4 @@ func (a *NMICollectionAdapter) ChargeSavedMethod(_ context.Context, method gen.O
 // readable; the LOCAL idempotency identity is untouched.
 func nmiWireOrderRef(idempotencyKey string) string {
 	return strings.NewReplacer("invoice:", "inv:", ":attempt:", ":a").Replace(strings.TrimSpace(idempotencyKey))
-}
-
-func nmiFailureCode(err *nmi.CustomerVaultError) string {
-	if err == nil {
-		return "nmi_declined"
-	}
-	if code := strings.TrimSpace(err.LocalizationID); code != "" {
-		return code
-	}
-	if err.ResponseCode != 0 {
-		return fmt.Sprintf("nmi_response_%d", err.ResponseCode)
-	}
-	return "nmi_declined"
-}
-
-func nmiCollectionHardDecline(code int) bool {
-	switch code {
-	case 420, 421, 430:
-		return false
-	default:
-		return true
-	}
 }

--- a/internal/modules/money/nmi_collection_sandbox_integration_test.go
+++ b/internal/modules/money/nmi_collection_sandbox_integration_test.go
@@ -128,5 +128,14 @@ func TestChargeOutstanding_NMISandbox_CollectsRealCharge(t *testing.T) {
 	require.Equal(t, 1, settledCount)
 	require.Equal(t, string(models.RailNMI), rail)
 	require.NotEmpty(t, railPaymentID, "OpenRails must record the real NMI sandbox transaction id")
-	t.Logf("APPROVED: OpenRails invoice %s settled via NMI sandbox; real transaction id = %s", inv.ID, railPaymentID)
+
+	// #297: the collection ran as a reference-less MIT on a legacy (unanchored)
+	// instrument, so the success must back-fill the unscheduled sequence anchor
+	// with the real sandbox transaction id.
+	var storedRef string
+	require.NoError(t, pool.QueryRow(ctx,
+		"SELECT stored_credential_unscheduled_ref FROM openrails.payment_methods WHERE id = $1", pm).Scan(&storedRef))
+	require.Equal(t, railPaymentID, storedRef, "successful collection must anchor the stored-credential sequence (#297)")
+
+	t.Logf("APPROVED: OpenRails invoice %s settled via NMI sandbox; real transaction id = %s (stored-credential anchor persisted)", inv.ID, railPaymentID)
 }

--- a/internal/modules/money/stored_credential_collection_integration_test.go
+++ b/internal/modules/money/stored_credential_collection_integration_test.go
@@ -1,0 +1,127 @@
+//go:build integration
+
+package money_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/integrations/nmi"
+	"github.com/open-rails/openrails/internal/modules/money"
+)
+
+// fakeClassicNMIGateway records every classic Direct Post sale form and
+// approves with a scripted transaction id per call.
+type fakeClassicNMIGateway struct {
+	mu    sync.Mutex
+	forms []url.Values
+	txn   func(call int) string
+}
+
+func (f *fakeClassicNMIGateway) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if r.Form.Get("type") != "sale" {
+			fmt.Fprint(w, "response=1")
+			return
+		}
+		f.mu.Lock()
+		f.forms = append(f.forms, r.Form)
+		call := len(f.forms)
+		f.mu.Unlock()
+		fmt.Fprintf(w, "response=1&responsetext=SUCCESS&authcode=OK&transactionid=%s&response_code=100", f.txn(call))
+	}
+}
+
+func (f *fakeClassicNMIGateway) form(t *testing.T, i int) url.Values {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	require.Greater(t, len(f.forms), i)
+	return f.forms[i]
+}
+
+// TestChargeOutstanding_StoredCredentialMITAndBackfill is the #297 collection
+// proof over the charge seam (ChargeOutstanding → ScopedCharger →
+// NMICollectionAdapter → nmidirect.Charger → classic Direct Post):
+//
+//  1. a LEGACY instrument (no stored-credential reference) collects as a
+//     reference-less unscheduled MIT (initiated_by=merchant +
+//     stored_credential_indicator=used, no initial_transaction_id) — the
+//     deliberate fail-open policy — and the success BACK-FILLS the anchor;
+//  2. the next collection on the SAME instrument replays the persisted anchor
+//     as initial_transaction_id.
+func TestChargeOutstanding_StoredCredentialMITAndBackfill(t *testing.T) {
+	svc, dbi, pool, payer, _, ctx := moneyInEnvWithDB(t)
+	cleanupInvoiceRows(t, pool, ctx, payer)
+
+	fake := &fakeClassicNMIGateway{txn: func(call int) string { return fmt.Sprintf("txn-297-%d", call) }}
+	server := httptest.NewServer(fake.handler())
+	t.Cleanup(server.Close)
+
+	client, err := nmi.NewClient(string(models.RailNMI), &config.NMIProviderSettings{SecurityKey: "test-key"}, true)
+	require.NoError(t, err)
+	client.DirectPostURL = server.URL
+	client.QueryURL = server.URL
+	client.V5BaseURL = server.URL
+
+	// Legacy instrument: seeded with NO stored-credential references.
+	pm := seedPaymentMethodWithVault(t, pool, ctx, payer, string(models.RailNMI), "vault-297-"+uuid.NewString()[:8])
+
+	charger := money.NewScopedCharger(dbi, money.NewNMICollectionAdapters(map[string]*nmi.NMIClient{
+		string(models.RailNMI): client,
+	}))
+
+	openAndCollect := func(sourceID string) {
+		t.Helper()
+		_, err := svc.UpsertAccountSettings(ctx, payer, money.DefaultCurrency, money.AccountSettingsInput{
+			BillingMode: strptr(money.BillingModeArrears), AutoTopupPaymentMethod: &pm,
+		})
+		require.NoError(t, err)
+		require.NoError(t, svc.SetCreditLimit(ctx, payer, money.DefaultCurrency, 2_000_000))
+		_, err = svc.AccrueOwed(ctx, payer, money.DefaultCurrency, "usage", sourceID, 150*10_000)
+		require.NoError(t, err)
+		_, err = svc.FinalizeInvoice(ctx, payer, money.DefaultCurrency, time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+		require.NoError(t, err)
+		n, err := svc.ChargeOutstanding(ctx, charger, 0)
+		require.NoError(t, err)
+		require.Equal(t, 1, n)
+	}
+
+	refOf := func() string {
+		t.Helper()
+		var ref string
+		require.NoError(t, pool.QueryRow(ctx,
+			"SELECT stored_credential_unscheduled_ref FROM openrails.payment_methods WHERE id = $1", pm).Scan(&ref))
+		return ref
+	}
+
+	// Leg 1: legacy reference-less MIT + backfill.
+	require.Empty(t, refOf(), "legacy instrument starts unanchored")
+	openAndCollect("297-leg1-" + uuid.NewString()[:8])
+	form := fake.form(t, 0)
+	assert.Equal(t, "merchant", form.Get("initiated_by"))
+	assert.Equal(t, "used", form.Get("stored_credential_indicator"))
+	_, hasInitial := form["initial_transaction_id"]
+	assert.False(t, hasInitial, "legacy instrument charges reference-less (fail-open policy)")
+	assert.Equal(t, "txn-297-1", refOf(), "success back-fills the unscheduled anchor write-once")
+
+	// Leg 2: the anchored instrument replays the reference.
+	openAndCollect("297-leg2-" + uuid.NewString()[:8])
+	form = fake.form(t, 1)
+	assert.Equal(t, "merchant", form.Get("initiated_by"))
+	assert.Equal(t, "used", form.Get("stored_credential_indicator"))
+	assert.Equal(t, "txn-297-1", form.Get("initial_transaction_id"), "MIT carries the persisted anchor")
+	assert.Equal(t, "txn-297-1", refOf(), "anchor is write-once — never overwritten by later charges")
+}

--- a/internal/modules/payments/charge/charge.go
+++ b/internal/modules/payments/charge/charge.go
@@ -1,0 +1,169 @@
+// Package charge is the narrow, rail-agnostic charge seam (#297 Phase A):
+// "charge instrument, amount, CIT/MIT context". It models card-network
+// stored-credential compliance once, in the engine, so every card rail —
+// the direct NMI rail today, a vaulted_card rail later (#297 Phase B) —
+// implements ONE interface and the vault lands as a rail, not a rewrite.
+//
+// Network model (verified against the NMI integration portal + docs.nmi.com,
+// 2026-07-06):
+//   - Every charge on a stored credential declares WHO initiated it
+//     (customer = CIT, merchant = MIT) and whether this is the INITIAL
+//     transaction of a credential-on-file sequence or a subsequent use.
+//   - The networks track a SEPARATE sequence per agreement type (recurring vs
+//     unscheduled); the initial transaction's reference anchors that sequence
+//     and is replayed on every subsequent MIT of the SAME type only.
+//   - The replay reference is RAIL-SCOPED: NMI uses its own gateway
+//     transactionid (mapped to the network transaction identifier inside the
+//     gateway); a vault rail forwards its vault-native reference. The engine
+//     persists whatever the rail hands back (payment_methods.
+//     stored_credential_{recurring,unscheduled}_ref) and never interprets it.
+//
+// Sites that cannot ride the generic seam still share this vocabulary: the
+// NMI subscription-engine lanes (add_subscription, rebill_subscription) charge
+// against NMI's own schedule objects rather than (instrument, amount), so they
+// derive their wire fields from a Context via the nmidirect mapping instead of
+// calling Charger.
+package charge
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/open-rails/openrails/internal/shared/moneyutil"
+)
+
+// Initiator is who initiates a charge on a stored credential.
+type Initiator string
+
+const (
+	// InitiatorCustomer: the cardholder is present and acting (CIT).
+	InitiatorCustomer Initiator = "customer"
+	// InitiatorMerchant: the engine charges off-session (MIT) — renewals,
+	// dunning retries, auto top-ups, arrears collection.
+	InitiatorMerchant Initiator = "merchant"
+)
+
+// Agreement is the card-network credential-on-file agreement type. The
+// networks keep independent stored-credential sequences per agreement, so a
+// reference captured under one type must never be replayed under the other.
+type Agreement string
+
+const (
+	// AgreementRecurring: fixed-cadence subscription charges and their dunning
+	// retries.
+	AgreementRecurring Agreement = "recurring"
+	// AgreementUnscheduled: no fixed cadence — one-time checkout on a stored
+	// card, auto top-ups, arrears/invoice collection.
+	AgreementUnscheduled Agreement = "unscheduled"
+)
+
+// Context is the CIT/MIT stored-credential posture of one charge.
+type Context struct {
+	Initiator Initiator
+	Agreement Agreement
+
+	// FirstUse: this charge is the initial transaction of the credential's
+	// agreement sequence (the anchor MITs will reference). Derived from
+	// reference-emptiness at the call site: an instrument with no persisted
+	// reference for the agreement type anchors its sequence on this charge —
+	// which also grandfathers legacy (pre-#297) instruments on their first
+	// post-upgrade charge.
+	FirstUse bool
+
+	// PriorRef is the rail-scoped replay reference captured from the
+	// sequence's initial transaction. Required on MITs when the instrument has
+	// one; empty on first use and on legacy instruments that have not been
+	// re-anchored yet (see Result.CapturedRef).
+	PriorRef string
+}
+
+// InitialOneTime: cardholder-present charge anchoring the unscheduled
+// sequence (first checkout charge on a newly stored or never-anchored card).
+func InitialOneTime() Context {
+	return Context{Initiator: InitiatorCustomer, Agreement: AgreementUnscheduled, FirstUse: true}
+}
+
+// OneTimeReuse: cardholder-present charge on an already-anchored stored
+// credential (returning customer, saved-card checkout, upgrade proration).
+func OneTimeReuse(priorRef string) Context {
+	return Context{Initiator: InitiatorCustomer, Agreement: AgreementUnscheduled, PriorRef: priorRef}
+}
+
+// InitialRecurring: cardholder-present enrollment charge anchoring the
+// recurring sequence (subscription signup / upgrade successor).
+func InitialRecurring() Context {
+	return Context{Initiator: InitiatorCustomer, Agreement: AgreementRecurring, FirstUse: true}
+}
+
+// RecurringReuse: cardholder-present recurring enrollment on a card whose
+// recurring sequence is already anchored (second subscription on one card).
+func RecurringReuse(priorRef string) Context {
+	return Context{Initiator: InitiatorCustomer, Agreement: AgreementRecurring, PriorRef: priorRef}
+}
+
+// RecurringMIT: merchant-initiated recurring charge (renewal, dunning retry).
+// priorRef "" = legacy instrument: the rail charges reference-less (with a
+// warning at the call site) and the success back-fills the anchor.
+func RecurringMIT(priorRef string) Context {
+	return Context{Initiator: InitiatorMerchant, Agreement: AgreementRecurring, PriorRef: priorRef}
+}
+
+// UnscheduledMIT: merchant-initiated unscheduled charge (auto top-up,
+// arrears/invoice collection). Same legacy semantics as RecurringMIT.
+func UnscheduledMIT(priorRef string) Context {
+	return Context{Initiator: InitiatorMerchant, Agreement: AgreementUnscheduled, PriorRef: priorRef}
+}
+
+// Instrument identifies the stored payment credential to charge, by its
+// rail-scoped handles (mirrors openrails.payment_methods).
+type Instrument struct {
+	// PaymentMethodID is the local payment_methods row id (uuid.Nil when the
+	// caller only holds rail handles).
+	PaymentMethodID uuid.UUID
+	Rail            string
+	// CustomerRef is the customer-scope rail handle (NMI customer_vault_id).
+	CustomerRef string
+	// MethodRef is the instrument-scope rail handle (NMI billing_id; "" =
+	// the vault's priority-1 entry).
+	MethodRef string
+}
+
+// Request charges one instrument for one amount under one CIT/MIT context.
+type Request struct {
+	Instrument Instrument
+	// AmountMinor is rail minor units (typed Cents, #671).
+	AmountMinor moneyutil.Cents
+	Currency    string
+	Description string
+	// OrderRef is the rail correlation handle (NMI order id) — the reference
+	// verify legs answer "did this charge land?" by.
+	OrderRef string
+	Context  Context
+}
+
+// Result is the normalized outcome of an executed charge. A (Result, nil)
+// return means the gateway answered: either an approval or a parsed hard
+// decline. Transport failures and transient gateway errors return an error
+// (callers classify ambiguity rail-side, e.g. nmi.IsTransportAmbiguous).
+type Result struct {
+	TransactionID string
+
+	// CapturedRef is the rail-scoped stored-credential replay reference this
+	// charge established for the request's agreement type — set on first use
+	// and on successful reference-less legacy charges. The caller persists it
+	// on the instrument (write-once). "" = nothing to persist.
+	CapturedRef string
+
+	// Declined: parsed hard decline — do not retry with the same instrument.
+	Declined       bool
+	FailureCode    *string
+	FailureMessage *string
+}
+
+// Charger is the seam: one interface per card rail. Implementations translate
+// Context into the rail's stored-credential wire fields and normalize the
+// outcome.
+type Charger interface {
+	Charge(ctx context.Context, req Request) (Result, error)
+}

--- a/internal/modules/payments/rails/nmidirect/charger.go
+++ b/internal/modules/payments/rails/nmidirect/charger.go
@@ -1,0 +1,129 @@
+// Package nmidirect implements the rail-agnostic charge seam (#297 Phase A,
+// internal/modules/payments/charge) for the direct NMI rail: it translates
+// CIT/MIT context into NMI's credential-on-file wire fields and normalizes
+// gateway outcomes. The future vaulted_card rail (#297 Phase B) is a sibling
+// implementation of the same seam.
+package nmidirect
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/open-rails/openrails/internal/integrations/nmi"
+	"github.com/open-rails/openrails/internal/modules/payments/charge"
+)
+
+// StoredCredentialFor maps the rail-agnostic CIT/MIT context onto NMI's
+// credential-on-file wire fields (see nmi.StoredCredential for the verified
+// combinations). It is shared by the seam Charger and by the NMI
+// subscription-engine lanes (add_subscription enrollments, rebill_subscription
+// dunning) that charge NMI schedule objects instead of (instrument, amount).
+func StoredCredentialFor(c charge.Context) *nmi.StoredCredential {
+	sc := &nmi.StoredCredential{
+		Recurring: c.Agreement == charge.AgreementRecurring,
+	}
+	switch c.Initiator {
+	case charge.InitiatorMerchant:
+		sc.InitiatedBy = nmi.InitiatedByMerchant
+	default:
+		sc.InitiatedBy = nmi.InitiatedByCustomer
+	}
+	// The sequence's initial transaction sends indicator=stored; everything
+	// after sends used. A merchant-initiated charge is never the initial
+	// transaction — a reference-less MIT (legacy instrument) still sends used,
+	// just without initial_transaction_id, and the success anchors the
+	// sequence (Result.CapturedRef).
+	if c.FirstUse && c.Initiator == charge.InitiatorCustomer {
+		sc.Indicator = nmi.IndicatorStored
+	} else {
+		sc.Indicator = nmi.IndicatorUsed
+	}
+	if ref := strings.TrimSpace(c.PriorRef); ref != "" {
+		sc.InitialTransactionID = ref
+	}
+	return sc
+}
+
+// Charger charges stored NMI instruments through the seam. Declines that the
+// gateway parsed cleanly come back as Result{Declined:true}; transient
+// gateway conditions (communication errors, duplicate detection) and
+// transport-ambiguous failures return an error for the caller's retry/verify
+// machinery (nmi.IsTransportAmbiguous distinguishes the latter).
+type Charger struct {
+	Client *nmi.NMIClient
+}
+
+func New(client *nmi.NMIClient) *Charger { return &Charger{Client: client} }
+
+var _ charge.Charger = (*Charger)(nil)
+
+func (c *Charger) Charge(ctx context.Context, req charge.Request) (charge.Result, error) {
+	if c == nil || c.Client == nil {
+		return charge.Result{}, errors.New("nmidirect charger not initialized")
+	}
+	vaultID := strings.TrimSpace(req.Instrument.CustomerRef)
+	if vaultID == "" {
+		return charge.Result{}, errors.New("nmi instrument missing customer vault id")
+	}
+	if req.AmountMinor <= 0 {
+		return charge.Result{}, errors.New("charge amount must be positive")
+	}
+
+	sale, err := c.Client.RunSale(nmi.SaleParams{
+		CustomerVaultID:  vaultID,
+		BillingID:        strings.TrimSpace(req.Instrument.MethodRef),
+		Amount:           req.AmountMinor,
+		Currency:         req.Currency,
+		OrderDescription: req.Description,
+		OrderID:          req.OrderRef,
+		StoredCredential: StoredCredentialFor(req.Context),
+	})
+	if err != nil {
+		var vaultErr *nmi.CustomerVaultError
+		if errors.As(err, &vaultErr) && isHardDecline(vaultErr.ResponseCode) {
+			code := failureCode(vaultErr)
+			message := vaultErr.Error()
+			return charge.Result{
+				Declined:       true,
+				FailureCode:    &code,
+				FailureMessage: &message,
+			}, nil
+		}
+		return charge.Result{}, err
+	}
+
+	res := charge.Result{TransactionID: strings.TrimSpace(sale.TransactionID)}
+	// A charge that ran without a replay reference anchors the credential's
+	// agreement sequence: NMI's reference IS its gateway transactionid.
+	if strings.TrimSpace(req.Context.PriorRef) == "" {
+		res.CapturedRef = res.TransactionID
+	}
+	return res, nil
+}
+
+// isHardDecline classifies parsed gateway response codes: communication
+// errors (420, 421) and duplicate-transaction detection (430) are transient —
+// everything else parsed as a failure is a hard decline.
+func isHardDecline(code int) bool {
+	switch code {
+	case 420, 421, 430:
+		return false
+	default:
+		return true
+	}
+}
+
+func failureCode(err *nmi.CustomerVaultError) string {
+	if err == nil {
+		return "nmi_declined"
+	}
+	if code := strings.TrimSpace(err.LocalizationID); code != "" {
+		return code
+	}
+	if err.ResponseCode != 0 {
+		return fmt.Sprintf("nmi_response_%d", err.ResponseCode)
+	}
+	return "nmi_declined"
+}

--- a/internal/modules/payments/rails/nmidirect/charger_test.go
+++ b/internal/modules/payments/rails/nmidirect/charger_test.go
@@ -1,0 +1,135 @@
+package nmidirect
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/integrations/nmi"
+	"github.com/open-rails/openrails/internal/modules/payments/charge"
+	"github.com/open-rails/openrails/internal/shared/moneyutil"
+)
+
+func TestStoredCredentialFor_ContextMapping(t *testing.T) {
+	cases := []struct {
+		name string
+		ctx  charge.Context
+		want nmi.StoredCredential
+	}{
+		{
+			"initial one-time CIT",
+			charge.InitialOneTime(),
+			nmi.StoredCredential{InitiatedBy: "customer", Indicator: "stored"},
+		},
+		{
+			"one-time reuse CIT",
+			charge.OneTimeReuse("ref-1"),
+			nmi.StoredCredential{InitiatedBy: "customer", Indicator: "used", InitialTransactionID: "ref-1"},
+		},
+		{
+			"initial recurring CIT",
+			charge.InitialRecurring(),
+			nmi.StoredCredential{InitiatedBy: "customer", Indicator: "stored", Recurring: true},
+		},
+		{
+			"recurring reuse CIT",
+			charge.RecurringReuse("ref-2"),
+			nmi.StoredCredential{InitiatedBy: "customer", Indicator: "used", InitialTransactionID: "ref-2", Recurring: true},
+		},
+		{
+			"recurring MIT",
+			charge.RecurringMIT("ref-3"),
+			nmi.StoredCredential{InitiatedBy: "merchant", Indicator: "used", InitialTransactionID: "ref-3", Recurring: true},
+		},
+		{
+			"unscheduled MIT",
+			charge.UnscheduledMIT("ref-4"),
+			nmi.StoredCredential{InitiatedBy: "merchant", Indicator: "used", InitialTransactionID: "ref-4"},
+		},
+		{
+			"legacy reference-less MIT stays 'used' with no reference",
+			charge.UnscheduledMIT(""),
+			nmi.StoredCredential{InitiatedBy: "merchant", Indicator: "used"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := StoredCredentialFor(tc.ctx)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.want, *got)
+		})
+	}
+}
+
+func newChargerAgainst(t *testing.T, handler http.HandlerFunc) *Charger {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	client, err := nmi.NewClient("nmi", &config.NMIProviderSettings{SecurityKey: "k"}, true)
+	require.NoError(t, err)
+	client.DirectPostURL = server.URL
+	client.QueryURL = server.URL
+	client.V5BaseURL = server.URL
+	return New(client)
+}
+
+func baseRequest(ctx charge.Context) charge.Request {
+	return charge.Request{
+		Instrument:  charge.Instrument{Rail: "nmi", CustomerRef: "v1", MethodRef: "b1"},
+		AmountMinor: moneyutil.Cents(500),
+		Currency:    "USD",
+		Description: "test charge",
+		OrderRef:    "order-1",
+		Context:     ctx,
+	}
+}
+
+func TestCharger_SuccessCapturesRefOnlyWhenUnanchored(t *testing.T) {
+	var form url.Values
+	c := newChargerAgainst(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		form = r.Form
+		fmt.Fprint(w, "response=1&transactionid=txn-99&authcode=OK&response_code=100")
+	})
+
+	// No prior reference: the success anchors the sequence.
+	res, err := c.Charge(context.Background(), baseRequest(charge.UnscheduledMIT("")))
+	require.NoError(t, err)
+	assert.Equal(t, "txn-99", res.TransactionID)
+	assert.Equal(t, "txn-99", res.CapturedRef, "reference-less charge anchors on its own transaction id")
+	assert.Equal(t, "merchant", form.Get("initiated_by"))
+	assert.Equal(t, "used", form.Get("stored_credential_indicator"))
+
+	// Anchored: nothing new to capture, the anchor rides the wire.
+	res, err = c.Charge(context.Background(), baseRequest(charge.UnscheduledMIT("anchor-1")))
+	require.NoError(t, err)
+	assert.Empty(t, res.CapturedRef)
+	assert.Equal(t, "anchor-1", form.Get("initial_transaction_id"))
+}
+
+func TestCharger_HardDeclineIsResultNotError(t *testing.T) {
+	c := newChargerAgainst(t, func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "response=2&responsetext=DECLINED&response_code=202")
+	})
+	res, err := c.Charge(context.Background(), baseRequest(charge.UnscheduledMIT("anchor-1")))
+	require.NoError(t, err)
+	assert.True(t, res.Declined)
+	require.NotNil(t, res.FailureCode)
+	assert.Equal(t, "insufficient_funds", *res.FailureCode)
+}
+
+func TestCharger_TransientGatewayConditionIsError(t *testing.T) {
+	// 430 duplicate-transaction: transient, never a hard decline.
+	c := newChargerAgainst(t, func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "response=2&responsetext=Duplicate&response_code=430")
+	})
+	_, err := c.Charge(context.Background(), baseRequest(charge.UnscheduledMIT("anchor-1")))
+	require.Error(t, err)
+}

--- a/migrations/postgres/0009_stored_credential_refs.up.sql
+++ b/migrations/postgres/0009_stored_credential_refs.up.sql
@@ -1,0 +1,25 @@
+-- #297 Phase A: card-network stored-credential (CIT/MIT) replay references.
+--
+-- The networks track a SEPARATE credential-on-file sequence per agreement type
+-- (recurring vs unscheduled) and an initial reference from one sequence is not
+-- valid on the other (NMI: "This transaction ID cannot be used for
+-- 'unscheduled' ... credential-on-file transactions"), so an instrument
+-- carries one replay reference per agreement type.
+--
+-- The value is RAIL-SCOPED: whatever the rail needs to replay the credential
+-- on a merchant-initiated charge. For NMI it is the gateway transactionid of
+-- the sequence's initial customer-initiated transaction (sent back as
+-- initial_transaction_id; NMI maps it to the network transaction identifier
+-- internally). A vaulted-card rail stores that rail's reference instead.
+--
+-- '' = no reference captured yet (legacy/pre-#297 instrument, or no charge on
+-- that agreement type yet). Merchant-initiated charges on such instruments run
+-- reference-less with a warning and the next successful charge back-fills the
+-- reference (write-once: captures never overwrite a non-empty value).
+ALTER TABLE openrails.payment_methods
+    ADD COLUMN stored_credential_recurring_ref text DEFAULT ''::text NOT NULL,
+    ADD COLUMN stored_credential_unscheduled_ref text DEFAULT ''::text NOT NULL;
+
+COMMENT ON COLUMN openrails.payment_methods.stored_credential_recurring_ref IS 'Rail-scoped stored-credential replay reference for the RECURRING card-network agreement (NMI: gateway transactionid of the initial recurring CIT, replayed as initial_transaction_id on recurring MITs). Empty = not captured yet.';
+
+COMMENT ON COLUMN openrails.payment_methods.stored_credential_unscheduled_ref IS 'Rail-scoped stored-credential replay reference for the UNSCHEDULED card-network agreement (NMI: gateway transactionid of the initial unscheduled CIT, replayed as initial_transaction_id on unscheduled MITs). Empty = not captured yet.';


### PR DESCRIPTION
Implements **Phase A of #297** (deplatforming-resilient-card-vault): the card-network stored-credential (CIT/MIT) framework and the narrow charge seam. Phases B–D stay blocked on the Phase-0 vault-vendor signature — no vault/Spreedly code here.

## What this is

Every merchant-initiated NMI charge OpenRails sends today (dunning rebills, invoice/arrears collection, auto top-ups) carried **zero** stored-credential data. This PR models credential-on-file compliance **rail-agnostically in the engine** and upgrades the direct NMI rail immediately — the prerequisite for any future vault MIT.

## Verified NMI semantics (integration portal + docs.nmi.com + live gateway)

- `initiated_by=customer|merchant`, `stored_credential_indicator=stored|used` — **singular** "credential" (the plural spelling in the issue's earlier note appears nowhere in NMI's docs).
- `initial_transaction_id` takes **NMI's own gateway transactionid** of the sequence's initial CIT; NMI maps it to the network transaction identifier internally. No raw NTID exists anywhere in the API.
- `billing_method=recurring` rides recurring CoF only; unscheduled CoF sends no billing_method.
- **Critical subtlety:** the networks track a *separate* CoF sequence per agreement type — a recurring anchor is not valid on unscheduled MITs and vice versa ("This transaction ID cannot be used for 'unscheduled' … credential-on-file transactions").
- **Live-verified 2026-07-06** against the real gateway (public sandbox key): CIT with stored-credential fields approved; MIT replaying the CIT transactionid as `initial_transaction_id` approved; full `ChargeOutstanding` collection approved with the anchor persisted.

## Design

- **Seam** (`internal/modules/payments/charge`): `Charger.Charge(instrument, amount, Context)` — Context = Initiator (customer/merchant) × Agreement (recurring/unscheduled) × FirstUse × PriorRef. `rails/nmidirect` implements it for direct NMI; `vaulted_card` (Phase B) lands as a sibling implementation. The NMI subscription-engine lanes (`add_subscription`, `rebill_subscription`) charge NMI schedule objects rather than (instrument, amount), so they share the same Context→wire mapping instead of the interface.
- **Schema** (`0009_stored_credential_refs`): two write-once rail-scoped columns on `payment_methods` — `stored_credential_recurring_ref` + `stored_credential_unscheduled_ref` (per instrument = per rail-merchant-account+card under the #682 one-vault-per-card policy).
- **Charge sites**: checkout sale / subscription enroll / upgrade (CIT, anchor captured on success); dunning rebill + collections (MIT + anchor). Scheduled renewals stay NMI-engine-driven (rebill_driver=provider) — NMI carries CoF on those itself.
- **Legacy instruments (no ref)**: charge **reference-less with a structured warning** (merchant+used, no `initial_transaction_id`) and **back-fill the anchor from the first successful charge**. Deliberate fail-open: networks tolerate missing references on legacy credentials; refusing would break every pre-migration renewal. The back-fill bounds the noncompliance window to one charge per instrument per agreement type.
- Stored-credential sales ride **classic Direct Post** (the portal-documented CoF lane, already live-exercised by targeted sales + rebills); context-less sales keep the v5 lane.

## Tests

- Wire-pinning unit tests (nmi + nmidirect): exact form fields per Context, decline classification, validation.
- Integration (fake gateway + real DB): checkout CIT sends stored + persists anchor; anchored checkout sends used+ref; dunning MIT sends the recurring combo + ref, legacy dunning back-fills; collection MIT + back-fill + second-charge replay; enforcement guard updated for the one new sanctioned `RunSale` call site.
- Sandbox (gated on `NMI_SANDBOX_SECURITY_KEY`, run green with NMI's public demo key): CIT→MIT chain against the real gateway; collection path asserts the DB anchor. Note: the demo key cannot use query.php, so `TestLiveSandboxClientSurface`'s query leg still needs a provisioned sandbox key (pre-existing, unrelated).
- Gate: gofmt/vet/build clean; `go test ./...` green; `-tags=integration` green on nmi, money, checkout, intents, paymentmethods, payments/*, db/*, reconcile, river, webhooks, subscriptions, migrations, tests.

## Notes

- doujins consumes the rail via the Go module; columns are additive with defaults and its explicit-column upserts are unaffected (picked up on a later bump).
- #330 illumination: the stuck-pending root cause predates the #674 write-through intent; current `nmi_subscription_create` finalize activates immediate subscriptions off the direct response — remaining #330 work is live-credential verification + the Paul2 replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)