### PR TITLE
feat(#777): merchant console price-change wizard

### DIFF
--- a/internal/db/gen/reprice_batches.sql.go
+++ b/internal/db/gen/reprice_batches.sql.go
@@ -121,3 +121,49 @@ func (q *Queries) ListRepriceBatches(ctx context.Context, arg ListRepriceBatches
 	}
 	return items, nil
 }
+
+const listRepriceBatchesByPriceKey = `-- name: ListRepriceBatchesByPriceKey :many
+SELECT id, merchant_id, price_key, to_price_id, effective_at, subscriptions_matched, subscriptions_scheduled, subscriptions_skipped, created_at FROM openrails.reprice_batches
+WHERE price_key = $1::text
+ORDER BY created_at DESC
+LIMIT $3::int OFFSET $2::int
+`
+
+type ListRepriceBatchesByPriceKeyParams struct {
+	PriceKey   string
+	PageOffset int32
+	PageLimit  int32
+}
+
+// #777: the console's price page needs "is there a pending migration for this
+// price key" without already knowing a batch id — list a key's bulk reprice
+// operations, most recent first.
+func (q *Queries) ListRepriceBatchesByPriceKey(ctx context.Context, arg ListRepriceBatchesByPriceKeyParams) ([]OpenrailsRepriceBatch, error) {
+	rows, err := q.db.Query(ctx, listRepriceBatchesByPriceKey, arg.PriceKey, arg.PageOffset, arg.PageLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []OpenrailsRepriceBatch
+	for rows.Next() {
+		var i OpenrailsRepriceBatch
+		if err := rows.Scan(
+			&i.ID,
+			&i.MerchantID,
+			&i.PriceKey,
+			&i.ToPriceID,
+			&i.EffectiveAt,
+			&i.SubscriptionsMatched,
+			&i.SubscriptionsScheduled,
+			&i.SubscriptionsSkipped,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/internal/db/queries/reprice_batches.sql
+++ b/internal/db/queries/reprice_batches.sql
@@ -17,3 +17,12 @@ SELECT * FROM openrails.reprice_batches WHERE id = $1;
 SELECT * FROM openrails.reprice_batches
 ORDER BY created_at DESC
 LIMIT sqlc.arg(page_limit)::int OFFSET sqlc.arg(page_offset)::int;
+
+-- #777: the console's price page needs "is there a pending migration for this
+-- price key" without already knowing a batch id — list a key's bulk reprice
+-- operations, most recent first.
+-- name: ListRepriceBatchesByPriceKey :many
+SELECT * FROM openrails.reprice_batches
+WHERE price_key = sqlc.arg(price_key)::text
+ORDER BY created_at DESC
+LIMIT sqlc.arg(page_limit)::int OFFSET sqlc.arg(page_offset)::int;

--- a/internal/http/handlers/admin_catalog.go
+++ b/internal/http/handlers/admin_catalog.go
@@ -357,6 +357,33 @@ func AdminGetPriceByKey(r *httprequest.Request) {
 	r.JSON(http.StatusOK, out)
 }
 
+// AdminGetPriceKeyHistory returns a price key's full version chain resolved
+// from the #774 pointer-movement log (most-recent-first) — the #777 console
+// price page's "version chain with dates" surface. Not part of #774's
+// original HTTP surface (which only exposed by-key resolution + relabel).
+func AdminGetPriceKeyHistory(r *httprequest.Request) {
+	key := strings.TrimSpace(r.Param("key"))
+	if key == "" {
+		r.ErrorJSON(http.StatusBadRequest, "key required")
+		return
+	}
+	svc, ok := newAdminBillingService(r)
+	if !ok {
+		return
+	}
+	items, err := svc.GetPriceKeyHistory(r.Request.Context(), key)
+	if err != nil {
+		writeCatalogError(r, priceLookupErr(err))
+		return
+	}
+	r.JSON(http.StatusOK, paginatedResponse[billingservice.PriceKeyHistoryEntry]{
+		Items:  items,
+		Total:  int64(len(items)),
+		Limit:  len(items),
+		Offset: 0,
+	})
+}
+
 type setPriceKeyRequest struct {
 	Key string `json:"key"`
 }

--- a/internal/http/handlers/admin_reprice.go
+++ b/internal/http/handlers/admin_reprice.go
@@ -142,6 +142,57 @@ func RepriceAllPriorVersions(r *httprequest.Request) {
 	r.JSON(http.StatusCreated, out)
 }
 
+// PreviewRepriceAllPriorVersions is #777's read-only dry-run counterpart to
+// RepriceAllPriorVersions: returns the affected-count WITHOUT scheduling
+// anything — the console wizard's Step 2 preview, called before the price
+// edit that would create the new version. Not part of #773's original
+// surface (which only exposed the mutating bulk call).
+func PreviewRepriceAllPriorVersions(r *httprequest.Request) {
+	key := strings.TrimSpace(r.Query("price_key"))
+	if key == "" {
+		r.ErrorJSON(http.StatusBadRequest, "price_key required")
+		return
+	}
+	if r.State.RepriceService == nil {
+		r.ErrorJSON(http.StatusInternalServerError, "reprice service unavailable")
+		return
+	}
+	out, err := r.State.RepriceService.PreviewAllPriorVersions(r.Request.Context(), key)
+	if err != nil {
+		writeRepriceError(r, err)
+		return
+	}
+	r.JSON(http.StatusOK, out)
+}
+
+// ListRepriceBatchesByKey lists a price key's bulk reprice operations, most
+// recent first — the #777 console price page's "is there a pending
+// migration for this key" surface (without already knowing a batch id).
+func ListRepriceBatchesByKey(r *httprequest.Request) {
+	key := strings.TrimSpace(r.Query("price_key"))
+	if key == "" {
+		r.ErrorJSON(http.StatusBadRequest, "price_key required")
+		return
+	}
+	if r.State.RepriceService == nil {
+		r.ErrorJSON(http.StatusInternalServerError, "reprice service unavailable")
+		return
+	}
+	limit := parseIntDefault(r.Query("limit"), 20)
+	offset := parseIntDefault(r.Query("offset"), 0)
+	items, err := r.State.RepriceService.ListBatchesForKey(r.Request.Context(), key, limit, offset)
+	if err != nil {
+		writeRepriceError(r, err)
+		return
+	}
+	r.JSON(http.StatusOK, paginatedResponse[*models.RepriceBatch]{
+		Items:  items,
+		Total:  int64(len(items)),
+		Limit:  limit,
+		Offset: offset,
+	})
+}
+
 // ListSubscriptionReprices lists scheduled/applied/canceled reprices, filtered
 // by subscription_id / reprice_batch_id / status — the inspect-before-effect
 // surface the #777 console wizard needs.

--- a/internal/http/routes/routes.go
+++ b/internal/http/routes/routes.go
@@ -618,6 +618,9 @@ func registerCatalogActionRoutes(catalog router.Router, rt *app.Runtime, opts Op
 	prices.Handle(http.MethodPost, "", h(httphandlers.AdminCreatePrice), writeMW...)
 	prices.Handle(http.MethodGet, "", h(httphandlers.AdminListPrices), readMW...)
 	prices.Handle(http.MethodGet, "/by-key/:key", h(httphandlers.AdminGetPriceByKey), readMW...)
+	// #777: the key's version chain resolved from the #774 pointer-movement
+	// log, most-recent-first — the console price page's "history with dates".
+	prices.Handle(http.MethodGet, "/by-key/:key/history", h(httphandlers.AdminGetPriceKeyHistory), readMW...)
 	prices.Handle(http.MethodGet, "/:id", h(httphandlers.AdminGetPrice), readMW...)
 	prices.Handle(http.MethodPatch, "/:id", h(httphandlers.AdminUpdatePrice), writeMW...)
 	prices.Handle(http.MethodPost, "/:id/activate", h(httphandlers.AdminActivatePrice), writeMW...)
@@ -688,8 +691,16 @@ func registerMerchantSupportRoutes(rr router.Router, opts Options, dbMW ...route
 	// the inspect (list/get) and cancel-before-effective surface the #777
 	// console wizard needs.
 	rr.Handle(http.MethodPost, "/catalog/reprice-all-prior-versions", h(httphandlers.RepriceAllPriorVersions), subWrite...)
+	// #777: read-only dry-run affected-count preview — the wizard's Step 2,
+	// called BEFORE the price edit that creates the new version (so never
+	// mutates, unlike the bulk call above).
+	rr.Handle(http.MethodGet, "/catalog/reprice-all-prior-versions/preview", h(httphandlers.PreviewRepriceAllPriorVersions), subRead...)
 	reprices := rr.Group("/reprices")
 	reprices.Handle(http.MethodGet, "", h(httphandlers.ListSubscriptionReprices), subRead...)
+	// #777: list a price key's bulk reprice batches (pending-migration display
+	// on the price page) — must be registered before "/:id" so "batches" is
+	// never captured as an id.
+	reprices.Handle(http.MethodGet, "/batches", h(httphandlers.ListRepriceBatchesByKey), subRead...)
 	reprices.Handle(http.MethodGet, "/:id", h(httphandlers.GetSubscriptionReprice), subRead...)
 	reprices.Handle(http.MethodPost, "/:id/cancel", h(httphandlers.CancelSubscriptionReprice), subWrite...)
 

--- a/internal/integrationharness/merchant_reprice_wizard_http_test.go
+++ b/internal/integrationharness/merchant_reprice_wizard_http_test.go
@@ -1,0 +1,274 @@
+//go:build integration
+
+package integrationharness
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/controlplane"
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/internal/modules/subscriptions"
+	"github.com/open-rails/openrails/pkg/catalog"
+	billingservice "github.com/open-rails/openrails/pkg/service"
+)
+
+// These tests drive the #777 console price-change wizard's backend contract
+// end to end over real HTTP: the read-only affected-count preview and
+// version-history endpoints added in this PR, plus the #773 bulk reprice /
+// list / cancel surface the wizard rides directly. UI-level behavior (step
+// defaults, the notice-window date gate, the review-in-words text) has NO
+// automated coverage — web/admin has no test runner (tsc/eslint/vite build
+// only) — so this file is the whole automated proof for the wizard's four
+// spec cases; everything at the React layer needs manual/future e2e
+// verification.
+
+// seedRepriceSubscription inserts an active subscription pinned to priceID
+// directly (no checkout rail needed for these read/schedule-path tests) —
+// mirrors internal/modules/subscriptions/reprice_integration_test.go's own
+// fixture idiom.
+func seedRepriceSubscription(t *testing.T, ctx context.Context, h *Harness, productID, priceID uuid.UUID) uuid.UUID {
+	t.Helper()
+	pool := h.Pool()
+	var customerID uuid.UUID
+	require.NoError(t, pool.QueryRow(ctx,
+		`INSERT INTO openrails.customers (merchant_id, subject) VALUES ($1,$2) RETURNING id`,
+		dbtest.TestMerchantID.UUID(), "wizard-customer-"+uuid.NewString()).Scan(&customerID))
+
+	now := time.Now().UTC()
+	var subID uuid.UUID
+	require.NoError(t, pool.QueryRow(ctx, `
+		INSERT INTO openrails.subscriptions (merchant_id, customer_id, product_id, price_id, status, rail, rail_subscription_id, current_period_starts_at, current_period_ends_at)
+		VALUES ($1,$2,$3,$4,'active','nmi',$5,$6,$7) RETURNING id`,
+		dbtest.TestMerchantID.UUID(), customerID, productID, priceID, "wizard-rail-sub-"+uuid.NewString(), now, now.Add(30*24*time.Hour)).Scan(&subID))
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), "DELETE FROM openrails.subscriptions WHERE id = $1", subID)
+		_, _ = pool.Exec(context.Background(), "DELETE FROM openrails.customers WHERE id = $1", customerID)
+	})
+	return subID
+}
+
+// TestStandaloneMerchantRepriceWizardIncreaseHTTP drives an INCREASE through
+// the wizard's whole backend contract: preview the affected count BEFORE the
+// price edit lands, bump the price under the same key (the #774 grandfather-
+// by-default outcome — no reprice call needed for existing subscribers to
+// stay put), confirm the version-history endpoint reflects both rows with
+// dates, then explicitly migrate via the bulk endpoint and cancel before
+// effective.
+func TestStandaloneMerchantRepriceWizardIncreaseHTTP(t *testing.T) {
+	ctx := context.Background()
+	h := New(t, ctx)
+	surface := h.StartStandalone("usd")
+	token := surface.MintAPIKey(
+		dbtest.TestMerchantSlug,
+		"reprice-wizard-"+uuid.NewString(),
+		[]string{
+			controlplane.PermMerchantCatalogRead, controlplane.PermMerchantCatalogUpdate,
+			controlplane.PermMerchantSubscriptionsRead, controlplane.PermMerchantSubscriptionsUpdate,
+		},
+	)
+
+	productKey := "wizard-inc-" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	priceKey := productKey + "-monthly"
+	publish := func(amount int64) {
+		t.Helper()
+		status, body := requestJSON(t, http.MethodPost, surface.BaseURL+"/v1/merchant/catalog/publish", token, map[string]any{
+			"catalog": catalog.Manifest{
+				Version: catalog.SupportedVersion,
+				Products: []catalog.Product{{
+					Key:         productKey,
+					DisplayName: "Wizard Increase Product",
+					Prices: []catalog.Price{{
+						UnitAmount: amount, Currency: "usd", Duration: "30d", AutoRenew: true,
+					}},
+				}},
+			},
+			"insert": true, "overwrite": true,
+		})
+		require.Equal(t, http.StatusOK, status, string(body))
+	}
+	getByKey := func() billingservice.CatalogPrice {
+		t.Helper()
+		status, body := requestJSON(t, http.MethodGet, surface.BaseURL+"/v1/merchant/catalog/prices/by-key/"+priceKey, token, nil)
+		require.Equal(t, http.StatusOK, status, string(body))
+		var p billingservice.CatalogPrice
+		require.NoError(t, json.Unmarshal(body, &p))
+		return p
+	}
+
+	// v1 at $10/mo.
+	publish(1000000)
+	v1 := getByKey()
+	require.EqualValues(t, 1000000, v1.UnitAmount)
+
+	// One existing subscriber pinned to v1.
+	seedRepriceSubscription(t, ctx, h, v1.ProductID, v1.ID)
+
+	// Step 2 preview, BEFORE the price edit: counts the whole chain (just v1
+	// today), so it already reflects who would move once the bump lands.
+	previewStatus, previewBody := requestJSON(t, http.MethodGet,
+		surface.BaseURL+"/v1/merchant/catalog/reprice-all-prior-versions/preview?price_key="+priceKey, token, nil)
+	require.Equal(t, http.StatusOK, previewStatus, string(previewBody))
+	var preview subscriptions.RepricePreviewResult
+	require.NoError(t, json.Unmarshal(previewBody, &preview))
+	require.Equal(t, 1, preview.Matched, "preview counts the existing subscriber before the bump")
+	require.Equal(t, v1.ID, preview.ToPriceID, "pre-bump, the current price IS the preview target")
+
+	// Step 3 confirm: catalog price update (the increase) lands first...
+	publish(1200000)
+	v2 := getByKey()
+	require.EqualValues(t, 1200000, v2.UnitAmount)
+	require.NotEqual(t, v1.ID, v2.ID)
+
+	// ...grandfather is the DEFAULT outcome on increase: without an explicit
+	// migrate call, the existing subscriber's price_id is untouched.
+	var pinnedPriceID uuid.UUID
+	require.NoError(t, h.Pool().QueryRow(ctx, `SELECT price_id FROM openrails.subscriptions WHERE product_id = $1 AND status = 'active' LIMIT 1`, v1.ProductID).Scan(&pinnedPriceID))
+	require.Equal(t, v1.ID, pinnedPriceID, "increase defaults to grandfather: subscriber stays on the old price")
+
+	// Version-chain history, most-recent-first, resolved from the movement
+	// log (not each row's own created_at).
+	histStatus, histBody := requestJSON(t, http.MethodGet, surface.BaseURL+"/v1/merchant/catalog/prices/by-key/"+priceKey+"/history", token, nil)
+	require.Equal(t, http.StatusOK, histStatus, string(histBody))
+	var hist struct {
+		Items []billingservice.PriceKeyHistoryEntry `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal(histBody, &hist))
+	require.Len(t, hist.Items, 2)
+	require.Equal(t, v2.ID, hist.Items[0].Price.ID, "most recent movement first")
+	require.Equal(t, v1.ID, hist.Items[1].Price.ID)
+	require.True(t, hist.Items[0].EffectiveAt.After(hist.Items[1].EffectiveAt) || hist.Items[0].EffectiveAt.Equal(hist.Items[1].EffectiveAt))
+
+	// Now explicitly migrate (ending the grandfather window): notice-window is
+	// NOT enforced server-side (#773 never implemented it — pure console UX
+	// gate) — an effective_at only a day out for an INCREASE is accepted
+	// without complaint, proving there's no server-side minimum-notice check
+	// to rely on.
+	effectiveAt := time.Now().UTC().Add(24 * time.Hour)
+	bulkStatus, bulkBody := requestJSON(t, http.MethodPost, surface.BaseURL+"/v1/merchant/catalog/reprice-all-prior-versions", token, map[string]any{
+		"price_key": priceKey, "effective_at": effectiveAt,
+	})
+	require.Equal(t, http.StatusCreated, bulkStatus, string(bulkBody))
+	var batchResult subscriptions.RepriceBatchResult
+	require.NoError(t, json.Unmarshal(bulkBody, &batchResult))
+	require.Equal(t, 1, batchResult.Matched)
+	require.Len(t, batchResult.Scheduled, 1)
+	require.Empty(t, batchResult.Skipped)
+	require.Equal(t, v2.ID, batchResult.ToPriceID)
+
+	// The price page's pending-migration lookup: find the batch by key
+	// without already knowing its id.
+	batchesStatus, batchesBody := requestJSON(t, http.MethodGet, surface.BaseURL+"/v1/merchant/reprices/batches?price_key="+priceKey, token, nil)
+	require.Equal(t, http.StatusOK, batchesStatus, string(batchesBody))
+	var batches struct {
+		Items []*models.RepriceBatch `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal(batchesBody, &batches))
+	require.Len(t, batches.Items, 1)
+	require.Equal(t, batchResult.BatchID, batches.Items[0].ID)
+	require.Equal(t, 1, batches.Items[0].SubscriptionsScheduled)
+
+	// Inspect the scheduled row for this batch.
+	repricesStatus, repricesBody := requestJSON(t, http.MethodGet,
+		surface.BaseURL+"/v1/merchant/reprices?reprice_batch_id="+batchResult.BatchID.String(), token, nil)
+	require.Equal(t, http.StatusOK, repricesStatus, string(repricesBody))
+	var reprices struct {
+		Items []*models.SubscriptionReprice `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal(repricesBody, &reprices))
+	require.Len(t, reprices.Items, 1)
+	require.Equal(t, models.RepriceStatusScheduled, reprices.Items[0].Status)
+
+	// Cancel before effective: allowed, flips to canceled.
+	cancelStatus, cancelBody := requestJSON(t, http.MethodPost,
+		surface.BaseURL+"/v1/merchant/reprices/"+reprices.Items[0].ID.String()+"/cancel", token, nil)
+	require.Equal(t, http.StatusOK, cancelStatus, string(cancelBody))
+
+	// A second cancel attempt on the same (now-canceled) row is refused.
+	recancelStatus, recancelBody := requestJSON(t, http.MethodPost,
+		surface.BaseURL+"/v1/merchant/reprices/"+reprices.Items[0].ID.String()+"/cancel", token, nil)
+	require.Equal(t, http.StatusConflict, recancelStatus, string(recancelBody))
+
+	// The subscriber is provably untouched throughout.
+	require.NoError(t, h.Pool().QueryRow(ctx, `SELECT price_id FROM openrails.subscriptions WHERE product_id = $1 AND status = 'active' LIMIT 1`, v1.ProductID).Scan(&pinnedPriceID))
+	require.Equal(t, v1.ID, pinnedPriceID, "canceled-before-effective reprice never touches the subscription")
+}
+
+// TestStandaloneMerchantRepriceWizardDecreaseHTTP drives a DECREASE: the
+// wizard's default is migrate-NOW (no notice-window gate applies to
+// decreases), so the bulk call is issued immediately with effective_at=now.
+func TestStandaloneMerchantRepriceWizardDecreaseHTTP(t *testing.T) {
+	ctx := context.Background()
+	h := New(t, ctx)
+	surface := h.StartStandalone("usd")
+	token := surface.MintAPIKey(
+		dbtest.TestMerchantSlug,
+		"reprice-wizard-dec-"+uuid.NewString(),
+		[]string{
+			controlplane.PermMerchantCatalogRead, controlplane.PermMerchantCatalogUpdate,
+			controlplane.PermMerchantSubscriptionsRead, controlplane.PermMerchantSubscriptionsUpdate,
+		},
+	)
+
+	productKey := "wizard-dec-" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	priceKey := productKey + "-monthly"
+	publish := func(amount int64) {
+		t.Helper()
+		status, body := requestJSON(t, http.MethodPost, surface.BaseURL+"/v1/merchant/catalog/publish", token, map[string]any{
+			"catalog": catalog.Manifest{
+				Version: catalog.SupportedVersion,
+				Products: []catalog.Product{{
+					Key:         productKey,
+					DisplayName: "Wizard Decrease Product",
+					Prices: []catalog.Price{{
+						UnitAmount: amount, Currency: "usd", Duration: "30d", AutoRenew: true,
+					}},
+				}},
+			},
+			"insert": true, "overwrite": true,
+		})
+		require.Equal(t, http.StatusOK, status, string(body))
+	}
+	getByKey := func() billingservice.CatalogPrice {
+		t.Helper()
+		status, body := requestJSON(t, http.MethodGet, surface.BaseURL+"/v1/merchant/catalog/prices/by-key/"+priceKey, token, nil)
+		require.Equal(t, http.StatusOK, status, string(body))
+		var p billingservice.CatalogPrice
+		require.NoError(t, json.Unmarshal(body, &p))
+		return p
+	}
+
+	publish(1000000) // $10/mo
+	v1 := getByKey()
+	seedRepriceSubscription(t, ctx, h, v1.ProductID, v1.ID)
+
+	publish(800000) // -> $8/mo
+	v2 := getByKey()
+	require.NotEqual(t, v1.ID, v2.ID)
+
+	// Decrease default: migrate everyone now (effective_at = now, no notice
+	// window applies to decreases per #773's design).
+	bulkStatus, bulkBody := requestJSON(t, http.MethodPost, surface.BaseURL+"/v1/merchant/catalog/reprice-all-prior-versions", token, map[string]any{
+		"price_key": priceKey, "effective_at": time.Now().UTC(),
+	})
+	require.Equal(t, http.StatusCreated, bulkStatus, string(bulkBody))
+	var batchResult subscriptions.RepriceBatchResult
+	require.NoError(t, json.Unmarshal(bulkBody, &batchResult))
+	require.Equal(t, 1, batchResult.Matched)
+	require.Len(t, batchResult.Scheduled, 1)
+	require.Equal(t, v2.ID, batchResult.ToPriceID)
+
+	// Scheduled, not yet applied (v1's only effective moment is the next
+	// renewal on/after effective_at — never instant, even for a decrease).
+	var status models.RepriceStatus
+	require.NoError(t, h.Pool().QueryRow(ctx, `SELECT status FROM openrails.subscription_reprices WHERE reprice_batch_id = $1`, batchResult.BatchID).Scan(&status))
+	require.Equal(t, models.RepriceStatusScheduled, status)
+}

--- a/internal/integrationharness/testdata/standalone_route_surface.txt
+++ b/internal/integrationharness/testdata/standalone_route_surface.txt
@@ -49,10 +49,12 @@ GET /v1/merchant/api-keys
 GET /v1/merchant/catalog/drift
 GET /v1/merchant/catalog/prices
 GET /v1/merchant/catalog/prices/by-key/{key}
+GET /v1/merchant/catalog/prices/by-key/{key}/history
 GET /v1/merchant/catalog/prices/{id}
 GET /v1/merchant/catalog/products
 GET /v1/merchant/catalog/products/by-key/{key}
 GET /v1/merchant/catalog/products/{id}
+GET /v1/merchant/catalog/reprice-all-prior-versions/preview
 GET /v1/merchant/credit-limit
 GET /v1/merchant/credits/balance
 GET /v1/merchant/customers
@@ -74,6 +76,7 @@ GET /v1/merchant/payments
 GET /v1/merchant/payments/{id}
 GET /v1/merchant/repair-alerts
 GET /v1/merchant/reprices
+GET /v1/merchant/reprices/batches
 GET /v1/merchant/reprices/{id}
 GET /v1/merchant/settings
 GET /v1/merchant/subscriptions

--- a/internal/modules/subscriptions/reprice_repo.go
+++ b/internal/modules/subscriptions/reprice_repo.go
@@ -149,6 +149,27 @@ func (r *RepriceRepo) Apply(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
+// ListBatchesByPriceKey lists a key's bulk reprice operations, most recent
+// first (#777: the console's price page needs "is there a pending migration
+// for this price key" without already knowing a batch id).
+func (r *RepriceRepo) ListBatchesByPriceKey(ctx context.Context, priceKey string, limit, offset int) ([]*models.RepriceBatch, error) {
+	limit32, _ := safecast.Convert[int32](limit)
+	offset32, _ := safecast.Convert[int32](offset)
+	rows, err := r.db.Gen(ctx).ListRepriceBatchesByPriceKey(ctx, gen.ListRepriceBatchesByPriceKeyParams{
+		PriceKey:   priceKey,
+		PageLimit:  limit32,
+		PageOffset: offset32,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*models.RepriceBatch, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, models.RepriceBatchFromGen(row))
+	}
+	return out, nil
+}
+
 // ListActiveSubscriptionsByPriceIDs returns every ACTIVE subscription pinned
 // to one of the given price rows — reprice_all_prior_versions' match set.
 func (r *RepriceRepo) ListActiveSubscriptionsByPriceIDs(ctx context.Context, priceIDs []uuid.UUID) ([]*models.Subscription, error) {

--- a/internal/modules/subscriptions/reprice_service.go
+++ b/internal/modules/subscriptions/reprice_service.go
@@ -202,6 +202,56 @@ func (s *RepriceService) RepriceAllPriorVersions(ctx context.Context, req Repric
 	return result, nil
 }
 
+// PreviewAllPriorVersions is #777's read-only dry-run counterpart to
+// RepriceAllPriorVersions: same target-set resolution, but NEVER creates a
+// batch, schedules a reprice, or emits a notification. Used by the console
+// wizard's Step 2 affected-count preview, called BEFORE the price-edit step
+// creates the new version — so unlike the real bulk call (which targets the
+// key's ARCHIVED prior versions once the new one is current), this counts the
+// key's WHOLE chain (current + archived): every active subscriber on it today
+// is a "prior version" candidate the instant the pending edit lands.
+func (s *RepriceService) PreviewAllPriorVersions(ctx context.Context, priceKey string) (*RepricePreviewResult, error) {
+	key := strings.TrimSpace(priceKey)
+	if key == "" {
+		return nil, fmt.Errorf("reprice_all_prior_versions preview: price_key required")
+	}
+	tid, err := merchant.Require(ctx)
+	if err != nil {
+		return nil, err
+	}
+	toPrice, err := s.prices.GetCurrentByKey(ctx, tid.UUID(), key)
+	if err != nil {
+		return nil, fmt.Errorf("reprice_all_prior_versions preview: price key %q has no current price: %w", key, err)
+	}
+	chain, err := s.prices.ListChainByKey(ctx, tid.UUID(), key)
+	if err != nil {
+		return nil, fmt.Errorf("reprice_all_prior_versions preview: list version chain: %w", err)
+	}
+	if len(chain) == 0 {
+		return &RepricePreviewResult{PriceKey: key, ToPriceID: toPrice.ID}, nil
+	}
+	chainIDs := make([]uuid.UUID, 0, len(chain))
+	for _, p := range chain {
+		chainIDs = append(chainIDs, p.ID)
+	}
+	subs, err := s.repo.ListActiveSubscriptionsByPriceIDs(ctx, chainIDs)
+	if err != nil {
+		return nil, fmt.Errorf("reprice_all_prior_versions preview: count affected subscriptions: %w", err)
+	}
+	return &RepricePreviewResult{PriceKey: key, ToPriceID: toPrice.ID, Matched: len(subs)}, nil
+}
+
+// ListBatchesForKey lists a price key's bulk reprice operations, most recent
+// first — the #777 console price page's "is there a pending migration"
+// surface.
+func (s *RepriceService) ListBatchesForKey(ctx context.Context, priceKey string, limit, offset int) ([]*models.RepriceBatch, error) {
+	key := strings.TrimSpace(priceKey)
+	if key == "" {
+		return nil, fmt.Errorf("list reprice batches: price_key required")
+	}
+	return s.repo.ListBatchesByPriceKey(ctx, key, limit, offset)
+}
+
 func (s *RepriceService) GetByID(ctx context.Context, id uuid.UUID) (*models.SubscriptionReprice, error) {
 	return s.repo.GetByID(ctx, id)
 }

--- a/internal/modules/subscriptions/reprice_types.go
+++ b/internal/modules/subscriptions/reprice_types.go
@@ -73,18 +73,33 @@ type RepriceAllPriorVersionsRequest struct {
 	EffectiveAt time.Time
 }
 
-// RepriceBatchResult summarizes a bulk reprice_all_prior_versions call.
+// RepriceBatchResult summarizes a bulk reprice_all_prior_versions call. JSON
+// tags match the shape documented for #777 console consumers: {batch_id,
+// to_price_id, matched, scheduled:[...], skipped:[...]}.
 type RepriceBatchResult struct {
-	BatchID   uuid.UUID
-	ToPriceID uuid.UUID
-	Matched   int
-	Scheduled []RepriceOutcome
-	Skipped   []RepriceOutcome
+	BatchID   uuid.UUID        `json:"batch_id"`
+	ToPriceID uuid.UUID        `json:"to_price_id"`
+	Matched   int              `json:"matched"`
+	Scheduled []RepriceOutcome `json:"scheduled"`
+	Skipped   []RepriceOutcome `json:"skipped"`
 }
 
 // RepriceOutcome is one subscription's result within a bulk reprice.
 type RepriceOutcome struct {
-	SubscriptionID uuid.UUID
-	RepriceID      uuid.UUID // zero when Skipped
-	Reason         string    // set when skipped (constraint violation)
+	SubscriptionID uuid.UUID `json:"subscription_id"`
+	RepriceID      uuid.UUID `json:"reprice_id,omitempty"` // zero when Skipped
+	Reason         string    `json:"reason,omitempty"`     // set when skipped (constraint violation)
+}
+
+// RepricePreviewResult is the #777 read-only "affected-count preview": how
+// many active subscriptions would move if the wizard's migration step ran
+// right now, WITHOUT scheduling anything. Computed over the key's WHOLE
+// version chain (current + archived) rather than #773's "prior versions"
+// definition, because preview always runs BEFORE the price-edit step creates
+// the new version — at that moment every existing subscriber on the key is
+// still, by definition, a "prior version" candidate once the bump lands.
+type RepricePreviewResult struct {
+	PriceKey  string    `json:"price_key"`
+	ToPriceID uuid.UUID `json:"to_price_id"`
+	Matched   int       `json:"matched"`
 }

--- a/pkg/service/price_key.go
+++ b/pkg/service/price_key.go
@@ -130,6 +130,53 @@ func (s *Service) SetPriceKey(ctx context.Context, priceID uuid.UUID, key string
 	return priceToCatalogPrice(current), nil
 }
 
+// PriceKeyHistoryEntry is one entry of a price key's version chain, resolved
+// from the #774 pointer-movement log — the #777 console price page's
+// "version chain with dates" surface. Most-recent-first (mirrors
+// ListKeyMovements).
+type PriceKeyHistoryEntry struct {
+	Price       CatalogPrice `json:"price"`
+	EffectiveAt time.Time    `json:"effective_at"`
+}
+
+// GetPriceKeyHistory resolves a key's full pointer-movement history log into
+// the priced rows it named at each effective date — NOT built by #774 (which
+// exposed only the key-resolution + per-price read surface), added here
+// because the #777 console needs it to render "key's history with dates"
+// rather than approximating from each price row's own created_at (which is
+// wrong for a REACTIVATED row: its created_at is its ORIGINAL creation, not
+// the date it most recently became current again).
+func (s *Service) GetPriceKeyHistory(ctx context.Context, key string) ([]PriceKeyHistoryEntry, error) {
+	prices, err := s.requirePriceService()
+	if err != nil {
+		return nil, err
+	}
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return nil, fmt.Errorf("key required")
+	}
+	tid, err := merchant.Require(ctx)
+	if err != nil {
+		return nil, err
+	}
+	movements, err := prices.ListKeyMovements(ctx, tid.UUID(), key)
+	if err != nil {
+		return nil, err
+	}
+	if len(movements) == 0 {
+		return nil, fmt.Errorf("price key %q not found", key)
+	}
+	out := make([]PriceKeyHistoryEntry, 0, len(movements))
+	for _, m := range movements {
+		p, err := prices.GetByID(ctx, m.PriceID)
+		if err != nil {
+			return nil, fmt.Errorf("resolve price %s for key %q movement: %w", m.PriceID, key, err)
+		}
+		out = append(out, PriceKeyHistoryEntry{Price: *priceToCatalogPrice(p), EffectiveAt: m.EffectiveAt})
+	}
+	return out, nil
+}
+
 // ResolvePriceReference resolves a caller-supplied price identifier that may
 // be either a price UUID or a #774 price_key. Tries the UUID parse first
 // (the common, cheap case); falls back to a key lookup only when the string

--- a/web/admin/src/components/fact-card.tsx
+++ b/web/admin/src/components/fact-card.tsx
@@ -1,0 +1,17 @@
+import * as React from "react"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+// Fact renders one labeled stat tile — shared across detail pages
+// (subscriptions, payments, catalog prices) so the "grid of facts" layout
+// reads identically everywhere.
+export function Fact({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <Card>
+      <CardHeader className="pb-1">
+        <CardTitle className="text-xs font-normal text-muted-foreground uppercase">{label}</CardTitle>
+      </CardHeader>
+      <CardContent className="text-sm">{children}</CardContent>
+    </Card>
+  )
+}

--- a/web/admin/src/lib/api/endpoints.ts
+++ b/web/admin/src/lib/api/endpoints.ts
@@ -25,8 +25,14 @@ import type {
   PaymentMethodResponse,
   PaymentObject,
   PaymentProviderConfig,
+  PriceKeyHistoryEntry,
   RawEntitlement,
   RepairAlert,
+  RepriceBatch,
+  RepriceBatchResult,
+  RepricePreviewResult,
+  RepriceStatus,
+  SubscriptionReprice,
   TeamInvite,
   TeamInviteResult,
   TeamMember,
@@ -154,6 +160,8 @@ export const listProducts = (limit: number, offset: number, activeOnly?: boolean
     query: { limit, offset, active_only: activeOnly },
   })
 
+export const getProduct = (id: string) => api<CatalogProduct>(`/merchant/catalog/products/${id}`)
+
 export interface ProductRequest {
   key: string
   display_name: string
@@ -190,16 +198,77 @@ export interface PriceRequest {
   auto_renew?: boolean
   trial_unit_amount?: number
   trial_duration_hours?: number
+  // Key (#774): declaring the SAME key as an existing live price with a
+  // DIFFERENT amount is a version bump (the #777 wizard's whole mechanism) —
+  // omit to auto-default.
+  key?: string
+  // Providers to (re)attach — e.g. carried over from the price being
+  // replaced so the new version doesn't silently lose its Stripe/CCBill/NMI
+  // links. Empty/omitted = DB-only price.
+  providers?: string[]
 }
 
 export const createPrice = (body: PriceRequest) =>
   api<CatalogPrice>("/merchant/catalog/prices", { method: "POST", body })
+
+export const getPrice = (id: string) => api<CatalogPrice>(`/merchant/catalog/prices/${id}`)
+
+export const getPriceByKey = (key: string) =>
+  api<CatalogPrice>(`/merchant/catalog/prices/by-key/${encodeURIComponent(key)}`)
 
 export const activatePrice = (id: string) =>
   api<CatalogPrice>(`/merchant/catalog/prices/${id}/activate`, { method: "POST" })
 
 export const deactivatePrice = (id: string) =>
   api<CatalogPrice>(`/merchant/catalog/prices/${id}/deactivate`, { method: "POST" })
+
+// getPriceKeyHistory returns a price key's version chain (most-recent-first),
+// resolved server-side from the #774 pointer-movement log — the price
+// detail page's "version chain with dates" (#777).
+export const getPriceKeyHistory = (key: string) =>
+  api<ItemsEnvelope<PriceKeyHistoryEntry>>(
+    `/merchant/catalog/prices/by-key/${encodeURIComponent(key)}/history`,
+  )
+
+// --- Repricing / migration (#773 primitive, #777 console wizard) ---
+
+// previewRepriceAllPriorVersions is the wizard's Step 2 affected-count
+// preview: a READ-ONLY dry run, called BEFORE the price edit lands (so it
+// never mutates, unlike repriceAllPriorVersions below).
+export const previewRepriceAllPriorVersions = (priceKey: string) =>
+  api<RepricePreviewResult>("/merchant/catalog/reprice-all-prior-versions/preview", {
+    query: { price_key: priceKey },
+  })
+
+// repriceAllPriorVersions bulk-schedules every active subscription pinned to
+// a prior version of priceKey to move to its current price at effectiveAt.
+export const repriceAllPriorVersions = (priceKey: string, effectiveAt: string) =>
+  api<RepriceBatchResult>("/merchant/catalog/reprice-all-prior-versions", {
+    method: "POST",
+    body: { price_key: priceKey, effective_at: effectiveAt },
+  })
+
+// listRepriceBatchesByKey finds a price key's bulk reprice operations
+// (most recent first) — the price page's pending-migration lookup, without
+// already knowing a batch id.
+export const listRepriceBatchesByKey = (priceKey: string, limit = 20) =>
+  api<ItemsEnvelope<RepriceBatch>>("/merchant/reprices/batches", {
+    query: { price_key: priceKey, limit },
+  })
+
+export interface RepriceFilters {
+  subscription_id?: string
+  reprice_batch_id?: string
+  status?: RepriceStatus
+}
+
+export const listReprices = (filters: RepriceFilters, limit = 100, offset = 0) =>
+  api<ItemsEnvelope<SubscriptionReprice>>("/merchant/reprices", {
+    query: { ...filters, limit, offset },
+  })
+
+export const cancelReprice = (id: string) =>
+  api<{ message: string }>(`/merchant/reprices/${id}/cancel`, { method: "POST" })
 
 export const publishCatalog = (manifest: unknown, opts: { plan_only?: boolean; insert?: boolean; overwrite?: boolean; prune?: boolean }) =>
   api<{ plan: unknown; result?: unknown }>("/merchant/catalog/publish", {

--- a/web/admin/src/lib/api/types.ts
+++ b/web/admin/src/lib/api/types.ts
@@ -42,11 +42,20 @@ export interface RawSubscription {
   updated_at: string
 }
 
+// RawPrice mirrors internal/db/models.Price verbatim — the shape embedded on
+// subscription responses (distinct from CatalogPrice, the catalog
+// endpoints' own view: NOTE the field is "amount" here, not "unit_amount").
 export interface RawPrice {
   id: string
   product_id?: string
-  unit_amount?: number
+  amount?: number
   currency?: string
+  archived?: boolean
+  // Key (#774): the durable, movable-pointer handle for this price's
+  // version chain — see CatalogPrice.key.
+  key?: string
+  access_duration_hours?: number
+  auto_renew?: boolean
   [k: string]: unknown
 }
 
@@ -189,6 +198,12 @@ export interface CatalogProviderState {
 
 export interface CatalogPrice {
   id: string
+  // Key (#774): the durable, per-merchant-unique MOVABLE POINTER to this
+  // price's substance-version chain — stable across amount edits, unlike id
+  // (which stays the immutable substance UUID). The wizard bumps the amount
+  // under the SAME key; archived predecessors keep the key as a
+  // back-reference to the chain they belong to.
+  key: string
   product_id: string
   archived: boolean
   unit_amount: number
@@ -201,6 +216,72 @@ export interface CatalogPrice {
   updated_at: string
   providers?: Record<string, CatalogProviderState>
   pending_manual_actions?: { provider: string; action: string; hint: string }[]
+}
+
+// --- Price repricing / migration (#773 primitive, #777 console wizard) ---
+
+// PriceKeyHistoryEntry is one entry of a price key's version chain, resolved
+// from the #774 pointer-movement log — GET .../prices/by-key/{key}/history.
+// Most-recent-first.
+export interface PriceKeyHistoryEntry {
+  price: CatalogPrice
+  effective_at: string
+}
+
+export type RepriceStatus = "scheduled" | "applied" | "canceled"
+
+// SubscriptionReprice mirrors internal/db/models.SubscriptionReprice.
+export interface SubscriptionReprice {
+  id: string
+  subscription_id: string
+  from_price_id: string
+  to_price_id: string
+  effective_at: string
+  status: RepriceStatus
+  reprice_batch_id?: string
+  created_at: string
+  applied_at?: string
+  canceled_at?: string
+}
+
+// RepriceBatch mirrors internal/db/models.RepriceBatch — the header row for
+// one bulk reprice_all_prior_versions call. Counts are frozen at schedule
+// time (subscriptions_scheduled is the migration's denominator; query
+// SubscriptionReprice rows by reprice_batch_id + status for live progress).
+export interface RepriceBatch {
+  id: string
+  price_key?: string
+  to_price_id: string
+  effective_at: string
+  subscriptions_matched: number
+  subscriptions_scheduled: number
+  subscriptions_skipped: number
+  created_at: string
+}
+
+// RepriceOutcome is one subscription's result within a bulk reprice call.
+export interface RepriceOutcome {
+  subscription_id: string
+  reprice_id?: string
+  reason?: string
+}
+
+// RepriceBatchResult is the response of POST .../reprice-all-prior-versions.
+export interface RepriceBatchResult {
+  batch_id: string
+  to_price_id: string
+  matched: number
+  scheduled: RepriceOutcome[]
+  skipped: RepriceOutcome[]
+}
+
+// RepricePreviewResult is the response of the #777 read-only GET
+// .../reprice-all-prior-versions/preview dry-run — the wizard's Step 2
+// affected-count preview, called BEFORE the price edit lands.
+export interface RepricePreviewResult {
+  price_key: string
+  to_price_id: string
+  matched: number
 }
 
 export interface CatalogDriftEvent {

--- a/web/admin/src/main.tsx
+++ b/web/admin/src/main.tsx
@@ -8,6 +8,7 @@ import { Toaster } from "@/components/ui/sonner"
 import { AppLayout } from "@/layouts/app-layout"
 import { AuthProvider } from "@/lib/auth"
 import { CatalogPage } from "@/pages/catalog"
+import { PriceDetailPage } from "@/pages/catalog/price-detail"
 import { CustomersPage } from "@/pages/customers"
 import { CustomerDetailPage } from "@/pages/customers/detail"
 import { DashboardPage } from "@/pages/dashboard"
@@ -34,6 +35,7 @@ const router = createBrowserRouter(
         { path: "payments", element: <PaymentsPage /> },
         { path: "payments/:id", element: <PaymentDetailPage /> },
         { path: "catalog", element: <CatalogPage /> },
+        { path: "catalog/prices/:id", element: <PriceDetailPage /> },
         { path: "ops", element: <OpsPage /> },
         { path: "settings", element: <SettingsPage /> },
       ],

--- a/web/admin/src/pages/catalog/index.tsx
+++ b/web/admin/src/pages/catalog/index.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { PlusIcon, RefreshCwIcon, UploadIcon } from "lucide-react"
+import { Link } from "react-router-dom"
 import { toast } from "sonner"
 
 import { StatusBadge } from "@/components/status-badge"
@@ -45,6 +46,8 @@ import {
 import type { CatalogPrice, CatalogProduct } from "@/lib/api/types"
 import { formatDate, formatMicros, microsFromInput, shortId } from "@/lib/format"
 import { toastApiError } from "@/lib/toast"
+import { priceIntervalLabel } from "@/pages/catalog/price-format"
+import { PriceChangeWizard } from "@/pages/catalog/price-wizard"
 
 export function CatalogPage() {
   return (
@@ -328,16 +331,14 @@ function PriceRow({
   }
   return (
     <TableRow className={price.archived ? "opacity-60" : undefined}>
-      <TableCell className="font-mono text-xs">{shortId(price.id, 13)}</TableCell>
+      <TableCell className="font-mono text-xs">
+        <Link className="underline-offset-2 hover:underline" to={`/catalog/prices/${price.id}`}>
+          {shortId(price.id, 13)}
+        </Link>
+      </TableCell>
       <TableCell>{productName}</TableCell>
       <TableCell>{formatMicros(price.unit_amount, price.currency)}</TableCell>
-      <TableCell>
-        {price.auto_renew
-          ? `every ${price.access_duration_hours ?? "?"}h`
-          : price.access_duration_hours
-            ? `${price.access_duration_hours}h once`
-            : "one-time"}
-      </TableCell>
+      <TableCell>{priceIntervalLabel(price)}</TableCell>
       <TableCell>
         <span className="flex flex-wrap gap-1">
           {Object.entries(price.providers ?? {}).map(([rail, state]) => (
@@ -354,9 +355,12 @@ function PriceRow({
       </TableCell>
       <TableCell>{price.archived ? <Badge variant="secondary">archived</Badge> : <StatusBadge status="active" />}</TableCell>
       <TableCell className="text-right">
-        <Button variant="outline" size="sm" disabled={busy} onClick={toggle}>
-          {price.archived ? "Activate" : "Deactivate"}
-        </Button>
+        <div className="flex justify-end gap-2">
+          <PriceChangeWizard price={price} productName={productName} onDone={onDone} />
+          <Button variant="outline" size="sm" disabled={busy} onClick={toggle}>
+            {price.archived ? "Activate" : "Deactivate"}
+          </Button>
+        </div>
       </TableCell>
     </TableRow>
   )

--- a/web/admin/src/pages/catalog/price-detail.tsx
+++ b/web/admin/src/pages/catalog/price-detail.tsx
@@ -1,0 +1,217 @@
+import * as React from "react"
+import { ArrowLeftIcon } from "lucide-react"
+import { Link, useNavigate, useParams } from "react-router-dom"
+import { toast } from "sonner"
+
+import { Fact } from "@/components/fact-card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useApiData } from "@/hooks/use-api-data"
+import {
+  cancelReprice,
+  getPrice,
+  getPriceKeyHistory,
+  getProduct,
+  listRepriceBatchesByKey,
+  listReprices,
+} from "@/lib/api/endpoints"
+import { formatDate, formatMicros, shortId } from "@/lib/format"
+import { toastApiError } from "@/lib/toast"
+import { priceIntervalLabel } from "@/pages/catalog/price-format"
+import { PriceChangeWizard } from "@/pages/catalog/price-wizard"
+
+// PriceDetailPage (#777): the version chain (from the #774 pointer-movement
+// log, with dates) and any pending scheduled migration (progress + cancel)
+// for one price key — the wizard's Step 1 entry point ("Change price") also
+// lives here alongside the catalog list row.
+export function PriceDetailPage() {
+  const { id = "" } = useParams()
+  const navigate = useNavigate()
+  const { data: price, loading, error, reload } = useApiData(() => getPrice(id), [id])
+  const { data: product } = useApiData(
+    () => (price ? getProduct(price.product_id) : Promise.resolve(null)),
+    [price?.product_id],
+  )
+  const { data: history, reload: reloadHistory } = useApiData(
+    () => (price ? getPriceKeyHistory(price.key) : Promise.resolve(null)),
+    [price?.key],
+  )
+  const { data: batches, reload: reloadBatches } = useApiData(
+    () => (price ? listRepriceBatchesByKey(price.key, 5) : Promise.resolve(null)),
+    [price?.key],
+  )
+  const latestBatch = batches?.items?.[0]
+  const {
+    data: batchReprices,
+    reload: reloadBatchReprices,
+  } = useApiData(
+    () =>
+      latestBatch
+        ? listReprices({ reprice_batch_id: latestBatch.id }, 1000)
+        : Promise.resolve(null),
+    [latestBatch?.id],
+  )
+
+  React.useEffect(() => {
+    if (error) toastApiError(error, "Load price")
+  }, [error])
+
+  const reloadAll = () => {
+    reload()
+    reloadHistory()
+    reloadBatches()
+  }
+
+  if (loading) return <p className="text-sm text-muted-foreground">Loading…</p>
+  if (!price) return <p className="text-sm text-muted-foreground">Price not found.</p>
+
+  const scheduled = batchReprices?.items?.filter((r) => r.status === "scheduled") ?? []
+  const applied = batchReprices?.items?.filter((r) => r.status === "applied") ?? []
+  const isPending = !!latestBatch && scheduled.length > 0
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="icon" onClick={() => navigate(-1)} aria-label="Back">
+          <ArrowLeftIcon className="size-4" />
+        </Button>
+        <div>
+          <h2 className="flex items-center gap-2 font-mono text-sm">
+            {price.key}
+            {price.archived && <Badge variant="secondary">archived</Badge>}
+          </h2>
+          <p className="text-xs text-muted-foreground">{shortId(price.id, 16)}</p>
+        </div>
+        <div className="ml-auto">
+          <PriceChangeWizard price={price} productName={product?.display_name ?? "…"} onDone={reloadAll} />
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <Fact label="Product">
+          <Link className="underline-offset-2 hover:underline" to={`/catalog`}>
+            {product?.display_name ?? shortId(price.product_id, 13)}
+          </Link>
+        </Fact>
+        <Fact label="Amount">{formatMicros(price.unit_amount, price.currency)}</Fact>
+        <Fact label="Currency · interval">
+          {price.currency.toUpperCase()} · {priceIntervalLabel(price)}
+        </Fact>
+        <Fact label="Created">{formatDate(price.created_at)}</Fact>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Version chain</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {!history?.items?.length ? (
+            <p className="text-sm text-muted-foreground">No history yet.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Amount</TableHead>
+                  <TableHead>Since</TableHead>
+                  <TableHead>State</TableHead>
+                  <TableHead>Price</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {history.items.map((entry) => (
+                  <TableRow key={`${entry.price.id}-${entry.effective_at}`}>
+                    <TableCell>{formatMicros(entry.price.unit_amount, entry.price.currency)}</TableCell>
+                    <TableCell>{formatDate(entry.effective_at)}</TableCell>
+                    <TableCell>
+                      {entry.price.archived ? (
+                        <Badge variant="secondary">grandfathered</Badge>
+                      ) : (
+                        <Badge className="bg-emerald-500/15 text-emerald-600 dark:text-emerald-400">current</Badge>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Link
+                        className="font-mono text-xs underline-offset-2 hover:underline"
+                        to={`/catalog/prices/${entry.price.id}`}
+                      >
+                        {shortId(entry.price.id, 13)}
+                      </Link>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {latestBatch && (
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between gap-2">
+            <CardTitle className="text-sm">
+              {isPending ? "Pending migration" : "Last migration"}
+            </CardTitle>
+            {isPending && (
+              <CancelMigrationButton
+                repriceIds={scheduled.map((r) => r.id)}
+                onDone={() => {
+                  reloadBatchReprices()
+                  reloadAll()
+                }}
+              />
+            )}
+          </CardHeader>
+          <CardContent className="flex flex-col gap-2 text-sm">
+            <p>
+              {applied.length} of {latestBatch.subscriptions_scheduled} migrated
+              {scheduled.length > 0 && ` · ${scheduled.length} still scheduled`}
+              {" · effective "}
+              {formatDate(latestBatch.effective_at)}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {latestBatch.subscriptions_skipped > 0 &&
+                `${latestBatch.subscriptions_skipped} subscription(s) were skipped (constraint violation or existing schedule conflict) at schedule time. `}
+              Progress is computed live from individual reprice rows (up to 1,000 fetched per batch).
+            </p>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}
+
+function CancelMigrationButton({ repriceIds, onDone }: { repriceIds: string[]; onDone: () => void }) {
+  const [busy, setBusy] = React.useState(false)
+  return (
+    <Button
+      variant="destructive"
+      size="sm"
+      disabled={busy || !repriceIds.length}
+      onClick={async () => {
+        setBusy(true)
+        try {
+          await Promise.all(repriceIds.map((id) => cancelReprice(id)))
+          toast.success(
+            `Canceled ${repriceIds.length} pending reprice${repriceIds.length === 1 ? "" : "s"}. Already-migrated subscribers stay migrated.`,
+          )
+          onDone()
+        } catch (err) {
+          toastApiError(err, "Cancel migration")
+        } finally {
+          setBusy(false)
+        }
+      }}
+    >
+      {busy ? "Canceling…" : "Cancel migration"}
+    </Button>
+  )
+}

--- a/web/admin/src/pages/catalog/price-format.ts
+++ b/web/admin/src/pages/catalog/price-format.ts
@@ -1,0 +1,12 @@
+import type { CatalogPrice } from "@/lib/api/types"
+
+// priceIntervalLabel renders a price's renewal cadence — shared between the
+// catalog list and the #777 price-change wizard so "currency + interval
+// locked" always reads identically in both places.
+export function priceIntervalLabel(
+  price: Pick<CatalogPrice, "auto_renew" | "access_duration_hours">,
+): string {
+  if (price.auto_renew) return `every ${price.access_duration_hours ?? "?"}h`
+  if (price.access_duration_hours) return `${price.access_duration_hours}h once`
+  return "one-time"
+}

--- a/web/admin/src/pages/catalog/price-wizard-logic.ts
+++ b/web/admin/src/pages/catalog/price-wizard-logic.ts
@@ -1,0 +1,98 @@
+// Pure logic for the #777 price-change wizard — kept isolated from React so
+// it's trivially unit-testable (web/admin has no test runner today; this
+// module is where that debt would be paid down first).
+import { formatMicros } from "@/lib/format"
+
+export type PriceDirection = "increase" | "decrease" | "unchanged"
+
+export function detectDirection(newAmount: number, currentAmount: number): PriceDirection {
+  if (newAmount > currentAmount) return "increase"
+  if (newAmount < currentAmount) return "decrease"
+  return "unchanged"
+}
+
+export type MigrationMode = "grandfather" | "migrate"
+
+// #773 shipped NO merchant-configurable notice window and NO server-side
+// enforcement of one — this is a console-only UX guardrail on the date
+// picker for increase+migrate. See the #777 tracker note and #773's Progress
+// section: the engine only emits the reprice_scheduled disclosure event: it
+// never rejects an early effective_at.
+export const NOTICE_WINDOW_DAYS = 30
+
+// defaultMigrationMode is the direction-aware Step 2 default: increases
+// default to grandfather (zero-risk — #774's existing behavior, no new
+// action); decreases default to migrate-now (you never grandfather a
+// decrease — #773's design ruling).
+export function defaultMigrationMode(direction: PriceDirection): MigrationMode {
+  return direction === "decrease" ? "migrate" : "grandfather"
+}
+
+// minEffectiveDate returns the earliest allowed migration date, or null when
+// there is no minimum (decreases may move everyone at next renewal starting
+// now — notice is optional goodwill, not a requirement).
+export function minEffectiveDate(direction: PriceDirection, now: Date): Date | null {
+  if (direction !== "increase") return null
+  const min = new Date(now)
+  min.setUTCDate(min.getUTCDate() + NOTICE_WINDOW_DAYS)
+  return min
+}
+
+// defaultEffectiveDate is Step 2's pre-filled migration date: the notice
+// window's floor for an increase, "now" for a decrease.
+export function defaultEffectiveDate(direction: PriceDirection, now: Date): Date {
+  return minEffectiveDate(direction, now) ?? now
+}
+
+// isEffectiveDateValid enforces the console-side notice-window gate: an
+// increase+migrate plan may not pick a date inside the notice window.
+export function isEffectiveDateValid(direction: PriceDirection, effectiveAt: Date, now: Date): boolean {
+  const min = minEffectiveDate(direction, now)
+  return !min || effectiveAt.getTime() >= min.getTime()
+}
+
+export interface MigrationPlan {
+  mode: MigrationMode
+  // ISO instant; only meaningful when mode === "migrate".
+  effectiveAt: string
+}
+
+const dateLabel = (iso: string) =>
+  new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
+
+// buildReviewText renders Step 3's "plan in words" exactly per the #777 spec
+// phrasing: "New subscribers pay $12 immediately. 1,204 existing subscribers
+// keep $10 until Sep 1, then move to $12 at their next renewal. Notices go
+// out on confirm."
+export function buildReviewText(params: {
+  newAmount: number
+  currentAmount: number
+  currency: string
+  affectedCount: number
+  plan: MigrationPlan
+  now: Date
+}): string {
+  const { newAmount, currentAmount, currency, affectedCount, plan, now } = params
+  const newLabel = formatMicros(newAmount, currency)
+  const oldLabel = formatMicros(currentAmount, currency)
+  const lead = `New subscribers pay ${newLabel} immediately.`
+
+  if (affectedCount === 0) {
+    return `${lead} No existing subscribers are on a prior version of this price.`
+  }
+  const subj = `${affectedCount.toLocaleString()} existing subscriber${affectedCount === 1 ? "" : "s"}`
+
+  if (plan.mode === "grandfather") {
+    return `${lead} ${subj} keep ${oldLabel} forever (grandfathered).`
+  }
+
+  // The engine emits a reprice_scheduled notification per affected
+  // subscriber at SCHEDULE time regardless of how far out effective_at is
+  // (#773) — always say so, not just for the delayed-migration phrasing.
+  const effective = new Date(plan.effectiveAt)
+  const immediate = effective.getTime() <= now.getTime()
+  if (immediate) {
+    return `${lead} ${subj} move to ${newLabel} at their next renewal. Notices go out on confirm.`
+  }
+  return `${lead} ${subj} keep ${oldLabel} until ${dateLabel(plan.effectiveAt)}, then move to ${newLabel} at their next renewal. Notices go out on confirm.`
+}

--- a/web/admin/src/pages/catalog/price-wizard.tsx
+++ b/web/admin/src/pages/catalog/price-wizard.tsx
@@ -1,0 +1,290 @@
+import * as React from "react"
+import { toast } from "sonner"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { createPrice, previewRepriceAllPriorVersions, repriceAllPriorVersions } from "@/lib/api/endpoints"
+import type { CatalogPrice } from "@/lib/api/types"
+import { formatMicros, microsFromInput } from "@/lib/format"
+import { toastApiError } from "@/lib/toast"
+import { priceIntervalLabel } from "@/pages/catalog/price-format"
+import {
+  buildReviewText,
+  defaultEffectiveDate,
+  defaultMigrationMode,
+  detectDirection,
+  isEffectiveDateValid,
+  minEffectiveDate,
+  NOTICE_WINDOW_DAYS,
+  type MigrationMode,
+} from "@/pages/catalog/price-wizard-logic"
+
+const toDateInputValue = (d: Date) => d.toISOString().slice(0, 10)
+
+// PriceChangeWizard is the #777 console price-change wizard — the ONLY
+// amount-edit affordance on a price. Three steps: new amount -> migration
+// plan (direction-aware defaults, live affected-count preview, notice-window
+// gate on increase+migrate) -> review in words, then confirm applies the
+// catalog price update followed (if migrating) by the reprice schedule.
+export function PriceChangeWizard({
+  price,
+  productName,
+  onDone,
+}: {
+  price: CatalogPrice
+  productName: string
+  onDone: () => void
+}) {
+  const [open, setOpen] = React.useState(false)
+  const [step, setStep] = React.useState<1 | 2 | 3>(1)
+  const [amountInput, setAmountInput] = React.useState(() => String(price.unit_amount / 1_000_000))
+  const [mode, setMode] = React.useState<MigrationMode>("grandfather")
+  const [effectiveAt, setEffectiveAt] = React.useState("")
+  const [previewLoading, setPreviewLoading] = React.useState(false)
+  const [affectedCount, setAffectedCount] = React.useState<number | null>(null)
+  const [busy, setBusy] = React.useState(false)
+
+  const [now] = React.useState(() => new Date())
+  const newAmount = microsFromInput(amountInput) ?? price.unit_amount
+  const direction = detectDirection(newAmount, price.unit_amount)
+
+  const reset = () => {
+    setStep(1)
+    setAmountInput(String(price.unit_amount / 1_000_000))
+    setMode("grandfather")
+    setEffectiveAt("")
+    setAffectedCount(null)
+  }
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) reset()
+    setOpen(next)
+  }
+
+  const enterStep2 = () => {
+    setMode(defaultMigrationMode(direction))
+    setEffectiveAt(toDateInputValue(defaultEffectiveDate(direction, now)))
+    setStep(2)
+    setPreviewLoading(true)
+    setAffectedCount(null)
+    previewRepriceAllPriorVersions(price.key)
+      .then((res) => setAffectedCount(res.matched))
+      .catch((err) => toastApiError(err, "Preview affected subscribers"))
+      .finally(() => setPreviewLoading(false))
+  }
+
+  const minDate = minEffectiveDate(direction, now)
+  const dateValid = mode !== "migrate" || (!!effectiveAt && isEffectiveDateValid(direction, new Date(effectiveAt), now))
+
+  // Archived (prior-version) rows are history, not the editable current
+  // price — editing rides the key's CURRENT row (GET .../prices/by-key/:key
+  // always resolves it) so there is exactly one live edit target per key.
+  if (price.archived) {
+    return (
+      <Button variant="outline" size="sm" disabled title="This is an archived prior version — change the current price for this key instead.">
+        Change price
+      </Button>
+    )
+  }
+
+  const confirm = async () => {
+    setBusy(true)
+    try {
+      const created = await createPrice({
+        product_id: price.product_id,
+        unit_amount: newAmount,
+        currency: price.currency,
+        access_duration_hours: price.access_duration_hours,
+        auto_renew: price.auto_renew,
+        trial_unit_amount: price.trial_unit_amount,
+        trial_duration_hours: price.trial_duration_hours,
+        key: price.key,
+        providers: Object.keys(price.providers ?? {}),
+      })
+      if (mode === "migrate") {
+        await repriceAllPriorVersions(price.key, new Date(effectiveAt).toISOString())
+      }
+      if (created.pending_manual_actions?.length) {
+        toast.warning(
+          `Price updated — manual step needed: ${created.pending_manual_actions.map((a) => `${a.provider}: ${a.hint}`).join("; ")}`,
+        )
+      } else {
+        toast.success(mode === "migrate" ? "Price updated and migration scheduled" : "Price updated")
+      }
+      handleOpenChange(false)
+      onDone()
+    } catch (err) {
+      toastApiError(err, "Change price")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          Change price
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Change price — {productName}</DialogTitle>
+          <DialogDescription>
+            Step {step} of 3: {step === 1 ? "new amount" : step === 2 ? "migration plan" : "review"}
+          </DialogDescription>
+        </DialogHeader>
+
+        {step === 1 && (
+          <div className="grid gap-3">
+            <div className="grid grid-cols-2 gap-3 text-sm">
+              <div>
+                <p className="text-xs text-muted-foreground uppercase">Current amount</p>
+                <p className="font-medium">{formatMicros(price.unit_amount, price.currency)}</p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground uppercase">Currency · interval</p>
+                <p className="font-medium">
+                  {price.currency.toUpperCase()} · {priceIntervalLabel(price)}
+                </p>
+              </div>
+            </div>
+            <div className="grid gap-1.5">
+              <Label htmlFor="wiz-amount">New amount (major units)</Label>
+              <Input
+                id="wiz-amount"
+                type="number"
+                step="any"
+                min="0"
+                value={amountInput}
+                onChange={(e) => setAmountInput(e.target.value)}
+                autoFocus
+              />
+            </div>
+            {direction !== "unchanged" && (
+              <p className="text-sm text-muted-foreground">
+                This is a price{" "}
+                <span className="font-medium text-foreground">{direction === "increase" ? "increase" : "decrease"}</span>.
+                Currency and interval stay locked to the current price.
+              </p>
+            )}
+          </div>
+        )}
+
+        {step === 2 && (
+          <div className="grid gap-3">
+            <p className="text-sm">
+              {affectedCount === null && previewLoading
+                ? "Checking affected subscribers…"
+                : `${(affectedCount ?? 0).toLocaleString()} active subscription${affectedCount === 1 ? "" : "s"} on prior versions of ${price.key}.`}
+            </p>
+            <div className="grid gap-2">
+              <label className="flex items-start gap-2 rounded-md border p-3 text-sm">
+                <input
+                  type="radio"
+                  name="migration-mode"
+                  className="mt-1"
+                  checked={mode === "grandfather"}
+                  onChange={() => setMode("grandfather")}
+                />
+                <span>
+                  <span className="font-medium">Grandfather</span> — existing subscribers keep the current price.
+                  {direction === "increase" && <Badge variant="secondary" className="ml-2">default</Badge>}
+                </span>
+              </label>
+              <label className="flex items-start gap-2 rounded-md border p-3 text-sm">
+                <input
+                  type="radio"
+                  name="migration-mode"
+                  className="mt-1"
+                  checked={mode === "migrate"}
+                  onChange={() => setMode("migrate")}
+                />
+                <span>
+                  <span className="font-medium">Migrate</span> — move everyone to the new price at their next renewal
+                  on/after a date.
+                  {direction === "decrease" && <Badge variant="secondary" className="ml-2">default</Badge>}
+                </span>
+              </label>
+            </div>
+            {mode === "migrate" && (
+              <div className="grid gap-1.5">
+                <Label htmlFor="wiz-effective">Effective date</Label>
+                <Input
+                  id="wiz-effective"
+                  type="date"
+                  value={effectiveAt}
+                  min={minDate ? toDateInputValue(minDate) : undefined}
+                  onChange={(e) => setEffectiveAt(e.target.value)}
+                />
+                {direction === "increase" ? (
+                  <p className="text-xs text-muted-foreground">
+                    Must be at least {NOTICE_WINDOW_DAYS} days out (card-network advance-notice window for amount
+                    increases — enforced here in the console; not by the API).
+                  </p>
+                ) : (
+                  <p className="text-xs text-muted-foreground">
+                    Decreases have no notice requirement — today is fine.
+                  </p>
+                )}
+                {!dateValid && <p className="text-xs text-destructive">Pick a later date.</p>}
+                <p className="text-xs text-muted-foreground">
+                  A reprice_scheduled notice is queued for every affected subscriber as soon as you confirm.
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+
+        {step === 3 && (
+          <div className="grid gap-3">
+            <p className="rounded-md border bg-muted/40 p-3 text-sm">
+              {buildReviewText({
+                newAmount,
+                currentAmount: price.unit_amount,
+                currency: price.currency,
+                affectedCount: affectedCount ?? 0,
+                plan: { mode, effectiveAt: mode === "migrate" ? new Date(effectiveAt).toISOString() : "" },
+                now,
+              })}
+            </p>
+          </div>
+        )}
+
+        <DialogFooter>
+          {step > 1 && (
+            <Button variant="outline" disabled={busy} onClick={() => setStep((s) => (s - 1) as 1 | 2)}>
+              Back
+            </Button>
+          )}
+          {step === 1 && (
+            <Button disabled={!amountInput || direction === "unchanged" || newAmount <= 0} onClick={enterStep2}>
+              Next
+            </Button>
+          )}
+          {step === 2 && (
+            <Button disabled={!dateValid || previewLoading} onClick={() => setStep(3)}>
+              Next
+            </Button>
+          )}
+          {step === 3 && (
+            <Button disabled={busy} onClick={confirm}>
+              {busy ? "Working…" : "Confirm"}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/admin/src/pages/payments/detail.tsx
+++ b/web/admin/src/pages/payments/detail.tsx
@@ -3,6 +3,7 @@ import { ArrowLeftIcon, Undo2Icon } from "lucide-react"
 import { Link, useNavigate, useParams } from "react-router-dom"
 import { toast } from "sonner"
 
+import { Fact } from "@/components/fact-card"
 import { StatusBadge } from "@/components/status-badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -137,17 +138,6 @@ export function PaymentDetailPage() {
         </CardContent>
       </Card>
     </div>
-  )
-}
-
-function Fact({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <Card>
-      <CardHeader className="pb-1">
-        <CardTitle className="text-xs font-normal text-muted-foreground uppercase">{label}</CardTitle>
-      </CardHeader>
-      <CardContent className="text-sm">{children}</CardContent>
-    </Card>
   )
 }
 

--- a/web/admin/src/pages/subscriptions/detail.tsx
+++ b/web/admin/src/pages/subscriptions/detail.tsx
@@ -3,8 +3,10 @@ import { ArrowLeftIcon } from "lucide-react"
 import { Link, useNavigate, useParams } from "react-router-dom"
 import { toast } from "sonner"
 
+import { Fact } from "@/components/fact-card"
 import { StatusBadge } from "@/components/status-badge"
 import { TypedConfirmDialog } from "@/components/typed-confirm-dialog"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
   Card,
@@ -41,12 +43,16 @@ import {
 } from "@/components/ui/table"
 import { useApiData } from "@/hooks/use-api-data"
 import {
+  cancelReprice,
   cancelSubscription,
   changeSubscriptionPaymentMethod,
   getCustomerPaymentMethods,
+  getPrice,
   getSubscription,
+  listReprices,
   resumeSubscription,
 } from "@/lib/api/endpoints"
+import type { SubscriptionReprice } from "@/lib/api/types"
 import { formatDate, formatMicros, shortId } from "@/lib/format"
 import { toastApiError } from "@/lib/toast"
 
@@ -54,6 +60,13 @@ export function SubscriptionDetailPage() {
   const { id = "" } = useParams()
   const navigate = useNavigate()
   const { data: sub, loading, error, reload } = useApiData(() => getSubscription(id), [id])
+  // #777: pending-reprice badge — at most one scheduled reprice can exist per
+  // subscription at a time.
+  const { data: scheduledReprices, reload: reloadReprices } = useApiData(
+    () => (id ? listReprices({ subscription_id: id, status: "scheduled" }) : Promise.resolve(null)),
+    [id],
+  )
+  const pendingReprice = scheduledReprices?.items?.[0]
   React.useEffect(() => {
     if (error) toastApiError(error, "Load subscription")
   }, [error])
@@ -106,9 +119,34 @@ export function SubscriptionDetailPage() {
           {formatDate(sub.current_period_starts_at)} → {formatDate(sub.current_period_ends_at)}
         </Fact>
         <Fact label="Price">
-          {sub.price?.unit_amount !== undefined && sub.price?.currency
-            ? formatMicros(sub.price.unit_amount, sub.price.currency)
-            : shortId(sub.price_id ?? "—", 13)}
+          <div className="flex flex-col gap-1">
+            <span className="flex items-center gap-2">
+              {sub.price?.amount !== undefined && sub.price?.currency ? (
+                <Link className="underline-offset-2 hover:underline" to={`/catalog/prices/${sub.price_id}`}>
+                  {formatMicros(sub.price.amount, sub.price.currency)}
+                </Link>
+              ) : (
+                <Link className="font-mono text-xs underline-offset-2 hover:underline" to={`/catalog/prices/${sub.price_id}`}>
+                  {shortId(sub.price_id ?? "—", 13)}
+                </Link>
+              )}
+              {sub.price?.archived && (
+                <Badge variant="secondary" title="Pinned to an archived (prior) version">
+                  prior version
+                </Badge>
+              )}
+            </span>
+            {sub.price?.key && <span className="font-mono text-xs text-muted-foreground">{sub.price.key}</span>}
+            {pendingReprice && (
+              <PendingRepriceBadge
+                reprice={pendingReprice}
+                onCancelled={() => {
+                  reloadReprices()
+                  reload()
+                }}
+              />
+            )}
+          </div>
         </Fact>
         <Fact label="Grace ends">{formatDate(sub.grace_ends_at)}</Fact>
         <Fact label="Retries">
@@ -155,17 +193,6 @@ export function SubscriptionDetailPage() {
         </CardContent>
       </Card>
     </div>
-  )
-}
-
-function Fact({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <Card>
-      <CardHeader className="pb-1">
-        <CardTitle className="text-xs font-normal text-muted-foreground uppercase">{label}</CardTitle>
-      </CardHeader>
-      <CardContent className="text-sm">{children}</CardContent>
-    </Card>
   )
 }
 
@@ -311,5 +338,43 @@ function ChangePaymentMethodDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  )
+}
+
+// PendingRepriceBadge (#777) surfaces a subscription's scheduled price move
+// (from the #773 primitive, usually scheduled in bulk by the price-change
+// wizard) with an inline cancel — allowed until the effective date; an
+// already-applied reprice cannot reach this badge (it's filtered to
+// status=scheduled by the caller).
+function PendingRepriceBadge({ reprice, onCancelled }: { reprice: SubscriptionReprice; onCancelled: () => void }) {
+  const { data: toPrice } = useApiData(() => getPrice(reprice.to_price_id), [reprice.to_price_id])
+  const [busy, setBusy] = React.useState(false)
+  return (
+    <span className="flex items-center gap-1.5">
+      <Badge className="bg-amber-500/15 text-amber-600 dark:text-amber-400">
+        moves to {toPrice ? formatMicros(toPrice.unit_amount, toPrice.currency) : shortId(reprice.to_price_id, 9)} on{" "}
+        {formatDate(reprice.effective_at)}
+      </Badge>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-5 px-1.5 text-xs"
+        disabled={busy}
+        onClick={async () => {
+          setBusy(true)
+          try {
+            await cancelReprice(reprice.id)
+            toast.success("Reprice canceled")
+            onCancelled()
+          } catch (err) {
+            toastApiError(err, "Cancel reprice")
+          } finally {
+            setBusy(false)
+          }
+        }}
+      >
+        cancel
+      </Button>
+    </span>
   )
 }


### PR DESCRIPTION
## Summary

Implements #777 — the merchant console price-change wizard — on top of the merged #773 (reprice primitive) + #774 (price keys). Three-step flow (amount -> migration plan -> review) as the ONLY amount-edit affordance on a price, plus price-page version chain / pending-migration display and a subscription-detail pending-reprice badge.

## Backend additions

The shipped #773/#774 HTTP surface didn't expose everything the wizard needs (confirmed by reading the merged code, not assumed):

- `GET /v1/merchant/catalog/prices/by-key/:key/history` — version chain resolved from the #774 pointer-movement log, with dates (not each row's own `created_at`, which is wrong for a reactivated/flip-flopped row).
- `GET /v1/merchant/catalog/reprice-all-prior-versions/preview?price_key=` — read-only affected-count dry run; the shipped bulk endpoint always mutates, so it can't double as a preview.
- `GET /v1/merchant/reprices/batches?price_key=` — find a price key's pending migration batch without already knowing its id (new sqlc query + repo/service methods).
- **Bug fix**: `RepriceBatchResult`/`RepriceOutcome` had no `json` tags at all — the wire format was PascalCase, contradicting the `{batch_id, to_price_id, matched, scheduled, skipped}` shape already documented in the tracker. Fixed to match the documented contract (no consumer existed yet).

Route-surface golden regenerated for the 3 new routes.

## Notice window — verified, not assumed

Grepped for `notice_window`/`MerchantConfiguration` and read `reprice_service.go` end to end: **#773 shipped zero server-side enforcement and no merchant-configurable value** — only the schedule-time `reprice_scheduled` notification (the disclosure hook itself). The console enforces a client-side-only 30-day default/floor for increase+migrate. A new integration test proves this by scheduling an increase+migrate 1 day out directly against the API and confirming the backend accepts it without complaint.

## Wizard flow

Step 1 (new amount; currency/interval read-only) -> Step 2 (migration plan; direction-aware defaults — increase defaults to grandfather, decrease defaults to migrate-now; live affected-count preview; notice-window date gate on increase) -> Step 3 (review sentence matching the spec's exact phrasing) -> **Confirm**: create the new price under the same key (re-attaching the old price's provider rails so it doesn't silently go DB-only), then schedule the bulk reprice if migrating — update-then-reprice, in that order.

Cancel-a-pending-migration is client-orchestrated (cancel each still-scheduled row in the batch via the existing per-row endpoint) — no atomic batch-cancel API, matching the tracker's own framing ("rides the #771 list/cancel API").

## Console pages

- Price detail page (`/catalog/prices/:id`, new route): version chain table, pending-migration progress card with cancel.
- Subscription detail: pinned price (linked), archived/"prior version" badge, pending-reprice badge with inline cancel. Drive-by fix: the Price fact was reading `sub.price.unit_amount`, a field that never existed on the wire (the embedded raw price model serializes `amount`) — always silently fell back to a short id.
- Extracted a `Fact` stat-tile component (duplicated verbatim across two existing detail pages) into `components/fact-card.tsx`, now shared by all three.

## Test coverage — stated honestly

web/admin has no test runner (`tsc`/`eslint`/`vite build` only) — the wizard's actual React interactions have zero automated coverage; that's a real gap, not one this PR works around.

What IS covered: `internal/integrationharness/merchant_reprice_wizard_http_test.go`, two new end-to-end HTTP tests against the real server — an INCREASE flow (preview before the bump, bump, grandfather-by-default verified against the DB, version history, explicit migrate, find-by-key, inspect, cancel-before-effective, re-cancel refused 409, subscriber untouched throughout) and a DECREASE flow (bump down, migrate-now bulk call, still only SCHEDULED never instant). Existing reprice/price-key suites re-run green, unmodified.

## Known pre-existing gap (unrelated, not touched here)

`go test -tags=integration ./tests` (`TestUpdateSubscriptionPaymentMethod*`) fails with `uq_prices_merchant_key_current` — a `tests/seed_data.go` fixture colliding with #774's new partial unique index. Confirmed identical on the merge commit this branch is based on (before any #777 change), via `git stash` + rerun. Flagging for whoever owns that fixture next.

## Test plan

- [x] `go build ./...` / `go build -tags console_assets ./cmd/openrails` clean
- [x] `go vet ./...` / `go vet -tags=integration ./...` clean
- [x] `gofmt -l` clean on touched files
- [x] `go test ./...` green
- [x] `go test -tags=integration` green on catalog, subscriptions, integrationharness, pkg/service, checkout, embed, river, embedded/controlplane, migrations/postgres
- [x] `pnpm build` / `tsc --noEmit` / `pnpm lint` clean in `web/admin`
- [ ] Manual/future e2e verification of the actual wizard UI (no test runner exists yet — see above)