### PR TITLE
import: book-declared live schedules arm the real delete intent; atomic decider enqueue

### DIFF
--- a/internal/billingimport/billingimport.go
+++ b/internal/billingimport/billingimport.go
@@ -69,6 +69,11 @@ type PaymentMethodRef struct {
 type CancelEvidence struct {
 	Kind string    `json:"kind,omitempty"`
 	At   time.Time `json:"at,omitempty"`
+	// ScheduleLive: the provider-side recurring schedule was NOT confirmed dead
+	// at AsOf (e.g. a legacy NMI schedule that may keep rebilling after the
+	// cancel). For rails with RemoteDeleteOnTerminalCancel the import stamps
+	// DeletionScheduledAt and enqueues the deferred delete intent atomically.
+	ScheduleLive bool `json:"schedule_live,omitempty"`
 }
 
 // DunningEvidence is the host's legacy dunning state at AsOf.
@@ -181,12 +186,14 @@ func Import(ctx context.Context, opts Options) (Result, error) {
 	// Lifecycle clock pinned at AsOf: every lifecycle write (ended_at, grace,
 	// updated_at) is dated at the horizon — deterministic re-runs.
 	lc := subscriptions.NewSubscriptionLifecycleService(database, nil, nil, nil, nil, nil, clockwork.NewFakeClockAt(asOf))
-	// A terminal cancel through the decider (ResolveCancelledRemoteAlive) must
-	// durably record the owed remote NMI delete. Enqueue the real ledger intent
-	// inline, same as the runtime producers — user-origin (these are the source
-	// system's user cancellations; system-origin would park under mode=limited),
-	// no rate ceiling (batch declaration of settled facts, not self-service).
-	lc.SetDeferredDeleteScheduler(intents.NewNMIDeleteScheduler(database, nil, intents.OriginUser, "billing-import terminal cancel, remote may be alive"))
+	// A terminal cancel — through the decider (ResolveCancelledRemoteAlive) or
+	// declared explicitly with a live remote schedule — must durably record the
+	// owed remote NMI delete. Enqueue the real ledger intent inline, same as the
+	// runtime producers — user-origin (these are the source system's user
+	// cancellations; system-origin would park under mode=limited), no rate
+	// ceiling (batch declaration of settled facts, not self-service).
+	deferDelete := intents.NewNMIDeleteScheduler(database, nil, intents.OriginUser, "billing-import terminal cancel, remote may be alive")
+	lc.SetDeferredDeleteScheduler(deferDelete)
 
 	err = database.RunInMerchantConn(ctx, func(ctx context.Context) error {
 		qx := database.Qx(ctx)
@@ -289,6 +296,7 @@ func Import(ctx context.Context, opts Options) (Result, error) {
 				PaidThrough:           s.PaidThrough,
 				CancelKind:            reconcile.DeclaredCancelKind(s.Cancel.Kind),
 				CancelAt:              s.Cancel.At,
+				CancelScheduleLive:    s.Cancel.ScheduleLive,
 				Evidence:              s.Evidence,
 			}
 			if s.Dunning != nil {
@@ -321,7 +329,7 @@ func Import(ctx context.Context, opts Options) (Result, error) {
 			facts = append(facts, f)
 		}
 
-		outcomes, err := reconcile.ImportDeclaredSubscriptions(ctx, database, lc, merchantID.UUID(), facts, txns, opts.Book.SubscriptionsExhaustive, asOf)
+		outcomes, err := reconcile.ImportDeclaredSubscriptions(ctx, database, lc, deferDelete, merchantID.UUID(), facts, txns, opts.Book.SubscriptionsExhaustive, asOf)
 		if err != nil {
 			return err
 		}

--- a/internal/modules/subscriptions/lifecycle_service.go
+++ b/internal/modules/subscriptions/lifecycle_service.go
@@ -1502,9 +1502,7 @@ func (s *SubscriptionLifecycleService) ResolveUnknownSubscription(ctx context.Co
 		fb := "cancelled at provider (converged from unknown)"
 		// #679 queue-always: the remote sub may still exist and keep retrying
 		// (stale decline, roster didn't confirm gone) — durably record the
-		// deferred NMI delete like FailMembership. Marker persists with the
-		// cancellation UPDATE; a failed enqueue is healed by the startup
-		// marker sweep (ConvertDeferredDeleteMarkersToIntents).
+		// deferred NMI delete like FailMembership.
 		scheduleDelete := false
 		if res == ResolveCancelledRemoteAlive {
 			fb = "renewal declined beyond dunning window (converged from unknown)"
@@ -1521,26 +1519,26 @@ func (s *SubscriptionLifecycleService) ResolveUnknownSubscription(ctx context.Co
 				}
 			}
 		}
-		if err := s.ApplyLocalCancellation(ctx, dbb, sub, LocalCancellation{
+		lcArgs := LocalCancellation{
 			EndedAt:       now,
 			CancelType:    models.CancelTypeExpired,
 			Feedback:      &fb,
 			RevokeReason:  models.EntitlementRevokeDunning,
 			RevokeAsOf:    asOf,
 			RevokeSources: []models.EntitlementSourceType{models.EntitlementSourceSubscription, models.EntitlementSourceGrace},
-		}); err != nil {
-			return err
 		}
-		if scheduleDelete {
-			if err := s.deferDelete.ScheduleNMIDelete(ctx, sub.CustomerID.String(), sub.ID, now); err != nil {
-				// Marker committed with the cancellation keeps the pending
-				// delete discoverable (startup marker sweep) — log, don't fail.
-				log.WithContext(ctx).WithError(err).WithFields(log.Fields{
-					"subscription_id": sub.ID,
-				}).Error("failed to enqueue deferred NMI delete for unknown-resolution cancel; startup marker sweep will convert the marker")
+		if !scheduleDelete {
+			return s.ApplyLocalCancellation(ctx, dbb, sub, lcArgs)
+		}
+		// Marker + intent commit atomically, same invariant as FailMembership:
+		// no crash window between the cancellation UPDATE and the enqueue.
+		return dbb.RunInTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+			txdb := db.NewWithPgxTx(tx)
+			if err := s.ApplyLocalCancellation(ctx, txdb, sub, lcArgs); err != nil {
+				return err
 			}
-		}
-		return nil
+			return s.deferDelete.WithTx(tx).ScheduleNMIDelete(ctx, sub.CustomerID.String(), sub.ID, now)
+		})
 	default:
 		return fmt.Errorf("resolve unknown: unknown resolution %d", res)
 	}

--- a/internal/reconcile/declared_import.go
+++ b/internal/reconcile/declared_import.go
@@ -13,6 +13,7 @@ import (
 	"github.com/open-rails/openrails/internal/db"
 	"github.com/open-rails/openrails/internal/db/gen"
 	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/modules/payments/rails"
 	"github.com/open-rails/openrails/internal/modules/subscriptions"
 )
 
@@ -55,6 +56,7 @@ type DeclaredSubscriptionFact struct {
 	PaidThrough           *time.Time // last paid-through evidence (legacy expiration)
 	CancelKind            DeclaredCancelKind
 	CancelAt              time.Time // required when CancelKind != none
+	CancelScheduleLive    bool      // provider-side recurring schedule NOT confirmed dead at AsOf
 	DunningLive           bool      // legacy dunning schedule still live at AsOf
 	DunningRetries        int       // legacy retry count → retry_attempts (forensics)
 	DunningLastRetryAt    *time.Time
@@ -89,6 +91,7 @@ func ImportDeclaredSubscriptions(
 	ctx context.Context,
 	database *db.DB,
 	lc *subscriptions.SubscriptionLifecycleService,
+	deferDelete subscriptions.DeferredDeleteScheduler,
 	merchantID uuid.UUID,
 	facts []DeclaredSubscriptionFact,
 	txns []RemoteTransaction,
@@ -256,6 +259,25 @@ func ImportDeclaredSubscriptions(
 			// pass, but money truth still lands.
 			if _, err := backfillSubscriptionPayments(ctx, q, sub, subscriptionTxns(txns, f.RailSubscriptionID), asOf, declaredImportLookback); err != nil {
 				return out, fmt.Errorf("declared import: backfill %s: %w", f.SourceID, err)
+			}
+			// Declared cancelled but the provider-side schedule was not confirmed
+			// dead at AsOf: record the owed remote delete exactly like the runtime
+			// producers — DeletionScheduledAt marker + nmi_delete intent in ONE
+			// transaction (no crash window, no out-of-band healing needed).
+			if f.CancelScheduleLive && deferDelete != nil &&
+				rails.RemoteDeleteOnTerminalCancel(models.Rail(f.Rail)) {
+				if err := database.RunInTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+					if _, err := tx.Exec(ctx,
+						`UPDATE openrails.subscriptions
+						 SET deletion_scheduled_at = $1, updated_at = $1
+						 WHERE id = $2 AND deletion_scheduled_at IS NULL`,
+						asOf, subID); err != nil {
+						return err
+					}
+					return deferDelete.WithTx(tx).ScheduleNMIDelete(ctx, f.Customer.String(), subID, asOf)
+				}); err != nil {
+					return out, fmt.Errorf("declared import: schedule remote delete for %s: %w", f.SourceID, err)
+				}
 			}
 		} else {
 			// Fresh ambiguous rows AND every pre-existing row (incremental

--- a/pkg/embedded/billing_import_integration_test.go
+++ b/pkg/embedded/billing_import_integration_test.go
@@ -39,8 +39,8 @@ func TestImportBilling_DeclaredBookClassifiesAtAsOf(t *testing.T) {
 	day := 24 * time.Hour
 
 	cust := func() uuid.UUID { return uuid.New() }
-	cRunway, cDunning, cLapsed, cUser, cChargeback, cParked, cIncr := cust(), cust(), cust(), cust(), cust(), cust(), cust()
-	allCust := []uuid.UUID{cRunway, cDunning, cLapsed, cUser, cChargeback, cParked, cIncr}
+	cRunway, cDunning, cLapsed, cUser, cUserNMI, cChargeback, cParked, cIncr := cust(), cust(), cust(), cust(), cust(), cust(), cust(), cust()
+	allCust := []uuid.UUID{cRunway, cDunning, cLapsed, cUser, cUserNMI, cChargeback, cParked, cIncr}
 
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
 		_, e := appDB.Qx(ctx).Exec(ctx,
@@ -81,8 +81,8 @@ func TestImportBilling_DeclaredBookClassifiesAtAsOf(t *testing.T) {
 	book := DeclaredBilling{
 		AsOf: asOf,
 		Customers: []DeclaredCustomer{
-			{Customer: cRunway}, {Customer: cDunning}, {Customer: cLapsed},
-			{Customer: cUser}, {Customer: cChargeback}, {Customer: cParked}, {Customer: cIncr},
+			{Customer: cRunway}, {Customer: cDunning}, {Customer: cLapsed}, {Customer: cUser},
+			{Customer: cUserNMI}, {Customer: cChargeback}, {Customer: cParked}, {Customer: cIncr},
 		},
 		PaymentMethods: []DeclaredPaymentMethod{{
 			Customer: cDunning, Rail: "nmi", RailCustomerRef: "vault-" + sfx, RailMethodRef: "",
@@ -109,6 +109,14 @@ func TestImportBilling_DeclaredBookClassifiesAtAsOf(t *testing.T) {
 				SourceID: "usercancel", Customer: cUser, Price: price, Rail: "ccbill",
 				RailSubscriptionID: "sub-user-" + sfx, StartedAt: asOf.Add(-90 * day), PaidThrough: &userPaidThrough,
 				Cancel: CancelEvidence{Kind: "user_cancelled", At: userCancelAt},
+			},
+			{
+				// Explicit user cancel on NMI whose legacy schedule was NOT
+				// confirmed dead at AsOf: the import must arm the marker AND
+				// enqueue the real delete intent (no boot-sweep reliance).
+				SourceID: "usercancel-nmi-live", Customer: cUserNMI, Price: price, Rail: "nmi",
+				RailSubscriptionID: "sub-user-nmi-" + sfx, StartedAt: asOf.Add(-90 * day), PaidThrough: &userPaidThrough,
+				Cancel: CancelEvidence{Kind: "user_cancelled", At: userCancelAt, ScheduleLive: true},
 			},
 			{
 				SourceID: "chargeback", Customer: cChargeback, Price: price, Rail: "nmi",
@@ -142,7 +150,7 @@ func TestImportBilling_DeclaredBookClassifiesAtAsOf(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Empty(t, res.Blocked, "no blocks expected: %v", res.Reasons)
-	require.ElementsMatch(t, []string{"runway", "dunning", "lapsed", "usercancel", "chargeback", "parked", "incremental"}, res.Imported)
+	require.ElementsMatch(t, []string{"runway", "dunning", "lapsed", "usercancel", "usercancel-nmi-live", "chargeback", "parked", "incremental"}, res.Imported)
 
 	type subRow struct {
 		status, cancelType             string
@@ -207,6 +215,27 @@ func TestImportBilling_DeclaredBookClassifiesAtAsOf(t *testing.T) {
 		require.NotNil(t, r.endedAt)
 		require.True(t, r.endedAt.Equal(userPaidThrough), "cancel-with-runway keeps the paid-through end")
 
+		// 4b) Declared user cancel on NMI with a live legacy schedule: marker
+		// stamped at AsOf AND the real delete intent enqueued atomically.
+		// The ccbill twin above gets NEITHER (no remote delete on that rail).
+		r = load(ctx, "sub-user-nmi-"+sfx)
+		require.Equal(t, "cancelled", r.status)
+		require.Equal(t, "user", r.cancelType, "declared kind stays faithful — marker never rewrites history")
+		require.NotNil(t, r.deletionScheduledAt, "ScheduleLive arms the deferred-delete marker")
+		require.True(t, r.deletionScheduledAt.Equal(asOf))
+		var nmiSubID uuid.UUID
+		require.NoError(t, appDB.Qx(ctx).QueryRow(ctx,
+			`SELECT id FROM openrails.subscriptions WHERE rail_subscription_id=$1`, "sub-user-nmi-"+sfx).Scan(&nmiSubID))
+		var declStatus, declOrigin string
+		require.NoError(t, appDB.Qx(ctx).QueryRow(ctx,
+			`SELECT status, origin FROM openrails.rail_intents
+			 WHERE subscription_id=$1 AND intent_type='nmi_delete_subscription'`, nmiSubID).
+			Scan(&declStatus, &declOrigin))
+		require.Equal(t, "pending", declStatus)
+		require.Equal(t, "user", declOrigin)
+		r = load(ctx, "sub-user-"+sfx)
+		require.Nil(t, r.deletionScheduledAt, "ccbill cancel: no remote-delete marker")
+
 		// 5) Chargeback: faithful type.
 		r = load(ctx, "sub-cb-"+sfx)
 		require.Equal(t, "cancelled", r.status)
@@ -237,7 +266,7 @@ func TestImportBilling_DeclaredBookClassifiesAtAsOf(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, res2.Imported)
 	require.Empty(t, res2.Blocked, "re-import blocks: %v", res2.Reasons)
-	require.ElementsMatch(t, []string{"runway", "dunning", "lapsed", "usercancel", "chargeback", "parked", "incremental"}, res2.Skipped)
+	require.ElementsMatch(t, []string{"runway", "dunning", "lapsed", "usercancel", "usercancel-nmi-live", "chargeback", "parked", "incremental"}, res2.Skipped)
 
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
 		var n int


### PR DESCRIPTION
Steps 1+3 of retiring the boot marker sweep (per Paul):

1. **`CancelEvidence.ScheduleLive`** — explicitly-cancelled declared subscriptions whose provider-side schedule wasn't confirmed dead at AsOf now get the `DeletionScheduledAt` marker AND the real `nmi_delete_subscription` intent in one transaction. This replaces doujins legacy-migrate's direct-DB marker stamp (which relied on the boot sweep to convert).
2. **Transactional decider enqueue** — `ResolveCancelledRemoteAlive` commits the cancellation UPDATE + intent enqueue atomically (`WithTx`, same invariant as `FailMembership`), removing the enqueue-after-commit crash window the sweep existed to heal.

After doujins switches to the book field, `ConvertDeferredDeleteMarkersToIntents` has no remaining producer and is deleted in a follow-up PR.

Verified: build, vet, `TestImportBilling*` (new NMI ScheduleLive fixture asserts marker at AsOf + pending user-origin intent; ccbill negative case), full `internal/reconcile` + `internal/modules/subscriptions` integration suites green. (`TestReconcileAdoptPreservesScheduledProviderActions` fails identically on unmodified master — pre-existing fixture flake, not this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)