### PR TITLE
fix(#781): server-side notice-window enforcement for scheduled price increases

### DIFF
--- a/internal/app/build_runtime.go
+++ b/internal/app/build_runtime.go
@@ -934,7 +934,7 @@ func createServices(database *db.DB, cfg *config.Config, railSet config.RailMerc
 	// #773: reprice primitive — moving existing subscribers to a different
 	// (same-product, same-currency, active) price at their next renewal.
 	repriceRepo := subscriptions.NewRepriceRepo(database)
-	repriceService := subscriptions.NewRepriceService(database, repriceRepo, priceService, subscriptionService, notificationService, clock)
+	repriceService := subscriptions.NewRepriceService(database, repriceRepo, priceService, subscriptionService, notificationService, merchantconfig.NewStore(database), clock)
 
 	vaultService := paymentmethods.NewVaultService(paymentMethodService, subscriptionService, nmiClients, database, cfg, railSet, clock)
 	subscriptionService.VaultService = vaultService

--- a/internal/db/gen/models.go
+++ b/internal/db/gen/models.go
@@ -1062,6 +1062,8 @@ type OpenrailsSubscriptionReprice struct {
 	CreatedAt      time.Time
 	AppliedAt      *time.Time
 	CanceledAt     *time.Time
+	// #781: true when this INCREASE reprice's effective_at was inside the merchant's configured notice window and was scheduled anyway via the explicit acknowledge_short_notice override on the request — the audit record for the support/emergency bypass path.
+	AcknowledgedShortNotice bool
 }
 
 // #733 append-only subscription status audit, written by trg_subscriptions_status_transition in the SAME tx as the status change. from_status NULL = row creation. Not retroactive: history begins at go-live.

--- a/internal/db/gen/subscription_reprices.sql.go
+++ b/internal/db/gen/subscription_reprices.sql.go
@@ -45,21 +45,23 @@ func (q *Queries) CancelSubscriptionReprice(ctx context.Context, id uuid.UUID) (
 const createSubscriptionReprice = `-- name: CreateSubscriptionReprice :one
 
 INSERT INTO openrails.subscription_reprices (
-    merchant_id, subscription_id, from_price_id, to_price_id, effective_at, reprice_batch_id
+    merchant_id, subscription_id, from_price_id, to_price_id, effective_at, reprice_batch_id, acknowledged_short_notice
 ) VALUES (
     $1::uuid, $2::uuid, $3::uuid,
-    $4::uuid, $5::timestamptz, $6::uuid
+    $4::uuid, $5::timestamptz, $6::uuid,
+    $7::bool
 )
-RETURNING id, merchant_id, subscription_id, from_price_id, to_price_id, effective_at, status, reprice_batch_id, created_at, applied_at, canceled_at
+RETURNING id, merchant_id, subscription_id, from_price_id, to_price_id, effective_at, status, reprice_batch_id, created_at, applied_at, canceled_at, acknowledged_short_notice
 `
 
 type CreateSubscriptionRepriceParams struct {
-	MerchantID     uuid.UUID
-	SubscriptionID uuid.UUID
-	FromPriceID    uuid.UUID
-	ToPriceID      uuid.UUID
-	EffectiveAt    time.Time
-	RepriceBatchID *uuid.UUID
+	MerchantID              uuid.UUID
+	SubscriptionID          uuid.UUID
+	FromPriceID             uuid.UUID
+	ToPriceID               uuid.UUID
+	EffectiveAt             time.Time
+	RepriceBatchID          *uuid.UUID
+	AcknowledgedShortNotice bool
 }
 
 // openrails.subscription_reprices (#773): per-subscription scheduled/applied/
@@ -72,6 +74,7 @@ func (q *Queries) CreateSubscriptionReprice(ctx context.Context, arg CreateSubsc
 		arg.ToPriceID,
 		arg.EffectiveAt,
 		arg.RepriceBatchID,
+		arg.AcknowledgedShortNotice,
 	)
 	var i OpenrailsSubscriptionReprice
 	err := row.Scan(
@@ -86,12 +89,13 @@ func (q *Queries) CreateSubscriptionReprice(ctx context.Context, arg CreateSubsc
 		&i.CreatedAt,
 		&i.AppliedAt,
 		&i.CanceledAt,
+		&i.AcknowledgedShortNotice,
 	)
 	return i, err
 }
 
 const getScheduledRepriceForSubscription = `-- name: GetScheduledRepriceForSubscription :one
-SELECT id, merchant_id, subscription_id, from_price_id, to_price_id, effective_at, status, reprice_batch_id, created_at, applied_at, canceled_at FROM openrails.subscription_reprices
+SELECT id, merchant_id, subscription_id, from_price_id, to_price_id, effective_at, status, reprice_batch_id, created_at, applied_at, canceled_at, acknowledged_short_notice FROM openrails.subscription_reprices
 WHERE subscription_id = $1::uuid AND status = 'scheduled'
 LIMIT 1
 `
@@ -115,12 +119,13 @@ func (q *Queries) GetScheduledRepriceForSubscription(ctx context.Context, subscr
 		&i.CreatedAt,
 		&i.AppliedAt,
 		&i.CanceledAt,
+		&i.AcknowledgedShortNotice,
 	)
 	return i, err
 }
 
 const getSubscriptionRepriceByID = `-- name: GetSubscriptionRepriceByID :one
-SELECT id, merchant_id, subscription_id, from_price_id, to_price_id, effective_at, status, reprice_batch_id, created_at, applied_at, canceled_at FROM openrails.subscription_reprices WHERE id = $1
+SELECT id, merchant_id, subscription_id, from_price_id, to_price_id, effective_at, status, reprice_batch_id, created_at, applied_at, canceled_at, acknowledged_short_notice FROM openrails.subscription_reprices WHERE id = $1
 `
 
 func (q *Queries) GetSubscriptionRepriceByID(ctx context.Context, id uuid.UUID) (OpenrailsSubscriptionReprice, error) {
@@ -138,12 +143,13 @@ func (q *Queries) GetSubscriptionRepriceByID(ctx context.Context, id uuid.UUID) 
 		&i.CreatedAt,
 		&i.AppliedAt,
 		&i.CanceledAt,
+		&i.AcknowledgedShortNotice,
 	)
 	return i, err
 }
 
 const listSubscriptionReprices = `-- name: ListSubscriptionReprices :many
-SELECT id, merchant_id, subscription_id, from_price_id, to_price_id, effective_at, status, reprice_batch_id, created_at, applied_at, canceled_at FROM openrails.subscription_reprices
+SELECT id, merchant_id, subscription_id, from_price_id, to_price_id, effective_at, status, reprice_batch_id, created_at, applied_at, canceled_at, acknowledged_short_notice FROM openrails.subscription_reprices
 WHERE ($1::uuid IS NULL OR subscription_id = $1::uuid)
   AND ($2::uuid IS NULL OR reprice_batch_id = $2::uuid)
   AND ($3::text IS NULL OR status = $3::text)
@@ -186,6 +192,7 @@ func (q *Queries) ListSubscriptionReprices(ctx context.Context, arg ListSubscrip
 			&i.CreatedAt,
 			&i.AppliedAt,
 			&i.CanceledAt,
+			&i.AcknowledgedShortNotice,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/models/genmap.go
+++ b/internal/db/models/genmap.go
@@ -383,17 +383,18 @@ func PriceKeyMovementsFromGen(rows []gen.OpenrailsPriceKeyMovement) []*PriceKeyM
 // SubscriptionRepriceFromGen maps a generated subscription_reprices row (#773).
 func SubscriptionRepriceFromGen(r gen.OpenrailsSubscriptionReprice) *SubscriptionReprice {
 	return &SubscriptionReprice{
-		ID:             r.ID,
-		MerchantID:     r.MerchantID,
-		SubscriptionID: r.SubscriptionID,
-		FromPriceID:    r.FromPriceID,
-		ToPriceID:      r.ToPriceID,
-		EffectiveAt:    r.EffectiveAt,
-		Status:         RepriceStatus(r.Status),
-		RepriceBatchID: r.RepriceBatchID,
-		CreatedAt:      r.CreatedAt,
-		AppliedAt:      r.AppliedAt,
-		CanceledAt:     r.CanceledAt,
+		ID:                      r.ID,
+		MerchantID:              r.MerchantID,
+		SubscriptionID:          r.SubscriptionID,
+		FromPriceID:             r.FromPriceID,
+		ToPriceID:               r.ToPriceID,
+		EffectiveAt:             r.EffectiveAt,
+		Status:                  RepriceStatus(r.Status),
+		RepriceBatchID:          r.RepriceBatchID,
+		CreatedAt:               r.CreatedAt,
+		AppliedAt:               r.AppliedAt,
+		CanceledAt:              r.CanceledAt,
+		AcknowledgedShortNotice: r.AcknowledgedShortNotice,
 	}
 }
 

--- a/internal/db/models/merchant_configuration.go
+++ b/internal/db/models/merchant_configuration.go
@@ -18,6 +18,12 @@ type MerchantConfiguration struct {
 	// AlertEmail is the merchant-operator address the #736 alerting engine sends
 	// critical alerts to. Unset ⇒ the email channel is inactive (fail-soft skip).
 	AlertEmail string `json:"alert_email,omitempty"`
+
+	// RepriceNoticeWindowDays (#781) is the minimum number of days' advance
+	// notice a subscription price INCREASE's effective_at must give existing
+	// subscribers. Decreases are exempt. Nil ⇒ DefaultRepriceNoticeWindowDays
+	// (30). Zero is a valid explicit merchant choice (no minimum enforced).
+	RepriceNoticeWindowDays *int `json:"reprice_notice_window_days,omitempty"`
 }
 
 // MerchantProfileConfiguration is merchant-owned public/communication metadata.

--- a/internal/db/models/subscription_reprice.go
+++ b/internal/db/models/subscription_reprice.go
@@ -32,6 +32,11 @@ type SubscriptionReprice struct {
 	CreatedAt      time.Time     `json:"created_at"`
 	AppliedAt      *time.Time    `json:"applied_at,omitempty"`
 	CanceledAt     *time.Time    `json:"canceled_at,omitempty"`
+	// AcknowledgedShortNotice (#781) is the audit trail for the escape hatch:
+	// true when this INCREASE reprice's effective_at was inside the
+	// merchant's configured notice window and was scheduled anyway via the
+	// request's explicit acknowledge_short_notice override.
+	AcknowledgedShortNotice bool `json:"acknowledged_short_notice"`
 }
 
 // IsDue reports whether this scheduled reprice should be applied at the

--- a/internal/db/queries/subscription_reprices.sql
+++ b/internal/db/queries/subscription_reprices.sql
@@ -3,10 +3,11 @@
 
 -- name: CreateSubscriptionReprice :one
 INSERT INTO openrails.subscription_reprices (
-    merchant_id, subscription_id, from_price_id, to_price_id, effective_at, reprice_batch_id
+    merchant_id, subscription_id, from_price_id, to_price_id, effective_at, reprice_batch_id, acknowledged_short_notice
 ) VALUES (
     sqlc.arg(merchant_id)::uuid, sqlc.arg(subscription_id)::uuid, sqlc.arg(from_price_id)::uuid,
-    sqlc.arg(to_price_id)::uuid, sqlc.arg(effective_at)::timestamptz, sqlc.narg(reprice_batch_id)::uuid
+    sqlc.arg(to_price_id)::uuid, sqlc.arg(effective_at)::timestamptz, sqlc.narg(reprice_batch_id)::uuid,
+    sqlc.arg(acknowledged_short_notice)::bool
 )
 RETURNING *;
 

--- a/internal/http/handlers/admin_reprice.go
+++ b/internal/http/handlers/admin_reprice.go
@@ -54,6 +54,8 @@ func repriceErrorCode(sentinel error) string {
 		return "reprice_cross_currency"
 	case errors.Is(sentinel, subscriptions.ErrRepriceInactivePrice):
 		return "reprice_inactive_price"
+	case errors.Is(sentinel, subscriptions.ErrRepriceNoticeWindowViolation):
+		return "reprice_notice_window_violation"
 	default:
 		return "reprice_constraint_violation"
 	}
@@ -63,6 +65,10 @@ type createSubscriptionRepriceRequest struct {
 	// ToPrice accepts either a price UUID/opaque id or a #774 price_key.
 	ToPrice     string    `json:"to_price"`
 	EffectiveAt time.Time `json:"effective_at"`
+	// AcknowledgeShortNotice (#781) explicitly bypasses the merchant's
+	// notice-window constraint on an INCREASE — the support/emergency
+	// escape hatch. Recorded on the row and logged; never silent.
+	AcknowledgeShortNotice bool `json:"acknowledge_short_notice,omitempty"`
 }
 
 // CreateSubscriptionReprice schedules subscription.PriceID -> to_price,
@@ -96,9 +102,10 @@ func CreateSubscriptionReprice(r *httprequest.Request) {
 		return
 	}
 	out, err := r.State.RepriceService.Reprice(ctx, subscriptions.RepriceRequest{
-		SubscriptionID: subscriptionID,
-		ToPriceID:      toPrice.ID,
-		EffectiveAt:    req.EffectiveAt,
+		SubscriptionID:         subscriptionID,
+		ToPriceID:              toPrice.ID,
+		EffectiveAt:            req.EffectiveAt,
+		AcknowledgeShortNotice: req.AcknowledgeShortNotice,
 	})
 	if err != nil {
 		writeRepriceError(r, err)
@@ -110,6 +117,9 @@ func CreateSubscriptionReprice(r *httprequest.Request) {
 type repriceAllPriorVersionsRequest struct {
 	PriceKey    string    `json:"price_key"`
 	EffectiveAt time.Time `json:"effective_at"`
+	// AcknowledgeShortNotice (#781): see createSubscriptionRepriceRequest.
+	// Applies uniformly to every subscription in the batch.
+	AcknowledgeShortNotice bool `json:"acknowledge_short_notice,omitempty"`
 }
 
 // RepriceAllPriorVersions bulk-schedules every active subscription pinned to
@@ -132,8 +142,9 @@ func RepriceAllPriorVersions(r *httprequest.Request) {
 		return
 	}
 	out, err := r.State.RepriceService.RepriceAllPriorVersions(r.Request.Context(), subscriptions.RepriceAllPriorVersionsRequest{
-		PriceKey:    req.PriceKey,
-		EffectiveAt: req.EffectiveAt,
+		PriceKey:               req.PriceKey,
+		EffectiveAt:            req.EffectiveAt,
+		AcknowledgeShortNotice: req.AcknowledgeShortNotice,
 	})
 	if err != nil {
 		writeRepriceError(r, err)

--- a/internal/http/handlers/service_admission.go
+++ b/internal/http/handlers/service_admission.go
@@ -337,11 +337,15 @@ type serviceMerchantConfigWindow struct {
 }
 
 type serviceMerchantSettingsRequest struct {
-	Profile                           *serviceMerchantProfileConfiguration  `json:"profile,omitempty"`
-	InvoiceCollectionThreshold        *int64                                `json:"collection_threshold,omitempty"`
-	InvoiceMonthlyFloor               *int64                                `json:"monthly_floor,omitempty"`
-	InvoiceBillingBoundary            string                                `json:"billing_period_boundary,omitempty"`
-	AlertEmail                        *string                               `json:"alert_email,omitempty"`
+	Profile                    *serviceMerchantProfileConfiguration `json:"profile,omitempty"`
+	InvoiceCollectionThreshold *int64                               `json:"collection_threshold,omitempty"`
+	InvoiceMonthlyFloor        *int64                               `json:"monthly_floor,omitempty"`
+	InvoiceBillingBoundary     string                               `json:"billing_period_boundary,omitempty"`
+	AlertEmail                 *string                              `json:"alert_email,omitempty"`
+	// RepriceNoticeWindowDays (#781): the minimum advance-notice window (in
+	// days) a subscription price INCREASE's effective_at must give existing
+	// subscribers. Unset ⇒ subscriptions.DefaultRepriceNoticeWindowDays (30).
+	RepriceNoticeWindowDays           *int                                  `json:"reprice_notice_window_days,omitempty"`
 	TrustLevelSchedules               []serviceMerchantTrustLevelSchedule   `json:"trust_level_schedules,omitempty"`
 	TrustLevelSpendLimits             []billingservice.PayerSpendLimitInput `json:"trust_level_spend_limits,omitempty"`
 	DelegatedInvokerWastedSpendLimits []serviceMerchantConfigWindow         `json:"delegated_invoker_wasted_spend_limits,omitempty"`
@@ -377,6 +381,7 @@ func ServiceGetMerchantSettings(r *httprequest.Request) {
 		InvoiceMonthlyFloor:               cfg.InvoiceMonthlyFloor,
 		InvoiceBillingBoundary:            cfg.InvoiceBillingBoundary,
 		AlertEmail:                        cfg.AlertEmail,
+		RepriceNoticeWindowDays:           cfg.RepriceNoticeWindowDays,
 		DelegatedInvokerWastedSpendLimits: serviceMerchantConfigWindows(cfg.DelegatedInvokerWastedSpendWindows),
 	})
 }
@@ -410,6 +415,7 @@ func ServiceSetMerchantSettings(r *httprequest.Request) {
 		InvoiceMonthlyFloor:                req.InvoiceMonthlyFloor,
 		InvoiceBillingBoundary:             req.InvoiceBillingBoundary,
 		AlertEmail:                         req.AlertEmail,
+		RepriceNoticeWindowDays:            req.RepriceNoticeWindowDays,
 		DelegatedInvokerWastedSpendWindows: windows,
 	}); err != nil {
 		r.ErrorJSON(http.StatusInternalServerError, "set merchant settings failed")

--- a/internal/integrationharness/merchant_reprice_notice_window_http_test.go
+++ b/internal/integrationharness/merchant_reprice_notice_window_http_test.go
@@ -1,0 +1,229 @@
+//go:build integration
+
+package integrationharness
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/controlplane"
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/pkg/catalog"
+	billingservice "github.com/open-rails/openrails/pkg/service"
+)
+
+// #781: server-side notice-window enforcement, end to end over real HTTP —
+// the primitive #773 shipped had NO server-side minimum-notice check (only a
+// client-side 30-day console gate); this is the replacement for #777's
+// gap-proving test (a 1-day-out increase used to be accepted without
+// complaint). Covers the full matrix the tracker calls out: typed refusal,
+// decrease exemption, the explicit acknowledge override with its audit trail,
+// and a merchant-configured window actually being honored.
+
+type repriceErrorEnvelope struct {
+	Error struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// noticeWindowFixture publishes one product with a current price (v1), an
+// active subscriber pinned to it, and gives the caller a `bump` helper to
+// create a successor version (v2) under the same key — everything the
+// single-subscription reprice endpoint's notice-window matrix needs.
+type noticeWindowFixture struct {
+	t                    *testing.T
+	ctx                  context.Context
+	h                    *Harness
+	surface              *Surface
+	token                string
+	productKey, priceKey string
+	v1                   billingservice.CatalogPrice
+	subID                uuid.UUID
+}
+
+func newNoticeWindowFixture(t *testing.T) *noticeWindowFixture {
+	t.Helper()
+	ctx := context.Background()
+	h := New(t, ctx)
+	surface := h.StartStandalone("usd")
+	token := surface.MintAPIKey(
+		dbtest.TestMerchantSlug,
+		"reprice-notice-window-"+uuid.NewString(),
+		[]string{
+			controlplane.PermMerchantCatalogRead, controlplane.PermMerchantCatalogUpdate,
+			controlplane.PermMerchantSubscriptionsRead, controlplane.PermMerchantSubscriptionsUpdate,
+			controlplane.PermMerchantSettingsRead, controlplane.PermMerchantSettingsUpdate,
+		},
+	)
+
+	f := &noticeWindowFixture{t: t, ctx: ctx, h: h, surface: surface, token: token}
+	f.productKey = "notice-window-" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	f.priceKey = f.productKey + "-monthly"
+
+	f.publish(1000000) // v1 at $10/mo
+	f.v1 = f.getByKey()
+	f.subID = seedRepriceSubscription(t, ctx, h, f.v1.ProductID, f.v1.ID)
+	return f
+}
+
+func (f *noticeWindowFixture) putSettings(body map[string]any) {
+	f.t.Helper()
+	status, respBody := requestJSON(f.t, http.MethodPut, f.surface.BaseURL+"/v1/merchant/settings", f.token, body)
+	require.Equal(f.t, http.StatusOK, status, string(respBody))
+}
+
+// setNoticeWindowDays exercises the real #781 seam the wizard reads from:
+// PUT/GET /v1/merchant/settings.
+func (f *noticeWindowFixture) setNoticeWindowDays(days int) {
+	f.t.Helper()
+	f.putSettings(map[string]any{"reprice_notice_window_days": days})
+
+	status, body := requestJSON(f.t, http.MethodGet, f.surface.BaseURL+"/v1/merchant/settings", f.token, nil)
+	require.Equal(f.t, http.StatusOK, status, string(body))
+	var settings struct {
+		RepriceNoticeWindowDays int `json:"reprice_notice_window_days"`
+	}
+	require.NoError(f.t, json.Unmarshal(body, &settings))
+	require.Equal(f.t, days, settings.RepriceNoticeWindowDays, "the read seam must reflect what was just written")
+}
+
+func (f *noticeWindowFixture) publish(amount int64) {
+	f.t.Helper()
+	status, body := requestJSON(f.t, http.MethodPost, f.surface.BaseURL+"/v1/merchant/catalog/publish", f.token, map[string]any{
+		"catalog": catalog.Manifest{
+			Version: catalog.SupportedVersion,
+			Products: []catalog.Product{{
+				Key:         f.productKey,
+				DisplayName: "Notice Window Product",
+				Prices: []catalog.Price{{
+					UnitAmount: amount, Currency: "usd", Duration: "30d", AutoRenew: true,
+				}},
+			}},
+		},
+		"insert": true, "overwrite": true,
+	})
+	require.Equal(f.t, http.StatusOK, status, string(body))
+}
+
+func (f *noticeWindowFixture) getByKey() billingservice.CatalogPrice {
+	f.t.Helper()
+	status, body := requestJSON(f.t, http.MethodGet, f.surface.BaseURL+"/v1/merchant/catalog/prices/by-key/"+f.priceKey, f.token, nil)
+	require.Equal(f.t, http.StatusOK, status, string(body))
+	var p billingservice.CatalogPrice
+	require.NoError(f.t, json.Unmarshal(body, &p))
+	return p
+}
+
+// bump publishes a successor version under the same key (an INCREASE over
+// v1) and returns it — the reprice target for the notice-window cases below.
+func (f *noticeWindowFixture) bump(amount int64) billingservice.CatalogPrice {
+	f.t.Helper()
+	f.publish(amount)
+	return f.getByKey()
+}
+
+func (f *noticeWindowFixture) reprice(toPrice string, effectiveAt time.Time, acknowledge bool) (int, []byte) {
+	f.t.Helper()
+	return requestJSON(f.t, http.MethodPost, f.surface.BaseURL+"/v1/merchant/subscriptions/"+f.subID.String()+"/reprice", f.token, map[string]any{
+		"to_price": toPrice, "effective_at": effectiveAt, "acknowledge_short_notice": acknowledge,
+	})
+}
+
+// TestStandaloneMerchantRepriceNoticeWindowHTTP_IncreaseInsideWindowRefused:
+// the default (unconfigured) window is 30 days — a 1-day-out INCREASE is
+// refused with a typed, machine-readable code.
+func TestStandaloneMerchantRepriceNoticeWindowHTTP_IncreaseInsideWindowRefused(t *testing.T) {
+	f := newNoticeWindowFixture(t)
+	f.setNoticeWindowDays(30)
+	v2 := f.bump(1200000) // $12/mo, an increase over v1's $10/mo
+
+	status, body := f.reprice(v2.Key, time.Now().UTC().Add(24*time.Hour), false)
+	require.Equal(t, http.StatusUnprocessableEntity, status, string(body))
+	var envelope repriceErrorEnvelope
+	require.NoError(t, json.Unmarshal(body, &envelope))
+	require.Equal(t, "reprice_notice_window_violation", envelope.Error.Code)
+
+	// Fail-closed: nothing was scheduled.
+	listStatus, listBody := requestJSON(t, http.MethodGet, f.surface.BaseURL+"/v1/merchant/reprices?subscription_id="+f.subID.String(), f.token, nil)
+	require.Equal(t, http.StatusOK, listStatus, string(listBody))
+	var list struct {
+		Items []*models.SubscriptionReprice `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal(listBody, &list))
+	require.Empty(t, list.Items)
+}
+
+// TestStandaloneMerchantRepriceNoticeWindowHTTP_DecreaseExempt: a DECREASE
+// effective just 1 day out is accepted outright — no notice window applies.
+func TestStandaloneMerchantRepriceNoticeWindowHTTP_DecreaseExempt(t *testing.T) {
+	f := newNoticeWindowFixture(t)
+	f.setNoticeWindowDays(30)
+	v2 := f.bump(800000) // $8/mo, a decrease from v1's $10/mo
+
+	status, body := f.reprice(v2.Key, time.Now().UTC().Add(24*time.Hour), false)
+	require.Equal(t, http.StatusCreated, status, string(body))
+	var rr models.SubscriptionReprice
+	require.NoError(t, json.Unmarshal(body, &rr))
+	require.Equal(t, models.RepriceStatusScheduled, rr.Status)
+	require.False(t, rr.AcknowledgedShortNotice, "a decrease never needs the override")
+}
+
+// TestStandaloneMerchantRepriceNoticeWindowHTTP_AcknowledgeOverride_AuditEvidence:
+// the explicit acknowledge_short_notice escape hatch schedules the increase
+// anyway, and the override is durably recorded — never silent.
+func TestStandaloneMerchantRepriceNoticeWindowHTTP_AcknowledgeOverride_AuditEvidence(t *testing.T) {
+	f := newNoticeWindowFixture(t)
+	f.setNoticeWindowDays(30)
+	v2 := f.bump(1200000)
+
+	status, body := f.reprice(v2.Key, time.Now().UTC().Add(24*time.Hour), true)
+	require.Equal(t, http.StatusCreated, status, string(body))
+	var rr models.SubscriptionReprice
+	require.NoError(t, json.Unmarshal(body, &rr))
+	require.Equal(t, models.RepriceStatusScheduled, rr.Status)
+	require.True(t, rr.AcknowledgedShortNotice, "the override must be visible on the creation response")
+
+	// Independently re-fetch — durable audit evidence, not just an echo.
+	getStatus, getBody := requestJSON(t, http.MethodGet, f.surface.BaseURL+"/v1/merchant/reprices/"+rr.ID.String(), f.token, nil)
+	require.Equal(t, http.StatusOK, getStatus, string(getBody))
+	var fetched models.SubscriptionReprice
+	require.NoError(t, json.Unmarshal(getBody, &fetched))
+	require.True(t, fetched.AcknowledgedShortNotice, "audit evidence persisted on the row, independently re-readable")
+}
+
+// TestStandaloneMerchantRepriceNoticeWindowHTTP_MerchantConfiguredWindowRespected:
+// a merchant that configures a SHORTER window (via the same settings seam the
+// wizard reads from) gets that shorter window enforced — no override needed
+// once the request satisfies it.
+func TestStandaloneMerchantRepriceNoticeWindowHTTP_MerchantConfiguredWindowRespected(t *testing.T) {
+	f := newNoticeWindowFixture(t)
+	f.setNoticeWindowDays(2)
+	v2 := f.bump(1200000)
+
+	// 3 days out would violate the DEFAULT (30d) window but satisfies this
+	// merchant's configured 2-day window — no acknowledge needed.
+	status, body := f.reprice(v2.Key, time.Now().UTC().Add(3*24*time.Hour), false)
+	require.Equal(t, http.StatusCreated, status, string(body))
+	var rr models.SubscriptionReprice
+	require.NoError(t, json.Unmarshal(body, &rr))
+	require.False(t, rr.AcknowledgedShortNotice)
+
+	// Tightening the window back up refuses the same effective_at for a
+	// second subscriber — proves the check re-reads the LIVE configured
+	// value on every call, not a value cached at fixture setup.
+	f.setNoticeWindowDays(10)
+	sub2 := seedRepriceSubscription(t, f.ctx, f.h, f.v1.ProductID, f.v1.ID)
+	refuseStatus, refuseBody := requestJSON(t, http.MethodPost, f.surface.BaseURL+"/v1/merchant/subscriptions/"+sub2.String()+"/reprice", f.token, map[string]any{
+		"to_price": v2.Key, "effective_at": time.Now().UTC().Add(3 * 24 * time.Hour), "acknowledge_short_notice": false,
+	})
+	require.Equal(t, http.StatusUnprocessableEntity, refuseStatus, string(refuseBody))
+}

