### PR TITLE
feat(#779): console catalog copilot — read-only Q&A + flag-gated drafting

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -99,3 +99,10 @@ admin_console:
 #   ask_enabled: false       # #756 consent: /metrics/ask sends aggregate query RESULTS to the
 #                            # LLM provider (widget generation sends only the schema) — opt in
 #                            # explicitly; env LLM_ASK_ENABLED
+#   catalog_copilot_enabled: false   # #779 Phase 1 consent: /catalog/ask sends aggregate
+#                            # catalog/subscriber-count data to the LLM provider; env
+#                            # LLM_CATALOG_COPILOT_ENABLED
+#   catalog_drafting_enabled: false  # #779 Phase 2: arms the draft_price_change/draft_catalog_diff
+#                            # tools (proposals only, never a mutation). KEEP FALSE until #781
+#                            # (server-side notice-window enforcement) ships; env
+#                            # LLM_CATALOG_DRAFTING_ENABLED

--- a/config/config.go
+++ b/config/config.go
@@ -372,6 +372,22 @@ type LLMConfig struct {
 	// sends aggregate query RESULTS too. Default false (fail-closed). Env:
 	// LLM_ASK_ENABLED.
 	AskEnabled bool `koanf:"ask_enabled,omitempty"`
+
+	// CatalogCopilotEnabled arms POST /v1/merchant/catalog/ask (#779 Phase 1):
+	// read-only catalog Q&A. Separate consent from AskEnabled/ask_enabled
+	// because the data flow is a distinct surface (aggregate catalog/
+	// subscriber-count data, not metrics). Default false (fail-closed). Env:
+	// LLM_CATALOG_COPILOT_ENABLED.
+	CatalogCopilotEnabled bool `koanf:"catalog_copilot_enabled,omitempty"`
+
+	// CatalogDraftingEnabled additionally arms the #779 Phase 2 draft_* tools
+	// inside the catalog copilot loop (draft_price_change / draft_catalog_diff
+	// — proposals only, never a mutation). MUST stay false until #781 (server-
+	// side notice-window enforcement) ships: the copilot's safety story is
+	// "the API refuses what the wizard would refuse", which depends on that
+	// enforcement existing. Flip this only after both #779 and #781 have
+	// merged. Default false (fail-closed). Env: LLM_CATALOG_DRAFTING_ENABLED.
+	CatalogDraftingEnabled bool `koanf:"catalog_drafting_enabled,omitempty"`
 }
 
 // IsConfigured reports whether NL widget generation can run (fail-closed on a
@@ -381,6 +397,19 @@ func (c *LLMConfig) IsConfigured() bool { return c != nil && strings.TrimSpace(c
 // AskConfigured reports whether metrics Q&A can run: a key AND the explicit
 // ask_enabled consent (results flow to the provider — never implied by the key).
 func (c *LLMConfig) AskConfigured() bool { return c.IsConfigured() && c.AskEnabled }
+
+// CatalogCopilotConfigured reports whether catalog Q&A (#779 Phase 1) can
+// run: a key AND the explicit catalog_copilot_enabled consent.
+func (c *LLMConfig) CatalogCopilotConfigured() bool {
+	return c.IsConfigured() && c.CatalogCopilotEnabled
+}
+
+// CatalogDraftingConfigured reports whether the #779 Phase 2 draft_* tools
+// are armed: catalog Q&A configured AND the explicit catalog_drafting_enabled
+// consent (see the field doc — stays false until #781 ships).
+func (c *LLMConfig) CatalogDraftingConfigured() bool {
+	return c.CatalogCopilotConfigured() && c.CatalogDraftingEnabled
+}
 
 // ResolvedProvider returns the effective provider name.
 func (c *LLMConfig) ResolvedProvider() string {

--- a/docs/admin-console.md
+++ b/docs/admin-console.md
@@ -284,3 +284,39 @@ the panel renders a pointed empty-state naming both knobs.
 External agents get the same power against the raw API (schema + query endpoints with
 a merchant API key) — see `docs/metrics-for-llms.md` for the two-endpoint recipe and a
 copy-paste tool definition.
+
+## Catalog copilot (#779)
+
+The catalog copilot extends the Ask pattern above from METRICS to the CATALOG: a panel
+on the Catalog page answers questions about products, prices, subscriber counts, and
+pending migrations via `POST /v1/merchant/catalog/ask`. Read-only tools (`list_catalog`,
+`get_price`, `price_history`, `list_reprice_batches`) run against the caller's
+RLS-pinned merchant; every listing carries its active-subscriber and grandfathered
+counts inline (no second call needed), and "0 results"/"no pending migrations" are
+stated explicitly. Same rate limit/cap doctrine as `/metrics/ask` (its own budget, never
+shared). Needs only `merchant:catalog:read` — Q&A never mutates.
+
+```yaml
+llm:
+  catalog_copilot_enabled: true    # aggregate catalog/subscriber data flows to the LLM
+  # catalog_drafting_enabled: false  # Phase 2 — see below; env LLM_CATALOG_DRAFTING_ENABLED
+```
+
+**The one safety principle:** the model NEVER mutates. When
+`llm.catalog_drafting_enabled` is armed, the loop gains two more tools —
+`draft_price_change` (a #777 wizard plan: new amount + migration mode + effective date,
+with the affected-subscriber count and review text already computed) and
+`draft_catalog_diff` (a new tier on an existing product) — but both only return a DRAFT
+payload. The console opens the draft, pre-filled, at the wizard's review step (or a
+plain create-price confirm for a new tier); nothing changes until a human clicks
+Confirm, which calls the exact same API the hand-typed flow does. A request that would
+need cross-product migration (moving subscribers onto a different, pre-existing
+product — #778, explicitly deferred) is refused with a typed reason and the
+archive-and-grandfather workaround, never drafted.
+
+**`catalog_drafting_enabled` MUST stay false until #781 ships** (server-side
+notice-window enforcement for scheduled price increases) — the copilot's safety story
+is "the API refuses what the wizard would refuse", which depends on that enforcement
+existing. Flag-off means the `draft_*` tools are entirely ABSENT from the tool list
+(the model cannot even attempt one), not present-but-erroring; flipping the flag on is
+the whole migration once #781 lands.

--- a/internal/app/build_runtime.go
+++ b/internal/app/build_runtime.go
@@ -37,6 +37,7 @@ import (
 	"github.com/open-rails/openrails/internal/modules/alerting"
 	"github.com/open-rails/openrails/internal/modules/catalog"
 	"github.com/open-rails/openrails/internal/modules/checkout"
+	"github.com/open-rails/openrails/internal/modules/copilot"
 	"github.com/open-rails/openrails/internal/modules/dashboard"
 	"github.com/open-rails/openrails/internal/modules/entitlements"
 	"github.com/open-rails/openrails/internal/modules/idempotency"
@@ -396,6 +397,7 @@ func buildRuntimeWithOverrides(cfg *config.Config, overrides *runtimeOverrides) 
 		MoneyService:           serviceInstances.MoneyService,
 		MetricsService:         serviceInstances.MetricsService,
 		DashboardService:       serviceInstances.DashboardService,
+		CopilotService:         serviceInstances.CopilotService,
 		AlertService:           alertService,
 		MoneyCharger:           moneyCharger,
 		RailCustomerService:    serviceInstances.RailCustomerService,
@@ -812,6 +814,7 @@ type servicesInstances struct {
 	MoneyService           *money.MoneyService
 	MetricsService         *metrics.Service
 	DashboardService       *dashboard.Service
+	CopilotService         *copilot.Service
 	RailCustomerService    *payments.RailCustomerService
 }
 
@@ -935,6 +938,31 @@ func createServices(database *db.DB, cfg *config.Config, railSet config.RailMerc
 	// (same-product, same-currency, active) price at their next renewal.
 	repriceRepo := subscriptions.NewRepriceRepo(database)
 	repriceService := subscriptions.NewRepriceService(database, repriceRepo, priceService, subscriptionService, notificationService, merchantconfig.NewStore(database), clock)
+
+	// #779 catalog copilot: read-only Q&A always (gated on
+	// llm.catalog_copilot_enabled); the Phase 2 draft_* tools additionally on
+	// llm.catalog_drafting_enabled, which MUST stay off until #781 (server-
+	// side notice-window enforcement) ships — see config.go's field doc.
+	// Rides the SAME LLM client as the dashboard (one provider/model/key
+	// config for the whole deployment); its own Redis-backed rate limiter
+	// (own key namespace, never shares #756's budget).
+	var copilotLimiter copilot.AskLimiter
+	if redisClient != nil {
+		copilotLimiter = copilot.NewAskLimiter(redisClient, clock.Now)
+	} else {
+		copilotLimiter = copilot.NewAskLimiter(nil, clock.Now)
+	}
+	copilotService := copilot.NewService(copilot.Deps{
+		Products: productService,
+		Prices:   priceService,
+		Subs:     subscriptionService,
+		Reprices: repriceService,
+		LLM:      dashboardLLM,
+		Enabled:  cfg.LLM != nil && cfg.LLM.CatalogCopilotEnabled,
+		Drafting: cfg.LLM != nil && cfg.LLM.CatalogDraftingEnabled,
+		Limiter:  copilotLimiter,
+		Clock:    clock,
+	})
 
 	vaultService := paymentmethods.NewVaultService(paymentMethodService, subscriptionService, nmiClients, database, cfg, railSet, clock)
 	subscriptionService.VaultService = vaultService
@@ -1080,6 +1108,7 @@ func createServices(database *db.DB, cfg *config.Config, railSet config.RailMerc
 		MoneyService:                 moneyService,
 		MetricsService:               metricsService,
 		DashboardService:             dashboardService,
+		CopilotService:               copilotService,
 		RailCustomerService:          railCustomerService,
 	}
 }

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -30,6 +30,7 @@ import (
 	"github.com/open-rails/openrails/internal/modules/alerting"
 	"github.com/open-rails/openrails/internal/modules/catalog"
 	"github.com/open-rails/openrails/internal/modules/checkout"
+	"github.com/open-rails/openrails/internal/modules/copilot"
 	"github.com/open-rails/openrails/internal/modules/dashboard"
 	"github.com/open-rails/openrails/internal/modules/entitlements"
 	"github.com/open-rails/openrails/internal/modules/idempotency"
@@ -123,6 +124,10 @@ type Runtime struct {
 	// DashboardService is the #741 configurable dashboard (saved widgets +
 	// NL widget generation; nil-LLM = generation fail-closed).
 	DashboardService *dashboard.Service
+	// CopilotService is the #779 catalog copilot (read-only Q&A always; the
+	// Phase 2 draft_* tools are additionally gated on
+	// llm.catalog_drafting_enabled — see copilot.Service.DraftingConfigured).
+	CopilotService *copilot.Service
 	// AlertService is the #736 metric-threshold alerting engine (rules,
 	// webhooks, notifications, the evaluator).
 	AlertService *alerting.Service

--- a/internal/http/handlers/merchant_catalog_copilot.go
+++ b/internal/http/handlers/merchant_catalog_copilot.go
@@ -1,0 +1,91 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+
+	httprequest "github.com/open-rails/openrails/internal/http/request"
+	"github.com/open-rails/openrails/internal/modules/copilot"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// CatalogCopilotAsk handles POST /v1/merchant/catalog/ask (#779): the
+// console catalog copilot. Phase 1 (read-only Q&A over catalog/pricing/
+// reprice data) always runs when configured; Phase 2's draft_price_change /
+// draft_catalog_diff tools are additionally present ONLY when
+// llm.catalog_drafting_enabled is set (flag-off = absent from the tool list,
+// never present-but-erroring). The model never mutates — its only
+// write-shaped output is a DRAFT for human review in the console.
+func CatalogCopilotAsk(r *httprequest.Request) {
+	svc := r.State.CopilotService
+	if svc == nil {
+		r.ErrorJSON(http.StatusServiceUnavailable, "catalog copilot service not configured")
+		return
+	}
+	if !svc.Configured() {
+		r.ErrorJSON(http.StatusNotImplemented,
+			"the catalog copilot is not configured on this deployment: set llm.api_key (env LLM_API_KEY) AND llm.catalog_copilot_enabled (env LLM_CATALOG_COPILOT_ENABLED=true) — see docs/admin-console.md")
+		return
+	}
+	var body struct {
+		Question string `json:"question"`
+	}
+	if err := json.NewDecoder(r.Request.Body).Decode(&body); err != nil || strings.TrimSpace(body.Question) == "" {
+		r.ErrorJSON(http.StatusBadRequest, `body must be {"question":"<what you want to know>"}`)
+		return
+	}
+	res, err := svc.Ask(r.Request.Context(), strings.TrimSpace(body.Question))
+	if err != nil {
+		var limited *copilot.RateLimitedError
+		var noAnswer *copilot.NoAnswerError
+		switch {
+		case errors.As(err, &limited):
+			r.SetHeader("Retry-After", strconv.Itoa(int(math.Ceil(limited.RetryAfter.Seconds()))))
+			r.ErrorJSON(http.StatusTooManyRequests, "catalog copilot rate limit exceeded — try again later")
+		case errors.As(err, &noAnswer):
+			r.ErrorJSON(http.StatusBadGateway, "the model did not produce an answer within the query budget — try a narrower question")
+		default:
+			r.ErrorJSON(http.StatusBadGateway, "catalog copilot failed: the LLM request did not complete")
+		}
+		return
+	}
+	r.JSON(http.StatusOK, res)
+}
+
+// CatalogCopilotConfirmDraft handles POST /v1/merchant/catalog/copilot/confirm
+// (#779): the console calls this immediately after a human confirms a
+// copilot-drafted price change / catalog diff through the normal wizard/
+// create-price flow — a pure audit-provenance log entry (drafted-by-copilot
+// marker), never a mutation itself (the confirm already happened via the
+// normal catalog/reprice endpoints). Best-effort: logging failure never
+// blocks the console (the mutation already succeeded by the time this is
+// called).
+func CatalogCopilotConfirmDraft(r *httprequest.Request) {
+	var body struct {
+		DraftID  string `json:"draft_id"`
+		Kind     string `json:"kind"`
+		PriceKey string `json:"price_key,omitempty"`
+	}
+	if err := json.NewDecoder(r.Request.Body).Decode(&body); err != nil || strings.TrimSpace(body.DraftID) == "" || strings.TrimSpace(body.Kind) == "" {
+		r.ErrorJSON(http.StatusBadRequest, `body must be {"draft_id":"...","kind":"price_change"|"catalog_diff","price_key":"..."}`)
+		return
+	}
+	ctx := r.Request.Context()
+	fields := log.Fields{
+		"draft_id":   body.DraftID,
+		"kind":       body.Kind,
+		"price_key":  body.PriceKey,
+		"drafted_by": copilot.DraftedBy,
+	}
+	if mid, err := merchant.Require(ctx); err == nil {
+		fields["merchant_id"] = mid.String()
+	}
+	log.WithContext(ctx).WithFields(fields).Info("copilot draft confirmed by human")
+	r.SuccessJSONMessage("draft confirmation logged")
+}

--- a/internal/http/routes/routes.go
+++ b/internal/http/routes/routes.go
@@ -632,6 +632,20 @@ func registerCatalogActionRoutes(catalog router.Router, rt *app.Runtime, opts Op
 	catalog.Handle(http.MethodGet, "/drift", h(httphandlers.AdminListCatalogDrift), readMW...)
 	catalog.Handle(http.MethodPost, "/drift/refresh", h(httphandlers.AdminRefreshCatalogDrift), writeMW...)
 	catalog.Handle(http.MethodPost, "/publish", h(httphandlers.MerchantPublishCatalog), writeMW...)
+
+	// #779 catalog copilot: read-only Q&A (+ flag-gated Phase 2 drafting,
+	// never a mutation) shares the catalog-read permission, like #756's
+	// metrics ask shares metrics-read — the LLM-cost axis is guarded by the
+	// service's own per-merchant rate limit + fail-closed consent flag. NOT
+	// manifest-guarded: it never mutates catalog rows, even when drafting.
+	catalog.Handle(http.MethodPost, "/ask", h(httphandlers.CatalogCopilotAsk), readMW...)
+	// The confirm-provenance log rides the catalog-WRITE permission (only a
+	// caller who could actually apply a price change should be able to log a
+	// draft as confirmed) but skips the mode-1 write guard: it never touches
+	// a catalog row, only an audit log entry, for a mutation that already
+	// happened via the normal catalog/reprice endpoints.
+	copilotConfirmMW := append([]router.Middleware{write}, dbMW...)
+	catalog.Handle(http.MethodPost, "/copilot/confirm", h(httphandlers.CatalogCopilotConfirmDraft), copilotConfirmMW...)
 }
 
 func registerPaymentProviderActionRoutes(providers router.Router, rt *app.Runtime, opts Options, dbMW ...router.Middleware) {

--- a/internal/http/routes_admin_console.go
+++ b/internal/http/routes_admin_console.go
@@ -23,10 +23,12 @@ func (s *Server) registerAdminConsoleRoutes(mux *http.ServeMux) error {
 			"or unset admin_console.enabled")
 	}
 	cfg := adminconsole.Config{
-		AuthBaseURL:      s.cfg.AdminConsole.AuthBaseURL,
-		APIBaseURL:       s.cfg.AdminConsole.APIBaseURL,
-		NLWidgetsEnabled: s.cfg.LLM.IsConfigured(),
-		AskEnabled:       s.cfg.LLM.AskConfigured(),
+		AuthBaseURL:            s.cfg.AdminConsole.AuthBaseURL,
+		APIBaseURL:             s.cfg.AdminConsole.APIBaseURL,
+		NLWidgetsEnabled:       s.cfg.LLM.IsConfigured(),
+		AskEnabled:             s.cfg.LLM.AskConfigured(),
+		CatalogCopilotEnabled:  s.cfg.LLM.CatalogCopilotConfigured(),
+		CatalogDraftingEnabled: s.cfg.LLM.CatalogDraftingConfigured(),
 	}
 	if cfg.AuthBaseURL == "" {
 		cfg.AuthBaseURL = ControlPlaneAuthPrefix

--- a/internal/integrationharness/catalog_copilot_http_test.go
+++ b/internal/integrationharness/catalog_copilot_http_test.go
@@ -1,0 +1,373 @@
+//go:build integration
+
+package integrationharness
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/controlplane"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/internal/modules/dashboard"
+	"github.com/open-rails/openrails/pkg/catalog"
+)
+
+// #779 catalog copilot: fail-closed consent gating (501 + config.json flags),
+// Q&A tool-loop execution against REAL catalog/subscription data (counts
+// match the DB, not canned numbers), Phase 2 drafting producing a VALID
+// wizard payload with direction defaults applied, a constraint-violating
+// request refused with a typed reason + workaround (never a mutation), and
+// flag-off meaning the draft_* tools are ABSENT from the tool list (not
+// present-but-erroring). The LLM is a deterministic scripted stub injected
+// via SetLLM — no network ever, same precedent as #756's metrics ask tests.
+
+type copilotScriptLLM struct {
+	script func(msgs []dashboard.ToolMessage) *dashboard.ToolTurn
+	convs  [][]dashboard.ToolMessage
+}
+
+func (f *copilotScriptLLM) Complete(context.Context, string, []dashboard.LLMMessage) (string, error) {
+	return "", nil
+}
+
+func (f *copilotScriptLLM) CompleteTools(_ context.Context, _ string, _ []dashboard.ToolDef, msgs []dashboard.ToolMessage, _ int) (*dashboard.ToolTurn, error) {
+	f.convs = append(f.convs, append([]dashboard.ToolMessage(nil), msgs...))
+	return f.script(msgs), nil
+}
+
+// oneToolThenAnswer scripts the canonical one-tool-call-then-answer loop.
+func oneToolThenAnswer(tool, args, answer string) func(msgs []dashboard.ToolMessage) *dashboard.ToolTurn {
+	return func(msgs []dashboard.ToolMessage) *dashboard.ToolTurn {
+		if len(msgs) == 1 {
+			return &dashboard.ToolTurn{ToolCalls: []dashboard.ToolCall{{ID: "call-1", Name: tool, Input: json.RawMessage(args)}}}
+		}
+		return &dashboard.ToolTurn{Text: answer}
+	}
+}
+
+func askCopilotOnce(t *testing.T, baseURL, token, question string) (int, []byte) {
+	t.Helper()
+	return requestJSON(t, http.MethodPost, baseURL+"/v1/merchant/catalog/ask", token, map[string]string{"question": question})
+}
+
+type copilotAskResp struct {
+	Answer   string `json:"answer"`
+	Evidence []struct {
+		Tool    string `json:"tool"`
+		Summary string `json:"summary"`
+	} `json:"evidence"`
+	Drafts []json.RawMessage `json:"drafts"`
+}
+
+func TestMerchantCatalogCopilotAsk(t *testing.T) {
+	ctx := context.Background()
+	h := New(t, ctx)
+
+	t.Run("keyless fails closed naming both knobs", func(t *testing.T) {
+		surface := h.StartStandalone("usd")
+		token := surface.MintAPIKey(dbtest.TestMerchantSlug, "copilot-keyless-"+uuid.NewString(),
+			[]string{controlplane.PermMerchantCatalogRead})
+		status, body := askCopilotOnce(t, surface.BaseURL, token, "what do we sell?")
+		require.Equal(t, http.StatusNotImplemented, status)
+		require.Contains(t, string(body), "LLM_API_KEY")
+		require.Contains(t, string(body), "LLM_CATALOG_COPILOT_ENABLED")
+	})
+
+	t.Run("key without consent fails closed naming the flag", func(t *testing.T) {
+		surface := h.StartStandalone("usd",
+			WithConsoleAssets(fixtureConsoleAssets()),
+			WithConfig(func(cfg *config.Config) {
+				cfg.AdminConsole = &config.AdminConsoleConfig{Enabled: true}
+				cfg.LLM = &config.LLMConfig{APIKey: "test-key-never-used"} // catalog_copilot_enabled NOT set
+			}))
+		token := surface.MintAPIKey(dbtest.TestMerchantSlug, "copilot-noconsent-"+uuid.NewString(),
+			[]string{controlplane.PermMerchantCatalogRead})
+		status, body := askCopilotOnce(t, surface.BaseURL, token, "what do we sell?")
+		require.Equal(t, http.StatusNotImplemented, status)
+		require.Contains(t, string(body), "LLM_CATALOG_COPILOT_ENABLED")
+
+		status, cfgBody, _ := getRaw(t, surface.BaseURL+"/admin/config.json")
+		require.Equal(t, http.StatusOK, status)
+		require.Contains(t, cfgBody, `"catalog_copilot_enabled":false`)
+		require.Contains(t, cfgBody, `"catalog_drafting_enabled":false`)
+	})
+
+	// One Q&A-armed surface (drafting OFF) for the read-only flows.
+	surface := h.StartStandalone("usd",
+		WithConsoleAssets(fixtureConsoleAssets()),
+		WithConfig(func(cfg *config.Config) {
+			cfg.AdminConsole = &config.AdminConsoleConfig{Enabled: true}
+			cfg.LLM = &config.LLMConfig{APIKey: "test-key-never-used", CatalogCopilotEnabled: true}
+		}))
+	svc := surface.App().Runtime.CopilotService
+	require.True(t, svc.Configured())
+	require.False(t, svc.DraftingConfigured(), "drafting must stay off until explicitly armed")
+	token := surface.MintAPIKey(dbtest.TestMerchantSlug, "copilot-"+uuid.NewString(),
+		[]string{controlplane.PermMerchantCatalogRead, controlplane.PermMerchantCatalogUpdate})
+
+	t.Run("config.json advertises catalog_copilot_enabled true, drafting false", func(t *testing.T) {
+		_, cfgBody, _ := getRaw(t, surface.BaseURL+"/admin/config.json")
+		require.Contains(t, cfgBody, `"catalog_copilot_enabled":true`)
+		require.Contains(t, cfgBody, `"catalog_drafting_enabled":false`)
+	})
+
+	// Seed a real catalog: premium-monthly at $10, then bumped to $12 (a real
+	// #774 version bump), with a real active subscription pinned to the OLD
+	// ($10) row — a genuine grandfathered subscriber, not a canned number.
+	productKey := "copilot-" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	priceKey := productKey + "-monthly"
+	publish := func(token string, amount int64) {
+		t.Helper()
+		status, body := requestJSON(t, http.MethodPost, surface.BaseURL+"/v1/merchant/catalog/publish", token, map[string]any{
+			"catalog": catalog.Manifest{
+				Version: catalog.SupportedVersion,
+				Products: []catalog.Product{{
+					Key: productKey, DisplayName: "Copilot Product",
+					Prices: []catalog.Price{{UnitAmount: amount, Currency: "usd", Duration: "30d", AutoRenew: true}},
+				}},
+			},
+			"insert": true, "overwrite": true,
+		})
+		require.Equal(t, http.StatusOK, status, string(body))
+	}
+	getByKey := func(token string) struct {
+		ID        uuid.UUID `json:"id"`
+		ProductID uuid.UUID `json:"product_id"`
+	} {
+		t.Helper()
+		status, body := requestJSON(t, http.MethodGet, surface.BaseURL+"/v1/merchant/catalog/prices/by-key/"+priceKey, token, nil)
+		require.Equal(t, http.StatusOK, status, string(body))
+		var p struct {
+			ID        uuid.UUID `json:"id"`
+			ProductID uuid.UUID `json:"product_id"`
+		}
+		require.NoError(t, json.Unmarshal(body, &p))
+		return p
+	}
+	publish(token, 10_000_000)
+	v1 := getByKey(token)
+	seedRepriceSubscription(t, ctx, h, v1.ProductID, v1.ID)
+	publish(token, 12_000_000)
+	v2 := getByKey(token)
+	require.NotEqual(t, v1.ID, v2.ID)
+
+	t.Run("list_catalog reflects real active + grandfathered counts", func(t *testing.T) {
+		llm := &copilotScriptLLM{script: oneToolThenAnswer("list_catalog", `{"product_key":"`+productKey+`"}`,
+			"one product, $12/mo, 0 active, 1 grandfathered.")}
+		svc.SetLLM(llm)
+		status, body := askCopilotOnce(t, surface.BaseURL, token, "what does "+productKey+" cost, and who's still on the old price?")
+		require.Equalf(t, http.StatusOK, status, "ask: %s", string(body))
+		var res copilotAskResp
+		require.NoError(t, json.Unmarshal(body, &res))
+		require.Len(t, res.Evidence, 1)
+		require.Equal(t, "list_catalog", res.Evidence[0].Tool)
+		require.Contains(t, res.Evidence[0].Summary, priceKey)
+		require.Contains(t, res.Evidence[0].Summary, "$12.000000 USD")
+		// 0 active on the CURRENT ($12) row, 1 grandfathered on the archived
+		// ($10) row — real counts from the seeded subscription above.
+		require.Regexp(t, priceKey+` \| \$12\.000000 USD \| monthly \| 0 \| 1`, res.Evidence[0].Summary)
+	})
+
+	t.Run("price_history is most-recent-first with per-version subscriber counts", func(t *testing.T) {
+		llm := &copilotScriptLLM{script: oneToolThenAnswer("price_history", `{"price_key":"`+priceKey+`"}`, "history")}
+		svc.SetLLM(llm)
+		status, body := askCopilotOnce(t, surface.BaseURL, token, "history of "+priceKey)
+		require.Equal(t, http.StatusOK, status, string(body))
+		var res copilotAskResp
+		require.NoError(t, json.Unmarshal(body, &res))
+		summary := res.Evidence[0].Summary
+		require.Contains(t, summary, "$12.000000 USD")
+		require.Contains(t, summary, "$10.000000 USD")
+		twelveIdx := strings.Index(summary, "$12.000000 USD")
+		tenIdx := strings.Index(summary, "$10.000000 USD")
+		require.Less(t, twelveIdx, tenIdx, "current ($12) must appear before the prior ($10) version")
+	})
+
+	t.Run("list_reprice_batches states 0 pending migrations explicitly", func(t *testing.T) {
+		llm := &copilotScriptLLM{script: oneToolThenAnswer("list_reprice_batches", `{"price_key":"`+priceKey+`"}`, "none pending")}
+		svc.SetLLM(llm)
+		status, body := askCopilotOnce(t, surface.BaseURL, token, "any pending migrations for "+priceKey+"?")
+		require.Equal(t, http.StatusOK, status, string(body))
+		var res copilotAskResp
+		require.NoError(t, json.Unmarshal(body, &res))
+		require.Contains(t, res.Evidence[0].Summary, "0 pending migrations")
+	})
+
+	t.Run("drafting tools absent when the flag is off", func(t *testing.T) {
+		llm := &copilotScriptLLM{script: oneToolThenAnswer("draft_price_change", `{"price_key":"`+priceKey+`","new_amount":15000000}`, "n/a")}
+		svc.SetLLM(llm)
+		status, body := askCopilotOnce(t, surface.BaseURL, token, "raise "+priceKey+" to $15")
+		require.Equal(t, http.StatusOK, status, string(body))
+		var res copilotAskResp
+		require.NoError(t, json.Unmarshal(body, &res))
+		require.Empty(t, res.Drafts)
+		last := llm.convs[len(llm.convs)-1]
+		tr := last[len(last)-1].ToolResults[0]
+		require.True(t, tr.IsError)
+		require.Contains(t, tr.Content, "unknown tool", "flag-off must look ABSENT, not present-but-erroring")
+	})
+
+	t.Run("auth gates", func(t *testing.T) {
+		status, _ := askCopilotOnce(t, surface.BaseURL, "", "anything")
+		require.Equal(t, http.StatusUnauthorized, status)
+	})
+
+	// -- Phase 2: a SEPARATE surface with drafting armed. --------------------
+
+	draftSurface := h.StartStandalone("usd",
+		WithConfig(func(cfg *config.Config) {
+			cfg.LLM = &config.LLMConfig{APIKey: "test-key-never-used", CatalogCopilotEnabled: true, CatalogDraftingEnabled: true}
+		}))
+	draftSvc := draftSurface.App().Runtime.CopilotService
+	require.True(t, draftSvc.DraftingConfigured())
+	draftToken := draftSurface.MintAPIKey(dbtest.TestMerchantSlug, "copilot-draft-"+uuid.NewString(),
+		[]string{controlplane.PermMerchantCatalogRead, controlplane.PermMerchantCatalogUpdate})
+
+	incKey := "copilot-inc-" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	incPriceKey := incKey + "-monthly"
+	status, body := requestJSON(t, http.MethodPost, draftSurface.BaseURL+"/v1/merchant/catalog/publish", draftToken, map[string]any{
+		"catalog": catalog.Manifest{
+			Version: catalog.SupportedVersion,
+			Products: []catalog.Product{{
+				Key: incKey, DisplayName: "Copilot Increase Product",
+				Prices: []catalog.Price{{UnitAmount: 10_000_000, Currency: "usd", Duration: "30d", AutoRenew: true}},
+			}},
+		}, "insert": true, "overwrite": true,
+	})
+	require.Equal(t, http.StatusOK, status, string(body))
+
+	t.Run("draft_price_change: increase defaults to grandfather with a real affected-count preview", func(t *testing.T) {
+		llm := &copilotScriptLLM{script: oneToolThenAnswer("draft_price_change", `{"price_key":"`+incPriceKey+`","new_amount":15000000}`, "drafted")}
+		draftSvc.SetLLM(llm)
+		status, body := askCopilotOnce(t, draftSurface.BaseURL, draftToken, "raise "+incPriceKey+" to $15")
+		require.Equalf(t, http.StatusOK, status, "ask: %s", string(body))
+		var res copilotAskResp
+		require.NoError(t, json.Unmarshal(body, &res))
+		require.Len(t, res.Drafts, 1)
+		var draft struct {
+			Kind        string `json:"kind"`
+			PriceChange struct {
+				DraftedBy     string `json:"drafted_by"`
+				Direction     string `json:"direction"`
+				MigrationMode string `json:"migration_mode"`
+				AffectedCount int    `json:"affected_count"`
+				CreatePrice   struct {
+					ProductID  string `json:"product_id"`
+					Key        string `json:"key"`
+					UnitAmount int64  `json:"unit_amount"`
+					Currency   string `json:"currency"`
+				} `json:"create_price"`
+			} `json:"price_change"`
+		}
+		require.NoError(t, json.Unmarshal(res.Drafts[0], &draft))
+		require.Equal(t, "price_change", draft.Kind)
+		require.Equal(t, "copilot", draft.PriceChange.DraftedBy)
+		require.Equal(t, "increase", draft.PriceChange.Direction)
+		require.Equal(t, "grandfather", draft.PriceChange.MigrationMode)
+		require.Equal(t, 0, draft.PriceChange.AffectedCount, "no subscribers seeded on this key")
+		require.Equal(t, incPriceKey, draft.PriceChange.CreatePrice.Key)
+		require.Equal(t, int64(15_000_000), draft.PriceChange.CreatePrice.UnitAmount)
+		require.Equal(t, "usd", draft.PriceChange.CreatePrice.Currency)
+		require.NotEmpty(t, draft.PriceChange.CreatePrice.ProductID)
+
+		// The draft is a PROPOSAL only — nothing in the real catalog changed.
+		status, priceBody := requestJSON(t, http.MethodGet, draftSurface.BaseURL+"/v1/merchant/catalog/prices/by-key/"+incPriceKey, draftToken, nil)
+		require.Equal(t, http.StatusOK, status)
+		var live struct {
+			UnitAmount int64 `json:"unit_amount"`
+		}
+		require.NoError(t, json.Unmarshal(priceBody, &live))
+		require.EqualValues(t, 10_000_000, live.UnitAmount, "drafting must never mutate the live price")
+	})
+
+	t.Run("draft_price_change: cross-product migrate_to_price_key is refused with a typed reason and workaround, not a mutation", func(t *testing.T) {
+		otherKey := "copilot-other-" + strings.ReplaceAll(uuid.NewString(), "-", "")
+		otherPriceKey := otherKey + "-monthly"
+		status, body := requestJSON(t, http.MethodPost, draftSurface.BaseURL+"/v1/merchant/catalog/publish", draftToken, map[string]any{
+			"catalog": catalog.Manifest{
+				Version: catalog.SupportedVersion,
+				Products: []catalog.Product{{
+					Key: otherKey, DisplayName: "Copilot Other Product",
+					Prices: []catalog.Price{{UnitAmount: 8_000_000, Currency: "usd", Duration: "30d", AutoRenew: true}},
+				}},
+			}, "insert": true, "overwrite": true,
+		})
+		require.Equal(t, http.StatusOK, status, string(body))
+
+		args := `{"price_key":"` + incPriceKey + `","new_amount":1,"migrate_to_price_key":"` + otherPriceKey + `"}`
+		llm := &copilotScriptLLM{script: oneToolThenAnswer("draft_price_change", args, "refused, explained")}
+		draftSvc.SetLLM(llm)
+		status, body = askCopilotOnce(t, draftSurface.BaseURL, draftToken, "migrate everyone from "+incKey+" onto "+otherKey)
+		require.Equalf(t, http.StatusOK, status, "ask: %s", string(body))
+		var res copilotAskResp
+		require.NoError(t, json.Unmarshal(body, &res))
+		require.Len(t, res.Drafts, 1)
+		var draft struct {
+			Kind    string `json:"kind"`
+			Refusal struct {
+				Code       string `json:"code"`
+				Workaround string `json:"workaround"`
+			} `json:"refusal"`
+		}
+		require.NoError(t, json.Unmarshal(res.Drafts[0], &draft))
+		require.Equal(t, "refused", draft.Kind)
+		require.Equal(t, "cross_product", draft.Refusal.Code)
+		require.Contains(t, draft.Refusal.Workaround, "grandfather")
+
+		// Confirm nothing was scheduled/mutated by this refused attempt.
+		status, batchesBody := requestJSON(t, http.MethodGet, draftSurface.BaseURL+"/v1/merchant/reprices/batches?price_key="+incPriceKey, draftToken, nil)
+		require.Equal(t, http.StatusOK, status)
+		var batches struct {
+			Items []json.RawMessage `json:"items"`
+		}
+		require.NoError(t, json.Unmarshal(batchesBody, &batches))
+		require.Empty(t, batches.Items, "a refused draft must never create a reprice batch")
+	})
+
+	t.Run("confirm endpoint logs provenance and never mutates", func(t *testing.T) {
+		status, body := requestJSON(t, http.MethodPost, draftSurface.BaseURL+"/v1/merchant/catalog/copilot/confirm", draftToken, map[string]any{
+			"draft_id": uuid.NewString(), "kind": "price_change", "price_key": incPriceKey,
+		})
+		require.Equal(t, http.StatusOK, status, string(body))
+	})
+
+	// -- RLS isolation: two merchants never see each other's catalog. -------
+
+	t.Run("RLS isolation across merchants", func(t *testing.T) {
+		a := surface.ProvisionOwnedMerchant("cpa" + strings.ReplaceAll(uuid.NewString(), "-", ""))
+		b := surface.ProvisionOwnedMerchant("cpb" + strings.ReplaceAll(uuid.NewString(), "-", ""))
+		aToken := surface.MintAPIKey(a.MerchantSlug, "cp-a-"+uuid.NewString(),
+			[]string{controlplane.PermMerchantCatalogRead, controlplane.PermMerchantCatalogUpdate})
+		bToken := surface.MintAPIKey(b.MerchantSlug, "cp-b-"+uuid.NewString(), []string{controlplane.PermMerchantCatalogRead})
+
+		aKey := "cpiso-a-" + strings.ReplaceAll(uuid.NewString(), "-", "")
+		status, body := requestJSON(t, http.MethodPost, surface.BaseURL+"/v1/merchant/catalog/publish", aToken, map[string]any{
+			"catalog": catalog.Manifest{Version: catalog.SupportedVersion, Products: []catalog.Product{{
+				Key: aKey, DisplayName: "A-only product",
+				Prices: []catalog.Price{{UnitAmount: 9_000_000, Currency: "usd", Duration: "30d", AutoRenew: true}},
+			}}}, "insert": true, "overwrite": true,
+		})
+		require.Equal(t, http.StatusOK, status, string(body))
+
+		llmA := &copilotScriptLLM{script: oneToolThenAnswer("list_catalog", `{}`, "a's catalog")}
+		svc.SetLLM(llmA)
+		_, aBody := askCopilotOnce(t, surface.BaseURL, aToken, "what do we sell?")
+		var aRes copilotAskResp
+		require.NoError(t, json.Unmarshal(aBody, &aRes))
+		require.Contains(t, aRes.Evidence[0].Summary, aKey+"-monthly")
+
+		llmB := &copilotScriptLLM{script: oneToolThenAnswer("list_catalog", `{}`, "b's catalog")}
+		svc.SetLLM(llmB)
+		_, bBody := askCopilotOnce(t, surface.BaseURL, bToken, "what do we sell?")
+		var bRes copilotAskResp
+		require.NoError(t, json.Unmarshal(bBody, &bRes))
+		require.NotContains(t, bRes.Evidence[0].Summary, aKey, "merchant B must never see merchant A's product in its catalog summary")
+	})
+}

--- a/internal/integrationharness/testdata/standalone_route_surface.txt
+++ b/internal/integrationharness/testdata/standalone_route_surface.txt
@@ -125,6 +125,8 @@ POST /v1/merchant/admissions/{id}/release
 POST /v1/merchant/alerts/rules
 POST /v1/merchant/alerts/rules/{id}/test
 POST /v1/merchant/api-keys
+POST /v1/merchant/catalog/ask
+POST /v1/merchant/catalog/copilot/confirm
 POST /v1/merchant/catalog/drift/refresh
 POST /v1/merchant/catalog/prices
 POST /v1/merchant/catalog/prices/{id}/activate

--- a/internal/modules/copilot/ask.go
+++ b/internal/modules/copilot/ask.go
@@ -1,0 +1,153 @@
+package copilot
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/open-rails/openrails/internal/modules/dashboard"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// Ask-loop caps, same doctrine as #756's dashboard.Service.Ask: every cost
+// axis is bounded so a cheap model can be trusted with the loop. One more
+// tool call than metrics' Ask allows, since a catalog question often chains
+// list_catalog -> price_history/list_reprice_batches -> (optionally) a draft
+// call.
+const (
+	askMaxToolCalls = 6
+	askMaxTokens    = 2048
+	askMaxTurns     = askMaxToolCalls + 2
+)
+
+// Ask answers a natural-language catalog question by letting the model run
+// read-only lookups (Phase 1) and, when armed, drafting tools (Phase 2) as
+// tool calls. The model never sees anything beyond aggregate catalog/
+// subscriber-count data and never triggers a mutation — see tools_draft.go.
+func (s *Service) Ask(ctx context.Context, question string) (*AskResult, error) {
+	if !s.Configured() {
+		return nil, ErrNotConfigured
+	}
+	if s.limiter != nil {
+		merchantID, err := merchant.Require(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("copilot ask: no merchant in context: %w", err)
+		}
+		allowed, retry, err := s.limiter.AllowAsk(ctx, uuid.UUID(merchantID).String())
+		if err != nil {
+			return nil, fmt.Errorf("copilot ask: rate limiter: %w", err)
+		}
+		if !allowed {
+			return nil, &RateLimitedError{RetryAfter: retry}
+		}
+	}
+
+	now := s.now().UTC()
+	system := s.systemPrompt(ctx, now)
+	tools := s.toolDefs()
+	msgs := []dashboard.ToolMessage{{Role: "user", Text: question}}
+	var evidence []Evidence
+	var drafts []Draft
+	attempts := 0
+
+	for turn := 0; turn < askMaxTurns; turn++ {
+		resp, err := s.llm.CompleteTools(ctx, system, tools, msgs, askMaxTokens)
+		if err != nil {
+			return nil, err
+		}
+		if len(resp.ToolCalls) == 0 {
+			answer := strings.TrimSpace(resp.Text)
+			if answer == "" {
+				return nil, fmt.Errorf("copilot ask: empty model response (stop_reason %q)", resp.StopReason)
+			}
+			return &AskResult{Answer: answer, Evidence: evidence, Drafts: drafts}, nil
+		}
+		results := make([]dashboard.ToolResult, 0, len(resp.ToolCalls))
+		for _, call := range resp.ToolCalls {
+			results = append(results, s.runTool(ctx, call, &evidence, &drafts, &attempts))
+		}
+		msgs = append(msgs,
+			dashboard.ToolMessage{Role: "assistant", Text: resp.Text, ToolCalls: resp.ToolCalls},
+			dashboard.ToolMessage{Role: "user", ToolResults: results},
+		)
+	}
+	return nil, &NoAnswerError{ToolCalls: attempts}
+}
+
+// toolDefs is the tool list the model sees this turn — drafting tools are
+// APPENDED only when armed (flag off = absent from the list entirely, never
+// present-but-erroring).
+func (s *Service) toolDefs() []dashboard.ToolDef {
+	defs := []dashboard.ToolDef{
+		toolDefListCatalog(), toolDefGetPrice(), toolDefPriceHistory(), toolDefListRepriceBatches(),
+	}
+	if s.DraftingConfigured() {
+		defs = append(defs, toolDefDraftPriceChange(), toolDefDraftCatalogDiff())
+	}
+	return defs
+}
+
+func toolNames(defs []dashboard.ToolDef) []string {
+	names := make([]string, len(defs))
+	for i, d := range defs {
+		names[i] = d.Name
+	}
+	return names
+}
+
+// runTool dispatches one tool call, enforcing the shared budget and
+// translating each tool's (content, error) — or (content, *Draft, error) for
+// drafting tools — into the wire ToolResult, collecting Q&A results into
+// evidence and drafts into drafts as a side effect.
+func (s *Service) runTool(ctx context.Context, call dashboard.ToolCall, evidence *[]Evidence, drafts *[]Draft, attempts *int) dashboard.ToolResult {
+	errResult := func(msg string) dashboard.ToolResult {
+		return dashboard.ToolResult{ToolUseID: call.ID, Content: msg, IsError: true}
+	}
+	known := map[string]bool{
+		toolListCatalog: true, toolGetPrice: true, toolPriceHistory: true, toolListRepriceBatches: true,
+		toolDraftPriceChange: s.DraftingConfigured(), toolDraftCatalogDiff: s.DraftingConfigured(),
+	}
+	if !known[call.Name] {
+		return errResult(fmt.Sprintf("unknown tool %q: available tools are %s", call.Name, strings.Join(toolNames(s.toolDefs()), ", ")))
+	}
+	if *attempts >= askMaxToolCalls {
+		return errResult(fmt.Sprintf("tool-call budget exhausted (max %d calls per question) — answer now from what you already have, or say what you could not determine", askMaxToolCalls))
+	}
+	*attempts++
+
+	qa := func(content string, err error) dashboard.ToolResult {
+		if err != nil {
+			return errResult(err.Error())
+		}
+		*evidence = append(*evidence, Evidence{Tool: call.Name, Args: string(call.Input), Summary: content})
+		return dashboard.ToolResult{ToolUseID: call.ID, Content: content}
+	}
+	draftResult := func(content string, draft *Draft, err error) dashboard.ToolResult {
+		if err != nil {
+			return errResult(err.Error())
+		}
+		if draft != nil {
+			*drafts = append(*drafts, *draft)
+		}
+		return dashboard.ToolResult{ToolUseID: call.ID, Content: content}
+	}
+
+	switch call.Name {
+	case toolListCatalog:
+		return qa(s.runListCatalog(ctx, call.Input))
+	case toolGetPrice:
+		return qa(s.runGetPrice(ctx, call.Input))
+	case toolPriceHistory:
+		return qa(s.runPriceHistory(ctx, call.Input))
+	case toolListRepriceBatches:
+		return qa(s.runListRepriceBatches(ctx, call.Input))
+	case toolDraftPriceChange:
+		return draftResult(s.runDraftPriceChange(ctx, call.Input))
+	case toolDraftCatalogDiff:
+		return draftResult(s.runDraftCatalogDiff(ctx, call.Input))
+	default:
+		return errResult(fmt.Sprintf("unknown tool %q", call.Name))
+	}
+}

--- a/internal/modules/copilot/ask_limiter.go
+++ b/internal/modules/copilot/ask_limiter.go
@@ -1,0 +1,123 @@
+package copilot
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/open-rails/openrails/internal/modules/ratelimit"
+)
+
+// Per-merchant catalog-ask budget (mirrors #756's dashboard.AskLimiter
+// doctrine exactly, own Redis key namespace — "catalog-ask:" — so the two
+// features never share a budget). Every ask is up to askMaxTurns LLM
+// requests, so this is the deployment's LLM spend guard for this surface.
+const (
+	askRatePerMinute = 10
+	askRatePerDay    = 200
+)
+
+var askRatePolicy = ratelimit.Policy{Windows: []ratelimit.Limit{
+	{Unit: "request", Window: time.Minute, Max: askRatePerMinute},
+	{Unit: "request", Window: 24 * time.Hour, Max: askRatePerDay},
+}}
+
+// AskLimiter rate-limits catalog Q&A/drafting per merchant. retryAfter is
+// meaningful only when allowed is false.
+type AskLimiter interface {
+	AllowAsk(ctx context.Context, merchantID string) (allowed bool, retryAfter time.Duration, err error)
+}
+
+// NewAskLimiter builds the production limiter: Redis-backed fixed windows
+// when configured, else an in-process fallback with the same windows.
+func NewAskLimiter(rdb redis.Cmdable, now func() time.Time) AskLimiter {
+	if now == nil {
+		now = time.Now
+	}
+	if rdb == nil {
+		return &memoryAskLimiter{now: now, counters: map[string]*memoryAskCounter{}}
+	}
+	l := ratelimit.NewLimiter(rdb)
+	l.SetClock(now)
+	return &redisAskLimiter{limiter: l}
+}
+
+type redisAskLimiter struct{ limiter *ratelimit.Limiter }
+
+func (r *redisAskLimiter) AllowAsk(ctx context.Context, merchantID string) (bool, time.Duration, error) {
+	dec, err := r.limiter.Check(ctx, "catalog-ask:"+merchantID, askRatePolicy, map[string]int64{"request": 1})
+	if err != nil {
+		// Redis down: allow (rate limiting is defense-in-depth; the ask loop's
+		// own caps bound per-request cost) but say so.
+		log.WithError(err).Warn("catalog ask rate limiter unavailable; allowing request")
+		return true, 0, nil
+	}
+	if dec.Allowed {
+		return true, 0, nil
+	}
+	var retry time.Duration
+	for _, w := range dec.Windows {
+		if w.Remaining <= 0 && w.ResetAfter > retry {
+			retry = w.ResetAfter
+		}
+	}
+	if retry <= 0 {
+		retry = time.Minute
+	}
+	return false, retry, nil
+}
+
+// memoryAskLimiter is the no-Redis fallback: same fixed windows, one process.
+type memoryAskLimiter struct {
+	mu       sync.Mutex
+	now      func() time.Time
+	counters map[string]*memoryAskCounter
+}
+
+type memoryAskCounter struct {
+	bucket int64
+	count  int64
+}
+
+func (m *memoryAskLimiter) AllowAsk(_ context.Context, merchantID string) (bool, time.Duration, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	now := m.now().UTC()
+
+	type slot struct {
+		c     *memoryAskCounter
+		reset time.Duration
+	}
+	slots := make([]slot, 0, len(askRatePolicy.Windows))
+	var retry time.Duration
+	blocked := false
+	for _, w := range askRatePolicy.Windows {
+		secs := int64(w.Window / time.Second)
+		bucket := now.Unix() / secs
+		key := fmt.Sprintf("%s:%d", merchantID, secs)
+		c, ok := m.counters[key]
+		if !ok || c.bucket != bucket {
+			c = &memoryAskCounter{bucket: bucket}
+			m.counters[key] = c
+		}
+		reset := time.Duration(secs-(now.Unix()%secs)) * time.Second
+		if c.count+1 > w.Max {
+			blocked = true
+			if reset > retry {
+				retry = reset
+			}
+		}
+		slots = append(slots, slot{c: c, reset: reset})
+	}
+	if blocked {
+		return false, retry, nil
+	}
+	for _, s := range slots {
+		s.c.count++
+	}
+	return true, 0, nil
+}

--- a/internal/modules/copilot/copilot_test.go
+++ b/internal/modules/copilot/copilot_test.go
@@ -1,0 +1,591 @@
+package copilot
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/modules/dashboard"
+	"github.com/open-rails/openrails/internal/modules/subscriptions"
+	"github.com/open-rails/openrails/pkg/merchant"
+	"github.com/open-rails/openrails/pkg/query"
+)
+
+// -- fakes ---------------------------------------------------------------------
+
+// scriptLLM plays ToolTurns in order (last repeats) and records every
+// conversation + system prompt — mirrors dashboard's toolScriptLLM.
+type scriptLLM struct {
+	turns   []*dashboard.ToolTurn
+	convs   [][]dashboard.ToolMessage
+	systems []string
+}
+
+func (f *scriptLLM) Complete(context.Context, string, []dashboard.LLMMessage) (string, error) {
+	return "", errors.New("scriptLLM: text completion not scripted")
+}
+
+func (f *scriptLLM) CompleteTools(_ context.Context, system string, _ []dashboard.ToolDef, msgs []dashboard.ToolMessage, _ int) (*dashboard.ToolTurn, error) {
+	f.systems = append(f.systems, system)
+	f.convs = append(f.convs, append([]dashboard.ToolMessage(nil), msgs...))
+	i := len(f.convs) - 1
+	if i >= len(f.turns) {
+		i = len(f.turns) - 1
+	}
+	return f.turns[i], nil
+}
+
+func toolCall(id, name, args string) *dashboard.ToolTurn {
+	return &dashboard.ToolTurn{ToolCalls: []dashboard.ToolCall{{ID: id, Name: name, Input: json.RawMessage(args)}}}
+}
+
+type fakeProducts struct {
+	byKey map[string]*models.Product
+	byID  map[uuid.UUID]*models.Product
+	list  []*models.Product
+}
+
+func (f *fakeProducts) GetActive(context.Context) ([]*models.Product, error) { return f.list, nil }
+func (f *fakeProducts) GetByKey(_ context.Context, key string) (*models.Product, error) {
+	if p, ok := f.byKey[key]; ok {
+		return p, nil
+	}
+	return nil, fmt.Errorf("product %q not found", key)
+}
+func (f *fakeProducts) GetByID(_ context.Context, id uuid.UUID) (*models.Product, error) {
+	if p, ok := f.byID[id]; ok {
+		return p, nil
+	}
+	return nil, fmt.Errorf("product %s not found", id)
+}
+
+type fakePrices struct {
+	current   map[string]*models.Price // key -> current row
+	byID      map[uuid.UUID]*models.Price
+	active    map[uuid.UUID][]*models.Price // productID -> active prices
+	movements map[string][]*models.PriceKeyMovement
+}
+
+func (f *fakePrices) GetActiveByProductID(_ context.Context, productID uuid.UUID) ([]*models.Price, error) {
+	return f.active[productID], nil
+}
+func (f *fakePrices) GetCurrentByKey(_ context.Context, _ uuid.UUID, key string) (*models.Price, error) {
+	if p, ok := f.current[key]; ok {
+		return p, nil
+	}
+	return nil, fmt.Errorf("price key %q not found", key)
+}
+func (f *fakePrices) ListChainByKey(context.Context, uuid.UUID, string) ([]*models.Price, error) {
+	return nil, nil
+}
+func (f *fakePrices) ListKeyMovements(_ context.Context, _ uuid.UUID, key string) ([]*models.PriceKeyMovement, error) {
+	return f.movements[key], nil
+}
+func (f *fakePrices) GetByID(_ context.Context, id uuid.UUID) (*models.Price, error) {
+	if p, ok := f.byID[id]; ok {
+		return p, nil
+	}
+	return nil, fmt.Errorf("price %s not found", id)
+}
+
+type fakeSubs struct{ counts map[uuid.UUID]int64 }
+
+func (f *fakeSubs) GetSubscribers(_ context.Context, params query.QueryOptions[subscriptions.GetSubscriptionsFilters]) ([]*models.Subscription, int64, error) {
+	return nil, f.counts[params.Filters.PriceID], nil
+}
+
+type fakeReprices struct {
+	previews map[string]*subscriptions.RepricePreviewResult
+	batches  map[string][]*models.RepriceBatch
+	repRows  map[uuid.UUID][]*models.SubscriptionReprice
+}
+
+func (f *fakeReprices) PreviewAllPriorVersions(_ context.Context, key string) (*subscriptions.RepricePreviewResult, error) {
+	if p, ok := f.previews[key]; ok {
+		return p, nil
+	}
+	return &subscriptions.RepricePreviewResult{PriceKey: key}, nil
+}
+func (f *fakeReprices) ListBatchesForKey(_ context.Context, key string, _, _ int) ([]*models.RepriceBatch, error) {
+	return f.batches[key], nil
+}
+func (f *fakeReprices) List(_ context.Context, filter subscriptions.SubscriptionRepriceFilter, _, _ int) ([]*models.SubscriptionReprice, error) {
+	if filter.RepriceBatchID == nil {
+		return nil, nil
+	}
+	return f.repRows[*filter.RepriceBatchID], nil
+}
+
+// testFixture is a small two-product catalog shared by most tests:
+// - premium-monthly: $10, product "premium", 3 active subscribers, 2 grandfathered.
+// - basic-monthly: $5, product "basic", eur currency (for cross-currency tests).
+type testFixture struct {
+	premiumProduct, basicProduct *models.Product
+	premiumV1, premiumV2, basic  *models.Price
+	products                     *fakeProducts
+	prices                       *fakePrices
+	subs                         *fakeSubs
+	reprices                     *fakeReprices
+}
+
+func newFixture() *testFixture {
+	premiumProduct := &models.Product{ID: uuid.New(), Key: "premium", DisplayName: "Premium"}
+	basicProduct := &models.Product{ID: uuid.New(), Key: "basic", DisplayName: "Basic"}
+	dur := 720
+
+	premiumV1 := &models.Price{ID: uuid.New(), ProductID: premiumProduct.ID, Key: "premium-monthly",
+		Amount: 10_000_000, Currency: "usd", AccessDurationHours: &dur, AutoRenew: true, Archived: true}
+	premiumV2 := &models.Price{ID: uuid.New(), ProductID: premiumProduct.ID, Key: "premium-monthly",
+		Amount: 12_000_000, Currency: "usd", AccessDurationHours: &dur, AutoRenew: true,
+		Rails: map[string]map[string]string{"stripe": {"price_id": "price_123"}}}
+	basic := &models.Price{ID: uuid.New(), ProductID: basicProduct.ID, Key: "basic-monthly",
+		Amount: 5_000_000, Currency: "eur", AccessDurationHours: &dur, AutoRenew: true}
+
+	f := &testFixture{
+		premiumProduct: premiumProduct, basicProduct: basicProduct,
+		premiumV1: premiumV1, premiumV2: premiumV2, basic: basic,
+	}
+	f.products = &fakeProducts{
+		byKey: map[string]*models.Product{"premium": premiumProduct, "basic": basicProduct},
+		byID:  map[uuid.UUID]*models.Product{premiumProduct.ID: premiumProduct, basicProduct.ID: basicProduct},
+		list:  []*models.Product{premiumProduct, basicProduct},
+	}
+	f.prices = &fakePrices{
+		current: map[string]*models.Price{"premium-monthly": premiumV2, "basic-monthly": basic},
+		byID:    map[uuid.UUID]*models.Price{premiumV1.ID: premiumV1, premiumV2.ID: premiumV2, basic.ID: basic},
+		active:  map[uuid.UUID][]*models.Price{premiumProduct.ID: {premiumV2}, basicProduct.ID: {basic}},
+		movements: map[string][]*models.PriceKeyMovement{
+			"premium-monthly": {
+				{Key: "premium-monthly", PriceID: premiumV2.ID, EffectiveAt: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)},
+				{Key: "premium-monthly", PriceID: premiumV1.ID, EffectiveAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)},
+			},
+		},
+	}
+	f.subs = &fakeSubs{counts: map[uuid.UUID]int64{premiumV2.ID: 3, premiumV1.ID: 2, basic.ID: 1}}
+	f.reprices = &fakeReprices{
+		previews: map[string]*subscriptions.RepricePreviewResult{
+			"premium-monthly": {PriceKey: "premium-monthly", ToPriceID: premiumV2.ID, Matched: 5},
+		},
+		batches: map[string][]*models.RepriceBatch{},
+		repRows: map[uuid.UUID][]*models.SubscriptionReprice{},
+	}
+	return f
+}
+
+func (f *testFixture) service(llm dashboard.LLM, drafting bool) *Service {
+	return NewService(Deps{
+		Products: f.products, Prices: f.prices, Subs: f.subs, Reprices: f.reprices,
+		LLM: llm, Enabled: true, Drafting: drafting,
+		Clock: clockwork.NewFakeClockAt(time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)),
+	})
+}
+
+var testMerchantID = merchant.ID(uuid.New())
+
+// ctxWithMerchant is the ambient context every real HTTP request carries
+// (merchant resolved by middleware before any merchant-owned code runs) —
+// the tool handlers call merchant.Require(ctx) just like the production
+// catalog/reprice services do.
+func ctxWithMerchant() context.Context {
+	return merchant.WithID(context.Background(), testMerchantID)
+}
+
+func mustAsk(t *testing.T, s *Service, q string) *AskResult {
+	t.Helper()
+	res, err := s.Ask(ctxWithMerchant(), q)
+	require.NoError(t, err)
+	return res
+}
+
+// -- Phase 1 Q&A tests -----------------------------------------------------------
+
+func TestAsk_ListCatalogInlineAggregates(t *testing.T) {
+	f := newFixture()
+	llm := &scriptLLM{turns: []*dashboard.ToolTurn{
+		toolCall("t1", toolListCatalog, `{}`),
+		{Text: "You sell Premium at $12/mo (3 active, 2 grandfathered) and Basic at €5/mo."},
+	}}
+	res := mustAsk(t, f.service(llm, false), "what do we sell?")
+	require.Equal(t, "You sell Premium at $12/mo (3 active, 2 grandfathered) and Basic at €5/mo.", res.Answer)
+	require.Len(t, res.Evidence, 1)
+	require.Equal(t, toolListCatalog, res.Evidence[0].Tool)
+	require.Contains(t, res.Evidence[0].Summary, "premium-monthly")
+	require.Contains(t, res.Evidence[0].Summary, "3") // active subs
+	require.Contains(t, res.Evidence[0].Summary, "2") // grandfathered
+}
+
+func TestAsk_ListCatalogEmptyStateIsExplicit(t *testing.T) {
+	f := newFixture()
+	f.products.list = nil
+	llm := &scriptLLM{turns: []*dashboard.ToolTurn{
+		toolCall("t1", toolListCatalog, `{}`),
+		{Text: "nothing"},
+	}}
+	res := mustAsk(t, f.service(llm, false), "what do we sell?")
+	require.Equal(t, "0 active products/prices in the catalog.", res.Evidence[0].Summary)
+}
+
+func TestAsk_ListCatalogScopedToProduct(t *testing.T) {
+	f := newFixture()
+	llm := &scriptLLM{turns: []*dashboard.ToolTurn{
+		toolCall("t1", toolListCatalog, `{"product_key":"basic"}`),
+		{Text: "just basic"},
+	}}
+	res := mustAsk(t, f.service(llm, false), "what does basic cost?")
+	require.Contains(t, res.Evidence[0].Summary, "basic-monthly")
+	require.NotContains(t, res.Evidence[0].Summary, "premium-monthly")
+}
+
+func TestAsk_GetPriceDrillDown(t *testing.T) {
+	f := newFixture()
+	llm := &scriptLLM{turns: []*dashboard.ToolTurn{
+		toolCall("t1", toolGetPrice, `{"price_key":"premium-monthly"}`),
+		{Text: "premium-monthly is $12/mo, 3 active, 2 grandfathered, no pending migration."},
+	}}
+	res := mustAsk(t, f.service(llm, false), "tell me about premium-monthly")
+	require.Contains(t, res.Evidence[0].Summary, "active_subscribers: 3")
+	require.Contains(t, res.Evidence[0].Summary, "grandfathered (on prior versions): 2")
+	require.Contains(t, res.Evidence[0].Summary, "no pending migration")
+}
+
+func TestAsk_GetPriceUnknownKeyIsCorrective(t *testing.T) {
+	f := newFixture()
+	llm := &scriptLLM{turns: []*dashboard.ToolTurn{
+		toolCall("bad", toolGetPrice, `{"price_key":"nope"}`),
+		toolCall("good", toolGetPrice, `{"price_key":"premium-monthly"}`),
+		{Text: "found it"},
+	}}
+	res := mustAsk(t, f.service(llm, false), "tell me about nope")
+	require.Len(t, res.Evidence, 1, "the failed lookup must not produce evidence")
+	second := llm.convs[1]
+	tr := second[len(second)-1].ToolResults[0]
+	require.True(t, tr.IsError)
+	require.Contains(t, tr.Content, "not found")
+	require.Contains(t, tr.Content, "list_catalog", "the corrective next step must be named")
+}
+
+func TestAsk_PriceHistoryMostRecentFirstWithPerVersionCounts(t *testing.T) {
+	f := newFixture()
+	llm := &scriptLLM{turns: []*dashboard.ToolTurn{
+		toolCall("t1", toolPriceHistory, `{"price_key":"premium-monthly"}`),
+		{Text: "history"},
+	}}
+	res := mustAsk(t, f.service(llm, false), "who's still on the old premium price?")
+	lines := res.Evidence[0].Summary
+	require.Contains(t, lines, "2026-06-01")
+	require.Contains(t, lines, "2026-01-01")
+	// Most-recent-first: the June row appears before the January row.
+	require.Less(t, indexOf(lines, "2026-06-01"), indexOf(lines, "2026-01-01"))
+	require.Contains(t, lines, "current")
+	require.Contains(t, lines, "prior")
+}
+
+func TestAsk_ListRepriceBatchesEmptyStateIsExplicit(t *testing.T) {
+	f := newFixture()
+	llm := &scriptLLM{turns: []*dashboard.ToolTurn{
+		toolCall("t1", toolListRepriceBatches, `{"price_key":"premium-monthly"}`),
+		{Text: "none pending"},
+	}}
+	res := mustAsk(t, f.service(llm, false), "any pending migrations for premium?")
+	require.Equal(t, `0 pending migrations for price key "premium-monthly".`, res.Evidence[0].Summary)
+}
+
+func TestAsk_ListRepriceBatchesProgress(t *testing.T) {
+	f := newFixture()
+	batchID := uuid.New()
+	f.reprices.batches["premium-monthly"] = []*models.RepriceBatch{
+		{ID: batchID, EffectiveAt: time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC), SubscriptionsMatched: 3, CreatedAt: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)},
+	}
+	f.reprices.repRows[batchID] = []*models.SubscriptionReprice{
+		{Status: models.RepriceStatusApplied}, {Status: models.RepriceStatusScheduled}, {Status: models.RepriceStatusScheduled},
+	}
+	llm := &scriptLLM{turns: []*dashboard.ToolTurn{
+		toolCall("t1", toolListRepriceBatches, `{"price_key":"premium-monthly"}`),
+		{Text: "one batch"},
+	}}
+	res := mustAsk(t, f.service(llm, false), "is there a migration running for premium?")
+	require.Contains(t, res.Evidence[0].Summary, "1 applied / 2 scheduled / 0 canceled")
+	require.Contains(t, res.Evidence[0].Summary, "3 matched")
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}
+
+// -- Loop mechanics (mirrors dashboard's #756 test suite) ------------------------
+
+func TestAsk_ToolCallCapForcesAnswer(t *testing.T) {
+	f := newFixture()
+	turns := make([]*dashboard.ToolTurn, 0, askMaxToolCalls+1)
+	for i := 0; i < askMaxToolCalls+1; i++ {
+		turns = append(turns, toolCall(fmt.Sprintf("t%d", i), toolListCatalog, `{}`))
+	}
+	turns = append(turns, &dashboard.ToolTurn{Text: "answering with what I have"})
+	llm := &scriptLLM{turns: turns}
+	res := mustAsk(t, f.service(llm, false), "dig deep")
+	require.Equal(t, "answering with what I have", res.Answer)
+	require.Len(t, res.Evidence, askMaxToolCalls)
+	last := llm.convs[len(llm.convs)-1]
+	tr := last[len(last)-1].ToolResults[0]
+	require.True(t, tr.IsError)
+	require.Contains(t, tr.Content, "budget exhausted")
+}
+
+func TestAsk_ModelNeverAnswersIsAnError(t *testing.T) {
+	f := newFixture()
+	llm := &scriptLLM{turns: []*dashboard.ToolTurn{toolCall("t", toolListCatalog, `{}`)}} // repeats forever
+	_, err := f.service(llm, false).Ask(ctxWithMerchant(), "loop forever")
+	var noAnswer *NoAnswerError
+	require.ErrorAs(t, err, &noAnswer)
+	require.Equal(t, askMaxToolCalls, noAnswer.ToolCalls)
+}
+
+func TestAsk_UnknownToolNameIsRejectedWithoutExecuting(t *testing.T) {
+	f := newFixture()
+	llm := &scriptLLM{turns: []*dashboard.ToolTurn{
+		{ToolCalls: []dashboard.ToolCall{{ID: "x", Name: "delete_everything", Input: json.RawMessage(`{}`)}}},
+		{Text: "ok"},
+	}}
+	res := mustAsk(t, f.service(llm, false), "hi")
+	require.Empty(t, res.Evidence)
+	tr := llm.convs[1][len(llm.convs[1])-1].ToolResults[0]
+	require.True(t, tr.IsError)
+	require.Contains(t, tr.Content, "unknown tool")
+}
+
+func TestAsk_NotConfigured(t *testing.T) {
+	_, err := NewService(Deps{}).Ask(ctxWithMerchant(), "anything")
+	require.ErrorIs(t, err, ErrNotConfigured)
+
+	svc := NewService(Deps{LLM: &scriptLLM{turns: []*dashboard.ToolTurn{{Text: "x"}}}})
+	require.False(t, svc.Configured(), "LLM alone, without the consent flag, must not arm Q&A")
+	_, err = svc.Ask(ctxWithMerchant(), "anything")
+	require.ErrorIs(t, err, ErrNotConfigured)
+}
+
+type denyLimiter struct{ retry time.Duration }
+
+func (d denyLimiter) AllowAsk(context.Context, string) (bool, time.Duration, error) {
+	return false, d.retry, nil
+}
+
+func TestAsk_RateLimited(t *testing.T) {
+	f := newFixture()
+	svc := NewService(Deps{
+		Products: f.products, Prices: f.prices, Subs: f.subs, Reprices: f.reprices,
+		LLM: &scriptLLM{turns: []*dashboard.ToolTurn{{Text: "never reached"}}}, Enabled: true,
+		Limiter: denyLimiter{retry: 30 * time.Second},
+	})
+	_, err := svc.Ask(ctxWithMerchant(), "anything")
+	var limited *RateLimitedError
+	require.ErrorAs(t, err, &limited)
+	require.Equal(t, 30*time.Second, limited.RetryAfter)
+}
+
+func TestSystemPrompt_ContentFirstBeforeDoctrine(t *testing.T) {
+	f := newFixture()
+	s := f.service(&scriptLLM{}, false)
+	prompt := s.systemPrompt(ctxWithMerchant(), time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC))
+	summaryIdx := indexOf(prompt, "premium-monthly")
+	doctrineIdx := indexOf(prompt, "Catalog doctrine")
+	require.Greater(t, summaryIdx, 0)
+	require.Greater(t, doctrineIdx, 0)
+	require.Less(t, summaryIdx, doctrineIdx, "content (live catalog) must precede doctrine per the AXI content-first design")
+	require.Contains(t, prompt, "2026-07-07")
+}
+
+func TestSystemPrompt_DraftingDoctrineOnlyWhenArmed(t *testing.T) {
+	f := newFixture()
+	off := f.service(&scriptLLM{}, false).systemPrompt(context.Background(), time.Now())
+	require.NotContains(t, off, "Drafting:")
+	on := f.service(&scriptLLM{}, true).systemPrompt(context.Background(), time.Now())
+	require.Contains(t, on, "Drafting:")
+}
+
+// -- Phase 2 drafting tests -------------------------------------------------------
+
+func TestAsk_ToolListExcludesDraftToolsWhenFlagOff(t *testing.T) {
+	f := newFixture()
+	off := f.service(&scriptLLM{}, false)
+	names := toolNames(off.toolDefs())
+	require.NotContains(t, names, toolDraftPriceChange)
+	require.NotContains(t, names, toolDraftCatalogDiff)
+
+	on := f.service(&scriptLLM{}, true)
+	names = toolNames(on.toolDefs())
+	require.Contains(t, names, toolDraftPriceChange)
+	require.Contains(t, names, toolDraftCatalogDiff)
+}
+
+func TestAsk_DraftToolAbsentBehavesAsUnknownWhenFlagOff(t *testing.T) {
+	f := newFixture()
+	llm := &scriptLLM{turns: []*dashboard.ToolTurn{
+		toolCall("t1", toolDraftPriceChange, `{"price_key":"premium-monthly","new_amount":15000000}`),
+		{Text: "ok"},
+	}}
+	res := mustAsk(t, f.service(llm, false), "raise premium to $15")
+	require.Empty(t, res.Drafts)
+	tr := llm.convs[1][len(llm.convs[1])-1].ToolResults[0]
+	require.True(t, tr.IsError)
+	require.Contains(t, tr.Content, "unknown tool", "flag-off must look like the tool is ABSENT, not present-but-erroring")
+}
+
+func TestAsk_DraftPriceChange_IncreaseDefaultsToGrandfather(t *testing.T) {
+	f := newFixture()
+	llm := &scriptLLM{turns: []*dashboard.ToolTurn{
+		toolCall("t1", toolDraftPriceChange, `{"price_key":"premium-monthly","new_amount":15000000}`),
+		{Text: "drafted"},
+	}}
+	res := mustAsk(t, f.service(llm, true), "raise premium to $15")
+	require.Len(t, res.Drafts, 1)
+	d := res.Drafts[0]
+	require.Equal(t, "price_change", d.Kind)
+	require.NotNil(t, d.PriceChange)
+	require.Equal(t, "increase", d.PriceChange.Direction)
+	require.Equal(t, "grandfather", d.PriceChange.MigrationMode, "increase must default to grandfather")
+	require.Equal(t, int64(15_000_000), d.PriceChange.NewAmount)
+	require.Equal(t, int64(12_000_000), d.PriceChange.CurrentAmount)
+	require.Equal(t, 5, d.PriceChange.AffectedCount)
+	require.Equal(t, "copilot", d.PriceChange.DraftedBy)
+	require.NotEmpty(t, d.PriceChange.DraftID)
+	require.Nil(t, d.PriceChange.Reprice, "grandfather mode drafts no reprice call")
+	require.Equal(t, "premium-monthly", d.PriceChange.CreatePrice.Key)
+	require.Equal(t, f.premiumProduct.ID.String(), d.PriceChange.CreatePrice.ProductID)
+	require.Contains(t, d.PriceChange.CreatePrice.Providers, "stripe", "the version bump must re-attach the current price's rails")
+}
+
+func TestAsk_DraftPriceChange_DecreaseDefaultsToMigrateNow(t *testing.T) {
+	f := newFixture()
+	llm := &scriptLLM{turns: []*dashboard.ToolTurn{
+		toolCall("t1", toolDraftPriceChange, `{"price_key":"premium-monthly","new_amount":8000000}`),
+		{Text: "drafted"},
+	}}
+	res := mustAsk(t, f.service(llm, true), "drop premium to $8")
+	d := res.Drafts[0].PriceChange
+	require.Equal(t, "decrease", d.Direction)
+	require.Equal(t, "migrate", d.MigrationMode, "decrease must default to migrate-now")
+	require.NotNil(t, d.Reprice)
+	require.Equal(t, "premium-monthly", d.Reprice.PriceKey)
+	require.False(t, d.Reprice.EffectiveAt.After(time.Date(2026, 7, 7, 0, 0, 0, 1, time.UTC)), "decrease effective date defaults to now, not 30 days out")
+}
+
+func TestAsk_DraftPriceChange_ExplicitMigrationModeAndDate(t *testing.T) {
+	f := newFixture()
+	llm := &scriptLLM{turns: []*dashboard.ToolTurn{
+		toolCall("t1", toolDraftPriceChange, `{"price_key":"premium-monthly","new_amount":15000000,"migration_mode":"migrate","effective_date":"2026-09-01"}`),
+		{Text: "drafted"},
+	}}
+	res := mustAsk(t, f.service(llm, true), "raise premium to $15, migrate everyone Sep 1")
+	d := res.Drafts[0].PriceChange
+	require.Equal(t, "migrate", d.MigrationMode)
+	require.NotNil(t, d.Reprice)
+	require.Equal(t, 2026, d.Reprice.EffectiveAt.Year())
+	require.Equal(t, time.September, d.Reprice.EffectiveAt.Month())
+	require.Equal(t, 1, d.Reprice.EffectiveAt.Day())
+	require.Contains(t, d.ReviewText, "Sep 1, 2026")
+}
+
+func TestAsk_DraftPriceChange_CrossProductRefusalExplainsWorkaround(t *testing.T) {
+	f := newFixture()
+	llm := &scriptLLM{turns: []*dashboard.ToolTurn{
+		toolCall("t1", toolDraftPriceChange, `{"price_key":"premium-monthly","new_amount":1,"migrate_to_price_key":"basic-monthly"}`),
+		{Text: "refused, explained the workaround"},
+	}}
+	res := mustAsk(t, f.service(llm, true), "migrate everyone from premium onto basic")
+	require.Len(t, res.Drafts, 1)
+	d := res.Drafts[0]
+	require.Equal(t, "refused", d.Kind)
+	require.NotNil(t, d.Refusal)
+	require.Equal(t, "cross_product", d.Refusal.Code)
+	require.Contains(t, d.Refusal.Workaround, "archive")
+	require.Contains(t, d.Refusal.Workaround, "grandfather")
+	// The tool result content (what the model saw) must ALSO carry the
+	// refusal + workaround + an explicit "no draft was created" statement —
+	// this must be a well-formed, non-error tool result (a valid domain
+	// answer), not a validation error to retry.
+	tr := llm.convs[1][len(llm.convs[1])-1].ToolResults[0]
+	require.False(t, tr.IsError)
+	require.Contains(t, tr.Content, "cross_product")
+	require.Contains(t, tr.Content, "no draft was created")
+}
+
+func TestAsk_DraftPriceChange_CrossCurrencyRefusal(t *testing.T) {
+	f := newFixture()
+	// Add a same-product, different-currency price to isolate the currency
+	// check from the product check.
+	eurTwin := &models.Price{ID: uuid.New(), ProductID: f.premiumProduct.ID, Key: "premium-monthly-eur",
+		Amount: 11_000_000, Currency: "eur"}
+	f.prices.current["premium-monthly-eur"] = eurTwin
+	f.prices.byID[eurTwin.ID] = eurTwin
+
+	llm := &scriptLLM{turns: []*dashboard.ToolTurn{
+		toolCall("t1", toolDraftPriceChange, `{"price_key":"premium-monthly","new_amount":1,"migrate_to_price_key":"premium-monthly-eur"}`),
+		{Text: "refused"},
+	}}
+	res := mustAsk(t, f.service(llm, true), "move premium USD subscribers onto the EUR price")
+	d := res.Drafts[0]
+	require.Equal(t, "refused", d.Kind)
+	require.Equal(t, "cross_currency", d.Refusal.Code)
+}
+
+func TestAsk_DraftCatalogDiff_NewTierOnExistingProduct(t *testing.T) {
+	f := newFixture()
+	llm := &scriptLLM{turns: []*dashboard.ToolTurn{
+		toolCall("t1", toolDraftCatalogDiff, `{"product_key":"premium","new_price_key":"premium-with-ads","unit_amount":6000000}`),
+		{Text: "drafted a with-ads tier"},
+	}}
+	res := mustAsk(t, f.service(llm, true), "add a with-ads tier at $6 to premium")
+	require.Len(t, res.Drafts, 1)
+	d := res.Drafts[0]
+	require.Equal(t, "catalog_diff", d.Kind)
+	require.NotNil(t, d.CatalogDiff)
+	require.Equal(t, "premium-with-ads", d.CatalogDiff.CreatePrice.Key)
+	require.Equal(t, int64(6_000_000), d.CatalogDiff.CreatePrice.UnitAmount)
+	require.Equal(t, "usd", d.CatalogDiff.CreatePrice.Currency, "currency inferred from the product's existing price")
+	require.Equal(t, f.premiumProduct.ID.String(), d.CatalogDiff.CreatePrice.ProductID)
+}
+
+func TestAsk_DraftCatalogDiff_KeyCollisionRefused(t *testing.T) {
+	f := newFixture()
+	llm := &scriptLLM{turns: []*dashboard.ToolTurn{
+		toolCall("bad", toolDraftCatalogDiff, `{"product_key":"premium","new_price_key":"premium-monthly","unit_amount":6000000}`),
+		toolCall("good", toolDraftCatalogDiff, `{"product_key":"premium","new_price_key":"premium-with-ads","unit_amount":6000000}`),
+		{Text: "fixed"},
+	}}
+	res := mustAsk(t, f.service(llm, true), "add a tier using the same key by mistake")
+	require.Len(t, res.Drafts, 1, "the colliding attempt must not produce a draft")
+	second := llm.convs[1]
+	tr := second[len(second)-1].ToolResults[0]
+	require.True(t, tr.IsError)
+	require.Contains(t, tr.Content, "already in use")
+}
+
+func TestMemoryAskLimiter_WindowsAndIsolation(t *testing.T) {
+	now := time.Now()
+	l := NewAskLimiter(nil, func() time.Time { return now })
+	ctx := context.Background()
+	for i := 0; i < askRatePerMinute; i++ {
+		ok, _, err := l.AllowAsk(ctx, "merchant-a")
+		require.NoError(t, err)
+		require.Truef(t, ok, "call %d within budget must pass", i)
+	}
+	ok, retry, err := l.AllowAsk(ctx, "merchant-a")
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Greater(t, retry, time.Duration(0))
+	ok, _, _ = l.AllowAsk(ctx, "merchant-b")
+	require.True(t, ok, "a different merchant is unaffected")
+}

