### PR TITLE
import: enqueue the real nmi_delete intent inline; drop marker-only scheduler

### DIFF
--- a/internal/billingimport/billingimport.go
+++ b/internal/billingimport/billingimport.go
@@ -28,6 +28,7 @@ import (
 	"github.com/open-rails/openrails/config"
 	"github.com/open-rails/openrails/internal/db"
 	"github.com/open-rails/openrails/internal/db/gen"
+	"github.com/open-rails/openrails/internal/intents"
 	"github.com/open-rails/openrails/internal/modules/subscriptions"
 	"github.com/open-rails/openrails/internal/reconcile"
 	"github.com/open-rails/openrails/pkg/merchant"
@@ -180,11 +181,12 @@ func Import(ctx context.Context, opts Options) (Result, error) {
 	// Lifecycle clock pinned at AsOf: every lifecycle write (ended_at, grace,
 	// updated_at) is dated at the horizon — deterministic re-runs.
 	lc := subscriptions.NewSubscriptionLifecycleService(database, nil, nil, nil, nil, nil, clockwork.NewFakeClockAt(asOf))
-	// The import seam has no River producer to enqueue an nmi_delete intent
-	// inline, but a terminal cancel through the decider (ResolveCancelledRemoteAlive)
-	// must still leave the DeletionScheduledAt marker durably — see
-	// markerOnlyDeferredDelete below.
-	lc.SetDeferredDeleteScheduler(markerOnlyDeferredDelete{})
+	// A terminal cancel through the decider (ResolveCancelledRemoteAlive) must
+	// durably record the owed remote NMI delete. Enqueue the real ledger intent
+	// inline, same as the runtime producers — user-origin (these are the source
+	// system's user cancellations; system-origin would park under mode=limited),
+	// no rate ceiling (batch declaration of settled facts, not self-service).
+	lc.SetDeferredDeleteScheduler(intents.NewNMIDeleteScheduler(database, nil, intents.OriginUser, "billing-import terminal cancel, remote may be alive"))
 
 	err = database.RunInMerchantConn(ctx, func(ctx context.Context) error {
 		qx := database.Qx(ctx)
@@ -340,31 +342,6 @@ func Import(ctx context.Context, opts Options) (Result, error) {
 		return nil
 	})
 	return res, err
-}
-
-// markerOnlyDeferredDelete implements subscriptions.DeferredDeleteScheduler
-// by doing nothing beyond letting the caller stamp DeletionScheduledAt: it
-// exists only so the `s.deferDelete != nil` gate in ResolveUnknownSubscription
-// passes, so a terminal import-time cancel where the remote NMI schedule may
-// still be retrying leaves the marker on disk instead of losing it to a WARN
-// log. There is no River producer in the import path to enqueue an
-// nmi_delete intent inline — the marker alone is enough: the host's boot
-// sweep (app.ConvertDeferredDeleteMarkersToIntents) already exists precisely
-// to pick up out-of-band markers (direct-DB imports, #391) and convert them
-// to durable intents on the next boot. Doctrine: the marker means "remote
-// schedule may still be live; dispose when armed", never "already deleted".
-type markerOnlyDeferredDelete struct{}
-
-func (markerOnlyDeferredDelete) ScheduleNMIDelete(context.Context, string, uuid.UUID, time.Time) error {
-	return nil
-}
-
-func (markerOnlyDeferredDelete) CancelNMIDelete(context.Context, string, uuid.UUID) error {
-	return nil
-}
-
-func (m markerOnlyDeferredDelete) WithTx(pgx.Tx) subscriptions.DeferredDeleteScheduler {
-	return m
 }
 
 // openDB wraps a caller pool (borrowed; Close is a no-op) or opens from config.

--- a/pkg/embedded/billing_import_integration_test.go
+++ b/pkg/embedded/billing_import_integration_test.go
@@ -284,8 +284,8 @@ func TestImportBilling_DeclaredBookClassifiesAtAsOf(t *testing.T) {
 	// decider's "roster_past_due_beyond_window" law lands TransitionCancel with
 	// RemoteGone=false (the remote NMI schedule may still be retrying), so
 	// ResolveCancelledRemoteAlive fires: terminal cancel dated at the NEW AsOf,
-	// entitlement window closed, and — #737 Task 1's marker-only scheduler —
-	// the DeletionScheduledAt marker durably armed for NMI's boot sweep.
+	// entitlement window closed, the DeletionScheduledAt marker stamped, and
+	// the real nmi_delete_subscription ledger intent enqueued inline.
 	var subIncrID uuid.UUID
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
 		if err := appDB.Qx(ctx).QueryRow(ctx,
@@ -323,6 +323,16 @@ func TestImportBilling_DeclaredBookClassifiesAtAsOf(t *testing.T) {
 		require.True(t, r.endedAt.Equal(asOf2), "ended_at = the NEW import's AsOf, not the first")
 		require.NotNil(t, r.deletionScheduledAt, "NMI terminal cancel with remote possibly still alive arms the deferred-delete marker (#737 Task 1)")
 		require.True(t, r.deletionScheduledAt.Equal(asOf2))
+
+		// The import enqueues the real nmi_delete_subscription ledger intent
+		// inline (no reliance on the boot marker sweep).
+		var intentStatus, intentOrigin string
+		require.NoError(t, appDB.Qx(ctx).QueryRow(ctx,
+			`SELECT status, origin FROM openrails.rail_intents
+			 WHERE subscription_id=$1 AND intent_type='nmi_delete_subscription'`, subIncrID).
+			Scan(&intentStatus, &intentOrigin))
+		require.Equal(t, "pending", intentStatus)
+		require.Equal(t, "user", intentOrigin)
 
 		var revokedAt *time.Time
 		var revokeReason *string


### PR DESCRIPTION
Follow-up to #135, per Paul's review: the marker-only scheduler + boot-sweep dependence was stale doctrine. Since #358/#679 the deferred NMI delete is a durable `rail_intents` ledger row — no River producer needed — so the import seam enqueues the REAL intent inline, exactly like the runtime producers (user-origin, matching `ConvertDeferredDeleteMarkersToIntents`' converted-marker semantics; nil rate ceiling — batch declaration of settled facts).

Marker + intent land together; the import path no longer relies on the out-of-band boot sweep in any way.

Verified: build, vet, `TestImportBilling_DeclaredBookClassifiesAtAsOf` green — now also asserts the pending `nmi_delete_subscription` intent row (user-origin) exists after the import-time terminal cancel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)