--- a/internal/integrationharness/merchant_reprice_wizard_http_test.go
+++ b/internal/integrationharness/merchant_reprice_wizard_http_test.go
@@ -73,8 +73,20 @@ func TestStandaloneMerchantRepriceWizardIncreaseHTTP(t *testing.T) {
 		[]string{
 			controlplane.PermMerchantCatalogRead, controlplane.PermMerchantCatalogUpdate,
 			controlplane.PermMerchantSubscriptionsRead, controlplane.PermMerchantSubscriptionsUpdate,
+			controlplane.PermMerchantSettingsUpdate,
 		},
 	)
+
+	// #781: pin this merchant's notice window explicitly via the real settings
+	// endpoint rather than relying on the "unset ⇒ default 30d" fallback — the
+	// merchant row is shared across every integration package in this suite
+	// (dbtest.TestMerchantID), so a deterministic explicit value keeps this
+	// test's notice-window assertions below independent of what any other
+	// package's fixtures last wrote to it.
+	settingsStatus, settingsBody := requestJSON(t, http.MethodPut, surface.BaseURL+"/v1/merchant/settings", token, map[string]any{
+		"reprice_notice_window_days": 30,
+	})
+	require.Equal(t, http.StatusOK, settingsStatus, string(settingsBody))
 
 	productKey := "wizard-inc-" + strings.ReplaceAll(uuid.NewString(), "-", "")
 	priceKey := productKey + "-monthly"