--- a/internal/modules/copilot/doctrine.go
+++ b/internal/modules/copilot/doctrine.go
@@ -1,0 +1,58 @@
+package copilot
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// doctrinePrompt is the copilot's house doctrine, assembled from the
+// 2026-07-07 tracker rulings (#774/#773/#777/#778). Kept tight per the
+// design spec — the AXI tool results (inline aggregates, explicit empty
+// states, next-step hints) carry most of the intelligence; this only needs
+// to teach the model the vocabulary and the boundaries.
+const doctrinePrompt = `Catalog doctrine (how OpenRails prices work — assume the merchant does not know these terms):
+
+- A price KEY is a durable, human name (e.g. "premium-monthly") that points at the CURRENT version of a price. The underlying row is immutable and identified by its financial substance; editing the amount under the SAME key creates a NEW version, archives the old one, and re-points the key. Existing subscribers stay PINNED to the archived row automatically — this is "grandfathering", and it is the ZERO-ACTION default. Nothing else needs to happen for "existing users keep $10, new users pay $12".
+- Moving existing subscribers onto the new version is a SEPARATE, explicit step ("reprice" / "migrate"): schedule it if the merchant wants a full increase to take effect for everyone, or to end a grandfather window on a date.
+- Direction-aware defaults: a price INCREASE defaults to grandfather (existing subscribers keep the old price — zero risk, the safe assumption). A price DECREASE defaults to migrate-now (nobody is grandfathered into paying MORE than the new, lower price).
+- Mutate vs. new: when the SAME plan simply evolves (a rename, a new amount, updated entitlements for the one thing customers already have), mutate the existing product/price in place. When two DISTINCT things need to coexist (e.g. "keep premium AND add a cheaper with-ads tier"), that is a NEW product/price key — never a version of the old one.
+- Cross-product migration ("kill Basic, move everyone onto the pre-existing Standard plan") is explicitly OUT OF SCOPE for now (#778) — it changes what customers receive, not just the amount, and needs a human to plan entitlement/invoice/notice implications. If asked for this, explain the workaround: archive the dying product's prices (stops new sales) and leave the existing cohort grandfathered on it.
+- Card networks and consumer law require advance notice before a recurring amount INCREASE takes effect for existing subscribers; a price decrease has no such requirement and may take effect immediately.
+- Money in every tool argument and result is in MICROS: 1,000,000 micros = 1 currency unit. State amounts to the user in whole currency units.
+- Never fabricate a number. Every count, amount, or date in your answer must come from a tool result.`
+
+// draftingDoctrine is appended only when Phase 2 is armed.
+const draftingDoctrine = `
+Drafting: you may PROPOSE a price change or a new price via the draft_* tools, but you can NEVER apply one — every draft_* tool result is a proposal the merchant must review and confirm by hand in the console. Say so plainly whenever you hand back a draft. If a request would need cross-product migration, call draft_price_change with migrate_to_price_key set so the refusal and workaround come back typed — do not attempt to talk the merchant out of it yourself; relay the tool's reason and workaround verbatim.`
+
+// systemPrompt assembles the AXI content-first context pack: the LIVE
+// catalog summary FIRST (content, not schema docs), then the doctrine, then
+// the answering rules. now is used both for the date line and for any
+// tool that needs "today" (draft_price_change's default effective date).
+func (s *Service) systemPrompt(ctx context.Context, now time.Time) string {
+	rows, err := s.catalogRows(ctx, "")
+	summary := "catalog summary unavailable"
+	if err == nil {
+		summary = renderCatalogRows(rows)
+	}
+
+	doctrine := doctrinePrompt
+	if s.DraftingConfigured() {
+		doctrine += draftingDoctrine
+	}
+
+	return fmt.Sprintf(`You answer a merchant's questions about their product/price catalog and — only when told a draft tool is available below — draft price changes for human review. Today's date (UTC): %s.
+
+Live catalog summary (product_key | price_key | amount | interval | active_subscribers | grandfathered):
+%s
+
+%s
+
+Rules:
+- Use the tools to look anything up; never guess a key, amount, or count.
+- "0 results"/"no pending migrations" are definitive answers — state them plainly, do not treat an empty result as an error.
+- If a tool result includes a "next:" line, that is the legal next action — mention it when relevant instead of inventing your own next step.
+- Answer concisely. The UI shows every tool result verbatim next to your answer, so summarize and interpret — do not repeat whole tables in prose.`,
+		now.Format("2006-01-02"), summary, doctrine)
+}

