### PR TITLE
refactor(#250): mount control-plane auth via authhttp.MountHandler

### DIFF
--- a/internal/controlplane/posture_test.go
+++ b/internal/controlplane/posture_test.go
@@ -33,8 +33,11 @@ func TestHostedPostureIsCodeOnlyOptIn(t *testing.T) {
 	if cp.SelfHostedPosture() {
 		t.Fatal("hosted posture should not report self-hosted")
 	}
+	// Hosted groups derive from the live DefaultAPI surface; with no auth
+	// service wired the allow-list is empty — the mount registers nothing
+	// (fail closed), never AuthKit's implicit default surface.
 	if got := cp.MountedRouteGroups(); got != nil {
-		t.Fatalf("MountedRouteGroups() = %#v, want nil for AuthKit DefaultAPI", got)
+		t.Fatalf("MountedRouteGroups() = %#v, want nil without an auth service", got)
 	}
 	if got := registrationMode(false); got != authcore.RegistrationModeOpen {
 		t.Fatalf("registrationMode(false) = %q, want %q", got, authcore.RegistrationModeOpen)

--- a/internal/controlplane/routes.go
+++ b/internal/controlplane/routes.go
@@ -30,10 +30,11 @@ var IntentionalRouteGroups = []authhttp.RouteGroup{
 	authhttp.RoutePermissionGroups,
 }
 
-// MountedRouteGroups returns the AuthKit route groups this control plane mounts.
-// In locked-down mode it returns the intentional (non-DefaultAPI) subset; when
-// not locked down (hosted-SaaS posture) it returns nil to signal "mount the full
-// DefaultAPI surface" to the caller.
+// MountedRouteGroups returns the AuthKit route groups this control plane
+// mounts, always as an EXPLICIT allow-list (a nil MountOptions.Groups would
+// mount AuthKit's default surface plus browser OIDC). Locked-down mode returns
+// the intentional subset; hosted-SaaS posture returns the groups present in
+// AuthKit's DefaultAPI surface — still never browser OIDC or JWKS.
 func (c *ControlPlane) MountedRouteGroups() []authhttp.RouteGroup {
 	if c == nil {
 		return nil
@@ -43,45 +44,51 @@ func (c *ControlPlane) MountedRouteGroups() []authhttp.RouteGroup {
 		copy(out, IntentionalRouteGroups)
 		return out
 	}
-	// Hosted-SaaS posture: caller may choose to mount DefaultAPI. We still avoid
-	// returning DefaultAPI() implicitly here — see RouteSpecs.
-	return nil
+	if c.authSvc == nil {
+		return nil
+	}
+	var out []authhttp.RouteGroup
+	seen := map[authhttp.RouteGroup]bool{}
+	for _, spec := range c.authSvc.Routes().DefaultAPI() {
+		if !seen[spec.Group] {
+			seen[spec.Group] = true
+			out = append(out, spec.Group)
+		}
+	}
+	return out
 }
 
-// RouteSpecs returns the concrete AuthKit route specs to mount. In locked-down
-// mode this is ONLY the intentional groups (never DefaultAPI). When not locked
-// down it returns the full DefaultAPI surface.
+// RouteSpecs returns the concrete AuthKit route specs the control plane
+// serves (the posture's groups, lazy-customer-wrapped). The HTTP layer mounts
+// this exact surface via authhttp.MountHandler (#250) with the same
+// MountedRouteGroups + WrapAuthRoute inputs; the route-surface test pins the
+// two against each other.
 func (c *ControlPlane) RouteSpecs() []authhttp.RouteSpec {
 	if c == nil || c.authSvc == nil {
 		return nil
 	}
-	routes := c.authSvc.Routes()
-	var specs []authhttp.RouteSpec
-	if c.SelfHostedPosture() {
-		specs = routes.Groups(IntentionalRouteGroups...)
-	} else {
-		specs = routes.DefaultAPI()
+	groups := c.MountedRouteGroups()
+	if len(groups) == 0 {
+		return nil
 	}
-	return c.withLazyCustomerGroups(specs)
-}
-
-// The gin mounting of these route specs lives in
-// internal/controlplane/ginroutes.MountAuthRoutes (#285): it consumes RouteSpecs
-// and adapts each net/http handler to gin, keeping this core gin-free.
-
-func (c *ControlPlane) withLazyCustomerGroups(specs []authhttp.RouteSpec) []authhttp.RouteSpec {
+	specs := c.authSvc.Routes().Groups(groups...)
 	out := make([]authhttp.RouteSpec, len(specs))
 	copy(out, specs)
 	for i := range out {
-		if out[i].Group != authhttp.RoutePermissionGroups {
-			continue
-		}
-		if !strings.HasPrefix(out[i].Path, "/"+CustomerType+"/{instance_slug}/") {
-			continue
-		}
-		out[i].Handler = c.lazyCustomerGroupHandler(out[i].Handler)
+		out[i].Handler = c.WrapAuthRoute(out[i], out[i].Handler)
 	}
 	return out
+}
+
+// WrapAuthRoute is the control plane's per-route mount decoration
+// (MountOptions.Wrap): declared customer group-management routes get the lazy
+// customer permission-group ensure; everything else passes through.
+func (c *ControlPlane) WrapAuthRoute(spec authhttp.RouteSpec, h http.Handler) http.Handler {
+	if c == nil || spec.Group != authhttp.RoutePermissionGroups ||
+		!strings.HasPrefix(spec.Path, "/"+CustomerType+"/{instance_slug}/") {
+		return h
+	}
+	return c.lazyCustomerGroupHandler(h)
 }
 
 func (c *ControlPlane) lazyCustomerGroupHandler(next http.Handler) http.Handler {

--- a/internal/http/routes_controlplane.go
+++ b/internal/http/routes_controlplane.go
@@ -3,6 +3,7 @@ package server
 import (
 	"net/http"
 
+	authhttp "github.com/open-rails/authkit/authhttp"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -10,19 +11,46 @@ import (
 // groups (#224). It is a deliberate, narrow surface — NOT AuthKit DefaultAPI.
 const ControlPlaneAuthPrefix = "/auth"
 
-// registerControlPlaneAuthRoutes selectively mounts the AuthKit route groups
-// OpenRails intentionally exposes (#224 task 4). In locked-down/self-hosted mode
-// this is only the login/session/user groups; AuthKit DefaultAPI() is never
-// mounted. AuthKit specs are native net/http ServeMux patterns, so they mount
-// directly (#670 — the gin path translation shim is gone).
-func (s *Server) registerControlPlaneAuthRoutes(mux *http.ServeMux) {
-	specs := s.controlPlane.RouteSpecs()
-	for _, spec := range specs {
-		s.handle(mux, spec.Method+" "+ControlPlaneAuthPrefix+spec.Path, spec.Handler)
+// registerControlPlaneAuthRoutes mounts the AuthKit route groups OpenRails
+// intentionally exposes (#224 task 4) as ONE neutral authhttp.MountHandler
+// (authkit #250) under /auth. Groups is the posture's explicit allow-list
+// (ControlPlane.MountedRouteGroups — never nil, which would mount AuthKit's
+// default surface plus browser OIDC); JWKS is excluded (OpenRails does not
+// expose AuthKit's JWKS on this surface) and browser OIDC is in no mounted
+// group list. The lazy customer permission-group ensure rides
+// MountOptions.Wrap.
+func (s *Server) registerControlPlaneAuthRoutes(mux *http.ServeMux) error {
+	cp := s.controlPlane
+	if cp == nil || cp.AuthService() == nil {
+		return nil
 	}
+	groups := cp.MountedRouteGroups()
+	if len(groups) == 0 {
+		// Fail closed: an empty allow-list mounts nothing, never the default surface.
+		return nil
+	}
+	mount, err := authhttp.MountHandler(cp.AuthService(), authhttp.MountOptions{
+		Groups:        groups,
+		APIPrefix:     ControlPlaneAuthPrefix,
+		ExcludeRoutes: []authhttp.RouteRef{{Method: http.MethodGet, Path: authhttp.JWKSPath}},
+		Wrap:          cp.WrapAuthRoute,
+	})
+	if err != nil {
+		return err
+	}
+	// Record the served surface per spec — the mount serves exactly
+	// ControlPlane.RouteSpecs() under /auth (pinned by the route-surface test).
+	specs := cp.RouteSpecs()
+	for _, spec := range specs {
+		s.recordRoute(spec.Method + " " + ControlPlaneAuthPrefix + spec.Path)
+	}
+	mux.Handle(ControlPlaneAuthPrefix+"/", mount)
+	// Exact /auth: the mount's clean 404, not ServeMux's implicit 301 to /auth/.
+	mux.Handle(ControlPlaneAuthPrefix, mount)
 	log.WithFields(log.Fields{
 		"prefix":      ControlPlaneAuthPrefix,
 		"routes":      len(specs),
-		"self_hosted": s.controlPlane.SelfHostedPosture(),
+		"self_hosted": cp.SelfHostedPosture(),
 	}).Info("control plane: mounted selective AuthKit route groups")
+	return nil
 }

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -388,10 +388,13 @@ func New(deps Dependencies) (*Server, error) {
 	// standalone-only (root-group-gated; no embedded analogue).
 	s.registerPlatformRoutes(mux)
 
-	// Selective AuthKit route mounting (#224). In locked-down mode this mounts
-	// ONLY the intentional AuthKit route groups (login/session/user) under
-	// /auth — never AuthKit DefaultAPI.
-	s.registerControlPlaneAuthRoutes(mux)
+	// Selective AuthKit route mounting (#224, authhttp.MountHandler since
+	// authkit #250). In locked-down mode this mounts ONLY the intentional
+	// AuthKit route groups (login/session/user) under /auth — never AuthKit
+	// DefaultAPI.
+	if err := s.registerControlPlaneAuthRoutes(mux); err != nil {
+		return nil, err
+	}
 
 	// Merchant admin console SPA (#740/#754): mounted only when assets are
 	// present AND admin_console.enabled; enabled without assets refuses boot.


### PR DESCRIPTION
Migrates the /auth control-plane mounting off the hand iteration of `ControlPlane.RouteSpecs()` onto authkit #250's `authhttp.MountHandler` — the API MountHandler was modeled on (openrails #583/#769), so the posture maps directly:

- `APIPrefix: "/auth"` anchors the JSON API at the existing prefix (no MountPrefix — paths arrive canonical).
- `Groups` = the posture's explicit allow-list: locked-down/self-hosted keeps `IntentionalRouteGroups` verbatim; hosted-SaaS now derives the explicit group list from the live DefaultAPI surface instead of returning nil (a nil `MountOptions.Groups` would implicitly add browser OIDC — never mounted here).
- JWKS excluded via `ExcludeRoutes` (OpenRails does not expose AuthKit's JWKS on this surface); browser OIDC is in no mounted group list. Exposure unchanged.
- The lazy customer permission-group ensure rides `MountOptions.Wrap` (`ControlPlane.WrapAuthRoute`); `RouteSpecs()` derives from the same groups + wrap, and the route-surface test keeps pinning the mounted /auth surface against it verbatim (per-spec patterns still recorded in RouteTable).
- Exact `/auth` registered alongside `/auth/` so ServeMux's implicit 301 never appears (was a 404, stays a 404).
- Mount construction failures propagate as boot errors (fail closed; an empty allow-list mounts nothing, never the default surface).

Tests: `go build ./...`, `go vet ./...` + `go vet -tags integration ./...`, `go test ./...` green; `scripts/test_integration.sh ./...` running (results before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)