@@ -147,12 +159,26 @@ func TestStandaloneMerchantRepriceWizardIncreaseHTTP(t *testing.T) {
 	require.Equal(t, v1.ID, hist.Items[1].Price.ID)
 	require.True(t, hist.Items[0].EffectiveAt.After(hist.Items[1].EffectiveAt) || hist.Items[0].EffectiveAt.Equal(hist.Items[1].EffectiveAt))
 
-	// Now explicitly migrate (ending the grandfather window): notice-window is
-	// NOT enforced server-side (#773 never implemented it — pure console UX
-	// gate) — an effective_at only a day out for an INCREASE is accepted
-	// without complaint, proving there's no server-side minimum-notice check
-	// to rely on.
-	effectiveAt := time.Now().UTC().Add(24 * time.Hour)
+	// Now explicitly migrate (ending the grandfather window). #781: the
+	// server now enforces a notice window for INCREASE reprices — an
+	// effective_at only a day out is REFUSED (this used to be #777's
+	// gap-proving assertion: pre-#781, the backend accepted it without
+	// complaint). TestStandaloneMerchantRepriceNoticeWindowHTTP owns the full
+	// notice-window matrix (refusal/decrease-exemption/acknowledge-override/
+	// merchant-configured-window); here we just confirm the wizard's own flow
+	// hits the gate, then proceed with a compliant date so the rest of this
+	// end-to-end flow (batch listing, cancel) still exercises real data.
+	shortNoticeStatus, shortNoticeBody := requestJSON(t, http.MethodPost, surface.BaseURL+"/v1/merchant/catalog/reprice-all-prior-versions", token, map[string]any{
+		"price_key": priceKey, "effective_at": time.Now().UTC().Add(24 * time.Hour),
+	})
+	require.Equal(t, http.StatusCreated, shortNoticeStatus, string(shortNoticeBody), "bulk never aborts — the 1-day-out increase is SKIPPED, not a batch-level error")
+	var shortNoticeResult subscriptions.RepriceBatchResult
+	require.NoError(t, json.Unmarshal(shortNoticeBody, &shortNoticeResult))
+	require.Empty(t, shortNoticeResult.Scheduled, "a 1-day-out increase must not be scheduled")
+	require.Len(t, shortNoticeResult.Skipped, 1)
+	require.Contains(t, shortNoticeResult.Skipped[0].Reason, "notice window")
+
+	effectiveAt := time.Now().UTC().Add(31 * 24 * time.Hour)
 	bulkStatus, bulkBody := requestJSON(t, http.MethodPost, surface.BaseURL+"/v1/merchant/catalog/reprice-all-prior-versions", token, map[string]any{
 		"price_key": priceKey, "effective_at": effectiveAt,
 	})
@@ -165,16 +191,19 @@ func TestStandaloneMerchantRepriceWizardIncreaseHTTP(t *testing.T) {
 	require.Equal(t, v2.ID, batchResult.ToPriceID)
 
 	// The price page's pending-migration lookup: find the batch by key
-	// without already knowing its id.
+	// without already knowing its id. Two batches exist now — the short-notice
+	// attempt above (fully skipped) and this one (fully scheduled) — most
+	// recent first.
 	batchesStatus, batchesBody := requestJSON(t, http.MethodGet, surface.BaseURL+"/v1/merchant/reprices/batches?price_key="+priceKey, token, nil)
 	require.Equal(t, http.StatusOK, batchesStatus, string(batchesBody))
 	var batches struct {
 		Items []*models.RepriceBatch `json:"items"`
 	}
 	require.NoError(t, json.Unmarshal(batchesBody, &batches))
-	require.Len(t, batches.Items, 1)
-	require.Equal(t, batchResult.BatchID, batches.Items[0].ID)
+	require.Len(t, batches.Items, 2)
+	require.Equal(t, batchResult.BatchID, batches.Items[0].ID, "most recent (the successful migrate) first")
 	require.Equal(t, 1, batches.Items[0].SubscriptionsScheduled)
+	require.Equal(t, 0, batches.Items[1].SubscriptionsScheduled, "the short-notice attempt scheduled nothing")
 
 	// Inspect the scheduled row for this batch.
 	repricesStatus, repricesBody := requestJSON(t, http.MethodGet,

--- a/internal/modules/subscriptions/renewal_charger_sandbox_integration_test.go
+++ b/internal/modules/subscriptions/renewal_charger_sandbox_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/open-rails/openrails/internal/integrations/nmi"
 	"github.com/open-rails/openrails/internal/modules/catalog"
 	"github.com/open-rails/openrails/internal/modules/entitlements"
+	"github.com/open-rails/openrails/internal/modules/merchantconfig"
 	"github.com/open-rails/openrails/internal/modules/payments"
 	"github.com/open-rails/openrails/internal/modules/payments/rails/nmidirect"
 )
@@ -114,7 +115,13 @@ func TestRenewalCharger_NMISandbox_SameAnchorAcrossReprice(t *testing.T) {
 	paymentSvc := payments.NewPaymentService(dbi)
 	subSvc := NewSubscriptionService(dbi, priceSvc, productSvc, nil, nil, nil)
 	lifecycle := NewSubscriptionLifecycleService(dbi, productSvc, priceSvc, entitlementSvc, notifSvc, paymentSvc)
-	repriceSvc := NewRepriceService(dbi, NewRepriceRepo(dbi), priceSvc, subSvc, notifSvc, nil)
+	// #781: this proof is about the stored-credential anchor surviving a
+	// reprice, not notice-window semantics — disable the gate explicitly
+	// (effective_at=now below would otherwise violate the 30-day default).
+	configStore := merchantconfig.NewStore(dbi)
+	zeroWindow := 0
+	require.NoError(t, configStore.Upsert(ctx, models.MerchantConfiguration{RepriceNoticeWindowDays: &zeroWindow}))
+	repriceSvc := NewRepriceService(dbi, NewRepriceRepo(dbi), priceSvc, subSvc, notifSvc, configStore, nil)
 	rc := &RenewalCharger{Charger: nmidirect.New(client), Reprice: repriceSvc, Lifecycle: lifecycle, DB: dbi}
 
 	loadPM := func() *models.PaymentMethod {

--- a/internal/modules/subscriptions/reprice_integration_test.go
+++ b/internal/modules/subscriptions/reprice_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/open-rails/openrails/internal/dbtest"
 	"github.com/open-rails/openrails/internal/modules/catalog"
 	"github.com/open-rails/openrails/internal/modules/entitlements"
+	"github.com/open-rails/openrails/internal/modules/merchantconfig"
 	"github.com/open-rails/openrails/internal/modules/payments"
 	"github.com/open-rails/openrails/internal/modules/payments/charge"
 )
@@ -34,6 +35,7 @@ type repriceFixture struct {
 	lifecycle   *SubscriptionLifecycleService
 	repriceRepo *RepriceRepo
 	repriceSvc  *RepriceService
+	config      *merchantconfig.Store
 
 	merchantID              uuid.UUID
 	productID               uuid.UUID
@@ -92,11 +94,20 @@ func newRepriceFixture(t *testing.T) *repriceFixture {
 	subSvc := NewSubscriptionService(dbi, priceSvc, productSvc, nil, nil, nil, clock)
 	lifecycle := NewSubscriptionLifecycleService(dbi, productSvc, priceSvc, entitlementSvc, notifSvc, paymentSvc, clock)
 	repriceRepo := NewRepriceRepo(dbi)
-	repriceSvc := NewRepriceService(dbi, repriceRepo, priceSvc, subSvc, notifSvc, clock)
+	configStore := merchantconfig.NewStore(dbi)
+	// #781: this fixture's low/high prices exist to test renewal-boundary,
+	// cancel, and constraint mechanics — NOT notice-window semantics — so
+	// disable the gate (an explicit merchant override of 0 days) here rather
+	// than making every existing case pick a 30-day-compliant effective_at
+	// (which would fight the fake clock's real-wall-clock ceiling, see above).
+	// The dedicated notice-window tests set their own window explicitly.
+	zeroWindow := 0
+	require.NoError(t, configStore.Upsert(ctx, models.MerchantConfiguration{RepriceNoticeWindowDays: &zeroWindow}))
+	repriceSvc := NewRepriceService(dbi, repriceRepo, priceSvc, subSvc, notifSvc, configStore, clock)
 
 	f := &repriceFixture{
 		dbi: dbi, pool: pool, clock: clock, priceSvc: priceSvc, subSvc: subSvc,
-		lifecycle: lifecycle, repriceRepo: repriceRepo, repriceSvc: repriceSvc,
+		lifecycle: lifecycle, repriceRepo: repriceRepo, repriceSvc: repriceSvc, config: configStore,
 		merchantID: merchantID, productID: productID,
 		lowPriceID: lowPriceID, highPriceID: highPriceID,
 		otherProductPriceID: otherProductPriceID, otherCurrencyPriceID: otherCurrencyPriceID,
@@ -112,6 +123,15 @@ func newRepriceFixture(t *testing.T) *repriceFixture {
 		_, _ = pool.Exec(context.Background(), "DELETE FROM openrails.products WHERE id IN ($1,$2)", productID, otherProductID)
 	})
 	return f
+}
+
+// setNoticeWindowDays (#781) overrides this fixture's merchant-configured
+// reprice notice window (the fixture defaults to 0 — disabled — so every
+// pre-existing non-notice-window test is unaffected; tests exercising the
+// window call this explicitly).
+func (f *repriceFixture) setNoticeWindowDays(t *testing.T, ctx context.Context, days int) {
+	t.Helper()
+	require.NoError(t, f.config.Upsert(ctx, models.MerchantConfiguration{RepriceNoticeWindowDays: &days}))
 }
 
 // createSubscription seeds an active subscription pinned to priceID, billing
@@ -332,6 +352,162 @@ func TestRepriceAllPriorVersions_BulkSchedulesOnlyPriorVersions(t *testing.T) {
 
 	_, err = f.repriceRepo.GetScheduledForSubscription(ctx, unrelated)
 	require.ErrorIs(t, err, pgx.ErrNoRows, "a subscription pinned to a DIFFERENT key/product must not be touched")
+}
+
+// TestReprice_NoticeWindow_IncreaseInsideWindow_Refused (#781): an INCREASE
+// whose effective_at is nearer than the merchant's configured notice window
+// is refused with a typed constraint error — the server-side gate #773 never
+// had (proven, pre-#781, by the wizard's own integration test accepting a
+// 1-day-out increase without complaint).
+func TestReprice_NoticeWindow_IncreaseInsideWindow_Refused(t *testing.T) {
+	f := newRepriceFixture(t)
+	ctx := dbtest.WithTestMerchant(context.Background())
+	f.setNoticeWindowDays(t, ctx, 30)
+	subID, _ := f.createSubscription(t, ctx, f.lowPriceID)
+
+	_, err := f.repriceSvc.Reprice(ctx, RepriceRequest{
+		SubscriptionID: subID, ToPriceID: f.highPriceID, EffectiveAt: f.clock.Now().Add(24 * time.Hour),
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrRepriceNoticeWindowViolation)
+	var constraintErr *RepriceConstraintError
+	require.ErrorAs(t, err, &constraintErr)
+	require.Equal(t, subID, constraintErr.SubscriptionID)
+
+	// Fail-closed: nothing was scheduled.
+	_, err = f.repriceRepo.GetScheduledForSubscription(ctx, subID)
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+}
+
+// TestReprice_NoticeWindow_DecreaseExempt_EvenOneDayOut: decreases never need
+// advance notice, regardless of the configured window.
+func TestReprice_NoticeWindow_DecreaseExempt_EvenOneDayOut(t *testing.T) {
+	f := newRepriceFixture(t)
+	ctx := dbtest.WithTestMerchant(context.Background())
+	f.setNoticeWindowDays(t, ctx, 30)
+	subID, _ := f.createSubscription(t, ctx, f.highPriceID)
+
+	rr, err := f.repriceSvc.Reprice(ctx, RepriceRequest{
+		SubscriptionID: subID, ToPriceID: f.lowPriceID, EffectiveAt: f.clock.Now().Add(24 * time.Hour),
+	})
+	require.NoError(t, err)
+	require.Equal(t, models.RepriceStatusScheduled, rr.Status)
+	require.False(t, rr.AcknowledgedShortNotice, "a decrease never needs the override")
+}
+
+// TestReprice_NoticeWindow_AcknowledgeShortNotice_OverridesAndAudits: the
+// explicit support/emergency escape hatch schedules the increase anyway and
+// leaves audit evidence on the persisted row — never silent.
+func TestReprice_NoticeWindow_AcknowledgeShortNotice_OverridesAndAudits(t *testing.T) {
+	f := newRepriceFixture(t)
+	ctx := dbtest.WithTestMerchant(context.Background())
+	f.setNoticeWindowDays(t, ctx, 30)
+	subID, _ := f.createSubscription(t, ctx, f.lowPriceID)
+
+	rr, err := f.repriceSvc.Reprice(ctx, RepriceRequest{
+		SubscriptionID: subID, ToPriceID: f.highPriceID, EffectiveAt: f.clock.Now().Add(24 * time.Hour),
+		AcknowledgeShortNotice: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, models.RepriceStatusScheduled, rr.Status)
+	require.True(t, rr.AcknowledgedShortNotice, "the override must be recorded on the row, never silent")
+
+	// Re-fetch independently — the audit trail is durable, not just an
+	// in-memory echo of the request.
+	fetched, err := f.repriceRepo.GetByID(ctx, rr.ID)
+	require.NoError(t, err)
+	require.True(t, fetched.AcknowledgedShortNotice)
+}
+
+// TestReprice_NoticeWindow_MerchantConfiguredWindowRespected: a merchant that
+// configures a SHORTER window than the default gets that shorter window
+// enforced, with no override needed.
+func TestReprice_NoticeWindow_MerchantConfiguredWindowRespected(t *testing.T) {
+	f := newRepriceFixture(t)
+	ctx := dbtest.WithTestMerchant(context.Background())
+	f.setNoticeWindowDays(t, ctx, 2)
+	subID, _ := f.createSubscription(t, ctx, f.lowPriceID)
+
+	// 3 days out would violate the DEFAULT (30d) window but satisfies this
+	// merchant's configured 2-day window.
+	rr, err := f.repriceSvc.Reprice(ctx, RepriceRequest{
+		SubscriptionID: subID, ToPriceID: f.highPriceID, EffectiveAt: f.clock.Now().Add(3 * 24 * time.Hour),
+	})
+	require.NoError(t, err)
+	require.False(t, rr.AcknowledgedShortNotice, "no override needed — the configured window is satisfied")
+
+	// Tightening the window back up refuses a second subscription at the same
+	// (now non-compliant) notice.
+	f.setNoticeWindowDays(t, ctx, 10)
+	subID2, _ := f.createSubscription(t, ctx, f.lowPriceID)
+	_, err = f.repriceSvc.Reprice(ctx, RepriceRequest{
+		SubscriptionID: subID2, ToPriceID: f.highPriceID, EffectiveAt: f.clock.Now().Add(3 * 24 * time.Hour),
+	})
+	require.ErrorIs(t, err, ErrRepriceNoticeWindowViolation)
+}
+
+// TestRepriceAllPriorVersions_NoticeWindow_IncreaseInsideWindowSkipped: the
+// bulk operation's skip-not-abort semantics apply to the notice-window
+// constraint exactly like the others (cross-product/currency/inactive) —
+// matched but skipped, with a typed reason, never silently scheduled early.
+func TestRepriceAllPriorVersions_NoticeWindow_IncreaseInsideWindowSkipped(t *testing.T) {
+	f := newRepriceFixture(t)
+	ctx := dbtest.WithTestMerchant(context.Background())
+	f.setNoticeWindowDays(t, ctx, 30)
+
+	key := "reprice-notice-bulk-key-" + uuid.NewString()[:8]
+	require.NoError(t, f.priceSvc.SetKey(ctx, f.lowPriceID, key))
+	require.NoError(t, f.priceSvc.SetArchived(ctx, f.lowPriceID, true))
+	require.NoError(t, f.priceSvc.SetKey(ctx, f.highPriceID, key))
+	require.NoError(t, f.priceSvc.RecordKeyMovement(ctx, f.merchantID, f.lowPriceID, key, f.clock.Now().Add(-time.Hour)))
+	require.NoError(t, f.priceSvc.RecordKeyMovement(ctx, f.merchantID, f.highPriceID, key, f.clock.Now()))
+
+	pinned, _ := f.createSubscription(t, ctx, f.lowPriceID)
+
+	result, err := f.repriceSvc.RepriceAllPriorVersions(ctx, RepriceAllPriorVersionsRequest{
+		PriceKey: key, EffectiveAt: f.clock.Now().Add(24 * time.Hour),
+	})
+	require.NoError(t, err, "bulk never aborts on a per-subscription constraint violation")
+	require.Equal(t, 1, result.Matched)
+	require.Empty(t, result.Scheduled)
+	require.Len(t, result.Skipped, 1)
+	require.Equal(t, pinned, result.Skipped[0].SubscriptionID)
+	require.Contains(t, result.Skipped[0].Reason, "notice window")
+
+	_, err = f.repriceRepo.GetScheduledForSubscription(ctx, pinned)
+	require.ErrorIs(t, err, pgx.ErrNoRows, "skipped, never scheduled")
+}
+
+// TestRepriceAllPriorVersions_NoticeWindow_AcknowledgeShortNotice: the bulk
+// override schedules the whole batch anyway, with audit evidence on both the
+// API response and the persisted rows.
+func TestRepriceAllPriorVersions_NoticeWindow_AcknowledgeShortNotice(t *testing.T) {
+	f := newRepriceFixture(t)
+	ctx := dbtest.WithTestMerchant(context.Background())
+	f.setNoticeWindowDays(t, ctx, 30)
+
+	key := "reprice-notice-bulk-ack-key-" + uuid.NewString()[:8]
+	require.NoError(t, f.priceSvc.SetKey(ctx, f.lowPriceID, key))
+	require.NoError(t, f.priceSvc.SetArchived(ctx, f.lowPriceID, true))
+	require.NoError(t, f.priceSvc.SetKey(ctx, f.highPriceID, key))
+	require.NoError(t, f.priceSvc.RecordKeyMovement(ctx, f.merchantID, f.lowPriceID, key, f.clock.Now().Add(-time.Hour)))
+	require.NoError(t, f.priceSvc.RecordKeyMovement(ctx, f.merchantID, f.highPriceID, key, f.clock.Now()))
+
+	pinned, _ := f.createSubscription(t, ctx, f.lowPriceID)
+
+	result, err := f.repriceSvc.RepriceAllPriorVersions(ctx, RepriceAllPriorVersionsRequest{
+		PriceKey: key, EffectiveAt: f.clock.Now().Add(24 * time.Hour), AcknowledgeShortNotice: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Matched)
+	require.Empty(t, result.Skipped)
+	require.Len(t, result.Scheduled, 1)
+	require.Equal(t, pinned, result.Scheduled[0].SubscriptionID)
+	require.True(t, result.Scheduled[0].AcknowledgedShortNotice, "audit evidence on the API response")
+
+	scheduled, err := f.repriceRepo.GetScheduledForSubscription(ctx, pinned)
+	require.NoError(t, err)
+	require.True(t, scheduled.AcknowledgedShortNotice, "audit evidence durably persisted on the row")
 }
 
 // fakeCharger captures the last charge.Request it received, so tests can

--- a/internal/modules/subscriptions/reprice_repo.go
+++ b/internal/modules/subscriptions/reprice_repo.go
@@ -55,19 +55,22 @@ func (r *RepriceRepo) GetBatchByID(ctx context.Context, id uuid.UUID) (*models.R
 }
 
 // CreateSubscriptionReprice schedules one subscription's price move.
-// batchID is nil for a single ad-hoc reprice() call.
-func (r *RepriceRepo) CreateSubscriptionReprice(ctx context.Context, subscriptionID, fromPriceID, toPriceID uuid.UUID, effectiveAt time.Time, batchID *uuid.UUID) (*models.SubscriptionReprice, error) {
+// batchID is nil for a single ad-hoc reprice() call. acknowledgedShortNotice
+// (#781) records whether this row's effective_at was inside the merchant's
+// configured notice window and was scheduled anyway via an explicit override.
+func (r *RepriceRepo) CreateSubscriptionReprice(ctx context.Context, subscriptionID, fromPriceID, toPriceID uuid.UUID, effectiveAt time.Time, batchID *uuid.UUID, acknowledgedShortNotice bool) (*models.SubscriptionReprice, error) {
 	tid, err := merchant.Require(ctx)
 	if err != nil {
 		return nil, err
 	}
 	row, err := r.db.Gen(ctx).CreateSubscriptionReprice(ctx, gen.CreateSubscriptionRepriceParams{
-		MerchantID:     tid.UUID(),
-		SubscriptionID: subscriptionID,
-		FromPriceID:    fromPriceID,
-		ToPriceID:      toPriceID,
-		EffectiveAt:    effectiveAt,
-		RepriceBatchID: batchID,
+		MerchantID:              tid.UUID(),
+		SubscriptionID:          subscriptionID,
+		FromPriceID:             fromPriceID,
+		ToPriceID:               toPriceID,
+		EffectiveAt:             effectiveAt,
+		RepriceBatchID:          batchID,
+		AcknowledgedShortNotice: acknowledgedShortNotice,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/modules/subscriptions/reprice_service.go
+++ b/internal/modules/subscriptions/reprice_service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/open-rails/openrails/internal/db"
 	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/modules/catalog"
+	"github.com/open-rails/openrails/internal/modules/merchantconfig"
 	"github.com/open-rails/openrails/internal/shared/timeutil"
 	"github.com/open-rails/openrails/internal/shared/uuidutil"
 	"github.com/open-rails/openrails/pkg/merchant"
@@ -32,16 +33,18 @@ type RepriceService struct {
 	prices        *catalog.PriceService
 	subscriptions *SubscriptionService
 	notifications *NotificationService
+	config        *merchantconfig.Store
 	clock         clockwork.Clock
 }
 
-func NewRepriceService(d *db.DB, repo *RepriceRepo, prices *catalog.PriceService, subscriptions *SubscriptionService, notifications *NotificationService, clock clockwork.Clock) *RepriceService {
+func NewRepriceService(d *db.DB, repo *RepriceRepo, prices *catalog.PriceService, subscriptions *SubscriptionService, notifications *NotificationService, config *merchantconfig.Store, clock clockwork.Clock) *RepriceService {
 	return &RepriceService{
 		db:            d,
 		repo:          repo,
 		prices:        prices,
 		subscriptions: subscriptions,
 		notifications: notifications,
+		config:        config,
 		clock:         timeutil.FirstClock(clock),
 	}
 }
@@ -68,6 +71,43 @@ func validateRepriceConstraints(subscriptionID uuid.UUID, from, to *models.Price
 		return &RepriceConstraintError{Sentinel: ErrRepriceCrossCurrency, SubscriptionID: subscriptionID, FromPriceID: from.ID, ToPriceID: to.ID}
 	}
 	return nil
+}
+
+// noticeWindowDays (#781) resolves the merchant's configured minimum notice
+// window for a price-increase reprice, falling back to
+// DefaultRepriceNoticeWindowDays when the merchant has no override (or no
+// config store is wired at all, e.g. some lightweight test fixtures).
+func (s *RepriceService) noticeWindowDays(ctx context.Context) (int, error) {
+	if s.config == nil {
+		return DefaultRepriceNoticeWindowDays, nil
+	}
+	cfg, _, err := s.config.Get(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("reprice: load merchant notice-window config: %w", err)
+	}
+	if cfg.RepriceNoticeWindowDays != nil {
+		return *cfg.RepriceNoticeWindowDays, nil
+	}
+	return DefaultRepriceNoticeWindowDays, nil
+}
+
+// checkNoticeWindow (#781) is the fail-closed notice-window gate: an INCREASE
+// (to.Amount > from.Amount) whose effectiveAt is nearer than the merchant's
+// configured window violates. Decreases never violate — card-network/
+// consumer-protection advance-notice requirements apply to increases only.
+func (s *RepriceService) checkNoticeWindow(ctx context.Context, from, to *models.Price, effectiveAt time.Time) (violates bool, err error) {
+	if to.Amount <= from.Amount {
+		return false, nil
+	}
+	days, err := s.noticeWindowDays(ctx)
+	if err != nil {
+		return false, err
+	}
+	if days <= 0 {
+		return false, nil
+	}
+	minEffective := s.now().Add(time.Duration(days) * 24 * time.Hour)
+	return effectiveAt.Before(minEffective), nil
 }
 
 // scheduledConflict returns ErrRepriceAlreadyScheduled if the subscription
@@ -108,8 +148,24 @@ func (s *RepriceService) Reprice(ctx context.Context, req RepriceRequest) (*mode
 	if err := s.scheduledConflict(ctx, req.SubscriptionID); err != nil {
 		return nil, err
 	}
+	violatesNotice, err := s.checkNoticeWindow(ctx, fromPrice, toPrice, req.EffectiveAt)
+	if err != nil {
+		return nil, err
+	}
+	if violatesNotice && !req.AcknowledgeShortNotice {
+		return nil, &RepriceConstraintError{Sentinel: ErrRepriceNoticeWindowViolation, SubscriptionID: req.SubscriptionID, FromPriceID: fromPrice.ID, ToPriceID: toPrice.ID}
+	}
+	acknowledgedShortNotice := violatesNotice && req.AcknowledgeShortNotice
+	if acknowledgedShortNotice {
+		log.WithContext(ctx).WithFields(log.Fields{
+			"subscription_id": req.SubscriptionID,
+			"from_price_id":   fromPrice.ID,
+			"to_price_id":     toPrice.ID,
+			"effective_at":    req.EffectiveAt,
+		}).Warn("reprice: short-notice override acknowledged for a price increase inside the merchant's notice window")
+	}
 
-	rr, err := s.repo.CreateSubscriptionReprice(ctx, req.SubscriptionID, fromPrice.ID, toPrice.ID, req.EffectiveAt, nil)
+	rr, err := s.repo.CreateSubscriptionReprice(ctx, req.SubscriptionID, fromPrice.ID, toPrice.ID, req.EffectiveAt, nil, acknowledgedShortNotice)
 	if err != nil {
 		return nil, fmt.Errorf("reprice: schedule: %w", err)
 	}
@@ -160,12 +216,14 @@ func (s *RepriceService) RepriceAllPriorVersions(ctx context.Context, req Repric
 	}
 
 	type toSchedule struct {
-		sub  *models.Subscription
-		from *models.Price
+		sub                     *models.Subscription
+		from                    *models.Price
+		acknowledgedShortNotice bool
 	}
 	var (
-		schedule []toSchedule
-		skipped  []RepriceOutcome
+		schedule          []toSchedule
+		skipped           []RepriceOutcome
+		acknowledgedCount int
 	)
 	for _, sub := range subs {
 		fromPrice := priorByID[sub.PriceID]
@@ -182,21 +240,48 @@ func (s *RepriceService) RepriceAllPriorVersions(ctx context.Context, req Repric
 			skipped = append(skipped, RepriceOutcome{SubscriptionID: sub.ID, Reason: err.Error()})
 			continue
 		}
-		schedule = append(schedule, toSchedule{sub: sub, from: fromPrice})
+		// #781: per-subscription, since a bulk call's prior versions can carry
+		// different amounts (some higher, some lower than the target) — the
+		// notice window only ever gates the subset that are true increases.
+		violatesNotice, err := s.checkNoticeWindow(ctx, fromPrice, toPrice, req.EffectiveAt)
+		if err != nil {
+			return nil, fmt.Errorf("reprice_all_prior_versions: check notice window for subscription %s: %w", sub.ID, err)
+		}
+		if violatesNotice && !req.AcknowledgeShortNotice {
+			skipped = append(skipped, RepriceOutcome{
+				SubscriptionID: sub.ID,
+				Reason:         (&RepriceConstraintError{Sentinel: ErrRepriceNoticeWindowViolation, SubscriptionID: sub.ID, FromPriceID: fromPrice.ID, ToPriceID: toPrice.ID}).Error(),
+			})
+			continue
+		}
+		acknowledged := violatesNotice && req.AcknowledgeShortNotice
+		if acknowledged {
+			acknowledgedCount++
+		}
+		schedule = append(schedule, toSchedule{sub: sub, from: fromPrice, acknowledgedShortNotice: acknowledged})
 	}
 
 	batch, err := s.repo.CreateBatch(ctx, &key, toPrice.ID, req.EffectiveAt, len(subs), len(schedule), len(skipped))
 	if err != nil {
 		return nil, fmt.Errorf("reprice_all_prior_versions: create batch: %w", err)
 	}
+	if acknowledgedCount > 0 {
+		log.WithContext(ctx).WithFields(log.Fields{
+			"batch_id":           batch.ID,
+			"price_key":          key,
+			"to_price_id":        toPrice.ID,
+			"effective_at":       req.EffectiveAt,
+			"acknowledged_count": acknowledgedCount,
+		}).Warn("reprice_all_prior_versions: short-notice override acknowledged for a price increase inside the merchant's notice window")
+	}
 	result := &RepriceBatchResult{BatchID: batch.ID, ToPriceID: toPrice.ID, Matched: len(subs), Skipped: skipped}
 	batchID := batch.ID
 	for _, item := range schedule {
-		rr, err := s.repo.CreateSubscriptionReprice(ctx, item.sub.ID, item.from.ID, toPrice.ID, req.EffectiveAt, &batchID)
+		rr, err := s.repo.CreateSubscriptionReprice(ctx, item.sub.ID, item.from.ID, toPrice.ID, req.EffectiveAt, &batchID, item.acknowledgedShortNotice)
 		if err != nil {
 			return nil, fmt.Errorf("reprice_all_prior_versions: schedule subscription %s: %w", item.sub.ID, err)
 		}
-		result.Scheduled = append(result.Scheduled, RepriceOutcome{SubscriptionID: item.sub.ID, RepriceID: rr.ID})
+		result.Scheduled = append(result.Scheduled, RepriceOutcome{SubscriptionID: item.sub.ID, RepriceID: rr.ID, AcknowledgedShortNotice: item.acknowledgedShortNotice})
 		s.emitScheduledNotification(ctx, item.sub, item.from, toPrice, req.EffectiveAt)
 	}
 	return result, nil

--- a/internal/modules/subscriptions/reprice_types.go
+++ b/internal/modules/subscriptions/reprice_types.go
@@ -36,7 +36,21 @@ var (
 	// Surfaced by both Cancel (cancel-before-effective) and the renewal-boundary
 	// pickup (safe to retry).
 	ErrRepriceNotScheduled = errors.New("reprice: not in scheduled status")
+
+	// ErrRepriceNoticeWindowViolation (#781): an INCREASE reprice (to_price
+	// amount > from_price amount) whose effective_at is nearer than the
+	// merchant's configured notice window (default DefaultRepriceNoticeWindowDays).
+	// Decreases are exempt. Bypassed only by an explicit
+	// AcknowledgeShortNotice on the request — never silently coerced.
+	ErrRepriceNoticeWindowViolation = errors.New("reprice: effective_at is inside the merchant's configured notice window for a price increase")
 )
+
+// DefaultRepriceNoticeWindowDays (#781) is the notice window used when a
+// merchant has no explicit openrails.merchant_configurations override — card
+// networks and consumer-protection law generally require advance notice for
+// recurring-amount increases; 30 days is the console's own long-standing UX
+// default (#777's price-wizard-logic.ts), now also the server-side floor.
+const DefaultRepriceNoticeWindowDays = 30
 
 // RepriceConstraintError carries the offending ids for a refused reprice.
 type RepriceConstraintError struct {
@@ -62,6 +76,13 @@ type RepriceRequest struct {
 	SubscriptionID uuid.UUID
 	ToPriceID      uuid.UUID
 	EffectiveAt    time.Time
+	// AcknowledgeShortNotice (#781) explicitly bypasses the merchant's
+	// notice-window constraint on an INCREASE whose effective_at is nearer
+	// than the window — the support/emergency escape hatch. Recorded on the
+	// scheduled row (AcknowledgedShortNotice) and logged; never silent. No
+	// effect when the window is already satisfied or the reprice is a
+	// decrease.
+	AcknowledgeShortNotice bool
 }
 
 // RepriceAllPriorVersionsRequest is the bulk reprice_all_prior_versions(key,
@@ -71,6 +92,12 @@ type RepriceRequest struct {
 type RepriceAllPriorVersionsRequest struct {
 	PriceKey    string
 	EffectiveAt time.Time
+	// AcknowledgeShortNotice (#781): see RepriceRequest. Applies uniformly to
+	// every subscription in the batch — a per-subscription override isn't
+	// exposed at v1 (matches the constraint set's existing skip-not-abort
+	// granularity: subscriptions violating the window are individually
+	// skipped, with a reason, when this is false).
+	AcknowledgeShortNotice bool
 }
 
 // RepriceBatchResult summarizes a bulk reprice_all_prior_versions call. JSON
@@ -89,6 +116,11 @@ type RepriceOutcome struct {
 	SubscriptionID uuid.UUID `json:"subscription_id"`
 	RepriceID      uuid.UUID `json:"reprice_id,omitempty"` // zero when Skipped
 	Reason         string    `json:"reason,omitempty"`     // set when skipped (constraint violation)
+	// AcknowledgedShortNotice (#781) is true when this scheduled item's
+	// effective_at was inside the merchant's notice window and was scheduled
+	// anyway via the batch's AcknowledgeShortNotice override — audit evidence
+	// alongside the persisted row.
+	AcknowledgedShortNotice bool `json:"acknowledged_short_notice,omitempty"`
 }
 
 // RepricePreviewResult is the #777 read-only "affected-count preview": how

--- a/migrations/postgres/0012_reprice_notice_window.up.sql
+++ b/migrations/postgres/0012_reprice_notice_window.up.sql
@@ -1,0 +1,16 @@
+-- #781: server-side notice-window enforcement for scheduled price INCREASES.
+-- The merchant-configurable window itself (default 30 days) lives in the
+-- existing general merchant-config JSONB row (#499,
+-- openrails.merchant_configurations.config.reprice_notice_window_days) — no
+-- new column needed there.
+--
+-- acknowledged_short_notice is the audit trail for the one escape hatch
+-- (#781's acknowledge_short_notice request flag): true when a reprice whose
+-- effective_at fell inside the merchant's configured notice window (an
+-- INCREASE only — decreases are exempt) was scheduled anyway via an explicit
+-- override. Never set silently — the service also emits a warn-level log line
+-- whenever it is used.
+ALTER TABLE openrails.subscription_reprices
+    ADD COLUMN acknowledged_short_notice boolean DEFAULT false NOT NULL;
+
+COMMENT ON COLUMN openrails.subscription_reprices.acknowledged_short_notice IS '#781: true when this INCREASE reprice''s effective_at was inside the merchant''s configured notice window and was scheduled anyway via the explicit acknowledge_short_notice override on the request — the audit record for the support/emergency bypass path.';

--- a/pkg/service/admission.go
+++ b/pkg/service/admission.go
@@ -312,6 +312,12 @@ type MerchantConfiguration struct {
 	// AlertEmail is the merchant-operator alert destination (#736). A nil pointer
 	// preserves the stored value; a non-nil pointer sets it (empty string clears).
 	AlertEmail *string
+	// RepriceNoticeWindowDays (#781) is the merchant-configurable minimum
+	// advance-notice window (in days) for a subscription price INCREASE. A
+	// nil pointer preserves the stored value; a non-nil pointer sets it (the
+	// reprice service falls back to
+	// subscriptions.DefaultRepriceNoticeWindowDays when unset).
+	RepriceNoticeWindowDays *int
 }
 
 // GetMerchantConfiguration returns the stored merchant-scoped configuration row.
@@ -330,6 +336,7 @@ func (s *Service) GetMerchantConfiguration(ctx context.Context) (MerchantConfigu
 		InvoiceMonthlyFloor:                cfg.InvoiceMonthlyFloor,
 		InvoiceBillingBoundary:             cfg.InvoiceBillingBoundary,
 		AlertEmail:                         &alertEmail,
+		RepriceNoticeWindowDays:            cfg.RepriceNoticeWindowDays,
 		DelegatedInvokerWastedSpendWindows: make([]abuse.WastedWindow, 0, len(cfg.DelegatedInvokerWastedSpendWindows)),
 	}
 	for _, w := range cfg.DelegatedInvokerWastedSpendWindows {
@@ -381,6 +388,12 @@ func (s *Service) SetMerchantConfiguration(ctx context.Context, in MerchantConfi
 	}
 	if in.AlertEmail != nil {
 		cfg.AlertEmail = strings.TrimSpace(*in.AlertEmail)
+	}
+	if in.RepriceNoticeWindowDays != nil {
+		if *in.RepriceNoticeWindowDays < 0 {
+			return fmt.Errorf("reprice_notice_window_days must be >= 0")
+		}
+		cfg.RepriceNoticeWindowDays = in.RepriceNoticeWindowDays
 	}
 	cfg.DelegatedInvokerWastedSpendWindows = make([]models.BudgetWindowPolicy, 0, len(in.DelegatedInvokerWastedSpendWindows))
 	for _, w := range in.DelegatedInvokerWastedSpendWindows {

--- a/tests/seed_data.go
+++ b/tests/seed_data.go
@@ -134,7 +134,11 @@ func (suite *TestContainerSuite) DefaultTestProducts() []TestProduct {
 				},
 				{
 					// Price 1.3: Monthly EUR recurring
-					ID:                  uuid.MustParse("22222222-2222-2222-2222-222222222224"),
+					ID: uuid.MustParse("22222222-2222-2222-2222-222222222224"),
+					// Explicit key: same product+interval as price 1.1 (USD monthly)
+					// would otherwise both auto-derive "premium-monthly" and collide
+					// on uq_prices_merchant_key_current (#774).
+					Key:                 "premium-monthly-eur",
 					Amount:              8_990_000,
 					Currency:            "eur",
 					AccessDurationHours: intPtr(720), AutoRenew: true,
@@ -150,7 +154,9 @@ func (suite *TestContainerSuite) DefaultTestProducts() []TestProduct {
 				},
 				{
 					// Price 1.4: Monthly JPY recurring
-					ID:                  uuid.MustParse("22222222-2222-2222-2222-222222222225"),
+					ID: uuid.MustParse("22222222-2222-2222-2222-222222222225"),
+					// Explicit key: see 1.3 — would otherwise also collide as "premium-monthly".
+					Key:                 "premium-monthly-jpy",
 					Amount:              1_200_000_000,
 					Currency:            "jpy",
 					AccessDurationHours: intPtr(720), AutoRenew: true,
@@ -236,7 +242,10 @@ func (suite *TestContainerSuite) DefaultTestProducts() []TestProduct {
 				},
 				{
 					// Price 2.3: Monthly EUR recurring
-					ID:                  uuid.MustParse("44444444-4444-4444-4444-444444444446"),
+					ID: uuid.MustParse("44444444-4444-4444-4444-444444444446"),
+					// Explicit key: same product+interval as price 2.1 (USD monthly)
+					// would otherwise both auto-derive "pro-monthly" and collide (#774).
+					Key:                 "pro-monthly-eur",
 					Amount:              17_990_000,
 					Currency:            "eur",
 					AccessDurationHours: intPtr(720), AutoRenew: true,
@@ -286,7 +295,10 @@ func (suite *TestContainerSuite) DefaultTestProducts() []TestProduct {
 				},
 				{
 					// Price 3.2: One-time EUR purchase
-					ID:                  uuid.MustParse("66666666-6666-6666-6666-666666666667"),
+					ID: uuid.MustParse("66666666-6666-6666-6666-666666666667"),
+					// Explicit key: same product+interval as price 3.1 (USD one-time)
+					// would otherwise both auto-derive "lifetime-onetime" and collide (#774).
+					Key:                 "lifetime-onetime-eur",
 					Amount:              269_990_000,
 					Currency:            "eur",
 					AccessDurationHours: nil, AutoRenew: false, // One-time purchase
@@ -302,7 +314,9 @@ func (suite *TestContainerSuite) DefaultTestProducts() []TestProduct {
 				},
 				{
 					// Price 3.3: One-time JPY purchase
-					ID:                  uuid.MustParse("66666666-6666-6666-6666-666666666668"),
+					ID: uuid.MustParse("66666666-6666-6666-6666-666666666668"),
+					// Explicit key: see 3.2 — would otherwise also collide as "lifetime-onetime".
+					Key:                 "lifetime-onetime-jpy",
 					Amount:              39_800_000_000,
 					Currency:            "jpy",
 					AccessDurationHours: nil, AutoRenew: false, // One-time purchase
@@ -395,18 +409,22 @@ func (suite *TestContainerSuite) upsertProduct(ctx context.Context, p *models.Pr
 	require.NoError(suite.t, err, "Failed to seed product %s", p.Key)
 }
 
-// insertPriceIfAbsent inserts a price with ON CONFLICT (id) DO NOTHING.
+// insertPriceIfAbsent inserts a price with ON CONFLICT (id) DO NOTHING. Key is
+// included so fixtures that would otherwise collide on the #774
+// uq_prices_merchant_key_current partial index (same product + interval, e.g.
+// several same-product/duration prices differing only by currency) can supply
+// a distinct explicit key; a blank Key still auto-derives via the DB trigger.
 func (suite *TestContainerSuite) insertPriceIfAbsent(ctx context.Context, price *models.Price) {
 	suite.t.Helper()
 	_, err := suite.Pool.Exec(ctx, `
 		INSERT INTO openrails.prices (
 			id, product_id, archived, amount, currency, access_duration_hours, auto_renew,
-			rails, created_at, updated_at, merchant_id
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+			rails, key, created_at, updated_at, merchant_id
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NULLIF($9, ''), $10, $11, $12)
 		ON CONFLICT (id) DO NOTHING`,
 		price.ID, price.ProductID, price.Archived, price.Amount, price.Currency,
 		price.AccessDurationHours, price.AutoRenew,
-		suite.mustJSONB(price.Rails, len(price.Rails) == 0),
+		suite.mustJSONB(price.Rails, len(price.Rails) == 0), price.Key,
 		price.CreatedAt, price.UpdatedAt, dbtest.TestMerchantID.UUID())
 	require.NoError(suite.t, err, "Failed to seed price %s", price.ID)
 }

--- a/web/admin/src/lib/api/types.ts
+++ b/web/admin/src/lib/api/types.ts
@@ -388,6 +388,10 @@ export interface MerchantSettings {
   // engine (service_admission.go). Unset ⇒ the email channel is inactive
   // (fail-soft to in_app + webhooks).
   alert_email?: string
+  // Minimum advance-notice window (days) a subscription price INCREASE's
+  // effective_at must give existing subscribers (#781). Unset ⇒ the server's
+  // DefaultRepriceNoticeWindowDays (30). Decreases are exempt.
+  reprice_notice_window_days?: number
 }
 
 export interface PaymentProviderConfig {

--- a/web/admin/src/pages/catalog/price-wizard-logic.ts
+++ b/web/admin/src/pages/catalog/price-wizard-logic.ts
@@ -13,12 +13,15 @@ export function detectDirection(newAmount: number, currentAmount: number): Price
 
 export type MigrationMode = "grandfather" | "migrate"
 
-// #773 shipped NO merchant-configurable notice window and NO server-side
-// enforcement of one — this is a console-only UX guardrail on the date
-// picker for increase+migrate. See the #777 tracker note and #773's Progress
-// section: the engine only emits the reprice_scheduled disclosure event: it
-// never rejects an early effective_at.
-export const NOTICE_WINDOW_DAYS = 30
+// DEFAULT_NOTICE_WINDOW_DAYS is only a fallback for the brief window before
+// the merchant's configured value (GET /v1/merchant/settings,
+// reprice_notice_window_days) has loaded — it mirrors the server's own
+// default (subscriptions.DefaultRepriceNoticeWindowDays) so the UI never
+// under-gates while loading. #781: the server now ALSO enforces this
+// server-side (an INCREASE whose effective_at is inside the merchant's
+// configured window is refused, 422 reprice_notice_window_violation) — this
+// client-side gate is fail-fast UX, not the boundary.
+export const DEFAULT_NOTICE_WINDOW_DAYS = 30
 
 // defaultMigrationMode is the direction-aware Step 2 default: increases
 // default to grandfather (zero-risk — #774's existing behavior, no new
@@ -31,23 +34,23 @@ export function defaultMigrationMode(direction: PriceDirection): MigrationMode {
 // minEffectiveDate returns the earliest allowed migration date, or null when
 // there is no minimum (decreases may move everyone at next renewal starting
 // now — notice is optional goodwill, not a requirement).
-export function minEffectiveDate(direction: PriceDirection, now: Date): Date | null {
+export function minEffectiveDate(direction: PriceDirection, now: Date, noticeWindowDays: number): Date | null {
   if (direction !== "increase") return null
   const min = new Date(now)
-  min.setUTCDate(min.getUTCDate() + NOTICE_WINDOW_DAYS)
+  min.setUTCDate(min.getUTCDate() + noticeWindowDays)
   return min
 }
 
 // defaultEffectiveDate is Step 2's pre-filled migration date: the notice
 // window's floor for an increase, "now" for a decrease.
-export function defaultEffectiveDate(direction: PriceDirection, now: Date): Date {
-  return minEffectiveDate(direction, now) ?? now
+export function defaultEffectiveDate(direction: PriceDirection, now: Date, noticeWindowDays: number): Date {
+  return minEffectiveDate(direction, now, noticeWindowDays) ?? now
 }
 
 // isEffectiveDateValid enforces the console-side notice-window gate: an
 // increase+migrate plan may not pick a date inside the notice window.
-export function isEffectiveDateValid(direction: PriceDirection, effectiveAt: Date, now: Date): boolean {
-  const min = minEffectiveDate(direction, now)
+export function isEffectiveDateValid(direction: PriceDirection, effectiveAt: Date, now: Date, noticeWindowDays: number): boolean {
+  const min = minEffectiveDate(direction, now, noticeWindowDays)
   return !min || effectiveAt.getTime() >= min.getTime()
 }
 

--- a/web/admin/src/pages/catalog/price-wizard.tsx
+++ b/web/admin/src/pages/catalog/price-wizard.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { createPrice, previewRepriceAllPriorVersions, repriceAllPriorVersions } from "@/lib/api/endpoints"
+import { createPrice, getMerchantSettings, previewRepriceAllPriorVersions, repriceAllPriorVersions } from "@/lib/api/endpoints"
 import type { CatalogPrice } from "@/lib/api/types"
 import { formatMicros, microsFromInput } from "@/lib/format"
 import { toastApiError } from "@/lib/toast"
@@ -23,10 +23,10 @@ import {
   buildReviewText,
   defaultEffectiveDate,
   defaultMigrationMode,
+  DEFAULT_NOTICE_WINDOW_DAYS,
   detectDirection,
   isEffectiveDateValid,
   minEffectiveDate,
-  NOTICE_WINDOW_DAYS,
   type MigrationMode,
 } from "@/pages/catalog/price-wizard-logic"
 
@@ -54,6 +54,12 @@ export function PriceChangeWizard({
   const [previewLoading, setPreviewLoading] = React.useState(false)
   const [affectedCount, setAffectedCount] = React.useState<number | null>(null)
   const [busy, setBusy] = React.useState(false)
+  // #781: the merchant-configurable notice window, read from the API (the
+  // console used to hard-code 30 days here; the server is now the actual
+  // boundary — GET /v1/merchant/settings — this is only the fail-fast UX
+  // gate). DEFAULT_NOTICE_WINDOW_DAYS covers the brief window before the
+  // fetch resolves.
+  const [noticeWindowDays, setNoticeWindowDays] = React.useState(DEFAULT_NOTICE_WINDOW_DAYS)
 
   const [now] = React.useState(() => new Date())
   const newAmount = microsFromInput(amountInput) ?? price.unit_amount
@@ -68,13 +74,21 @@ export function PriceChangeWizard({
   }
 
   const handleOpenChange = (next: boolean) => {
-    if (!next) reset()
+    if (!next) {
+      reset()
+    } else {
+      getMerchantSettings()
+        .then((settings) => setNoticeWindowDays(settings.reprice_notice_window_days ?? DEFAULT_NOTICE_WINDOW_DAYS))
+        .catch(() => {
+          /* fail-soft: keep the default fallback — the server enforces the real window regardless. */
+        })
+    }
     setOpen(next)
   }
 
   const enterStep2 = () => {
     setMode(defaultMigrationMode(direction))
-    setEffectiveAt(toDateInputValue(defaultEffectiveDate(direction, now)))
+    setEffectiveAt(toDateInputValue(defaultEffectiveDate(direction, now, noticeWindowDays)))
     setStep(2)
     setPreviewLoading(true)
     setAffectedCount(null)
@@ -84,8 +98,9 @@ export function PriceChangeWizard({
       .finally(() => setPreviewLoading(false))
   }
 
-  const minDate = minEffectiveDate(direction, now)
-  const dateValid = mode !== "migrate" || (!!effectiveAt && isEffectiveDateValid(direction, new Date(effectiveAt), now))
+  const minDate = minEffectiveDate(direction, now, noticeWindowDays)
+  const dateValid =
+    mode !== "migrate" || (!!effectiveAt && isEffectiveDateValid(direction, new Date(effectiveAt), now, noticeWindowDays))
 
   // Archived (prior-version) rows are history, not the editable current
   // price — editing rides the key's CURRENT row (GET .../prices/by-key/:key
@@ -230,8 +245,8 @@ export function PriceChangeWizard({
                 />
                 {direction === "increase" ? (
                   <p className="text-xs text-muted-foreground">
-                    Must be at least {NOTICE_WINDOW_DAYS} days out (card-network advance-notice window for amount
-                    increases — enforced here in the console; not by the API).
+                    Must be at least {noticeWindowDays} days out (card-network advance-notice window for amount
+                    increases — configurable in Settings; enforced by the API).
                   </p>
                 ) : (
                   <p className="text-xs text-muted-foreground">

--- a/web/admin/src/pages/settings/index.tsx
+++ b/web/admin/src/pages/settings/index.tsx
@@ -88,7 +88,12 @@ function MerchantSettingsTab() {
     if (error) toastApiError(error, "Load settings")
   }, [error])
   if (loading) return <p className="text-sm text-muted-foreground">Loading…</p>
-  return <MerchantProfileForm initial={data?.profile} />
+  return (
+    <div className="grid gap-4">
+      <MerchantProfileForm initial={data?.profile} />
+      <RepriceNoticeWindowForm initial={data?.reprice_notice_window_days} />
+    </div>
+  )
 }
 
 function MerchantProfileForm({
@@ -135,6 +140,60 @@ function MerchantProfileForm({
                     logo_url: logoURL || undefined,
                   },
                 })
+                toast.success("Settings saved")
+              } catch (err) {
+                toastApiError(err, "Save settings")
+              } finally {
+                setBusy(false)
+              }
+            }}
+          >
+            {busy ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+// RepriceNoticeWindowForm (#781): the merchant-configurable minimum advance
+// notice (days) a subscription price INCREASE must give existing
+// subscribers. The catalog price-change wizard reads this same value
+// (GET /v1/merchant/settings) for its own date-picker gate; the API enforces
+// it regardless of what the console shows.
+function RepriceNoticeWindowForm({ initial }: { initial?: number }) {
+  const [days, setDays] = React.useState(String(initial ?? 30))
+  const [busy, setBusy] = React.useState(false)
+  const parsed = Number(days)
+  const valid = days.trim() !== "" && Number.isInteger(parsed) && parsed >= 0
+
+  return (
+    <Card className="max-w-xl">
+      <CardHeader>
+        <CardTitle className="text-sm">Price-increase notice window</CardTitle>
+        <CardDescription>
+          Minimum days' advance notice a scheduled subscription price INCREASE must give existing
+          subscribers before it takes effect. Decreases are never gated. Default 30 days.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-3">
+        <Field label="Notice window (days)" id="s-notice-window">
+          <Input
+            id="s-notice-window"
+            type="number"
+            step="1"
+            min="0"
+            value={days}
+            onChange={(e) => setDays(e.target.value)}
+          />
+        </Field>
+        <div>
+          <Button
+            disabled={busy || !valid}
+            onClick={async () => {
+              setBusy(true)
+              try {
+                await putMerchantSettings({ reprice_notice_window_days: parsed })
                 toast.success("Settings saved")
               } catch (err) {
                 toastApiError(err, "Save settings")


### PR DESCRIPTION
## Summary

- #773 shipped the reprice primitive with **no server-side notice-window enforcement** — only a client-side 30-day console gate (proven by #777's own integration test, which accepted a 1-day-out price increase without complaint). This inverted house doctrine: constraints belong in the API, not the UI.
- Adds a merchant-configurable `reprice_notice_window_days` (default 30, stored in the existing `openrails.merchant_configurations` JSONB row — same mechanism as #499's `delegated_invoker_wasted_spend_windows`) enforced in `RepriceService` for both single (`Reprice`) and bulk (`RepriceAllPriorVersions`) calls: an INCREASE (`to_price.amount > from_price.amount`) whose `effective_at` is nearer than the window is refused with a typed `RepriceConstraintError` (422 `reprice_notice_window_violation`), following the same #750/#773 sentinel pattern as the existing cross-product/cross-currency/inactive constraints. Decreases are exempt.
- An explicit `acknowledge_short_notice` request flag bypasses the gate (support/emergency escape hatch) and is durably recorded on the scheduled `subscription_reprices` row (new `acknowledged_short_notice` column) plus logged at warn level — never silent.
- The web/admin price-change wizard now reads the window from the already-consumed `GET /v1/merchant/settings` endpoint instead of its hardcoded `NOTICE_WINDOW_DAYS` constant; a new settings-page field lets merchants actually configure it.
- Replaces #777's gap-proving test assertion (1-day-out increase used to get `201 Created`) and adds a full notice-window test matrix at both the HTTP (`internal/integrationharness`) and service (`internal/modules/subscriptions`) layers: typed refusal, decrease exemption, acknowledge override with durable audit evidence, and merchant-configured window actually being honored.
- Also fixes `tests/seed_data.go`: several `DefaultTestProducts()` fixtures (same product+interval, different currency) shared an auto-derived price key, colliding with #774's `uq_prices_merchant_key_current` partial unique index (`go test -tags=integration ./tests` was red on master). Gives the colliding fixtures explicit distinct keys.

## Test plan

- [x] `gofmt` / `go vet` / `go vet -tags=integration` clean
- [x] `go build ./...` and `go build -tags=integration ./...` clean
- [x] `go test ./...` green
- [x] `-tags=integration` green: `pkg/service`, `internal/integrationharness` (full package), `internal/modules/subscriptions` (full package), `./tests`, `./embed`, `./internal/river`, `migrations/postgres`, `internal/modules/catalog`
- [x] `pnpm build` / `pnpm exec tsc --noEmit` / `pnpm lint` clean in `web/admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)