--- a/internal/modules/copilot/render.go
+++ b/internal/modules/copilot/render.go
@@ -1,0 +1,23 @@
+package copilot
+
+import "strings"
+
+// renderTable formats rows as a compact, token-efficient TOON-style table —
+// header + pipe-separated cells, one row per line — rather than pretty JSON.
+// Used both for the context pack's live catalog summary (content-first: the
+// model reads this before any doctrine text) and for tool results (AXI:
+// "token-efficient output"). An explicit empty-state line replaces a bare
+// header-only table so the model never has to infer "0 rows" from absence.
+func renderTable(headers []string, rows [][]string, emptyState string) string {
+	if len(rows) == 0 {
+		return emptyState
+	}
+	var b strings.Builder
+	b.WriteString(strings.Join(headers, " | "))
+	b.WriteByte('\n')
+	for _, row := range rows {
+		b.WriteString(strings.Join(row, " | "))
+		b.WriteByte('\n')
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/internal/modules/copilot/service.go
+++ b/internal/modules/copilot/service.go
@@ -1,0 +1,134 @@
+// Package copilot implements #779: the console catalog copilot. It extends
+// the #741/#756 LLM surface (schema-carries-the-intelligence, haiku-first,
+// fail-closed feature gates) from METRICS to the CATALOG: merchants ask
+// questions about products/prices/subscribers and, once #781 lands, draft
+// price changes conversationally.
+//
+// The one safety principle (non-negotiable, per the 2026-07-07 design
+// ruling): the model NEVER mutates. Its only write-shaped output is a DRAFT
+// of the same structured payload the human console produces (a #777 wizard
+// plan or a catalog diff), rendered through the wizard's own review step for
+// human confirmation. Every constraint the API enforces (same-currency,
+// same-product, active-price) is enforced there, not reimplemented here —
+// LLM proposes, primitives dispose.
+package copilot
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/modules/dashboard"
+	"github.com/open-rails/openrails/internal/modules/subscriptions"
+	"github.com/open-rails/openrails/pkg/query"
+)
+
+// ProductReader is the read-only product surface the copilot needs — the
+// exact method set catalog.ProductService already exports (no adapter: the
+// production wiring passes the real service directly).
+type ProductReader interface {
+	GetActive(ctx context.Context) ([]*models.Product, error)
+	GetByKey(ctx context.Context, key string) (*models.Product, error)
+	GetByID(ctx context.Context, id uuid.UUID) (*models.Product, error)
+}
+
+// PriceReader is the read-only price/key surface — catalog.PriceService's
+// existing method set.
+type PriceReader interface {
+	GetActiveByProductID(ctx context.Context, productID uuid.UUID) ([]*models.Price, error)
+	GetCurrentByKey(ctx context.Context, merchantID uuid.UUID, key string) (*models.Price, error)
+	ListChainByKey(ctx context.Context, merchantID uuid.UUID, key string) ([]*models.Price, error)
+	ListKeyMovements(ctx context.Context, merchantID uuid.UUID, key string) ([]*models.PriceKeyMovement, error)
+	GetByID(ctx context.Context, id uuid.UUID) (*models.Price, error)
+}
+
+// SubscriptionCounter is the per-price subscriber-count primitive —
+// subscriptions.SubscriptionService's existing GetSubscribers, called with
+// Limit:0 so only the COUNT query runs (the items page is discarded).
+type SubscriptionCounter interface {
+	GetSubscribers(ctx context.Context, params query.QueryOptions[subscriptions.GetSubscriptionsFilters]) ([]*models.Subscription, int64, error)
+}
+
+// RepricePreviewer is the #773/#777 read-only reprice surface the copilot
+// rides for affected-count previews and pending-migration lookups —
+// subscriptions.RepriceService's existing method set. NEVER call a method
+// beyond these three (Reprice / RepriceAllPriorVersions mutate; the copilot
+// tool layer must never reach them).
+type RepricePreviewer interface {
+	PreviewAllPriorVersions(ctx context.Context, priceKey string) (*subscriptions.RepricePreviewResult, error)
+	ListBatchesForKey(ctx context.Context, priceKey string, limit, offset int) ([]*models.RepriceBatch, error)
+	List(ctx context.Context, filter subscriptions.SubscriptionRepriceFilter, limit, offset int) ([]*models.SubscriptionReprice, error)
+}
+
+// Deps are the catalog copilot's collaborators. LLM may be nil (the feature
+// fails closed); Enabled is the llm.catalog_copilot_enabled consent (Q&A
+// sends aggregate catalog/subscriber-count data to the provider, like #756);
+// DraftingEnabled additionally arms the Phase 2 draft_* tools — MUST stay
+// false until #781 ships (see doctrine.go); Limiter may be nil (no
+// rate limiting).
+type Deps struct {
+	Products ProductReader
+	Prices   PriceReader
+	Subs     SubscriptionCounter
+	Reprices RepricePreviewer
+	LLM      dashboard.LLM
+	Enabled  bool
+	Drafting bool
+	Limiter  AskLimiter
+	Clock    clockwork.Clock
+}
+
+// Service answers catalog Q&A (#779 Phase 1) and, when armed, drafts price
+// changes / catalog diffs (Phase 2) for human review in the #777 wizard.
+type Service struct {
+	products ProductReader
+	prices   PriceReader
+	subs     SubscriptionCounter
+	reprices RepricePreviewer
+	llm      dashboard.LLM
+	enabled  bool
+	drafting bool
+	limiter  AskLimiter
+	clock    clockwork.Clock
+}
+
+func NewService(d Deps) *Service {
+	if d.Clock == nil {
+		d.Clock = clockwork.NewRealClock()
+	}
+	return &Service{
+		products: d.Products,
+		prices:   d.Prices,
+		subs:     d.Subs,
+		reprices: d.Reprices,
+		llm:      d.LLM,
+		enabled:  d.Enabled,
+		drafting: d.Drafting,
+		limiter:  d.Limiter,
+		clock:    d.Clock,
+	}
+}
+
+// SetLLM swaps the model backend (tests inject a deterministic stub).
+func (s *Service) SetLLM(l dashboard.LLM) { s.llm = l }
+
+// Configured reports whether catalog Q&A can run: an LLM AND the explicit
+// llm.catalog_copilot_enabled consent.
+func (s *Service) Configured() bool { return s != nil && s.llm != nil && s.enabled }
+
+// DraftingConfigured reports whether Phase 2 drafting tools are armed. Gated
+// on the SAME deployment flag as #781's presence per the tracker ruling:
+// stays false — drafting tools absent from the tool list entirely, not
+// present-but-erroring — until an operator flips llm.catalog_drafting_enabled
+// (intended: after both #779 and #781 merge).
+func (s *Service) DraftingConfigured() bool { return s.Configured() && s.drafting }
+
+func (s *Service) now() time.Time {
+	if s.clock != nil {
+		return s.clock.Now()
+	}
+	return time.Now()
+}

--- a/internal/modules/copilot/tools_draft.go
+++ b/internal/modules/copilot/tools_draft.go
@@ -1,0 +1,342 @@
+package copilot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/modules/dashboard"
+	"github.com/open-rails/openrails/internal/shared/moneyutil"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// Phase 2 (#779, flag-gated behind llm.catalog_drafting_enabled — see
+// service.go's DraftingConfigured): the copilot's ONLY write-shaped output is
+// a DRAFT of the exact payload the human console already produces (a #777
+// wizard plan or a create-price catalog diff). Neither tool below ever calls
+// a mutating service method — CreatePrice/RepriceAllPriorVersions are never
+// referenced here. The draft is handed to the console to open, pre-filled,
+// in the corresponding review step; the human's confirm click is the only
+// path that actually calls those APIs, which enforce every constraint anew.
+
+// noticeWindowDaysDoctrine mirrors web/admin/src/pages/catalog/price-wizard-logic.ts's
+// NOTICE_WINDOW_DAYS (#777) — duplicated, not imported (frontend/backend
+// boundary). It is a DEFAULT the copilot proposes, never an enforced floor:
+// #773/#777 shipped no server-side minimum-notice check, and #781 (in
+// flight) is what will make the API itself refuse an early increase. Once
+// #781 ships, this const should be replaced by reading the merchant's
+// configured window from the API.
+const noticeWindowDaysDoctrine = 30
+
+func priceDirection(newAmount, currentAmount int64) string {
+	switch {
+	case newAmount > currentAmount:
+		return "increase"
+	case newAmount < currentAmount:
+		return "decrease"
+	default:
+		return "unchanged"
+	}
+}
+
+// defaultMigrationMode mirrors price-wizard-logic.ts's defaultMigrationMode:
+// increases default to grandfather (zero-risk, today's behavior with no new
+// action); decreases default to migrate-now (never grandfather a decrease).
+func defaultMigrationMode(direction string) string {
+	if direction == "decrease" {
+		return "migrate"
+	}
+	return "grandfather"
+}
+
+// defaultEffectiveDate mirrors price-wizard-logic.ts's defaultEffectiveDate.
+func defaultEffectiveDate(direction string, now time.Time) time.Time {
+	if direction == "increase" {
+		return now.AddDate(0, 0, noticeWindowDaysDoctrine)
+	}
+	return now
+}
+
+// buildPriceChangeReviewText mirrors price-wizard-logic.ts's buildReviewText
+// phrasing exactly (independently implemented server-side; the console's own
+// TS copy renders the same words when a human edits the draft further).
+func buildPriceChangeReviewText(currency string, currentAmount, newAmount int64, affected int, mode string, effectiveAt, now time.Time) string {
+	lead := fmt.Sprintf("New subscribers pay %s immediately.", moneyutil.FormatDisplay(newAmount, currency))
+	if affected == 0 {
+		return lead + " No existing subscribers are on a prior version of this price."
+	}
+	subj := fmt.Sprintf("%d existing subscriber", affected)
+	if affected != 1 {
+		subj += "s"
+	}
+	if mode == "grandfather" {
+		return fmt.Sprintf("%s %s keep %s forever (grandfathered).", lead, subj, moneyutil.FormatDisplay(currentAmount, currency))
+	}
+	if !effectiveAt.After(now) {
+		return fmt.Sprintf("%s %s move to %s at their next renewal. Notices go out on confirm.", lead, subj, moneyutil.FormatDisplay(newAmount, currency))
+	}
+	return fmt.Sprintf("%s %s keep %s until %s, then move to %s at their next renewal. Notices go out on confirm.",
+		lead, subj, moneyutil.FormatDisplay(currentAmount, currency), effectiveAt.Format("Jan 2, 2006"), moneyutil.FormatDisplay(newAmount, currency))
+}
+
+// crossConstraintRefusal mirrors subscriptions.validateRepriceConstraints'
+// three checks EXACTLY (same order, same sentinel codes), independently
+// implemented read-only here — the copilot never imports the reprice
+// service's mutating methods, only its own reads (GetCurrentByKey etc.) to
+// pre-flight the same business rule the API would enforce if this ever
+// became a real reprice call.
+func crossConstraintRefusal(from, to *models.Price) *DraftRefusal {
+	if to.Archived {
+		return &DraftRefusal{
+			Code:       "inactive_price",
+			Reason:     "the target price is archived and cannot receive a migration",
+			Workaround: "point at the key's CURRENT price (call get_price to confirm which one that is) instead of an archived version.",
+		}
+	}
+	if to.ProductID != from.ProductID {
+		return &DraftRefusal{
+			Code:       "cross_product",
+			Reason:     "the target price belongs to a DIFFERENT product — moving subscribers onto a pre-existing, distinct product is plan consolidation, not a price change",
+			Workaround: "cross-product migration is deferred (#778) until a real consolidation need appears. Workaround: archive the old product's prices (stops new sales) and leave the existing cohort grandfathered on it; a genuine consolidation needs a human to plan the entitlement/invoice-naming implications.",
+		}
+	}
+	if !strings.EqualFold(strings.TrimSpace(to.Currency), strings.TrimSpace(from.Currency)) {
+		return &DraftRefusal{
+			Code:       "cross_currency",
+			Reason:     "the target price is in a different currency — repricing never crosses currencies (no FX surprises on an existing billing agreement)",
+			Workaround: "pick a target price in the same currency, or draft a same-currency successor under this key instead.",
+		}
+	}
+	return nil
+}
+
+// -- Tool: draft_price_change --------------------------------------------------
+
+const toolDraftPriceChange = "draft_price_change"
+
+func toolDefDraftPriceChange() dashboard.ToolDef {
+	return dashboard.ToolDef{
+		Name:        toolDraftPriceChange,
+		Description: "Draft a #777 wizard price-change plan for an EXISTING price key: a version bump (new amount, same key) plus an optional migration. NEVER mutates anything — returns a DRAFT payload for human review/confirm in the console wizard, with the affected-subscriber count and review text already computed. migration_mode defaults per direction (increase->grandfather, decrease->migrate); effective_date defaults to the notice-window floor for an increase, or now for a decrease/grandfather. Pass migrate_to_price_key ONLY if the merchant is asking to move subscribers onto a DIFFERENT, pre-existing product/price (plan consolidation) — that request is refused with a typed reason and workaround, never drafted. Amounts are in MICROS.",
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"price_key": {"type": "string", "description": "The key to change (its CURRENT version is the edit target)."},
+				"new_amount": {"type": "integer", "description": "New amount in micros (1,000,000 = 1 currency unit)."},
+				"migration_mode": {"type": "string", "enum": ["grandfather", "migrate"], "description": "Optional; defaults per direction."},
+				"effective_date": {"type": "string", "description": "Optional YYYY-MM-DD; only meaningful when migration_mode=migrate. Defaults per doctrine."},
+				"migrate_to_price_key": {"type": "string", "description": "Optional: a DIFFERENT existing key the merchant wants to move price_key's subscribers onto. Out of scope (#778) — always refused; included only so the refusal can be typed and explained."}
+			},
+			"required": ["price_key", "new_amount"],
+			"additionalProperties": false
+		}`),
+	}
+}
+
+type draftPriceChangeArgs struct {
+	PriceKey          string `json:"price_key"`
+	NewAmount         int64  `json:"new_amount"`
+	MigrationMode     string `json:"migration_mode,omitempty"`
+	EffectiveDate     string `json:"effective_date,omitempty"`
+	MigrateToPriceKey string `json:"migrate_to_price_key,omitempty"`
+}
+
+func (s *Service) runDraftPriceChange(ctx context.Context, raw json.RawMessage) (string, *Draft, error) {
+	var args draftPriceChangeArgs
+	if err := strictDecode(raw, &args); err != nil {
+		return "", nil, err
+	}
+	key := strings.TrimSpace(args.PriceKey)
+	if key == "" {
+		return "", nil, fmt.Errorf("price_key is required")
+	}
+	tid, err := merchant.Require(ctx)
+	if err != nil {
+		return "", nil, err
+	}
+	current, err := s.prices.GetCurrentByKey(ctx, tid.UUID(), key)
+	if err != nil {
+		return "", nil, fmt.Errorf("price_key %q not found — call list_catalog to see valid keys", key)
+	}
+
+	if toKey := strings.TrimSpace(args.MigrateToPriceKey); toKey != "" && toKey != key {
+		to, err := s.prices.GetCurrentByKey(ctx, tid.UUID(), toKey)
+		if err != nil {
+			return "", nil, fmt.Errorf("migrate_to_price_key %q not found", toKey)
+		}
+		refusal := crossConstraintRefusal(current, to)
+		if refusal == nil {
+			// Same product+currency: this is NOT #778 territory — it is an
+			// ordinary same-key version bump under a different name, which
+			// this tool does not support ambiguously. Ask for a plain
+			// draft_price_change on price_key instead.
+			refusal = &DraftRefusal{
+				Code:       "same_product_migration",
+				Reason:     "migrate_to_price_key resolves to the same product/currency — this tool only bumps price_key's OWN version; there is no separate 'move to a same-product key' operation",
+				Workaround: fmt.Sprintf("call draft_price_change with price_key=%q and the new amount directly.", key),
+			}
+		}
+		return fmt.Sprintf("refused (%s): %s\nworkaround: %s\nnext: relay this to the merchant — no draft was created, nothing was changed.",
+				refusal.Code, refusal.Reason, refusal.Workaround),
+			&Draft{Kind: "refused", Refusal: refusal}, nil
+	}
+
+	if args.NewAmount <= 0 {
+		return "", nil, fmt.Errorf("new_amount must be a positive number of micros")
+	}
+	direction := priceDirection(args.NewAmount, current.Amount)
+	if direction == "unchanged" {
+		return "", nil, fmt.Errorf("new_amount equals the current amount (%d) — nothing to draft", current.Amount)
+	}
+
+	mode := strings.TrimSpace(args.MigrationMode)
+	if mode == "" {
+		mode = defaultMigrationMode(direction)
+	} else if mode != "grandfather" && mode != "migrate" {
+		return "", nil, fmt.Errorf(`migration_mode must be "grandfather" or "migrate"`)
+	}
+
+	now := s.now().UTC()
+	effectiveAt := defaultEffectiveDate(direction, now)
+	if raw := strings.TrimSpace(args.EffectiveDate); raw != "" {
+		parsed, err := time.Parse("2006-01-02", raw)
+		if err != nil {
+			return "", nil, fmt.Errorf("effective_date must be YYYY-MM-DD")
+		}
+		effectiveAt = parsed.UTC()
+	}
+
+	affected := 0
+	if s.reprices != nil {
+		if preview, err := s.reprices.PreviewAllPriorVersions(ctx, key); err == nil {
+			affected = preview.Matched
+		}
+	}
+
+	reviewText := buildPriceChangeReviewText(current.Currency, current.Amount, args.NewAmount, affected, mode, effectiveAt, now)
+
+	providers := make([]string, 0, len(current.Rails))
+	for provider := range current.Rails {
+		providers = append(providers, provider)
+	}
+
+	draft := &PriceChangeDraft{
+		DraftID:       uuid.NewString(),
+		DraftedBy:     DraftedBy,
+		PriceKey:      key,
+		CurrentAmount: current.Amount,
+		NewAmount:     args.NewAmount,
+		Currency:      current.Currency,
+		Direction:     direction,
+		MigrationMode: mode,
+		AffectedCount: affected,
+		ReviewText:    reviewText,
+		CreatePrice: CreatePriceDraft{
+			ProductID: current.ProductID.String(), Key: key,
+			UnitAmount: args.NewAmount, Currency: current.Currency,
+			AccessDurationHours: current.AccessDurationHours, AutoRenew: current.AutoRenew,
+			TrialUnitAmount: current.TrialUnitAmount, TrialDurationHours: current.TrialDurationHours,
+			Providers: providers,
+		},
+	}
+	if mode == "migrate" {
+		draft.Reprice = &RepriceDraft{PriceKey: key, EffectiveAt: effectiveAt}
+	}
+
+	content := fmt.Sprintf("draft ready (draft_id=%s): %s\nnext: requires human confirm via the price-change wizard — nothing has been changed yet.", draft.DraftID, reviewText)
+	return content, &Draft{Kind: "price_change", PriceChange: draft}, nil
+}
+
+// -- Tool: draft_catalog_diff ---------------------------------------------------
+
+const toolDraftCatalogDiff = "draft_catalog_diff"
+
+func toolDefDraftCatalogDiff() dashboard.ToolDef {
+	return dashboard.ToolDef{
+		Name:        toolDraftCatalogDiff,
+		Description: "Draft a NEW price (a new tier/plan variant, e.g. \"add a with-ads tier at $6\") on an EXISTING product. NEVER mutates anything — returns a create-price DRAFT for human review/confirm in the console. Only adds a price to a product that already exists; drafting a brand-new PRODUCT is out of scope for v1 (create the product first, then ask again). Amounts are in MICROS.",
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"product_key": {"type": "string", "description": "An EXISTING product's key to add the price to."},
+				"new_price_key": {"type": "string", "description": "Optional; auto-defaults to \"<product_key>-<interval>\" (refused if that key is already in use — pass an explicit distinct key, e.g. \"...-with-ads\")."},
+				"unit_amount": {"type": "integer", "description": "Amount in micros (1,000,000 = 1 currency unit)."},
+				"currency": {"type": "string", "description": "Optional; defaults to the product's existing price currency if it has one."},
+				"access_duration_hours": {"type": "integer", "description": "Billing period in hours (720=~monthly, 8760=~yearly). Omit for a durable one-time purchase."},
+				"auto_renew": {"type": "boolean", "description": "Whether it recurs. Requires access_duration_hours."}
+			},
+			"required": ["product_key", "unit_amount"],
+			"additionalProperties": false
+		}`),
+	}
+}
+
+type draftCatalogDiffArgs struct {
+	ProductKey          string `json:"product_key"`
+	NewPriceKey         string `json:"new_price_key,omitempty"`
+	UnitAmount          int64  `json:"unit_amount"`
+	Currency            string `json:"currency,omitempty"`
+	AccessDurationHours *int   `json:"access_duration_hours,omitempty"`
+	AutoRenew           bool   `json:"auto_renew,omitempty"`
+}
+
+func (s *Service) runDraftCatalogDiff(ctx context.Context, raw json.RawMessage) (string, *Draft, error) {
+	var args draftCatalogDiffArgs
+	if err := strictDecode(raw, &args); err != nil {
+		return "", nil, err
+	}
+	productKey := strings.TrimSpace(args.ProductKey)
+	if productKey == "" {
+		return "", nil, fmt.Errorf("product_key is required")
+	}
+	if args.UnitAmount <= 0 {
+		return "", nil, fmt.Errorf("unit_amount must be a positive number of micros")
+	}
+	product, err := s.products.GetByKey(ctx, productKey)
+	if err != nil {
+		return "", nil, fmt.Errorf("product_key %q not found — create the product first (out of scope for this tool)", productKey)
+	}
+
+	currency := strings.ToLower(strings.TrimSpace(args.Currency))
+	if currency == "" {
+		existing, err := s.prices.GetActiveByProductID(ctx, product.ID)
+		if err == nil && len(existing) > 0 {
+			currency = existing[0].Currency
+		} else {
+			return "", nil, fmt.Errorf("currency is required: product %q has no existing prices to infer it from", productKey)
+		}
+	}
+
+	interval := priceIntervalLabel(args.AccessDurationHours, args.AutoRenew)
+	key := strings.TrimSpace(args.NewPriceKey)
+	if key == "" {
+		key = productKey + "-" + interval
+	}
+	tid, err := merchant.Require(ctx)
+	if err != nil {
+		return "", nil, err
+	}
+	if _, err := s.prices.GetCurrentByKey(ctx, tid.UUID(), key); err == nil {
+		return "", nil, fmt.Errorf("key %q is already in use by an existing price — pass a distinct new_price_key", key)
+	}
+
+	reviewText := fmt.Sprintf("New tier %q on %s: %s / %s. No existing subscribers are affected until you create it.",
+		key, product.DisplayName, moneyutil.FormatDisplay(args.UnitAmount, currency), interval)
+
+	draft := &CatalogDiffDraft{
+		DraftID: uuid.NewString(), DraftedBy: DraftedBy,
+		ProductKey: productKey, ReviewText: reviewText,
+		CreatePrice: CreatePriceDraft{
+			ProductID: product.ID.String(), Key: key,
+			UnitAmount: args.UnitAmount, Currency: currency,
+			AccessDurationHours: args.AccessDurationHours, AutoRenew: args.AutoRenew,
+		},
+	}
+	content := fmt.Sprintf("draft ready (draft_id=%s): %s\nnext: requires human confirm via the console's new-price form — nothing has been changed yet.", draft.DraftID, reviewText)
+	return content, &Draft{Kind: "catalog_diff", CatalogDiff: draft}, nil
+}

