### PR TITLE
fix(#772): refuse WithMerchant ctx pin that mismatches the bound engine merchant

### DIFF
--- a/client.go
+++ b/client.go
@@ -41,7 +41,18 @@ const (
 // MerchantID is an OpenRails merchant identifier.
 type MerchantID = merchant.ID
 
-// WithMerchant pins merchant-scoped SDK calls to a merchant.
+// WithMerchant pins a per-call merchant onto ctx for merchant-scoped SDK
+// calls. Semantics differ by transport:
+//
+//   - REMOTE client (NewRemote): a no-op. Merchant identity comes from the
+//     service credential (the Bearer token), never the ctx.
+//   - EMBEDDED client (openrails/embed): the engine binds to ONE merchant no
+//     later than its first UpsertMerchantConfig. Before that bind, a
+//     WithMerchant pin is honored per call. Once bound, a ctx pin that agrees
+//     with the bound merchant is a no-op; a ctx pin naming a DIFFERENT
+//     merchant errors, naming both merchants (#772) — one embedded engine
+//     serves one merchant, so a mismatched pin is refused rather than
+//     silently executed against the bound merchant.
 func WithMerchant(ctx context.Context, id MerchantID) context.Context {
 	return merchant.WithID(ctx, id)
 }

--- a/embed/client.go
+++ b/embed/client.go
@@ -68,20 +68,35 @@ type localClient struct {
 
 // merchantCtx replicates the transport's merchant pinning (transport.go) for
 // the transcribed path: live-read the bound merchant (provisioning may bind it
-// after New), fall back to a per-call ctx pin, and stamp it before any
-// merchant-owned DB access. Without this every store call fails
+// after New), fall back to a per-call ctx pin while unbound, and stamp it
+// before any merchant-owned DB access. Without this every store call fails
 // merchant.Require in embedded mode.
-func (c *localClient) merchantCtx(ctx context.Context) context.Context {
+//
+// #772: an explicit per-call pin (openrails.WithMerchant) that disagrees with
+// an already-bound merchant is refused rather than silently overridden by the
+// bound one — one embedded engine serves one merchant.
+func (c *localClient) merchantCtx(ctx context.Context) (context.Context, error) {
 	mid := c.rt.ConfiguredMerchant()
-	if mid.IsZero() {
-		if v, ok := merchant.FromContext(ctx); ok {
+	if v, ok := merchant.FromContext(ctx); ok {
+		if !mid.IsZero() && v != mid {
+			return ctx, openrails.NewStatusError(http.StatusConflict, "", merchantMismatchMsg(mid, v))
+		}
+		if mid.IsZero() {
 			mid = v
 		}
 	}
 	if !mid.IsZero() {
 		ctx = merchant.WithID(ctx, mid)
 	}
-	return ctx
+	return ctx, nil
+}
+
+// merchantMismatchMsg is the shared error text for both merchant-pinning
+// paths (transport.go RoundTrip and this file's merchantCtx): an engine bound
+// to one merchant received a call explicitly pinned (openrails.WithMerchant)
+// to a DIFFERENT merchant (#772).
+func merchantMismatchMsg(bound, pinned merchant.ID) string {
+	return fmt.Sprintf("openrails embed: call pinned to merchant %s but engine is bound to merchant %s; one embedded engine serves one merchant", pinned, bound)
 }
 
 // ClientOption configures Runtime.Client.
@@ -187,7 +202,11 @@ func (c *localClient) Admit(ctx context.Context, req openrails.AdmitRequest) (*o
 	}
 	req.Currency = currency
 
-	res, err := c.svc.Admit(c.merchantCtx(ctx), admitInputFromSDK(req, payer))
+	mctx, err := c.merchantCtx(ctx)
+	if err != nil {
+		return nil, err
+	}
+	res, err := c.svc.Admit(mctx, admitInputFromSDK(req, payer))
 	if err != nil {
 		return nil, wrapInternalErr("admission check failed", err)
 	}
@@ -261,7 +280,11 @@ func (c *localClient) SetCustomerSpendDelegations(ctx context.Context, customerI
 			Windows:  windows,
 		})
 	}
-	if err := c.svc.ReplaceInvokerSpendLimits(c.merchantCtx(ctx), payer, next); err != nil {
+	mctx, err := c.merchantCtx(ctx)
+	if err != nil {
+		return err
+	}
+	if err := c.svc.ReplaceInvokerSpendLimits(mctx, payer, next); err != nil {
 		return wrapInternalErr("set customer spend delegations failed", err)
 	}
 	return nil

--- a/embed/localclient_admit_integration_test.go
+++ b/embed/localclient_admit_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 
@@ -119,5 +120,80 @@ func TestLocalClientAdmit(t *testing.T) {
 		require.Equal(t, 500, se.Status)
 		require.Contains(t, se.Message, "admission check failed", "stable prefix must be kept")
 		require.NotEqual(t, "admission check failed", se.Message, "the cause must be appended, not just the constant prefix")
+	})
+}
+
+// TestMerchantPinMismatch is the regression for #772: on an engine already
+// bound to a merchant (first UpsertMerchantConfig, #770), an explicit per-call
+// pin via openrails.WithMerchant naming a DIFFERENT merchant used to be
+// silently ignored — the call executed against the bound merchant instead of
+// erroring — in BOTH places that read the bound merchant: the in-process
+// transport (embed/transport.go RoundTrip, the wire path underneath
+// GetMerchantSettings) and the transcribed localClient path (embed/client.go
+// merchantCtx, underneath SetCustomerSpendDelegations). A ctx pin that AGREES
+// with the bound merchant must keep behaving exactly like an unpinned call.
+func TestMerchantPinMismatch(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+	cfg := &config.Config{Env: "dev", TestMode: config.CredentialPostureLive, DB: &config.DBConfig{URL: dsn}}
+
+	pool, err := pgxpool.New(ctx, dsn)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	slug := fmt.Sprintf("embed-merchant-pin-mismatch-%d", time.Now().UnixNano())
+	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg}})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rt.Close(context.Background()) })
+
+	boundID, err := rt.UpsertMerchantConfig(ctx, slug, embed.MerchantConfig{DisplayName: slug})
+	require.NoError(t, err)
+
+	otherID := openrails.MerchantID(uuid.New())
+	customerID := dbtest.EnsureCustomerIDPgx(ctx, t, pool, "e9e9e9e9-0000-4000-8000-000000000042")
+
+	client := rt.Client()
+
+	t.Run("wire path: GetMerchantSettings mismatch is refused", func(t *testing.T) {
+		mismatchCtx := openrails.WithMerchant(ctx, otherID)
+		_, err := client.GetMerchantSettings(mismatchCtx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), boundID.String(), "error must name the bound merchant")
+		require.Contains(t, err.Error(), otherID.String(), "error must name the pinned merchant")
+		var se *openrails.StatusError
+		require.True(t, errors.As(err, &se), "must be a *openrails.StatusError, got %T: %v", err, err)
+		require.True(t, errors.Is(err, openrails.ErrConflict))
+	})
+
+	t.Run("transcribed path: SetCustomerSpendDelegations mismatch is refused", func(t *testing.T) {
+		mismatchCtx := openrails.WithMerchant(ctx, otherID)
+		err := client.SetCustomerSpendDelegations(mismatchCtx, customerID.String(), []openrails.SpendDelegationInput{{
+			Scope:    "invoker",
+			ScopeKey: "test-invoker-mismatch",
+			Windows:  []openrails.SpendLimitWindow{{Key: "day", WindowSeconds: 86400, Limit: 5_000_000, Currency: "USD"}},
+		}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), boundID.String(), "error must name the bound merchant")
+		require.Contains(t, err.Error(), otherID.String(), "error must name the pinned merchant")
+		var se *openrails.StatusError
+		require.True(t, errors.As(err, &se), "must be a *openrails.StatusError, got %T: %v", err, err)
+		require.True(t, errors.Is(err, openrails.ErrConflict))
+	})
+
+	t.Run("matching pin behaves exactly like unpinned", func(t *testing.T) {
+		matchCtx := openrails.WithMerchant(ctx, boundID)
+
+		settings, err := client.GetMerchantSettings(matchCtx)
+		require.NoError(t, err)
+		unpinnedSettings, err := client.GetMerchantSettings(ctx)
+		require.NoError(t, err)
+		require.Equal(t, unpinnedSettings, settings)
+
+		err = client.SetCustomerSpendDelegations(matchCtx, customerID.String(), []openrails.SpendDelegationInput{{
+			Scope:    "invoker",
+			ScopeKey: "test-invoker-match",
+			Windows:  []openrails.SpendLimitWindow{{Key: "day", WindowSeconds: 86400, Limit: 5_000_000, Currency: "USD"}},
+		}})
+		require.NoError(t, err, "a ctx pin matching the bound merchant must not be refused")
 	})
 }

--- a/embed/transport.go
+++ b/embed/transport.go
@@ -2,6 +2,7 @@ package embed
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 	"github.com/open-rails/openrails/internal/controlplane"
 	"github.com/open-rails/openrails/internal/http/router"
 	httproutes "github.com/open-rails/openrails/internal/http/routes"
+	"github.com/open-rails/openrails/pkg/api"
 	"github.com/open-rails/openrails/pkg/billingauth"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
@@ -58,8 +60,17 @@ func (t *inprocessTransport) RoundTrip(req *http.Request) (*http.Response, error
 	ctx := req.Context()
 	// Live read: EnsureMerchant/provisioning may bind the merchant after New.
 	mid := t.rt.ConfiguredMerchant()
-	if mid.IsZero() {
-		if v, ok := merchant.FromContext(ctx); ok {
+	if v, ok := merchant.FromContext(ctx); ok {
+		if !mid.IsZero() && v != mid {
+			// #772: an explicit per-call pin (openrails.WithMerchant) that
+			// disagrees with the bound merchant is refused rather than
+			// silently executed against the bound one. Synthesized as a
+			// response (not a RoundTrip error): an error here would surface
+			// via remote.go's doRaw as ErrUnreachable, which is wrong for a
+			// well-formed request the engine deliberately refuses.
+			return mismatchResponse(req, mid, v), nil
+		}
+		if mid.IsZero() {
 			mid = v // host pinned it per call via openrails.WithMerchant
 		}
 	}
@@ -75,6 +86,28 @@ func (t *inprocessTransport) RoundTrip(req *http.Request) (*http.Response, error
 	w := &bufferedResponse{header: make(http.Header)}
 	t.handler.ServeHTTP(w, req.Clone(ctx))
 	return w.response(req), nil
+}
+
+// mismatchResponse synthesizes a 409 response in the pkg/api Stripe error
+// envelope shape ({"error":{"type","code","message"}}) for a merchant-pin
+// mismatch (#772). remote.go's do/statusErrorFromBody parses this envelope
+// like any real non-2xx wire response, so the call surfaces as a StatusError
+// (ErrConflict) identically to every other in-process rejection.
+func mismatchResponse(req *http.Request, bound, pinned merchant.ID) *http.Response {
+	body, _ := json.Marshal(api.ConflictError(merchantMismatchMsg(bound, pinned)).ToResponse())
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+	return &http.Response{
+		Status:        fmt.Sprintf("%d %s", http.StatusConflict, http.StatusText(http.StatusConflict)),
+		StatusCode:    http.StatusConflict,
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        header,
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+		Request:       req,
+	}
 }
 
 // bufferedResponse is a minimal in-memory http.ResponseWriter for the


### PR DESCRIPTION
## Summary
- Guard 2 of the 2026-07-06 merchant-bind discussion (#770 closed guard 1, the upsert path).
- An embedded engine bound to merchant A silently ignored an explicit per-call `openrails.WithMerchant(ctx, B)`, executing the call against A anyway — in both `embed/transport.go` (`inprocessTransport.RoundTrip`) and the transcribed `embed/client.go` (`localClient.merchantCtx`, underneath `Admit`/`SetCustomerSpendDelegations`).
- Both spots now refuse the call when the ctx-pinned merchant disagrees with the bound one, naming both merchants in the error. The transport synthesizes a 409 response in the `pkg/api` Stripe error-envelope shape (rather than returning a `RoundTrip` error, which `remote.go`'s `doRaw` would map to the wrong sentinel, `ErrUnreachable`) so it surfaces identically to a real wire rejection — `ErrConflict`. The transcribed path returns an `openrails.NewStatusError(409, ...)` directly.
- Matching or absent ctx pins, and the ctx fallback while the engine is unbound, are unchanged.
- Doc-only: `openrails.WithMerchant`'s comment now states the real per-transport semantics (remote: no-op; embedded: pre-bind pin, post-bind mismatch errors).

## Test plan
- [x] `go build ./... && go vet ./embed/ . && gofmt -l embed/ .` clean
- [x] New `TestMerchantPinMismatch` in `embed/localclient_admit_integration_test.go`: verified RED on unfixed code (stashed the fix, both mismatch subtests failed with "expected error, got nil"; matching-pin subtest passed), GREEN after restoring the fix.
- [x] `go test -tags integration ./embed/ -count=1` fully green (no regressions in the conformance / #767 / #768 tests).