### PR TITLE
delete the boot marker sweep; make the admin findings cancel atomic

### DIFF
--- a/internal/app/deferred_delete_scheduler.go
+++ b/internal/app/deferred_delete_scheduler.go
@@ -1,17 +1,8 @@
 package app
 
 import (
-	"context"
-	"fmt"
-	"strings"
-	"time"
-
-	log "github.com/sirupsen/logrus"
-
 	"github.com/open-rails/openrails/internal/db"
-	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/intents"
-	"github.com/open-rails/openrails/internal/modules/payments/rails"
 	"github.com/open-rails/openrails/internal/modules/subscriptions"
 )
 
@@ -19,90 +10,11 @@ import (
 // NMI delete scheduler. The implementation moved to intents.NMIDeleteScheduler
 // (#679) so the unknown-reconcile path and tests can construct the REAL
 // production scheduler; this shim keeps the composition root unchanged.
+//
+// Every producer writes the DeletionScheduledAt marker and the nmi_delete
+// intent in ONE transaction (runtime paths since #679/#138; the DeclaredBilling
+// import since #138), so marker and intent cannot diverge — the old
+// out-of-band startup marker sweep is gone.
 func newIntentDeferredDeleteScheduler(d *db.DB, ceiling *intents.RateCeiling, origin intents.Origin, reason string) subscriptions.DeferredDeleteScheduler {
 	return intents.NewNMIDeleteScheduler(d, ceiling, origin, reason)
-}
-
-// ConvertDeferredDeleteMarkersToIntents is the startup sweep that converts
-// any cancelled subscription still carrying a DeletionScheduledAt marker
-// WITHOUT a live intent into a durable nmi_delete_subscription intent (the
-// marker stays, as the read model, until the intent's finalize clears it).
-//
-// In steady state this finds nothing: the producers write marker + intent in
-// ONE transaction, so they cannot diverge. The sweep exists for markers
-// written OUT OF BAND — above all direct-DB imports (the doujins legacy
-// migration stamps deletion_scheduled_at on imported void subscriptions,
-// #391, and this sweep is what turns them into delete intents on the next
-// boot). Idempotent via the intent idempotency_key. Each intent is due at
-// max(now, DeletionScheduledAt): a still-open undo window is honored,
-// anything overdue runs on the executor's next pass.
-//
-// Converted markers are enqueued user-origin: the pre-ledger delete job
-// executed under mode=limited (only the kill switch gated it), and most
-// markers are user cancellations' undo windows — system-origin would park
-// them under limited and silently change behavior.
-func (r *Runtime) ConvertDeferredDeleteMarkersToIntents(ctx context.Context) (int, error) {
-	if r == nil || r.DB == nil {
-		return 0, nil
-	}
-
-	rows, err := r.DB.Gen(ctx).ListPendingDeletionScheduledSubscriptions(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("list pending deferred-delete markers: %w", err)
-	}
-	if len(rows) == 0 {
-		log.Info("Deferred-delete marker sweep: no pending markers")
-		return 0, nil
-	}
-
-	now := time.Now().UTC()
-	if r.Clock != nil {
-		now = r.Clock.Now().UTC()
-	}
-	store := intents.NewStore(r.DB)
-
-	converted := 0
-	for _, sub := range rows {
-		if !rails.IsNMI(models.Rail(sub.Rail)) {
-			// Only NMI-backed paths set the marker; skip defensively (the
-			// marker stays discoverable for #107 reconciliation).
-			log.WithFields(log.Fields{
-				"subscription_id": sub.ID,
-				"rail":            sub.Rail,
-			}).Warn("Deferred-delete marker sweep: skipping non-NMI-backed subscription with deletion marker")
-			continue
-		}
-		runAt := now
-		if sub.DeletionScheduledAt != nil && sub.DeletionScheduledAt.After(now) {
-			runAt = sub.DeletionScheduledAt.UTC()
-		}
-		subID := sub.ID
-		_, err := store.Enqueue(ctx, intents.EnqueueParams{
-			MerchantID:     sub.MerchantID,
-			Provider:       strings.ToLower(sub.Rail),
-			IntentType:     intents.TypeNMIDeleteSubscription,
-			SubscriptionID: &subID,
-			Payload: intents.NMIDeletePayload{
-				UserID:             sub.CustomerID.String(),
-				RailSubscriptionID: sub.RailSubscriptionID,
-			},
-			IdempotencyKey: intents.NMIDeleteIdempotencyKey(subID),
-			NextAttemptAt:  runAt,
-			Origin:         intents.OriginUser,
-			OriginReason:   "deferred-delete marker conversion (startup sweep)",
-		})
-		if err != nil {
-			log.WithError(err).WithFields(log.Fields{
-				"subscription_id": sub.ID,
-			}).Error("Deferred-delete marker sweep: failed to enqueue intent")
-			continue
-		}
-		converted++
-	}
-
-	log.WithFields(log.Fields{
-		"pending":   len(rows),
-		"converted": converted,
-	}).Info("Deferred-delete marker sweep completed")
-	return converted, nil
 }

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -366,18 +366,6 @@ func (r *Runtime) RunWorkers(ctx context.Context) error {
 		go r.SolanaPayPoller.Start(ctx)
 	}
 
-	// Startup sweep (#358): convert deletion markers that exist WITHOUT a
-	// live intent — in steady state none exist (producers write marker +
-	// intent in one transaction); this heals markers written out of band,
-	// chiefly direct-DB legacy imports (#391). Idempotent: markers already
-	// on the ledger are a no-op. Pure DB work, so it runs in both the
-	// in-process and external River wirings. Best-effort: on failure the
-	// markers stay discoverable for #107 reconciliation and the next boot
-	// retries.
-	if _, err := r.ConvertDeferredDeleteMarkersToIntents(ctx); err != nil {
-		log.WithError(err).Warn("Deferred-delete marker sweep failed; markers remain for reconciliation")
-	}
-
 	// If external client, don't start River workers - host is responsible
 	if r.externalRiverClient {
 		log.Info("External River client configured - skipping River worker startup")

--- a/internal/db/gen/subscriptions.sql.go
+++ b/internal/db/gen/subscriptions.sql.go
@@ -1045,67 +1045,6 @@ func (q *Queries) ListDueDunningSubscriptions(ctx context.Context, arg ListDueDu
 	return items, nil
 }
 
-const listPendingDeletionScheduledSubscriptions = `-- name: ListPendingDeletionScheduledSubscriptions :many
-SELECT id, price_id, product_id, status, rail, rail_subscription_id, user_email, payment_method_id, current_period_starts_at, current_period_ends_at, started_at, ended_at, grace_ends_at, scheduled_price_id, last_retry_at, retry_attempts, next_retry_at, cancelled_at, cancel_type, cancel_feedback, entitlements_spec_snapshot, credits_spec_snapshot, gateway_response, created_at, updated_at, tier_group, deletion_scheduled_at, merchant_id, customer_id, rail_merchant_account_id FROM openrails.subscriptions sub
-WHERE sub.status = 'cancelled'
-  AND sub.deletion_scheduled_at IS NOT NULL
-`
-
-// Boot rescan (#344 follow-up): cancelled subscriptions still carrying the
-// deletion_scheduled_at marker — their deferred rail-side delete never
-// finalized (the deletion kill switch skipped it, or the job was lost). The
-// worker-startup rescan re-enqueues these via the deferred-delete scheduler.
-func (q *Queries) ListPendingDeletionScheduledSubscriptions(ctx context.Context) ([]OpenrailsSubscription, error) {
-	rows, err := q.db.Query(ctx, listPendingDeletionScheduledSubscriptions)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []OpenrailsSubscription
-	for rows.Next() {
-		var i OpenrailsSubscription
-		if err := rows.Scan(
-			&i.ID,
-			&i.PriceID,
-			&i.ProductID,
-			&i.Status,
-			&i.Rail,
-			&i.RailSubscriptionID,
-			&i.UserEmail,
-			&i.PaymentMethodID,
-			&i.CurrentPeriodStartsAt,
-			&i.CurrentPeriodEndsAt,
-			&i.StartedAt,
-			&i.EndedAt,
-			&i.GraceEndsAt,
-			&i.ScheduledPriceID,
-			&i.LastRetryAt,
-			&i.RetryAttempts,
-			&i.NextRetryAt,
-			&i.CancelledAt,
-			&i.CancelType,
-			&i.CancelFeedback,
-			&i.EntitlementsSpecSnapshot,
-			&i.CreditsSpecSnapshot,
-			&i.GatewayResponse,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.TierGroup,
-			&i.DeletionScheduledAt,
-			&i.MerchantID,
-			&i.CustomerID,
-			&i.RailMerchantAccountID,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listSubscriptionsByCustomerPaged = `-- name: ListSubscriptionsByCustomerPaged :many
 SELECT id, price_id, product_id, status, rail, rail_subscription_id, user_email, payment_method_id, current_period_starts_at, current_period_ends_at, started_at, ended_at, grace_ends_at, scheduled_price_id, last_retry_at, retry_attempts, next_retry_at, cancelled_at, cancel_type, cancel_feedback, entitlements_spec_snapshot, credits_spec_snapshot, gateway_response, created_at, updated_at, tier_group, deletion_scheduled_at, merchant_id, customer_id, rail_merchant_account_id FROM openrails.subscriptions sub
 WHERE sub.customer_id = $1

--- a/internal/db/queries/subscriptions.sql
+++ b/internal/db/queries/subscriptions.sql
@@ -254,15 +254,6 @@ WHERE id = $1
   AND status = 'past_due'
   AND next_retry_at IS NOT NULL AND next_retry_at <= sqlc.arg(claimed_at)::timestamptz;
 
--- name: ListPendingDeletionScheduledSubscriptions :many
--- Boot rescan (#344 follow-up): cancelled subscriptions still carrying the
--- deletion_scheduled_at marker — their deferred rail-side delete never
--- finalized (the deletion kill switch skipped it, or the job was lost). The
--- worker-startup rescan re-enqueues these via the deferred-delete scheduler.
-SELECT * FROM openrails.subscriptions sub
-WHERE sub.status = 'cancelled'
-  AND sub.deletion_scheduled_at IS NOT NULL;
-
 -- name: GetLatestResumableCancelledSubscription :one
 SELECT * FROM openrails.subscriptions sub
 WHERE sub.customer_id = $1

--- a/internal/http/handlers/admin_findings_actions.go
+++ b/internal/http/handlers/admin_findings_actions.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/open-rails/openrails/internal/db"
 	"github.com/open-rails/openrails/internal/db/models"
@@ -230,8 +232,8 @@ func executeCancelAndRefund(r *httprequest.Request, finding reconcile.FindingRec
 // lifecycle chokepoint; the remote side of NMI-backed rails rides the durable
 // nmi_delete_subscription intent (queue-always #679 — the breaker gates its
 // EXECUTION, never the enqueue). Mirrors the ResolveCancelledRemoteAlive
-// pattern: marker persists with the cancellation; the startup marker sweep
-// heals a missed enqueue.
+// pattern: cancellation UPDATE (with the marker) and intent enqueue commit in
+// ONE transaction.
 func cancelSubscriptionForFinding(r *httprequest.Request, subID uuid.UUID, reason string, result map[string]any) error {
 	if r.State.SubscriptionService == nil || r.State.SubscriptionLifecycleService == nil {
 		return errors.New("subscription services unavailable")
@@ -257,27 +259,31 @@ func cancelSubscriptionForFinding(r *httprequest.Request, subID uuid.UUID, reaso
 		if scheduleDelete {
 			sub.DeletionScheduledAt = &now
 		}
-		if err := r.State.SubscriptionLifecycleService.ApplyLocalCancellation(ctx, r.State.DB, sub, subscriptions.LocalCancellation{
+		lcArgs := subscriptions.LocalCancellation{
 			EndedAt:       now,
 			CancelType:    models.CancelTypeMerchant,
 			Feedback:      &feedback,
 			RevokeReason:  models.EntitlementRevokeAdmin,
 			RevokeAsOf:    now,
 			RevokeSources: []models.EntitlementSourceType{models.EntitlementSourceSubscription, models.EntitlementSourceGrace},
-		}); err != nil {
+		}
+		if scheduleDelete {
+			scheduler := intents.NewNMIDeleteScheduler(r.State.DB, r.State.RateCeiling(), intents.OriginAdmin, reason)
+			if err := r.State.DB.RunInTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+				txdb := db.NewWithPgxTx(tx)
+				if err := r.State.SubscriptionLifecycleService.ApplyLocalCancellation(ctx, txdb, sub, lcArgs); err != nil {
+					return err
+				}
+				return scheduler.WithTx(tx).ScheduleNMIDelete(ctx, sub.CustomerID.String(), sub.ID, now)
+			}); err != nil {
+				return fmt.Errorf("cancel subscription %s: %w", subID, err)
+			}
+			result["delete_intent"] = "queued"
+		} else if err := r.State.SubscriptionLifecycleService.ApplyLocalCancellation(ctx, r.State.DB, sub, lcArgs); err != nil {
 			return fmt.Errorf("cancel subscription %s: %w", subID, err)
 		}
 		result["cancel"] = "cancelled"
 		result["subscription_id"] = subID.String()
-		if scheduleDelete {
-			if err := intents.NewNMIDeleteScheduler(r.State.DB, r.State.RateCeiling(), intents.OriginAdmin, reason).
-				ScheduleNMIDelete(ctx, sub.CustomerID.String(), sub.ID, now); err != nil {
-				// Marker committed with the cancellation keeps the delete
-				// discoverable (startup marker sweep converts it).
-				return fmt.Errorf("local cancel applied but delete intent enqueue failed (marker sweep will convert it): %w", err)
-			}
-			result["delete_intent"] = "queued"
-		}
 		return nil
 	case sub.Rail == models.RailCCBill:
 		// #696: local cancel + durable ccbill_cancel_subscription intent

--- a/internal/modules/subscriptions/lifecycle_service.go
+++ b/internal/modules/subscriptions/lifecycle_service.go
@@ -2009,12 +2009,11 @@ func (s *SubscriptionLifecycleService) FailMembership(ctx context.Context, param
 		return err
 	}
 
-	// Schedule the deferred NMI delete AFTER the cancellation committed. Runs
-	// at "now": the undo-window semantics of user cancellations do not apply to
+	// The deferred NMI delete intent committed inside the failure-flow
+	// transaction above, atomically with the cancellation + marker. Runs at
+	// "now": the undo-window semantics of user cancellations do not apply to
 	// dunning exhaustion. Idempotent via the intent ledger's idempotency_key
-	// (#358). On failure the persisted DeletionScheduledAt marker keeps the
-	// pending delete discoverable (startup marker sweep / #107
-	// reconciliation), so we log instead of failing the flow.
+	// (#358).
 	if scheduleDeferredDelete {
 		// Enqueued inside the failure-flow transaction above; this is just
 		// the operator-visible confirmation.

--- a/internal/modules/subscriptions/subscription_repo.go
+++ b/internal/modules/subscriptions/subscription_repo.go
@@ -652,17 +652,6 @@ func (r *SubscriptionRepo) ListDueDunningSubscriptions(ctx context.Context, rail
 	return out, nil
 }
 
-// ListPendingDeletionScheduled returns cancelled subscriptions that still
-// carry a deletion_scheduled_at marker — their deferred rail-side delete
-// never finalized (#344 follow-up boot rescan). No relations attached.
-func (r *SubscriptionRepo) ListPendingDeletionScheduled(ctx context.Context) ([]*models.Subscription, error) {
-	rows, err := r.db.Gen(ctx).ListPendingDeletionScheduledSubscriptions(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return models.SubscriptionsFromGen(rows)
-}
-
 // GetLatestResumableCancelled returns the payer's most recent cancelled
 // subscription whose paid period has not elapsed (resume candidate), or
 // pgx.ErrNoRows.

--- a/tests/deferred_delete_followups_test.go
+++ b/tests/deferred_delete_followups_test.go
@@ -82,67 +82,6 @@ func (r *recordingDeferredDeleteScheduler) WithTx(pgx.Tx) subscriptions.Deferred
 	return r
 }
 
-// TestMarkerConversionSweepEnqueuesIntents verifies the #358 startup sweep
-// that replaced the #344 boot rescan: cancelled subscriptions whose
-// DeletionScheduledAt marker survived (kill switch skipped the delete, or a
-// pre-ledger job was lost) get a durable nmi_delete_subscription intent
-// enqueued, due at max(now, deletion_scheduled_at). Idempotent via the intent
-// idempotency_key.
-func TestMarkerConversionSweepEnqueuesIntents(t *testing.T) {
-	suite := getSharedTestSuite(t)
-	ctx := dbtest.WithTestMerchant(context.Background())
-
-	products := suite.SeedProducts()
-	priceID := products[0].Prices[0].ID
-
-	now := time.Now().UTC()
-	futureDelete := now.Add(2 * time.Hour)
-	pastDelete := now.Add(-48 * time.Hour)
-
-	// Marker with a still-open undo window: the intent must be due AT the
-	// marker time (undo window honored).
-	futureSub := suite.CreateTestSubscriptionWithOptions(SubscriptionOptions{
-		UserID:              uuid.New().String(),
-		PriceID:             priceID,
-		Status:              models.StatusCancelled,
-		Rail:                models.RailNMI,
-		DeletionScheduledAt: &futureDelete,
-	})
-
-	// Overdue marker (e.g. kill switch was on for two days): due at ~now.
-	pastSub := suite.CreateTestSubscriptionWithOptions(SubscriptionOptions{
-		UserID:              uuid.New().String(),
-		PriceID:             priceID,
-		Status:              models.StatusCancelled,
-		Rail:                models.RailNMI,
-		DeletionScheduledAt: &pastDelete,
-	})
-
-	converted, err := suite.App.Runtime.ConvertDeferredDeleteMarkersToIntents(ctx)
-	require.NoError(t, err)
-	// Other tests in the shared suite may have left markers too.
-	assert.GreaterOrEqual(t, converted, 2, "both seeded markers should be converted")
-
-	// Future marker: one intent due at the marker time.
-	count, status, nextAt := queryNMIDeleteIntents(t, suite, futureSub.ID)
-	require.Equal(t, 1, count, "exactly one delete intent for the future-marker subscription")
-	assert.Equal(t, intents.StatusPending, status)
-	assert.WithinDuration(t, futureDelete, nextAt, time.Minute)
-
-	// Past marker: one intent due at ~now (clamped, never in the past).
-	count, _, nextAt = queryNMIDeleteIntents(t, suite, pastSub.ID)
-	require.GreaterOrEqual(t, count, 1, "a delete intent exists for the overdue-marker subscription")
-	assert.True(t, nextAt.After(pastDelete), "overdue delete is clamped to now, not the stale marker time")
-	assert.WithinDuration(t, now, nextAt, time.Minute)
-
-	// Idempotency: a second sweep must not stack a duplicate intent
-	// (idempotency_key conflict refreshes the pending row).
-	_, err = suite.App.Runtime.ConvertDeferredDeleteMarkersToIntents(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, 1, countLiveNMIDeleteIntents(t, suite, futureSub.ID), "sweep is idempotent for pending intents")
-	assert.Equal(t, 1, countLiveNMIDeleteIntents(t, suite, pastSub.ID))
-}
-
 // TestFailMembershipDunningExhaustionSchedulesNMIDelete verifies the #344
 // follow-up webhook-path fix end-to-end via the runtime's shared lifecycle
 // service (the instance the NMI webhook handlers use): a past_due NMI-backed


### PR DESCRIPTION
Step 4 (final) of retiring the boot marker sweep — follows #136, #138, doujins#463.

Every producer of `DeletionScheduledAt` now writes marker + `nmi_delete_subscription` intent in ONE transaction: FailMembership and user-cancel already did (#679), the unknown-decider and DeclaredBilling import do since #138, doujins' legacy migration now declares `Cancel.ScheduleLive` in the book (doujins#463) instead of direct-DB stamping, and this PR makes the last stragglers atomic (admin findings cancel) / fixes stale comments. With no way left for a marker to exist without its intent, `ConvertDeferredDeleteMarkersToIntents` is provably dead in every state — deleted along with its boot call, repo method, sqlc query, and test (~150 lines).

Verified: build, vet (incl. integration tags), sqlc regenerated, deferred-delete integration tests + admin-findings handler suite + `TestImportBilling*` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)