--- a/internal/modules/copilot/tools_qa.go
+++ b/internal/modules/copilot/tools_qa.go
@@ -1,0 +1,381 @@
+package copilot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/modules/dashboard"
+	"github.com/open-rails/openrails/internal/modules/subscriptions"
+	"github.com/open-rails/openrails/internal/shared/moneyutil"
+	"github.com/open-rails/openrails/pkg/merchant"
+	"github.com/open-rails/openrails/pkg/query"
+)
+
+// priceIntervalLabel mirrors pkg/service.PriceIntervalLabel (#774) exactly —
+// duplicated rather than imported because pkg/service transitively imports
+// internal/app, which imports this package (a cycle). Keep in sync with
+// pkg/service/price_key.go and migrations/postgres/0010_price_keys.up.sql's
+// backfill CASE if the interval buckets ever change.
+func priceIntervalLabel(accessDurationHours *int, autoRenew bool) string {
+	if !autoRenew || accessDurationHours == nil {
+		return "onetime"
+	}
+	switch *accessDurationHours {
+	case 168:
+		return "weekly"
+	case 720, 744:
+		return "monthly"
+	case 2160, 2184:
+		return "quarterly"
+	case 8760, 8784:
+		return "yearly"
+	default:
+		return fmt.Sprintf("%dd", *accessDurationHours/24)
+	}
+}
+
+// activeSubscriberCount is the per-price-row subscriber count primitive: the
+// COUNT(*) query only (Limit:0 discards the items page — cheap regardless of
+// cohort size, same pattern #757/#733 pagination already uses everywhere).
+func (s *Service) activeSubscriberCount(ctx context.Context, priceID uuid.UUID) (int, error) {
+	if s.subs == nil {
+		return 0, fmt.Errorf("subscription service unavailable")
+	}
+	_, total, err := s.subs.GetSubscribers(ctx, query.QueryOptions[subscriptions.GetSubscriptionsFilters]{
+		Filters: subscriptions.GetSubscriptionsFilters{PriceID: priceID, Status: string(models.StatusActive)},
+		Limit:   0,
+	})
+	if err != nil {
+		return 0, err
+	}
+	return int(total), nil
+}
+
+// catalogRow is one LEAN projection row (AXI: key, amount, status, inline
+// aggregates — never the full price row).
+type catalogRow struct {
+	ProductKey    string
+	ProductName   string
+	PriceKey      string
+	PriceID       uuid.UUID
+	Amount        int64
+	Currency      string
+	Interval      string
+	ActiveSubs    int
+	Grandfathered int
+}
+
+// catalogRows lists every ACTIVE product's ACTIVE (current) prices with
+// inline active-subscriber + grandfathered counts — the content-first live
+// summary that opens both the system prompt and the list_catalog tool
+// result. productKeyFilter, when set, scopes to one product.
+func (s *Service) catalogRows(ctx context.Context, productKeyFilter string) ([]catalogRow, error) {
+	if s.products == nil || s.prices == nil {
+		return nil, fmt.Errorf("catalog service unavailable")
+	}
+	var products []*models.Product
+	var err error
+	if productKeyFilter != "" {
+		p, err := s.products.GetByKey(ctx, productKeyFilter)
+		if err != nil {
+			return nil, fmt.Errorf("product_key %q not found", productKeyFilter)
+		}
+		products = []*models.Product{p}
+	} else {
+		products, err = s.products.GetActive(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var rows []catalogRow
+	for _, p := range products {
+		prices, err := s.prices.GetActiveByProductID(ctx, p.ID)
+		if err != nil {
+			return nil, fmt.Errorf("list prices for product %q: %w", p.Key, err)
+		}
+		for _, price := range prices {
+			active, err := s.activeSubscriberCount(ctx, price.ID)
+			if err != nil {
+				return nil, fmt.Errorf("count active subscribers for price %q: %w", price.Key, err)
+			}
+			grand := 0
+			if s.reprices != nil {
+				preview, err := s.reprices.PreviewAllPriorVersions(ctx, price.Key)
+				if err == nil && preview.Matched > active {
+					grand = preview.Matched - active
+				}
+			}
+			rows = append(rows, catalogRow{
+				ProductKey: p.Key, ProductName: p.DisplayName,
+				PriceKey: price.Key, PriceID: price.ID,
+				Amount: price.Amount, Currency: price.Currency,
+				Interval:   priceIntervalLabel(price.AccessDurationHours, price.AutoRenew),
+				ActiveSubs: active, Grandfathered: grand,
+			})
+		}
+	}
+	return rows, nil
+}
+
+func renderCatalogRows(rows []catalogRow) string {
+	table := make([][]string, 0, len(rows))
+	for _, r := range rows {
+		table = append(table, []string{
+			r.ProductKey, r.PriceKey, moneyutil.FormatDisplay(r.Amount, r.Currency), r.Interval,
+			itoa(r.ActiveSubs), itoa(r.Grandfathered),
+		})
+	}
+	return renderTable(
+		[]string{"product_key", "price_key", "amount", "interval", "active_subscribers", "grandfathered"},
+		table, "0 active products/prices in the catalog.",
+	)
+}
+
+func itoa(n int) string { return fmt.Sprintf("%d", n) }
+
+// -- Tool: list_catalog -------------------------------------------------------
+
+const toolListCatalog = "list_catalog"
+
+func toolDefListCatalog() dashboard.ToolDef {
+	return dashboard.ToolDef{
+		Name:        toolListCatalog,
+		Description: "List every active product and its current (live) prices, 3-4 fields each, with the active-subscriber count and grandfathered (still on a prior version) count already computed inline — never call another tool to learn the blast radius of a price. Optionally scope to one product. Amounts are in MICROS (1,000,000 micros = 1 currency unit). Idempotent, safe to retry.",
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"product_key": {"type": "string", "description": "Optional: scope to one product's key."}
+			},
+			"additionalProperties": false
+		}`),
+	}
+}
+
+type listCatalogArgs struct {
+	ProductKey string `json:"product_key,omitempty"`
+}
+
+func (s *Service) runListCatalog(ctx context.Context, raw json.RawMessage) (string, error) {
+	var args listCatalogArgs
+	if err := strictDecode(raw, &args); err != nil {
+		return "", err
+	}
+	rows, err := s.catalogRows(ctx, strings.TrimSpace(args.ProductKey))
+	if err != nil {
+		return "", err
+	}
+	return renderCatalogRows(rows), nil
+}
+
+// -- Tool: get_price -----------------------------------------------------------
+
+const toolGetPrice = "get_price"
+
+func toolDefGetPrice() dashboard.ToolDef {
+	return dashboard.ToolDef{
+		Name:        toolGetPrice,
+		Description: "Full detail for ONE price key: amount, currency, interval, product, active-subscriber count, grandfathered count, and whether a reprice migration is currently pending for it. The escape hatch beyond list_catalog's lean rows. Idempotent, safe to retry.",
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {"price_key": {"type": "string"}},
+			"required": ["price_key"],
+			"additionalProperties": false
+		}`),
+	}
+}
+
+type getPriceArgs struct {
+	PriceKey string `json:"price_key"`
+}
+
+func (s *Service) runGetPrice(ctx context.Context, raw json.RawMessage) (string, error) {
+	var args getPriceArgs
+	if err := strictDecode(raw, &args); err != nil {
+		return "", err
+	}
+	key := strings.TrimSpace(args.PriceKey)
+	if key == "" {
+		return "", fmt.Errorf("price_key is required")
+	}
+	tid, err := merchant.Require(ctx)
+	if err != nil {
+		return "", err
+	}
+	price, err := s.prices.GetCurrentByKey(ctx, tid.UUID(), key)
+	if err != nil {
+		return "", fmt.Errorf("price_key %q not found — call list_catalog to see valid keys", key)
+	}
+	product, err := s.products.GetByID(ctx, price.ProductID)
+	if err != nil {
+		return "", fmt.Errorf("resolve product for price_key %q: %w", key, err)
+	}
+	active, err := s.activeSubscriberCount(ctx, price.ID)
+	if err != nil {
+		return "", err
+	}
+	grand := 0
+	pending := "no pending migration"
+	if s.reprices != nil {
+		if preview, err := s.reprices.PreviewAllPriorVersions(ctx, key); err == nil && preview.Matched > active {
+			grand = preview.Matched - active
+		}
+		if batches, err := s.reprices.ListBatchesForKey(ctx, key, 1, 0); err == nil && len(batches) > 0 {
+			b := batches[0]
+			pending = fmt.Sprintf("pending migration: batch effective %s, %d/%d scheduled, %d skipped",
+				b.EffectiveAt.Format("2006-01-02"), b.SubscriptionsScheduled, b.SubscriptionsMatched, b.SubscriptionsSkipped)
+		}
+	}
+	lines := []string{
+		fmt.Sprintf("price_key: %s", price.Key),
+		fmt.Sprintf("product: %s (%s)", product.DisplayName, product.Key),
+		fmt.Sprintf("amount: %s", moneyutil.FormatDisplay(price.Amount, price.Currency)),
+		fmt.Sprintf("interval: %s", priceIntervalLabel(price.AccessDurationHours, price.AutoRenew)),
+		fmt.Sprintf("active_subscribers: %d", active),
+		fmt.Sprintf("grandfathered (on prior versions): %d", grand),
+		pending,
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+// -- Tool: price_history -------------------------------------------------------
+
+const toolPriceHistory = "price_history"
+
+func toolDefPriceHistory() dashboard.ToolDef {
+	return dashboard.ToolDef{
+		Name:        toolPriceHistory,
+		Description: "The full version-chain history for a price key, most-recent-first, resolved from the durable pointer-movement log (not each row's own creation date — a reactivated amount shows its most recent movement). Each entry carries the active-subscriber count STILL on that specific historical amount (\"who's still on the old price?\"). Idempotent, safe to retry.",
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {"price_key": {"type": "string"}},
+			"required": ["price_key"],
+			"additionalProperties": false
+		}`),
+	}
+}
+
+func (s *Service) runPriceHistory(ctx context.Context, raw json.RawMessage) (string, error) {
+	var args getPriceArgs
+	if err := strictDecode(raw, &args); err != nil {
+		return "", err
+	}
+	key := strings.TrimSpace(args.PriceKey)
+	if key == "" {
+		return "", fmt.Errorf("price_key is required")
+	}
+	tid, err := merchant.Require(ctx)
+	if err != nil {
+		return "", err
+	}
+	movements, err := s.prices.ListKeyMovements(ctx, tid.UUID(), key)
+	if err != nil || len(movements) == 0 {
+		return "", fmt.Errorf("price_key %q not found — call list_catalog to see valid keys", key)
+	}
+	table := make([][]string, 0, len(movements))
+	for _, m := range movements {
+		price, err := s.prices.GetByID(ctx, m.PriceID)
+		if err != nil {
+			return "", fmt.Errorf("resolve historical price %s: %w", m.PriceID, err)
+		}
+		active, err := s.activeSubscriberCount(ctx, price.ID)
+		if err != nil {
+			return "", err
+		}
+		current := "prior"
+		if !price.Archived {
+			current = "current"
+		}
+		table = append(table, []string{
+			m.EffectiveAt.Format("2006-01-02"), moneyutil.FormatDisplay(price.Amount, price.Currency),
+			current, itoa(active),
+		})
+	}
+	return renderTable([]string{"effective_at", "amount", "status", "active_subscribers"}, table, "no history"), nil
+}
+
+// -- Tool: list_reprice_batches -------------------------------------------------
+
+const toolListRepriceBatches = "list_reprice_batches"
+
+func toolDefListRepriceBatches() dashboard.ToolDef {
+	return dashboard.ToolDef{
+		Name:        toolListRepriceBatches,
+		Description: "List a price key's bulk reprice (migration) operations, most-recent-first, with progress (applied/scheduled/canceled counts out of the total matched). \"0 pending migrations\" is stated explicitly, never an empty list to interpret. Idempotent, safe to retry.",
+		InputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {"price_key": {"type": "string"}},
+			"required": ["price_key"],
+			"additionalProperties": false
+		}`),
+	}
+}
+
+// repriceBatchCountLimit caps the per-batch row fetch used to tally
+// applied/scheduled/canceled — generous for a Q&A summary; a batch beyond
+// this is noted as truncated rather than silently under-counted.
+const repriceBatchCountLimit = 2000
+
+func (s *Service) runListRepriceBatches(ctx context.Context, raw json.RawMessage) (string, error) {
+	var args getPriceArgs
+	if err := strictDecode(raw, &args); err != nil {
+		return "", err
+	}
+	key := strings.TrimSpace(args.PriceKey)
+	if key == "" {
+		return "", fmt.Errorf("price_key is required")
+	}
+	if s.reprices == nil {
+		return "", fmt.Errorf("reprice service unavailable")
+	}
+	batches, err := s.reprices.ListBatchesForKey(ctx, key, 20, 0)
+	if err != nil {
+		return "", err
+	}
+	table := make([][]string, 0, len(batches))
+	for _, b := range batches {
+		rows, err := s.reprices.List(ctx, subscriptions.SubscriptionRepriceFilter{RepriceBatchID: &b.ID}, repriceBatchCountLimit, 0)
+		if err != nil {
+			return "", err
+		}
+		var applied, scheduled, canceled int
+		for _, r := range rows {
+			switch r.Status {
+			case models.RepriceStatusApplied:
+				applied++
+			case models.RepriceStatusScheduled:
+				scheduled++
+			case models.RepriceStatusCanceled:
+				canceled++
+			}
+		}
+		note := ""
+		if len(rows) >= repriceBatchCountLimit {
+			note = " (truncated count)"
+		}
+		table = append(table, []string{
+			b.EffectiveAt.Format("2006-01-02"),
+			fmt.Sprintf("%d matched", b.SubscriptionsMatched),
+			fmt.Sprintf("%d applied / %d scheduled / %d canceled%s", applied, scheduled, canceled, note),
+			b.CreatedAt.Format("2006-01-02"),
+		})
+	}
+	return renderTable([]string{"effective_at", "matched", "progress", "created_at"}, table,
+		fmt.Sprintf("0 pending migrations for price key %q.", key)), nil
+}
+
+// strictDecode fails loudly on unknown fields (AXI + house DisallowUnknownField
+// posture, extended to tool args).
+func strictDecode(raw json.RawMessage, v any) error {
+	dec := json.NewDecoder(strings.NewReader(string(raw)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(v); err != nil {
+		return fmt.Errorf("invalid tool arguments: %w", err)
+	}
+	return nil
+}

--- a/internal/modules/copilot/types.go
+++ b/internal/modules/copilot/types.go
@@ -1,0 +1,126 @@
+package copilot
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrNotConfigured: no LLM key or no llm.catalog_copilot_enabled consent —
+// the endpoint answers 501 with a pointed message (mirrors #756's
+// ErrAskNotConfigured).
+var ErrNotConfigured = errors.New("copilot: catalog copilot not configured")
+
+// RateLimitedError: the merchant exceeded its per-merchant ask budget.
+type RateLimitedError struct{ RetryAfter time.Duration }
+
+func (e *RateLimitedError) Error() string {
+	return fmt.Sprintf("copilot: rate limit exceeded (retry after %s)", e.RetryAfter)
+}
+
+// NoAnswerError: the model never produced a text answer within the loop
+// budget (kept calling tools).
+type NoAnswerError struct{ ToolCalls int }
+
+func (e *NoAnswerError) Error() string {
+	return fmt.Sprintf("copilot: model produced no answer within the tool budget (%d tool calls)", e.ToolCalls)
+}
+
+// Evidence is one executed tool call: the tool name, its args, and the exact
+// compact-table text fed to the model — "trust = show your work" (#756):
+// on-screen evidence is byte-identical to what the model saw, never a
+// separate re-summarization.
+type Evidence struct {
+	Tool    string `json:"tool"`
+	Args    string `json:"args"`
+	Summary string `json:"summary"`
+}
+
+// Draft is the copilot's ONLY write-shaped output (Phase 2, flag-gated): a
+// proposal shaped exactly like a #777 wizard confirm or a catalog-diff
+// create-price call. It is never executed by the tool layer — the console
+// opens it, pre-filled, in the corresponding human review step. Exactly one
+// of PriceChange / CatalogDiff / Refusal is set.
+type Draft struct {
+	Kind        string            `json:"kind"` // "price_change" | "catalog_diff" | "refused"
+	PriceChange *PriceChangeDraft `json:"price_change,omitempty"`
+	CatalogDiff *CatalogDiffDraft `json:"catalog_diff,omitempty"`
+	Refusal     *DraftRefusal     `json:"refusal,omitempty"`
+}
+
+// DraftedBy marks every non-refused draft's provenance — forwarded by the
+// console on wizard confirm so the confirm event is audit-logged as
+// copilot-originated (see ConfirmDraft).
+const DraftedBy = "copilot"
+
+// CreatePriceDraft mirrors billingservice.CreatePriceRequest's WIRE shape
+// (field-for-field, not the Go type — importing pkg/service would cycle:
+// it transitively imports internal/app, which imports this package). This
+// is exactly the body the #777 wizard's confirm step POSTs to
+// /v1/merchant/catalog/prices.
+type CreatePriceDraft struct {
+	ProductID           string   `json:"product_id"`
+	Key                 string   `json:"key"`
+	UnitAmount          int64    `json:"unit_amount"`
+	Currency            string   `json:"currency"`
+	AccessDurationHours *int     `json:"access_duration_hours,omitempty"`
+	AutoRenew           bool     `json:"auto_renew"`
+	TrialUnitAmount     *int64   `json:"trial_unit_amount,omitempty"`
+	TrialDurationHours  *int     `json:"trial_duration_hours,omitempty"`
+	Providers           []string `json:"providers,omitempty"`
+}
+
+// RepriceDraft mirrors the #773 bulk reprice-all-prior-versions body
+// (subscriptions.RepriceAllPriorVersionsRequest's wire shape).
+type RepriceDraft struct {
+	PriceKey    string    `json:"price_key"`
+	EffectiveAt time.Time `json:"effective_at"`
+}
+
+// PriceChangeDraft is the #777 wizard payload: a version bump on PriceKey
+// plus an optional migration plan. CreatePrice is ALWAYS populated (the
+// version-bump call); Reprice is populated only when MigrationMode is
+// "migrate". AffectedCount and ReviewText are computed inline (AXI: the
+// model never needs a second call to know the blast radius).
+type PriceChangeDraft struct {
+	DraftID       string           `json:"draft_id"`
+	DraftedBy     string           `json:"drafted_by"`
+	PriceKey      string           `json:"price_key"`
+	CurrentAmount int64            `json:"current_amount"`
+	NewAmount     int64            `json:"new_amount"`
+	Currency      string           `json:"currency"`
+	Direction     string           `json:"direction"` // increase | decrease | unchanged
+	MigrationMode string           `json:"migration_mode"`
+	AffectedCount int              `json:"affected_count"`
+	ReviewText    string           `json:"review_text"`
+	CreatePrice   CreatePriceDraft `json:"create_price"`
+	Reprice       *RepriceDraft    `json:"reprice,omitempty"`
+}
+
+// CatalogDiffDraft is a new-price ("add a tier") proposal on an EXISTING
+// product — never a new product (out of scope for v1; see doctrine.go).
+type CatalogDiffDraft struct {
+	DraftID     string           `json:"draft_id"`
+	DraftedBy   string           `json:"drafted_by"`
+	ProductKey  string           `json:"product_key"`
+	ReviewText  string           `json:"review_text"`
+	CreatePrice CreatePriceDraft `json:"create_price"`
+}
+
+// DraftRefusal is a typed, corrective refusal — the copilot's mirror of
+// #773's RepriceConstraintError sentinels, surfaced BEFORE a draft is even
+// built (never a mutation attempt). Code is machine-stable
+// ("cross_product" | "cross_currency" | "inactive_price"); Workaround is the
+// human-facing next step (#778's archive-and-grandfather for cross_product).
+type DraftRefusal struct {
+	Code       string `json:"code"`
+	Reason     string `json:"reason"`
+	Workaround string `json:"workaround"`
+}
+
+// AskResult is the POST /v1/merchant/catalog/ask response.
+type AskResult struct {
+	Answer   string     `json:"answer"`
+	Evidence []Evidence `json:"evidence"`
+	Drafts   []Draft    `json:"drafts,omitempty"`
+}

--- a/pkg/adminconsole/adminconsole.go
+++ b/pkg/adminconsole/adminconsole.go
@@ -33,6 +33,14 @@ type Config struct {
 	// endpoint would 501). Distinct consent from NLWidgetsEnabled because /ask
 	// sends aggregate query results to the LLM provider.
 	AskEnabled bool `json:"ask_enabled"`
+	// CatalogCopilotEnabled mirrors the #779 catalog copilot Q&A gate
+	// (llm.catalog_copilot_enabled AND an LLM key): false renders the catalog
+	// copilot panel as a pointed empty-state.
+	CatalogCopilotEnabled bool `json:"catalog_copilot_enabled"`
+	// CatalogDraftingEnabled mirrors the #779 Phase 2 gate
+	// (llm.catalog_drafting_enabled): false hides the drafting UI entirely —
+	// the copilot panel stays Q&A-only. Stays false until #781 ships.
+	CatalogDraftingEnabled bool `json:"catalog_drafting_enabled"`
 }
 
 // Present reports whether assets hold a servable console build: a non-nil

--- a/web/admin/src/lib/api/client.ts
+++ b/web/admin/src/lib/api/client.ts
@@ -11,6 +11,13 @@ export interface BootstrapConfig {
   // #756 metrics Q&A gate (llm.ask_enabled AND an LLM key): false renders the
   // Ask panel as a pointed empty-state (the ask endpoint would answer 501).
   ask_enabled: boolean
+  // #779 catalog copilot Q&A gate (llm.catalog_copilot_enabled AND an LLM
+  // key): false renders the catalog copilot panel as a pointed empty-state.
+  catalog_copilot_enabled: boolean
+  // #779 Phase 2 gate (llm.catalog_drafting_enabled): false hides the
+  // drafting affordances — the copilot panel stays Q&A-only. Stays false
+  // until #781 (server-side notice-window enforcement) ships.
+  catalog_drafting_enabled: boolean
 }
 
 export interface TokenPair {

--- a/web/admin/src/lib/api/copilot.ts
+++ b/web/admin/src/lib/api/copilot.ts
@@ -1,0 +1,87 @@
+// #779 catalog copilot: read-only Q&A (always, when configured) + flag-gated
+// Phase 2 drafting. Types mirror internal/modules/copilot's wire shapes
+// exactly. The model NEVER mutates — a draft is only ever opened, pre-filled,
+// in the normal price-change wizard / new-price dialog for a human to confirm.
+import { api } from "./client"
+
+export interface CopilotEvidence {
+  tool: string
+  args: string
+  summary: string
+}
+
+// CreatePriceDraft mirrors the #777 wizard/PriceDialog's create-price body —
+// the SAME shape createPrice() in endpoints.ts already sends.
+export interface CreatePriceDraft {
+  product_id: string
+  key: string
+  unit_amount: number
+  currency: string
+  access_duration_hours?: number
+  auto_renew: boolean
+  trial_unit_amount?: number
+  trial_duration_hours?: number
+  providers?: string[]
+}
+
+export interface RepriceDraft {
+  price_key: string
+  effective_at: string
+}
+
+export interface PriceChangeDraft {
+  draft_id: string
+  drafted_by: string
+  price_key: string
+  current_amount: number
+  new_amount: number
+  currency: string
+  direction: "increase" | "decrease" | "unchanged"
+  migration_mode: "grandfather" | "migrate"
+  affected_count: number
+  review_text: string
+  create_price: CreatePriceDraft
+  reprice?: RepriceDraft
+}
+
+export interface CatalogDiffDraft {
+  draft_id: string
+  drafted_by: string
+  product_key: string
+  review_text: string
+  create_price: CreatePriceDraft
+}
+
+export interface DraftRefusal {
+  code: string
+  reason: string
+  workaround: string
+}
+
+export interface CopilotDraft {
+  kind: "price_change" | "catalog_diff" | "refused"
+  price_change?: PriceChangeDraft
+  catalog_diff?: CatalogDiffDraft
+  refusal?: DraftRefusal
+}
+
+export interface CopilotAskResponse {
+  answer: string
+  evidence: CopilotEvidence[]
+  drafts?: CopilotDraft[]
+}
+
+// askCatalogCopilot: free-form catalog question -> LLM-run catalog/pricing
+// lookups + an answer, plus any drafts the model proposed. 501 when
+// llm.catalog_copilot_enabled / the LLM key are not configured.
+export const askCatalogCopilot = (question: string) =>
+  api<CopilotAskResponse>("/merchant/catalog/ask", { method: "POST", body: { question } })
+
+// confirmCopilotDraft: fire-and-forget audit-provenance log, called AFTER a
+// human has already confirmed a copilot-drafted change through the normal
+// wizard/create-price flow. Never a mutation itself.
+export const confirmCopilotDraft = (draftId: string, kind: string, priceKey?: string) =>
+  api<{ message: string }>("/merchant/catalog/copilot/confirm", {
+    method: "POST",
+    body: { draft_id: draftId, kind, price_key: priceKey },
+  })

--- a/web/admin/src/pages/catalog/copilot-panel.tsx
+++ b/web/admin/src/pages/catalog/copilot-panel.tsx
@@ -1,0 +1,249 @@
+// Catalog copilot (#779): free-form Q&A over the catalog/pricing/reprice
+// data, mirroring the dashboard's #756 Ask panel exactly (one-shot question,
+// answer + evidence). The ONLY additional surface is drafts (Phase 2,
+// flag-gated): the model never mutates anything — a draft only opens,
+// pre-filled, in the normal #777 wizard (price change) or a plain
+// create-price call (new tier) for a human to explicitly confirm.
+import * as React from "react"
+import { Loader2Icon, MessageCircleQuestionIcon, SparklesIcon, XIcon } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  askCatalogCopilot,
+  confirmCopilotDraft,
+  type CatalogDiffDraft,
+  type CopilotAskResponse,
+  type CopilotDraft,
+  type PriceChangeDraft,
+} from "@/lib/api/copilot"
+import { ApiError } from "@/lib/api/client"
+import { createPrice, getPriceByKey, getProduct } from "@/lib/api/endpoints"
+import type { CatalogPrice } from "@/lib/api/types"
+import { formatMicros } from "@/lib/format"
+import { toastApiError } from "@/lib/toast"
+import { PriceChangeWizard } from "@/pages/catalog/price-wizard"
+
+const DISABLED_MESSAGE =
+  "The catalog copilot needs explicit consent: set llm.catalog_copilot_enabled (env LLM_CATALOG_COPILOT_ENABLED=true) plus an LLM key (llm.api_key / env LLM_API_KEY) — answers send aggregate catalog/subscriber data to the LLM provider. See docs/admin-console.md."
+
+export function CatalogCopilotPanel({
+  enabled,
+  draftingEnabled,
+  onCatalogChanged,
+}: {
+  enabled: boolean
+  draftingEnabled: boolean
+  onCatalogChanged: () => void
+}) {
+  const [question, setQuestion] = React.useState("")
+  const [asking, setAsking] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  const [result, setResult] = React.useState<CopilotAskResponse | null>(null)
+
+  const ask = async () => {
+    const q = question.trim()
+    if (!q || asking) return
+    setAsking(true)
+    setError(null)
+    setResult(null) // one-shot: a new question replaces the previous answer
+    try {
+      setResult(await askCatalogCopilot(q))
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : "ask failed")
+    } finally {
+      setAsking(false)
+    }
+  }
+
+  if (!enabled) {
+    return (
+      <div className="text-muted-foreground rounded-xl border border-dashed p-4 text-xs">
+        <span className="text-foreground mr-1 font-medium">Catalog copilot:</span>
+        {DISABLED_MESSAGE}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border p-4">
+      <form
+        className="flex items-center gap-2"
+        onSubmit={(e) => {
+          e.preventDefault()
+          void ask()
+        }}
+      >
+        <MessageCircleQuestionIcon className="text-muted-foreground size-4 shrink-0" />
+        <Input
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          placeholder={
+            draftingEnabled
+              ? 'Ask about your catalog, or ask for a change — e.g. "who is still on the old premium price?" or "raise premium to $12"'
+              : 'Ask about your catalog — e.g. "what do we sell?" or "who is still on the old premium price?"'
+          }
+          className="flex-1"
+        />
+        <Button type="submit" size="sm" disabled={asking || !question.trim()}>
+          {asking ? <Loader2Icon className="size-3.5 animate-spin" /> : null}
+          Ask
+        </Button>
+      </form>
+
+      {asking ? <p className="text-muted-foreground text-xs">Checking your catalog…</p> : null}
+      {error ? <p className="text-destructive text-xs whitespace-pre-wrap">{error}</p> : null}
+
+      {result ? (
+        <div className="flex flex-col gap-3">
+          <div className="flex items-start justify-between gap-2">
+            <p className="text-sm whitespace-pre-wrap">{result.answer}</p>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-6 shrink-0"
+              aria-label="Dismiss answer"
+              onClick={() => {
+                setResult(null)
+                setError(null)
+              }}
+            >
+              <XIcon className="size-3.5" />
+            </Button>
+          </div>
+
+          {result.evidence.length > 0 && (
+            <div className="flex flex-col gap-2">
+              {result.evidence.map((ev, i) => (
+                <div key={i} className="bg-muted/30 rounded-lg border p-2">
+                  <span className="text-muted-foreground mb-1 block text-xs font-medium uppercase">{ev.tool}</span>
+                  <pre className="max-h-48 overflow-auto text-xs whitespace-pre-wrap">{ev.summary}</pre>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {result.drafts?.map((draft, i) => (
+            <DraftCard key={i} draft={draft} onCatalogChanged={onCatalogChanged} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function DraftCard({ draft, onCatalogChanged }: { draft: CopilotDraft; onCatalogChanged: () => void }) {
+  if (draft.kind === "refused" && draft.refusal) {
+    return (
+      <div className="rounded-lg border border-dashed p-3 text-xs">
+        <p className="mb-1 flex items-center gap-2 font-medium">
+          <Badge variant="secondary">refused: {draft.refusal.code}</Badge>
+        </p>
+        <p className="text-muted-foreground">{draft.refusal.reason}</p>
+        <p className="mt-1">{draft.refusal.workaround}</p>
+      </div>
+    )
+  }
+  if (draft.kind === "price_change" && draft.price_change) {
+    return <PriceChangeDraftCard draft={draft.price_change} onCatalogChanged={onCatalogChanged} />
+  }
+  if (draft.kind === "catalog_diff" && draft.catalog_diff) {
+    return <CatalogDiffDraftCard draft={draft.catalog_diff} onCatalogChanged={onCatalogChanged} />
+  }
+  return null
+}
+
+// PriceChangeDraftCard: "Review in wizard" fetches the live CatalogPrice +
+// product name, then opens the SAME #777 wizard used everywhere else,
+// pre-filled at Step 3 — the human reviews and clicks Confirm exactly as
+// they would for a hand-typed change.
+function PriceChangeDraftCard({ draft, onCatalogChanged }: { draft: PriceChangeDraft; onCatalogChanged: () => void }) {
+  const [reviewing, setReviewing] = React.useState(false)
+  const [price, setPrice] = React.useState<CatalogPrice | null>(null)
+  const [productName, setProductName] = React.useState("")
+  const [loading, setLoading] = React.useState(false)
+
+  const openWizard = async () => {
+    setLoading(true)
+    try {
+      const p = await getPriceByKey(draft.price_key)
+      const product = await getProduct(p.product_id)
+      setPrice(p)
+      setProductName(product.display_name)
+      setReviewing(true)
+    } catch (err) {
+      toastApiError(err, "Load draft for review")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="bg-muted/30 rounded-lg border p-3 text-sm">
+      <div className="mb-1 flex items-center gap-2">
+        <SparklesIcon className="text-muted-foreground size-3.5" />
+        <span className="text-muted-foreground text-xs font-medium uppercase">Draft: price change</span>
+        <Badge variant="secondary">{draft.direction}</Badge>
+      </div>
+      <p>{draft.review_text}</p>
+      <p className="text-muted-foreground mt-1 text-xs">
+        {formatMicros(draft.current_amount, draft.currency)} → {formatMicros(draft.new_amount, draft.currency)} ·{" "}
+        {draft.affected_count.toLocaleString()} affected · requires human confirm
+      </p>
+      {reviewing && price ? (
+        <PriceChangeWizard
+          price={price}
+          productName={productName}
+          draft={draft}
+          onDone={() => {
+            setReviewing(false)
+            onCatalogChanged()
+          }}
+        />
+      ) : (
+        <Button size="sm" className="mt-2" disabled={loading} onClick={openWizard}>
+          {loading ? "Loading…" : "Review in wizard"}
+        </Button>
+      )}
+    </div>
+  )
+}
+
+// CatalogDiffDraftCard: "Create this price" calls the SAME createPrice the
+// New Price form uses — a plain, explicit human confirm, never triggered by
+// the tool layer itself.
+function CatalogDiffDraftCard({ draft, onCatalogChanged }: { draft: CatalogDiffDraft; onCatalogChanged: () => void }) {
+  const [busy, setBusy] = React.useState(false)
+  const [created, setCreated] = React.useState(false)
+
+  const confirm = async () => {
+    setBusy(true)
+    try {
+      await createPrice(draft.create_price)
+      confirmCopilotDraft(draft.draft_id, "catalog_diff", draft.create_price.key).catch(() => {})
+      setCreated(true)
+      onCatalogChanged()
+    } catch (err) {
+      toastApiError(err, "Create drafted price")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="bg-muted/30 rounded-lg border p-3 text-sm">
+      <div className="mb-1 flex items-center gap-2">
+        <SparklesIcon className="text-muted-foreground size-3.5" />
+        <span className="text-muted-foreground text-xs font-medium uppercase">Draft: new price</span>
+      </div>
+      <p>{draft.review_text}</p>
+      <p className="text-muted-foreground mt-1 font-mono text-xs">
+        key: {draft.create_price.key} · {formatMicros(draft.create_price.unit_amount, draft.create_price.currency)}
+      </p>
+      <Button size="sm" className="mt-2" disabled={busy || created} onClick={confirm}>
+        {created ? "Created" : busy ? "Creating…" : "Create this price"}
+      </Button>
+    </div>
+  )
+}

--- a/web/admin/src/pages/catalog/index.tsx
+++ b/web/admin/src/pages/catalog/index.tsx
@@ -29,6 +29,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
 import { useApiData } from "@/hooks/use-api-data"
+import { getBootstrap } from "@/lib/api/client"
 import {
   activatePrice,
   activateProduct,
@@ -46,27 +47,56 @@ import {
 import type { CatalogPrice, CatalogProduct } from "@/lib/api/types"
 import { formatDate, formatMicros, microsFromInput, shortId } from "@/lib/format"
 import { toastApiError } from "@/lib/toast"
+import { CatalogCopilotPanel } from "@/pages/catalog/copilot-panel"
 import { priceIntervalLabel } from "@/pages/catalog/price-format"
 import { PriceChangeWizard } from "@/pages/catalog/price-wizard"
 
+function catalogCopilotEnabled(): boolean {
+  try {
+    return getBootstrap().catalog_copilot_enabled
+  } catch {
+    return false
+  }
+}
+
+function catalogDraftingEnabled(): boolean {
+  try {
+    return getBootstrap().catalog_drafting_enabled
+  } catch {
+    return false
+  }
+}
+
 export function CatalogPage() {
+  // Bumped whenever a copilot draft is confirmed, so the Products/Prices
+  // tabs refetch and reflect the change — the SAME reload path a hand-typed
+  // edit already triggers via each tab's own onDone.
+  const [refreshKey, setRefreshKey] = React.useState(0)
+
   return (
-    <Tabs defaultValue="products" className="flex flex-col gap-4">
-      <TabsList>
-        <TabsTrigger value="products">Products</TabsTrigger>
-        <TabsTrigger value="prices">Prices</TabsTrigger>
-        <TabsTrigger value="drift">Drift</TabsTrigger>
-      </TabsList>
-      <TabsContent value="products">
-        <ProductsTab />
-      </TabsContent>
-      <TabsContent value="prices">
-        <PricesTab />
-      </TabsContent>
-      <TabsContent value="drift">
-        <DriftTab />
-      </TabsContent>
-    </Tabs>
+    <div className="flex flex-col gap-4">
+      <CatalogCopilotPanel
+        enabled={catalogCopilotEnabled()}
+        draftingEnabled={catalogDraftingEnabled()}
+        onCatalogChanged={() => setRefreshKey((k) => k + 1)}
+      />
+      <Tabs defaultValue="products" className="flex flex-col gap-4">
+        <TabsList>
+          <TabsTrigger value="products">Products</TabsTrigger>
+          <TabsTrigger value="prices">Prices</TabsTrigger>
+          <TabsTrigger value="drift">Drift</TabsTrigger>
+        </TabsList>
+        <TabsContent value="products">
+          <ProductsTab key={refreshKey} />
+        </TabsContent>
+        <TabsContent value="prices">
+          <PricesTab key={refreshKey} />
+        </TabsContent>
+        <TabsContent value="drift">
+          <DriftTab />
+        </TabsContent>
+      </Tabs>
+    </div>
   )
 }
 

--- a/web/admin/src/pages/catalog/price-wizard.tsx
+++ b/web/admin/src/pages/catalog/price-wizard.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { confirmCopilotDraft, type PriceChangeDraft } from "@/lib/api/copilot"
 import { createPrice, getMerchantSettings, previewRepriceAllPriorVersions, repriceAllPriorVersions } from "@/lib/api/endpoints"
 import type { CatalogPrice } from "@/lib/api/types"
 import { formatMicros, microsFromInput } from "@/lib/format"
@@ -37,22 +38,35 @@ const toDateInputValue = (d: Date) => d.toISOString().slice(0, 10)
 // plan (direction-aware defaults, live affected-count preview, notice-window
 // gate on increase+migrate) -> review in words, then confirm applies the
 // catalog price update followed (if migrating) by the reprice schedule.
+//
+// draft (#779): when the catalog copilot proposed this change, the dialog
+// opens PRE-FILLED straight at Step 3 (review) — the affected count already
+// rode in the draft, so no extra preview call is needed. Confirm behaves
+// EXACTLY as a hand-typed change (same createPrice/repriceAllPriorVersions
+// calls); the only addition is a best-effort audit-provenance log after
+// success, never before, never blocking the real confirm.
 export function PriceChangeWizard({
   price,
   productName,
+  draft,
   onDone,
 }: {
   price: CatalogPrice
   productName: string
+  draft?: PriceChangeDraft
   onDone: () => void
 }) {
-  const [open, setOpen] = React.useState(false)
-  const [step, setStep] = React.useState<1 | 2 | 3>(1)
-  const [amountInput, setAmountInput] = React.useState(() => String(price.unit_amount / 1_000_000))
-  const [mode, setMode] = React.useState<MigrationMode>("grandfather")
-  const [effectiveAt, setEffectiveAt] = React.useState("")
+  const [open, setOpen] = React.useState(() => !!draft)
+  const [step, setStep] = React.useState<1 | 2 | 3>(() => (draft ? 3 : 1))
+  const [amountInput, setAmountInput] = React.useState(() =>
+    String((draft?.new_amount ?? price.unit_amount) / 1_000_000),
+  )
+  const [mode, setMode] = React.useState<MigrationMode>(() => draft?.migration_mode ?? "grandfather")
+  const [effectiveAt, setEffectiveAt] = React.useState(() =>
+    draft?.reprice ? toDateInputValue(new Date(draft.reprice.effective_at)) : "",
+  )
   const [previewLoading, setPreviewLoading] = React.useState(false)
-  const [affectedCount, setAffectedCount] = React.useState<number | null>(null)
+  const [affectedCount, setAffectedCount] = React.useState<number | null>(draft?.affected_count ?? null)
   const [busy, setBusy] = React.useState(false)
   // #781: the merchant-configurable notice window, read from the API (the
   // console used to hard-code 30 days here; the server is now the actual
@@ -137,6 +151,11 @@ export function PriceChangeWizard({
       } else {
         toast.success(mode === "migrate" ? "Price updated and migration scheduled" : "Price updated")
       }
+      // Best-effort audit-provenance log: fires AFTER the real confirm above
+      // already succeeded, never blocks or affects it.
+      if (draft) {
+        confirmCopilotDraft(draft.draft_id, "price_change", price.key).catch(() => {})
+      }
       handleOpenChange(false)
       onDone()
     } catch (err) {
@@ -148,14 +167,19 @@ export function PriceChangeWizard({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogTrigger asChild>
-        <Button variant="outline" size="sm">
-          Change price
-        </Button>
-      </DialogTrigger>
+      {!draft && (
+        <DialogTrigger asChild>
+          <Button variant="outline" size="sm">
+            Change price
+          </Button>
+        </DialogTrigger>
+      )}
       <DialogContent className="max-w-lg">
         <DialogHeader>
-          <DialogTitle>Change price — {productName}</DialogTitle>
+          <DialogTitle className="flex items-center gap-2">
+            Change price — {productName}
+            {draft && <Badge variant="secondary">drafted by copilot</Badge>}
+          </DialogTitle>
           <DialogDescription>
             Step {step} of 3: {step === 1 ? "new amount" : step === 2 ? "migration plan" : "review"}
           </DialogDescription>


### PR DESCRIPTION
## Summary

Extends the console's existing LLM surface (#741 NL widgets, #756 metrics Ask, #761 providers) from METRICS to the CATALOG, per the AXI agent-native design (github.com/kunchenguid/axi): lean 3-4 field projections, inline aggregates, explicit empty states, typed errors with corrective next steps, next-step hints ending every tool result, token-compact rendering, content-first context pack.

- **Phase 1 — catalog Q&A (complete, enabled)**: new `internal/modules/copilot` package + `POST /v1/merchant/catalog/ask`. Tools: `list_catalog` (products + current prices, 3-4 fields, inline active-subscriber + grandfathered counts), `get_price` (full detail drill-down), `price_history` (the #774 pointer-movement log, most-recent-first, per-version subscriber counts), `list_reprice_batches` (pending migrations with progress). Gated on its own consent flag `llm.catalog_copilot_enabled` (env `LLM_CATALOG_COPILOT_ENABLED`) + rate limiter, mirroring #756's data-flow-consent doctrine exactly.
- **Phase 2 — drafting (built, flag-gated off)**: `draft_price_change` (a #777 wizard payload: version bump + migration plan, direction-aware defaults, affected-count preview inline) and `draft_catalog_diff` (a new-tier create-price proposal). Gated behind `llm.catalog_drafting_enabled`, which **must stay off until #781 merges** — the copilot's safety story is "the API refuses what the wizard would refuse", which depends on #781's server-side notice-window enforcement. Flag-off means the `draft_*` tools are absent from the tool list entirely (never present-but-erroring). The model never mutates: every draft is a proposal shaped exactly like the human confirm flow, carrying a `drafted-by-copilot` marker; the console opens it pre-filled at the wizard's review step (or a plain create-price confirm) for a human to explicitly confirm. A cross-product/cross-currency request (#778 boundary) is refused with a typed code + workaround, never drafted.
- **Doctrine prompt**: tight system-prompt text assembled from the 2026-07-07 tracker rulings (grandfather/pin semantics, mutate-vs-new-product idiom, direction defaults, the #778 cross-product boundary) — the AXI tool results carry most of the intelligence, so this stays short.
- **Console**: a copilot panel on the Catalog page (mirrors the dashboard's Ask panel); `PriceChangeWizard` gained an optional `draft` prop to open pre-filled at Step 3 and log confirm provenance afterward.

## Test plan

- [x] 24 unit tests in `internal/modules/copilot` (fake catalog/subscription/reprice readers + a scripted LLM): inline aggregates, explicit empty states, most-recent-first history, migration progress, tool-call budget/loop mechanics, content-first system prompt, direction-default drafts, cross-product/cross-currency refusals with workaround text, flag-off tool-list exclusion.
- [x] `internal/integrationharness/catalog_copilot_http_test.go` against real Postgres+Redis: fail-closed consent gating (both knobs named), `config.json` flags, real active/grandfathered counts from seeded subscriptions, a valid `draft_price_change` payload with a real affected-count preview, a refused cross-product draft (never creates a reprice batch), the confirm-provenance endpoint, flag-off absence, and 2-merchant RLS isolation.
- [x] `gofmt` / `go vet` / `go vet -tags=integration` clean; `go build ./...` and `go build -tags console_assets ./...` clean; `go test ./...` green.
- [x] `-tags=integration` green on `internal/integrationharness` (full package, incl. regenerated #670 route-surface golden), `internal/modules/dashboard`, `internal/modules/catalog`, `internal/modules/subscriptions`, `internal/modules/copilot`, `config`, `internal/http`, `pkg/service`.
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm build` clean in `web/admin` (one pre-existing TanStack warning, unrelated).
- Known pre-existing, unrelated: `go test -tags=integration ./tests` is red on this branch's base with the `uq_prices_merchant_key_current` fixture collision documented in #781's own progress notes (already fixed on their branch, not yet merged to master as of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)