### PR TITLE
fix(#775): manifest-mode checkout pre-gate + route derivation honor DB-armed rail accounts

### DIFF
--- a/embed/manifest_mode_integration_test.go
+++ b/embed/manifest_mode_integration_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/open-rails/openrails/internal/modules/money"
 	"github.com/open-rails/openrails/internal/reconcile"
 	"github.com/open-rails/openrails/internal/shared/moneyutil"
+	"github.com/open-rails/openrails/pkg/api"
 	"github.com/open-rails/openrails/pkg/billingauth"
 	"github.com/open-rails/openrails/pkg/embedded"
 	"github.com/open-rails/openrails/pkg/merchant"
@@ -522,4 +523,147 @@ func TestManifestMode_ReadSideBindKeepsWorking(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, id, boundID, "the empty upsert binds to the same merchant")
 	require.Equal(t, boundID, reader.Embedded().App().Runtime.ConfiguredMerchant())
+}
+
+// bootManifestRuntimeWithRailAccounts boots a MODE-1 runtime declaring
+// railAccounts through UpsertMerchantConfig directly (no manifest bytes/YAML,
+// no catalog) — the same doujins/hentai0 shape as
+// TestEmbeddedPullArming_ManifestSecretsNoPaymentProviders. Options.PaymentProviders
+// is deliberately unset, so Runtime.Rails (the legacy boot-config bridge) stays
+// empty while Runtime.Merchants arms from the DB-projected accounts (#775).
+func bootManifestRuntimeWithRailAccounts(t *testing.T, ctx context.Context, dsn, slug string, railAccounts map[string]embed.RailMerchantAccountConfig) (*embed.Runtime, merchant.ID) {
+	t.Helper()
+	appDB := dbtest.OpenAppDB(t, dsn)
+	cfg := manifestModeConfig(dsn)
+	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg}})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rt.Close(context.Background()) })
+	id, err := rt.UpsertMerchantConfig(ctx, slug, embed.MerchantConfig{
+		DisplayName:          slug,
+		RailMerchantAccounts: railAccounts,
+	})
+	require.NoError(t, err)
+	require.False(t, id.IsZero())
+	t.Cleanup(func() {
+		for _, stmt := range []string{
+			`DELETE FROM openrails.rail_merchant_accounts WHERE merchant_id = $1`,
+			`DELETE FROM openrails.merchants WHERE id = $1`,
+		} {
+			_, _ = appDB.Pool().Exec(context.Background(), stmt, id.UUID())
+		}
+	})
+	require.Empty(t, rt.Embedded().App().Runtime.Rails, "MODE-1 manifest host never populates the legacy Rails bridge")
+	return rt, id
+}
+
+// TestManifestMode_CheckoutPreGateAcceptsDBArmedRail is #775's RED/GREEN pin:
+// before the fix, checkoutRailConfigured only consulted the DB for NMI, so a
+// MODE-1 host with a manifest-armed ccbill account (and no
+// embedded.Options.PaymentProviders, since manifest hosts deliberately don't
+// use it) 400s "unsupported rail" on POST /v1/me/checkout with rail=ccbill —
+// even though the deeper checkout service would resolve the account fine.
+//
+// A deliberately-nonexistent price_id is used: the point of this test is the
+// PRE-GATE boundary, not a full checkout — proving the request reaches
+// price-lookup validation (a DIFFERENT 400 message) instead of being rejected
+// by the rail pre-gate is exactly what distinguishes the two behaviors.
+func TestManifestMode_CheckoutPreGateAcceptsDBArmedRail(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+
+	nano := time.Now().UnixNano()
+	slug := fmt.Sprintf("mccbill%d", nano)
+	ccbillAccount := fmt.Sprintf("92%04d-0000", nano%10_000)
+
+	rt, id := bootManifestRuntimeWithRailAccounts(t, ctx, dsn, slug, map[string]embed.RailMerchantAccountConfig{
+		"ccbill": {
+			"ccbill": {
+				Environment: "live",
+				AccountID:   ccbillAccount,
+				Secrets: map[string]string{
+					"datalink_username": "dl-user-" + slug,
+					"datalink_password": "dl-pass-" + slug,
+				},
+			},
+		},
+	})
+
+	authn := billingauth.DelegatedAuthenticatorFunc(func(context.Context, *http.Request) (*billingauth.DelegatedPrincipal, error) {
+		return &billingauth.DelegatedPrincipal{MerchantID: id.UUID().String(), SubjectID: uuid.NewString()}, nil
+	})
+	handler, err := embedded.MountHandler(rt.Embedded(), embedded.MountOptions{
+		RouteSets:              []embed.RouteSet{embed.RouteSetCustomer},
+		DelegatedAuthenticator: authn,
+	})
+	require.NoError(t, err)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	body := fmt.Sprintf(`{"price_id":%q,"payment":{"rail":"ccbill"}}`, api.FormatPriceID(uuid.New()))
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/me/checkout", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer host-credential")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode, string(raw))
+	require.NotContains(t, string(raw), "unsupported rail", "the ccbill pre-gate must pass: an active manifest/DB-armed ccbill account exists")
+	require.Contains(t, string(raw), "price not found", "past the pre-gate, the request fails deeper on the fabricated price_id")
+}
+
+// TestManifestMode_ProviderRoutesDeriveWebhooksFromDBArmedAccounts is #775's
+// other RED/GREEN pin: ProviderRoutesForRuntime derived the mounted provider
+// surface from the empty Rails bridge alone, silently dropping the webhook
+// routes for a MODE-1 host with a manifest-armed rail account. With the fix,
+// an armed ccbill account is enough to mount the merchant webhook route: the
+// request reaches the ccbill handler (403 IP-allowlist, since this isn't a
+// real CCBill source) instead of 404 (route never registered).
+func TestManifestMode_ProviderRoutesDeriveWebhooksFromDBArmedAccounts(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+
+	nano := time.Now().UnixNano()
+	slug := fmt.Sprintf("mwebhook%d", nano)
+	ccbillAccount := fmt.Sprintf("93%04d-0000", nano%10_000)
+
+	rt, _ := bootManifestRuntimeWithRailAccounts(t, ctx, dsn, slug, map[string]embed.RailMerchantAccountConfig{
+		"ccbill": {
+			"ccbill": {
+				Environment: "live",
+				AccountID:   ccbillAccount,
+				Secrets: map[string]string{
+					"datalink_username": "dl-user-" + slug,
+					"datalink_password": "dl-pass-" + slug,
+				},
+			},
+		},
+	})
+
+	// RouteSetWebhooks alone needs neither Gate nor Authenticator
+	// (validateAuthBoundary only requires them for checkout/customer/merchant-admin
+	// route sets) — and ProviderRoutes is left nil, so MountHandler must derive it
+	// via ProviderRoutesForRuntime.
+	handler, err := embedded.MountHandler(rt.Embedded(), embedded.MountOptions{
+		RouteSets: []embed.RouteSet{embed.RouteSetWebhooks},
+	})
+	require.NoError(t, err)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/merchants/"+slug+"/webhooks/ccbill", strings.NewReader("{}"))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	require.NotEqual(t, http.StatusNotFound, resp.StatusCode, string(raw))
+	require.Equal(t, http.StatusForbidden, resp.StatusCode, string(raw))
+	require.Contains(t, string(raw), "Unauthorized webhook source", "the route must be mounted and resolve the merchant slug to reach the ccbill IP-allowlist check")
 }

--- a/internal/http/embedhttp/self.go
+++ b/internal/http/embedhttp/self.go
@@ -1,6 +1,7 @@
 package embedhttp
 
 import (
+	"context"
 	"net/http"
 
 	redis "github.com/redis/go-redis/v9"
@@ -8,6 +9,7 @@ import (
 	"github.com/open-rails/openrails/config"
 	"github.com/open-rails/openrails/internal/app"
 	"github.com/open-rails/openrails/internal/captcha"
+	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/http/middleware"
 	"github.com/open-rails/openrails/internal/http/router"
 	httproutes "github.com/open-rails/openrails/internal/http/routes"
@@ -82,17 +84,55 @@ func NewSelfHandler(rt *app.Runtime, authn billingauth.DelegatedAuthenticator, p
 // ProviderRoutesForRuntime derives provider-specific route gating from the
 // runtime's configured rails + probed capabilities (#661); an explicit override
 // wins; no runtime information means the permissive default.
+//
+// rt.Rails is the legacy boot-config bridge (only populated by
+// embedded.Options.PaymentProviders) — empty in every MODE-1 manifest host
+// (#775). When it's empty but a merchant is bound, derive the surface from
+// that merchant's DB-armed rail accounts instead of silently deriving "no
+// routes" from the empty bridge.
 func ProviderRoutesForRuntime(rt *app.Runtime, override *routesurface.ProviderRoutes) routesurface.ProviderRoutes {
 	if override != nil {
 		return *override
 	}
-	if rt != nil {
-		if len(rt.Rails) > 0 || !rt.ConfiguredMerchant().IsZero() {
-			if caps := rt.RouteCapabilities; caps != nil {
-				return routesurface.ProviderRoutesFromRailsWithCapabilities(rt.Rails, *caps)
-			}
-			return routesurface.ProviderRoutesFromRails(rt.Rails)
+	if rt == nil {
+		return routesurface.AllProviderRoutes()
+	}
+	if len(rt.Rails) > 0 {
+		if caps := rt.RouteCapabilities; caps != nil {
+			return routesurface.ProviderRoutesFromRailsWithCapabilities(rt.Rails, *caps)
 		}
+		return routesurface.ProviderRoutesFromRails(rt.Rails)
+	}
+	if mid := rt.ConfiguredMerchant(); !mid.IsZero() && rt.Merchants != nil {
+		r := armedProviderRoutes(context.Background(), rt, mid)
+		if caps := rt.RouteCapabilities; caps != nil {
+			r.SolanaSigning = r.Solana && caps.SolanaCanSign
+			r.SecretWrite = caps.SecretWrite
+		} else {
+			r.SolanaSigning = r.Solana
+			r.SecretWrite = true
+		}
+		return r
 	}
 	return routesurface.AllProviderRoutes()
+}
+
+// armedProviderRoutes derives the route surface from mid's DB-armed rail
+// accounts (#775) — the mount-time analogue of the per-request DB fallback
+// checkoutRailConfigured / effectiveSolanaRailConfig use. This runs ONCE at
+// handler-assembly time (not per request), so one query per rail is not a hot
+// path concern.
+func armedProviderRoutes(ctx context.Context, rt *app.Runtime, mid merchant.ID) routesurface.ProviderRoutes {
+	env := config.ExpectedProviderEnvironment(rt.Config != nil && rt.Config.IsTestMode())
+	armed := func(rail string) bool {
+		_, ok, err := rt.Merchants.ActiveRailMerchantAccountScope(ctx, mid, rail, env)
+		return err == nil && ok
+	}
+	stripe := armed(string(models.RailStripe))
+	solana := armed(string(models.RailSolana))
+	return routesurface.ProviderRoutes{
+		StripePortal: stripe,
+		Solana:       solana,
+		Webhooks:     stripe || armed(string(models.RailNMI)) || armed(string(models.RailCCBill)),
+	}
 }

--- a/internal/http/handlers/checkout_session.go
+++ b/internal/http/handlers/checkout_session.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/open-rails/openrails/config"
-	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/http/middleware"
 	httprequest "github.com/open-rails/openrails/internal/http/request"
 	"github.com/open-rails/openrails/internal/modules/checkout"
@@ -127,6 +126,13 @@ func CreateCheckoutSession(r *httprequest.Request) {
 	r.SuccessJSON(resp)
 }
 
+// checkoutRailConfigured reports whether rail is usable for this request's
+// checkout. r.State.Rails is the legacy boot-config bridge (only populated by
+// embedded.Options.PaymentProviders) — empty in every MODE-1 manifest host, so
+// the fallback below (the same DB-armed-account pattern
+// effectiveSolanaRailConfig uses, #775) is the primary signal there: ANY rail
+// with an active manifest/DB-armed account for the request merchant +
+// environment is configured, not just NMI.
 func checkoutRailConfigured(r *httprequest.Request, rail string) bool {
 	if r == nil || r.State == nil {
 		return false
@@ -134,7 +140,7 @@ func checkoutRailConfigured(r *httprequest.Request, rail string) bool {
 	if rails.IsConfigured(r.State.Rails, rail) {
 		return true
 	}
-	if !rails.IsNMI(models.Rail(rail)) || r.State.Merchants == nil {
+	if r.State.Merchants == nil {
 		return false
 	}
 	mid, ok := merchant.FromContext(r.Request.Context())
@@ -143,7 +149,7 @@ func checkoutRailConfigured(r *httprequest.Request, rail string) bool {
 	}
 	// Environment follows deployment posture (#681): test rows under test_mode.
 	env := config.ExpectedProviderEnvironment(r.State.Config != nil && r.State.Config.IsTestMode())
-	_, ok, err := r.State.Merchants.ActiveRailMerchantAccountSecretName(r.Request.Context(), mid, string(models.RailNMI), env, "security_key")
+	_, ok, err := r.State.Merchants.ActiveRailMerchantAccountScope(r.Request.Context(), mid, rail, env)
 	return err == nil && ok
 }
 func GetCheckoutSession(r *httprequest.Request) {


### PR DESCRIPTION
## Summary
- `checkoutRailConfigured` (internal/http/handlers/checkout_session.go) generalizes its DB fallback from NMI-only to any rail, via `Runtime.Merchants.ActiveRailMerchantAccountScope` — the pattern `effectiveSolanaRailConfig` already uses. Fixes `POST /v1/me/checkout` 400ing "unsupported rail" for ccbill/stripe/solana on MODE-1 (`merchant_source=manifest`) embedded hosts.
- `ProviderRoutesForRuntime` (internal/http/embedhttp/self.go) now derives the provider-route surface from the merchant's DB-armed rail accounts when `Runtime.Rails` (the legacy boot-config bridge, only populated by `embedded.Options.PaymentProviders`) is empty but a merchant is bound — instead of silently deriving "no routes" from the empty bridge and dropping webhook/solana routes.

Follows #775's suggested fix as-is; no deviation.

Performance: the DB fallback in `checkoutRailConfigured` is the same one-roundtrip-per-check pattern already used for NMI (now for every rail); `armedProviderRoutes` runs once at handler-assembly/mount time, not per request, so the extra per-rail queries aren't a hot path.

## Test plan
- [x] New integration tests in `embed/manifest_mode_integration_test.go` (build tag `integration`):
  - `TestManifestMode_CheckoutPreGateAcceptsDBArmedRail` — MODE-1 host with a manifest-armed ccbill account accepts the checkout pre-gate (asserted through the HTTP surface via `embedded.MountHandler`).
  - `TestManifestMode_ProviderRoutesDeriveWebhooksFromDBArmedAccounts` — `ProviderRoutesForRuntime` (nil `MountOptions.ProviderRoutes`) mounts the webhook route from DB-armed accounts.
- [x] Verified RED on both tests against the unfixed code (stash/unstash), GREEN after the fix.
- [x] `go test -tags integration ./embed/...` — full package green.
- [x] `go test -tags integration ./tests/... -run Checkout` — existing standalone checkout tests unaffected.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean.