### PR TITLE
feat(#787): pump requires_review findings into operator notifications

### DIFF
--- a/internal/app/river_register.go
+++ b/internal/app/river_register.go
@@ -83,6 +83,7 @@ func (r *Runtime) addBillingWorkersToRegistry(ctx context.Context, workers *rive
 		SolanaRPC:           r.SolanaRPC,
 		DeferDelete:         r.DeferredDeletes,
 		NotificationService: r.NotificationService,
+		Alerts:              r.AlertService, // #787: requires_review findings -> operator notifications
 	}); err != nil {
 		return fmt.Errorf("add provider refresh worker: %w", err)
 	}
@@ -121,6 +122,7 @@ func (r *Runtime) addBillingWorkersToRegistry(ctx context.Context, workers *rive
 		DB:     r.DB,
 		Config: r.Config,
 		Clock:  clock,
+		Alerts: r.AlertService, // #787: requires_review findings -> operator notifications
 	}); err != nil {
 		return fmt.Errorf("add converge sweep worker: %w", err)
 	}
@@ -280,6 +282,15 @@ func (r *Runtime) addBillingWorkersToRegistry(ctx context.Context, workers *rive
 		Clock:  clock,
 	}); err != nil {
 		return fmt.Errorf("add alert eval worker: %w", err)
+	}
+	// Low-severity reconciliation-findings digest (#787): a SEPARATE
+	// notification source from the rule evaluator above — findings are
+	// event-sourced, not a metric-threshold rule.
+	if err := addTrackedWorker(r, workers, &riverjobs.FindingsDigestWorker{
+		DB:     r.DB,
+		Alerts: r.AlertService,
+	}); err != nil {
+		return fmt.Errorf("add findings digest worker: %w", err)
 	}
 	// Worker health checker (#689): evaluates per-kind health rows written by the
 	// WorkerHealthMiddleware and raises repair alerts for never-succeeded /
@@ -686,6 +697,21 @@ func (r *Runtime) buildRiverPeriodicJobs(ctx context.Context) ([]*river.Periodic
 		15*time.Minute,
 		func() (river.JobArgs, *river.InsertOpts) {
 			return riverjobs.AlertEvalArgs{}, &river.InsertOpts{
+				Queue:      riverjobs.QueueBilling,
+				UniqueOpts: river.UniqueOpts{ByQueue: true, ByPeriod: 15 * time.Minute},
+			}
+		},
+		&river.PeriodicJobOpts{RunOnStart: false},
+	))
+
+	// Every 15 minutes: low-severity reconciliation-findings digest (#787). The
+	// outer tick is cheap (indexed armed-merchant scan); the daily cadence gate
+	// lives inside DigestFindings, same shape as the payment_methods_expiring
+	// digest above.
+	jobs = append(jobs, r.healthPeriodic(
+		15*time.Minute,
+		func() (river.JobArgs, *river.InsertOpts) {
+			return riverjobs.FindingsDigestArgs{}, &river.InsertOpts{
 				Queue:      riverjobs.QueueBilling,
 				UniqueOpts: river.UniqueOpts{ByQueue: true, ByPeriod: 15 * time.Minute},
 			}

--- a/internal/db/gen/models.go
+++ b/internal/db/gen/models.go
@@ -315,6 +315,13 @@ type OpenrailsEntitlement struct {
 	GrantID    *uuid.UUID
 }
 
+// #787: one row per merchant recording when the low-severity reconciliation-findings digest last fired.
+type OpenrailsFindingDigestState struct {
+	MerchantID     uuid.UUID
+	LastDigestedAt *time.Time
+	UpdatedAt      time.Time
+}
+
 // #690 episode analytics: spans of entitlement access NOT covered by payment (subscription paid-through snapshot, completed one_off payment, or a live matching grant). Open episodes (window still granting) end at now(). Causes label sanctioned unpaid access (sanctioned_dunning, awaiting_verification) vs failure (unsanctioned). Approximations: paid-through is the current-period snapshot (renewals overwrite it, healed historical lapses are invisible); coverage is contiguous-from-the-left (uncovered TAIL only); cause reads the sub's CURRENT state; refund time falls back to the purchase time when no refund row links.
 type OpenrailsFreeloaderEpisode struct {
 	MerchantID    uuid.UUID
@@ -952,6 +959,10 @@ type OpenrailsReconciliationFinding struct {
 	Evidence []byte
 	// Authenticated admin identity stamped on manual resolution (approve/ignore via the findings queue, #692); NULL for automatic resolutions.
 	ResolvedBy *string
+	// #787: last time this OPEN finding pushed an operator notification; NULL = not yet notified this open episode. Cleared to NULL on every resolution so a reopened finding notifies again.
+	NotifiedAt *time.Time
+	// #787: severity at last notification; a further increase while still open re-fires, re-observation at the same/lower severity does not.
+	NotifiedSeverity *string
 }
 
 // One row per manual reconcile run (#107): advisory diffs or enforce convergence against the payment rails. Summary jsonb carries per-rail counts and the dunning-forensics report.

--- a/internal/db/gen/rail_intents.sql.go
+++ b/internal/db/gen/rail_intents.sql.go
@@ -573,7 +573,7 @@ func (q *Queries) GetRailIntent(ctx context.Context, id uuid.UUID) (OpenrailsRai
 }
 
 const getReconciliationFindingByIdentity = `-- name: GetReconciliationFindingByIdentity :one
-SELECT id, merchant_id, finding_type, subject_key, severity, status, recommended_action, first_seen_run, last_seen_run, last_seen_at, resolved_at, resolution, operator_notes, created_at, updated_at, evidence, resolved_by FROM openrails.reconciliation_findings
+SELECT id, merchant_id, finding_type, subject_key, severity, status, recommended_action, first_seen_run, last_seen_run, last_seen_at, resolved_at, resolution, operator_notes, created_at, updated_at, evidence, resolved_by, notified_at, notified_severity FROM openrails.reconciliation_findings
 WHERE merchant_id = $1::uuid
   AND finding_type = $2
   AND subject_key = $3
@@ -608,6 +608,8 @@ func (q *Queries) GetReconciliationFindingByIdentity(ctx context.Context, arg Ge
 		&i.UpdatedAt,
 		&i.Evidence,
 		&i.ResolvedBy,
+		&i.NotifiedAt,
+		&i.NotifiedSeverity,
 	)
 	return i, err
 }

--- a/internal/db/gen/reconciliation.sql.go
+++ b/internal/db/gen/reconciliation.sql.go
@@ -18,6 +18,7 @@ SET status = 'fixed',
     resolution = 'admin_fixed',
     operator_notes = $1,
     resolved_at = now(),
+    notified_at = NULL, notified_severity = NULL, -- #787: resolution clears the notify linkage
     updated_at = now()
 WHERE id = $2 AND status IN ('reconcile_required', 'requires_review', 'auto_fixed')
 `
@@ -42,6 +43,7 @@ SET status = 'ignored',
     operator_notes = $1,
     resolved_by = $2,
     resolved_at = now(),
+    notified_at = NULL, notified_severity = NULL, -- #787: resolution clears the notify linkage
     updated_at = now()
 WHERE id = $3 AND status IN ('reconcile_required', 'requires_review')
 `
@@ -65,7 +67,7 @@ func (q *Queries) AdminIgnoreReconciliationFinding(ctx context.Context, arg Admi
 
 const adminListReconciliationFindings = `-- name: AdminListReconciliationFindings :many
 
-SELECT f.id, f.merchant_id, f.finding_type, f.subject_key, f.severity, f.status, f.recommended_action, f.first_seen_run, f.last_seen_run, f.last_seen_at, f.resolved_at, f.resolution, f.operator_notes, f.created_at, f.updated_at, f.evidence, f.resolved_by, count(*) OVER () AS total_count
+SELECT f.id, f.merchant_id, f.finding_type, f.subject_key, f.severity, f.status, f.recommended_action, f.first_seen_run, f.last_seen_run, f.last_seen_at, f.resolved_at, f.resolution, f.operator_notes, f.created_at, f.updated_at, f.evidence, f.resolved_by, f.notified_at, f.notified_severity, count(*) OVER () AS total_count
 FROM openrails.reconciliation_findings f
 WHERE f.merchant_id = $1::uuid
   AND (CASE
@@ -135,6 +137,8 @@ func (q *Queries) AdminListReconciliationFindings(ctx context.Context, arg Admin
 			&i.OpenrailsReconciliationFinding.UpdatedAt,
 			&i.OpenrailsReconciliationFinding.Evidence,
 			&i.OpenrailsReconciliationFinding.ResolvedBy,
+			&i.OpenrailsReconciliationFinding.NotifiedAt,
+			&i.OpenrailsReconciliationFinding.NotifiedSeverity,
 			&i.TotalCount,
 		); err != nil {
 			return nil, err
@@ -158,6 +162,7 @@ SET status = 'fixed',
         ELSE jsonb_set(COALESCE(evidence, '{}'::jsonb), '{resolution}', $3::jsonb, true)
     END,
     resolved_at = now(),
+    notified_at = NULL, notified_severity = NULL, -- #787: resolution clears the notify linkage
     updated_at = now()
 WHERE id = $4 AND status IN ('reconcile_required', 'requires_review')
 `
@@ -216,6 +221,7 @@ UPDATE openrails.reconciliation_findings f
 SET status = 'fixed',
     resolution = 'auto_vanished',
     resolved_at = now(),
+    notified_at = NULL, notified_severity = NULL, -- #787: resolution clears the notify linkage
     updated_at = now()
 WHERE f.merchant_id = $1::uuid
   AND f.finding_type = 'life.provider_intent.stuck'
@@ -252,6 +258,7 @@ UPDATE openrails.reconciliation_findings
 SET status = 'fixed',
     resolution = 'auto_vanished',
     resolved_at = now(),
+    notified_at = NULL, notified_severity = NULL, -- #787: resolution clears the notify linkage
     updated_at = now()
 WHERE evidence->>'provider' = $1
   AND status IN ('reconcile_required', 'requires_review')
@@ -325,6 +332,19 @@ func (q *Queries) CountErrorEpisodeTotals(ctx context.Context, merchantID uuid.U
 		&i.OrphanedDays,
 	)
 	return i, err
+}
+
+const countLowSeverityFindingsPendingDigest = `-- name: CountLowSeverityFindingsPendingDigest :one
+SELECT count(*) FROM openrails.reconciliation_findings
+WHERE merchant_id = $1::uuid
+  AND status = 'requires_review' AND severity = 'low' AND notified_at IS NULL
+`
+
+func (q *Queries) CountLowSeverityFindingsPendingDigest(ctx context.Context, merchantID uuid.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, countLowSeverityFindingsPendingDigest, merchantID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
 }
 
 const countOpenReconciliationFindingsByTypeSeverity = `-- name: CountOpenReconciliationFindingsByTypeSeverity :many
@@ -454,6 +474,7 @@ SET status = 'ignored',
     resolution = 'ignored',
     operator_notes = $1,
     resolved_at = now(),
+    notified_at = NULL, notified_severity = NULL, -- #787: resolution clears the notify linkage
     updated_at = now()
 WHERE id = $2 AND status IN ('reconcile_required', 'requires_review', 'auto_fixed', 'fixed')
 `
@@ -500,6 +521,22 @@ func (q *Queries) FinishReconciliationRun(ctx context.Context, arg FinishReconci
 	return result.RowsAffected(), nil
 }
 
+const getFindingDigestWatermark = `-- name: GetFindingDigestWatermark :one
+SELECT (
+    SELECT last_digested_at FROM openrails.finding_digest_state
+    WHERE merchant_id = $1::uuid
+) AS last_digested_at
+`
+
+// Scalar subquery (not a plain SELECT ... WHERE) so a merchant with no digest
+// row yet returns one row with NULL rather than :one erroring on zero rows.
+func (q *Queries) GetFindingDigestWatermark(ctx context.Context, merchantID uuid.UUID) (*time.Time, error) {
+	row := q.db.QueryRow(ctx, getFindingDigestWatermark, merchantID)
+	var last_digested_at *time.Time
+	err := row.Scan(&last_digested_at)
+	return last_digested_at, err
+}
+
 const getLatestReconciliationRun = `-- name: GetLatestReconciliationRun :one
 SELECT id, merchant_id, mode, rails, window_since, window_until, started_at, finished_at, status, summary, error FROM openrails.reconciliation_runs
 ORDER BY started_at DESC
@@ -526,7 +563,7 @@ func (q *Queries) GetLatestReconciliationRun(ctx context.Context) (OpenrailsReco
 }
 
 const getReconciliationFinding = `-- name: GetReconciliationFinding :one
-SELECT id, merchant_id, finding_type, subject_key, severity, status, recommended_action, first_seen_run, last_seen_run, last_seen_at, resolved_at, resolution, operator_notes, created_at, updated_at, evidence, resolved_by FROM openrails.reconciliation_findings WHERE id = $1
+SELECT id, merchant_id, finding_type, subject_key, severity, status, recommended_action, first_seen_run, last_seen_run, last_seen_at, resolved_at, resolution, operator_notes, created_at, updated_at, evidence, resolved_by, notified_at, notified_severity FROM openrails.reconciliation_findings WHERE id = $1
 `
 
 func (q *Queries) GetReconciliationFinding(ctx context.Context, id uuid.UUID) (OpenrailsReconciliationFinding, error) {
@@ -550,6 +587,8 @@ func (q *Queries) GetReconciliationFinding(ctx context.Context, id uuid.UUID) (O
 		&i.UpdatedAt,
 		&i.Evidence,
 		&i.ResolvedBy,
+		&i.NotifiedAt,
+		&i.NotifiedSeverity,
 	)
 	return i, err
 }
@@ -653,7 +692,7 @@ func (q *Queries) ListAbandonedProviderIntents(ctx context.Context, arg ListAban
 }
 
 const listActionableReconciliationFindingsByProvider = `-- name: ListActionableReconciliationFindingsByProvider :many
-SELECT id, merchant_id, finding_type, subject_key, severity, status, recommended_action, first_seen_run, last_seen_run, last_seen_at, resolved_at, resolution, operator_notes, created_at, updated_at, evidence, resolved_by FROM openrails.reconciliation_findings
+SELECT id, merchant_id, finding_type, subject_key, severity, status, recommended_action, first_seen_run, last_seen_run, last_seen_at, resolved_at, resolution, operator_notes, created_at, updated_at, evidence, resolved_by, notified_at, notified_severity FROM openrails.reconciliation_findings
 WHERE evidence->>'provider' = $1 AND status IN ('reconcile_required', 'requires_review')
 ORDER BY finding_type, subject_key
 `
@@ -685,6 +724,8 @@ func (q *Queries) ListActionableReconciliationFindingsByProvider(ctx context.Con
 			&i.UpdatedAt,
 			&i.Evidence,
 			&i.ResolvedBy,
+			&i.NotifiedAt,
+			&i.NotifiedSeverity,
 		); err != nil {
 			return nil, err
 		}
@@ -820,6 +861,33 @@ func (q *Queries) ListActiveSubsMissingEntitlementProjection(ctx context.Context
 			return nil, err
 		}
 		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listArmedFindingsDigestMerchants = `-- name: ListArmedFindingsDigestMerchants :many
+SELECT DISTINCT merchant_id FROM openrails.reconciliation_findings
+WHERE status = 'requires_review' AND severity = 'low' AND notified_at IS NULL
+`
+
+// #787: CROSS-MERCHANT (base pool / GenGlobal) armed-merchant scan for the
+// low-severity findings digest, mirroring ListArmedAlertMerchants's posture.
+func (q *Queries) ListArmedFindingsDigestMerchants(ctx context.Context) ([]uuid.UUID, error) {
+	rows, err := q.db.Query(ctx, listArmedFindingsDigestMerchants)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []uuid.UUID
+	for rows.Next() {
+		var merchant_id uuid.UUID
+		if err := rows.Scan(&merchant_id); err != nil {
+			return nil, err
+		}
+		items = append(items, merchant_id)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -1051,7 +1119,7 @@ func (q *Queries) ListLapsedSubscriptionsWithEvidence(ctx context.Context, arg L
 }
 
 const listReconciliationFindings = `-- name: ListReconciliationFindings :many
-SELECT id, merchant_id, finding_type, subject_key, severity, status, recommended_action, first_seen_run, last_seen_run, last_seen_at, resolved_at, resolution, operator_notes, created_at, updated_at, evidence, resolved_by FROM openrails.reconciliation_findings
+SELECT id, merchant_id, finding_type, subject_key, severity, status, recommended_action, first_seen_run, last_seen_run, last_seen_at, resolved_at, resolution, operator_notes, created_at, updated_at, evidence, resolved_by, notified_at, notified_severity FROM openrails.reconciliation_findings
 WHERE ($1::text IS NULL OR status = $1::text)
   AND ($2::text IS NULL OR evidence->>'provider' = $2::text)
   AND ($3::text IS NULL OR finding_type = $3::text)
@@ -1103,6 +1171,8 @@ func (q *Queries) ListReconciliationFindings(ctx context.Context, arg ListReconc
 			&i.UpdatedAt,
 			&i.Evidence,
 			&i.ResolvedBy,
+			&i.NotifiedAt,
+			&i.NotifiedSeverity,
 		); err != nil {
 			return nil, err
 		}
@@ -1403,12 +1473,33 @@ func (q *Queries) ListUnknownSubscriptions(ctx context.Context, arg ListUnknownS
 	return items, nil
 }
 
+const markLowSeverityFindingsDigested = `-- name: MarkLowSeverityFindingsDigested :execrows
+UPDATE openrails.reconciliation_findings
+SET notified_at = $1::timestamptz, notified_severity = 'low'
+WHERE merchant_id = $2::uuid
+  AND status = 'requires_review' AND severity = 'low' AND notified_at IS NULL
+`
+
+type MarkLowSeverityFindingsDigestedParams struct {
+	NotifiedAt time.Time
+	MerchantID uuid.UUID
+}
+
+func (q *Queries) MarkLowSeverityFindingsDigested(ctx context.Context, arg MarkLowSeverityFindingsDigestedParams) (int64, error) {
+	result, err := q.db.Exec(ctx, markLowSeverityFindingsDigested, arg.NotifiedAt, arg.MerchantID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const markReconciliationFindingAutoFixed = `-- name: MarkReconciliationFindingAutoFixed :execrows
 UPDATE openrails.reconciliation_findings
 SET status = 'auto_fixed',
     resolution = 'enforced',
     evidence = jsonb_set(COALESCE(evidence, '{}'::jsonb), '{resolution}', $1::jsonb, true),
     resolved_at = now(),
+    notified_at = NULL, notified_severity = NULL, -- #787: resolution clears the notify linkage
     updated_at = now()
 WHERE id = $2 AND status IN ('reconcile_required', 'requires_review')
 `
@@ -1426,11 +1517,36 @@ func (q *Queries) MarkReconciliationFindingAutoFixed(ctx context.Context, arg Ma
 	return result.RowsAffected(), nil
 }
 
+const markReconciliationFindingNotified = `-- name: MarkReconciliationFindingNotified :execrows
+UPDATE openrails.reconciliation_findings
+SET notified_at = $1::timestamptz,
+    notified_severity = $2::text
+WHERE id = $3
+`
+
+type MarkReconciliationFindingNotifiedParams struct {
+	NotifiedAt time.Time
+	Severity   string
+	ID         uuid.UUID
+}
+
+// #787: dedupe linkage for the immediate notify path — set once a finding
+// pushes an operator notification, cleared by every resolution statement below
+// so a reopened finding notifies again.
+func (q *Queries) MarkReconciliationFindingNotified(ctx context.Context, arg MarkReconciliationFindingNotifiedParams) (int64, error) {
+	result, err := q.db.Exec(ctx, markReconciliationFindingNotified, arg.NotifiedAt, arg.Severity, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const markReconciliationFindingVanished = `-- name: MarkReconciliationFindingVanished :execrows
 UPDATE openrails.reconciliation_findings
 SET status = 'fixed',
     resolution = 'auto_vanished',
     resolved_at = now(),
+    notified_at = NULL, notified_severity = NULL, -- #787: resolution clears the notify linkage
     updated_at = now()
 WHERE id = $1 AND status IN ('reconcile_required', 'requires_review')
 `
@@ -2035,6 +2151,24 @@ func (q *Queries) SetSubscriptionNextRetry(ctx context.Context, arg SetSubscript
 	return result.RowsAffected(), nil
 }
 
+const touchFindingDigestWatermark = `-- name: TouchFindingDigestWatermark :exec
+INSERT INTO openrails.finding_digest_state (merchant_id, last_digested_at, updated_at)
+VALUES ($1::uuid, $2::timestamptz, now())
+ON CONFLICT (merchant_id) DO UPDATE SET
+    last_digested_at = EXCLUDED.last_digested_at,
+    updated_at = now()
+`
+
+type TouchFindingDigestWatermarkParams struct {
+	MerchantID     uuid.UUID
+	LastDigestedAt time.Time
+}
+
+func (q *Queries) TouchFindingDigestWatermark(ctx context.Context, arg TouchFindingDigestWatermarkParams) error {
+	_, err := q.db.Exec(ctx, touchFindingDigestWatermark, arg.MerchantID, arg.LastDigestedAt)
+	return err
+}
+
 const upsertReconciliationFinding = `-- name: UpsertReconciliationFinding :one
 
 INSERT INTO openrails.reconciliation_findings (
@@ -2070,10 +2204,24 @@ ON CONFLICT (merchant_id, finding_type, subject_key) DO UPDATE SET
         WHEN EXCLUDED.status = 'auto_fixed' THEN EXCLUDED.resolution
         ELSE NULL
     END,
+    -- #787: an inline auto_fixed transition (the only resolution this upsert
+    -- itself can produce; fixed/ignored come via the separate admin/auto-
+    -- resolve statements below) is a resolution — clear the notify linkage so
+    -- a future reopen of this identity notifies again.
+    notified_at = CASE
+        WHEN openrails.reconciliation_findings.status = 'ignored' THEN openrails.reconciliation_findings.notified_at
+        WHEN EXCLUDED.status = 'auto_fixed' THEN NULL
+        ELSE openrails.reconciliation_findings.notified_at
+    END,
+    notified_severity = CASE
+        WHEN openrails.reconciliation_findings.status = 'ignored' THEN openrails.reconciliation_findings.notified_severity
+        WHEN EXCLUDED.status = 'auto_fixed' THEN NULL
+        ELSE openrails.reconciliation_findings.notified_severity
+    END,
     last_seen_run = COALESCE(EXCLUDED.last_seen_run, openrails.reconciliation_findings.last_seen_run),
     last_seen_at = now(),
     updated_at = now()
-RETURNING id, merchant_id, finding_type, subject_key, severity, status, recommended_action, first_seen_run, last_seen_run, last_seen_at, resolved_at, resolution, operator_notes, created_at, updated_at, evidence, resolved_by
+RETURNING id, merchant_id, finding_type, subject_key, severity, status, recommended_action, first_seen_run, last_seen_run, last_seen_at, resolved_at, resolution, operator_notes, created_at, updated_at, evidence, resolved_by, notified_at, notified_severity
 `
 
 type UpsertReconciliationFindingParams struct {
@@ -2124,6 +2272,8 @@ func (q *Queries) UpsertReconciliationFinding(ctx context.Context, arg UpsertRec
 		&i.UpdatedAt,
 		&i.Evidence,
 		&i.ResolvedBy,
+		&i.NotifiedAt,
+		&i.NotifiedSeverity,
 	)
 	return i, err
 }

--- a/internal/db/queries/reconciliation.sql
+++ b/internal/db/queries/reconciliation.sql
@@ -79,10 +79,65 @@ ON CONFLICT (merchant_id, finding_type, subject_key) DO UPDATE SET
         WHEN EXCLUDED.status = 'auto_fixed' THEN EXCLUDED.resolution
         ELSE NULL
     END,
+    -- #787: an inline auto_fixed transition (the only resolution this upsert
+    -- itself can produce; fixed/ignored come via the separate admin/auto-
+    -- resolve statements below) is a resolution — clear the notify linkage so
+    -- a future reopen of this identity notifies again.
+    notified_at = CASE
+        WHEN openrails.reconciliation_findings.status = 'ignored' THEN openrails.reconciliation_findings.notified_at
+        WHEN EXCLUDED.status = 'auto_fixed' THEN NULL
+        ELSE openrails.reconciliation_findings.notified_at
+    END,
+    notified_severity = CASE
+        WHEN openrails.reconciliation_findings.status = 'ignored' THEN openrails.reconciliation_findings.notified_severity
+        WHEN EXCLUDED.status = 'auto_fixed' THEN NULL
+        ELSE openrails.reconciliation_findings.notified_severity
+    END,
     last_seen_run = COALESCE(EXCLUDED.last_seen_run, openrails.reconciliation_findings.last_seen_run),
     last_seen_at = now(),
     updated_at = now()
 RETURNING *;
+
+-- name: MarkReconciliationFindingNotified :execrows
+-- #787: dedupe linkage for the immediate notify path — set once a finding
+-- pushes an operator notification, cleared by every resolution statement below
+-- so a reopened finding notifies again.
+UPDATE openrails.reconciliation_findings
+SET notified_at = sqlc.arg(notified_at)::timestamptz,
+    notified_severity = sqlc.arg(severity)::text
+WHERE id = sqlc.arg(id);
+
+-- name: ListArmedFindingsDigestMerchants :many
+-- #787: CROSS-MERCHANT (base pool / GenGlobal) armed-merchant scan for the
+-- low-severity findings digest, mirroring ListArmedAlertMerchants's posture.
+SELECT DISTINCT merchant_id FROM openrails.reconciliation_findings
+WHERE status = 'requires_review' AND severity = 'low' AND notified_at IS NULL;
+
+-- name: CountLowSeverityFindingsPendingDigest :one
+SELECT count(*) FROM openrails.reconciliation_findings
+WHERE merchant_id = sqlc.arg(merchant_id)::uuid
+  AND status = 'requires_review' AND severity = 'low' AND notified_at IS NULL;
+
+-- name: MarkLowSeverityFindingsDigested :execrows
+UPDATE openrails.reconciliation_findings
+SET notified_at = sqlc.arg(notified_at)::timestamptz, notified_severity = 'low'
+WHERE merchant_id = sqlc.arg(merchant_id)::uuid
+  AND status = 'requires_review' AND severity = 'low' AND notified_at IS NULL;
+
+-- name: GetFindingDigestWatermark :one
+-- Scalar subquery (not a plain SELECT ... WHERE) so a merchant with no digest
+-- row yet returns one row with NULL rather than :one erroring on zero rows.
+SELECT (
+    SELECT last_digested_at FROM openrails.finding_digest_state
+    WHERE merchant_id = sqlc.arg(merchant_id)::uuid
+) AS last_digested_at;
+
+-- name: TouchFindingDigestWatermark :exec
+INSERT INTO openrails.finding_digest_state (merchant_id, last_digested_at, updated_at)
+VALUES (sqlc.arg(merchant_id)::uuid, sqlc.arg(last_digested_at)::timestamptz, now())
+ON CONFLICT (merchant_id) DO UPDATE SET
+    last_digested_at = EXCLUDED.last_digested_at,
+    updated_at = now();
 
 -- name: GetReconciliationFinding :one
 SELECT * FROM openrails.reconciliation_findings WHERE id = $1;
@@ -108,6 +163,7 @@ UPDATE openrails.reconciliation_findings
 SET status = 'fixed',
     resolution = 'auto_vanished',
     resolved_at = now(),
+    notified_at = NULL, notified_severity = NULL, -- #787: resolution clears the notify linkage
     updated_at = now()
 WHERE evidence->>'provider' = sqlc.arg(provider)
   AND status IN ('reconcile_required', 'requires_review')
@@ -123,6 +179,7 @@ UPDATE openrails.reconciliation_findings f
 SET status = 'fixed',
     resolution = 'auto_vanished',
     resolved_at = now(),
+    notified_at = NULL, notified_severity = NULL, -- #787: resolution clears the notify linkage
     updated_at = now()
 WHERE f.merchant_id = sqlc.arg(merchant_id)::uuid
   AND f.finding_type = 'life.provider_intent.stuck'
@@ -140,6 +197,7 @@ UPDATE openrails.reconciliation_findings
 SET status = 'fixed',
     resolution = 'auto_vanished',
     resolved_at = now(),
+    notified_at = NULL, notified_severity = NULL, -- #787: resolution clears the notify linkage
     updated_at = now()
 WHERE id = sqlc.arg(id) AND status IN ('reconcile_required', 'requires_review');
 
@@ -149,6 +207,7 @@ SET status = 'auto_fixed',
     resolution = 'enforced',
     evidence = jsonb_set(COALESCE(evidence, '{}'::jsonb), '{resolution}', sqlc.narg(resolution_evidence)::jsonb, true),
     resolved_at = now(),
+    notified_at = NULL, notified_severity = NULL, -- #787: resolution clears the notify linkage
     updated_at = now()
 WHERE id = sqlc.arg(id) AND status IN ('reconcile_required', 'requires_review');
 
@@ -158,6 +217,7 @@ SET status = 'fixed',
     resolution = 'admin_fixed',
     operator_notes = sqlc.narg(operator_notes),
     resolved_at = now(),
+    notified_at = NULL, notified_severity = NULL, -- #787: resolution clears the notify linkage
     updated_at = now()
 WHERE id = sqlc.arg(id) AND status IN ('reconcile_required', 'requires_review', 'auto_fixed');
 
@@ -167,6 +227,7 @@ SET status = 'ignored',
     resolution = 'ignored',
     operator_notes = sqlc.narg(operator_notes),
     resolved_at = now(),
+    notified_at = NULL, notified_severity = NULL, -- #787: resolution clears the notify linkage
     updated_at = now()
 WHERE id = sqlc.arg(id) AND status IN ('reconcile_required', 'requires_review', 'auto_fixed', 'fixed');
 
@@ -218,6 +279,7 @@ SET status = 'fixed',
         ELSE jsonb_set(COALESCE(evidence, '{}'::jsonb), '{resolution}', sqlc.narg(resolution_evidence)::jsonb, true)
     END,
     resolved_at = now(),
+    notified_at = NULL, notified_severity = NULL, -- #787: resolution clears the notify linkage
     updated_at = now()
 WHERE id = sqlc.arg(id) AND status IN ('reconcile_required', 'requires_review');
 
@@ -231,6 +293,7 @@ SET status = 'ignored',
     operator_notes = sqlc.narg(operator_notes),
     resolved_by = sqlc.arg(resolved_by),
     resolved_at = now(),
+    notified_at = NULL, notified_severity = NULL, -- #787: resolution clears the notify linkage
     updated_at = now()
 WHERE id = sqlc.arg(id) AND status IN ('reconcile_required', 'requires_review');
 

--- a/internal/modules/alerting/alerting_integration_test.go
+++ b/internal/modules/alerting/alerting_integration_test.go
@@ -65,7 +65,7 @@ func seedMerchant(t *testing.T, pool *pgxpool.Pool, mid uuid.UUID) {
 	exec(t, pool, `INSERT INTO openrails.merchants (id, slug, status) VALUES ($1,$2,'active') ON CONFLICT (id) DO NOTHING`, mid, slug)
 	t.Cleanup(func() {
 		ctx := context.Background()
-		for _, tbl := range []string{"merchant_notifications", "alert_rules", "merchant_webhooks", "payments", "subscriptions", "prices", "products", "customers", "rail_merchant_accounts", "merchant_configurations", "webhook_health", "webhook_health_daily"} {
+		for _, tbl := range []string{"merchant_notifications", "alert_rules", "merchant_webhooks", "payments", "subscriptions", "prices", "products", "customers", "rail_merchant_accounts", "merchant_configurations", "webhook_health", "webhook_health_daily", "reconciliation_findings", "reconciliation_runs", "finding_digest_state"} {
 			_, _ = pool.Exec(ctx, `DELETE FROM openrails.`+tbl+` WHERE merchant_id = $1`, mid)
 		}
 		_, _ = pool.Exec(ctx, `DELETE FROM openrails.merchants WHERE id = $1`, mid)

--- a/internal/modules/alerting/channels.go
+++ b/internal/modules/alerting/channels.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/open-rails/openrails/internal/db"
@@ -56,11 +57,24 @@ func newDeliverer(database *db.DB, st *store, email EmailSender, httpClient *htt
 
 // dispatch delivers the alert to every channel on the rule, in order.
 func (d *deliverer) dispatch(ctx context.Context, rule Rule, alert Alert) []DeliveryResult {
-	results := make([]DeliveryResult, 0, len(rule.Channels))
-	for _, ch := range rule.Channels {
+	return d.dispatchChannels(ctx, rule.Channels, &rule.ID, alert)
+}
+
+// dispatchFinding delivers an alert built from a reconciliation finding (#787)
+// through an explicit channel set rather than a rule — findings are not
+// metric-threshold rules, so there is no Rule row to carry channels; callers
+// pass the severity-based default set instead. The stored notification's
+// rule_id stays NULL (informational-only column; no rule produced this alert).
+func (d *deliverer) dispatchFinding(ctx context.Context, channels []ChannelRef, alert Alert) []DeliveryResult {
+	return d.dispatchChannels(ctx, channels, nil, alert)
+}
+
+func (d *deliverer) dispatchChannels(ctx context.Context, channels []ChannelRef, ruleID *uuid.UUID, alert Alert) []DeliveryResult {
+	results := make([]DeliveryResult, 0, len(channels))
+	for _, ch := range channels {
 		switch ch.Type {
 		case ChannelInApp:
-			results = append(results, d.deliverInApp(ctx, rule, alert))
+			results = append(results, d.deliverInApp(ctx, ruleID, alert))
 		case ChannelEmail:
 			results = append(results, d.deliverEmail(ctx, alert))
 		case ChannelWebhook:
@@ -72,14 +86,13 @@ func (d *deliverer) dispatch(ctx context.Context, rule Rule, alert Alert) []Deli
 	return results
 }
 
-func (d *deliverer) deliverInApp(ctx context.Context, rule Rule, alert Alert) DeliveryResult {
-	ruleID := rule.ID
+func (d *deliverer) deliverInApp(ctx context.Context, ruleID *uuid.UUID, alert Alert) DeliveryResult {
 	_, err := d.store.createNotification(ctx, Notification{
 		Severity: alert.Severity,
 		Title:    alertTitle(alert),
 		Body:     alert.Summary,
 		Link:     alert.DashboardLink,
-		RuleID:   &ruleID,
+		RuleID:   ruleID,
 		Data:     alert,
 	})
 	if err != nil {

--- a/internal/modules/alerting/findings.go
+++ b/internal/modules/alerting/findings.go
@@ -1,0 +1,162 @@
+// #787: bridges internal/reconcile findings into this module's merchant
+// notification store + channel fan-out. Findings are event-sourced (one row
+// upserted per pull/converge pass) rather than a metric-threshold rule, so
+// this is a SEPARATE notification source — it reuses the store/deliverer, not
+// the alert_rules/template/evaluator registry.
+package alerting
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/open-rails/openrails/internal/reconcile"
+)
+
+var _ reconcile.FindingNotifier = (*Service)(nil)
+
+// FindingDigestCadence is the minimum spacing between low-severity findings
+// digests. Tighter than the #736 monthly DigestCadence (payment-method
+// expiry): findings need faster surfacing, just not one push per finding.
+const FindingDigestCadence = 24 * time.Hour
+
+// NotifyFinding is the #787 emit seam both reconcile engines (the pull Engine
+// and the Convergence Engine) call after persisting a finding.
+//
+// Predicate: only status == requires_review findings fire — that status IS
+// the finding model's own "needs a human decision" signal (see
+// internal/reconcile/findings.go: chargebacks, duplicate subscriptions, and
+// ambiguous PS-1 matches are always requires_review because the fix is remote
+// or judgment-dependent). A high/critical finding the engine can enforce
+// automatically stays reconcile_required and self-heals without ever
+// reaching here — notifying on severity alone would page operators for
+// problems the system already fixed.
+//
+// Severity SeverityLow requires_review findings are batched into the digest
+// (DigestFindings) instead of firing individually — noise control.
+//
+// Dedupe: NotifiedAt/NotifiedSeverity on the finding row are the linkage. A
+// nil NotifiedAt means this open episode hasn't notified yet. A non-nil one
+// blocks re-firing UNLESS severity has genuinely escalated (a strictly lower
+// SeverityRank) since the last notify — a re-observation at the same or a
+// lower severity is silent. Every resolution path clears the linkage (see
+// reconciliation.sql), so a finding that reopens later notifies again.
+func (s *Service) NotifyFinding(ctx context.Context, rec reconcile.FindingRecord) error {
+	if rec.Status != reconcile.FindingStatusRequiresReview {
+		return nil
+	}
+	if rec.Severity == reconcile.SeverityLow {
+		return nil // batched by DigestFindings, not fired here
+	}
+	if rec.NotifiedAt != nil && reconcile.SeverityRank(rec.Severity) >= reconcile.SeverityRank(reconcile.Severity(rec.NotifiedSeverity)) {
+		return nil // already notified at this severity or worse; not a genuine escalation
+	}
+	sev := findingAlertSeverity(rec.Severity)
+	alert := Alert{
+		Severity:      sev,
+		RuleName:      findingTitle(rec),
+		Summary:       findingSummary(rec),
+		DashboardLink: s.findingLink(rec.ID),
+		FiredAt:       s.now(),
+	}
+	s.deliverer.dispatchFinding(ctx, defaultChannels(sev), alert)
+	return s.store.markFindingNotified(ctx, rec.ID, s.now(), string(rec.Severity))
+}
+
+// FindingsDigestStats summarizes one merchant's digest pass.
+type FindingsDigestStats struct {
+	Digested int64
+}
+
+// ArmedFindingsDigestMerchantIDs returns merchants with at least one
+// undigested low-severity requires_review finding — the digest sweep's work
+// set (indexed; scales with backlog, never the merchant directory, #719).
+func (s *Service) ArmedFindingsDigestMerchantIDs(ctx context.Context) ([]uuid.UUID, error) {
+	return s.store.listArmedFindingsDigestMerchants(ctx)
+}
+
+// DigestFindings runs the merchant's low-severity findings digest if due
+// (FindingDigestCadence since the last one) and there is something to report.
+// Cadence-gated the same shape as the #736 payment_methods_expiring digest — a
+// stored watermark plus a duration check — reused as a PATTERN, not through
+// the rule/template registry (findings are not a metric-threshold rule).
+func (s *Service) DigestFindings(ctx context.Context) (FindingsDigestStats, error) {
+	var stats FindingsDigestStats
+	now := s.now()
+	last, err := s.store.getFindingDigestWatermark(ctx)
+	if err != nil {
+		return stats, fmt.Errorf("alerting: findings digest watermark: %w", err)
+	}
+	if last != nil && now.Sub(*last) < FindingDigestCadence {
+		return stats, nil
+	}
+	n, err := s.store.countLowSeverityFindingsPendingDigest(ctx)
+	if err != nil {
+		return stats, fmt.Errorf("alerting: count pending findings digest: %w", err)
+	}
+	if n == 0 {
+		// Nothing to report: do not advance the watermark, so a quiet merchant
+		// digests immediately once something low-severity actually opens
+		// (mirrors the payment_methods_expiring digest's cadence gate).
+		return stats, nil
+	}
+	alert := Alert{
+		Severity:      SeverityWarning,
+		RuleName:      "Reconciliation findings digest",
+		Summary:       fmt.Sprintf("%d low-severity reconciliation finding(s) pending review", n),
+		DashboardLink: s.findingsQueueLink(),
+		FiredAt:       now,
+	}
+	s.deliverer.dispatchFinding(ctx, defaultChannels(SeverityWarning), alert)
+	if _, err := s.store.markLowSeverityFindingsDigested(ctx, now); err != nil {
+		return stats, fmt.Errorf("alerting: mark findings digested: %w", err)
+	}
+	if err := s.store.touchFindingDigestWatermark(ctx, now); err != nil {
+		return stats, fmt.Errorf("alerting: touch findings digest watermark: %w", err)
+	}
+	stats.Digested = n
+	return stats, nil
+}
+
+// findingAlertSeverity maps a reconcile finding severity onto the coarser
+// alerting channel-routing severity (critical/high -> critical fans out to
+// email; medium -> warning stays in_app-only). Low never reaches here (it
+// digests instead).
+func findingAlertSeverity(sev reconcile.Severity) Severity {
+	if sev == reconcile.SeverityCritical || sev == reconcile.SeverityHigh {
+		return SeverityCritical
+	}
+	return SeverityWarning
+}
+
+func findingTitle(rec reconcile.FindingRecord) string {
+	return fmt.Sprintf("Reconciliation review needed: %s", rec.Type)
+}
+
+func findingSummary(rec reconcile.FindingRecord) string {
+	msg := fmt.Sprintf("%s finding on %s requires review", rec.Type, rec.SubjectKey)
+	if rec.RecommendedAction != "" {
+		msg += ": " + rec.RecommendedAction
+	}
+	return msg
+}
+
+// findingLink / findingsQueueLink are deep links into the console Ops tab,
+// same relative-path + optional base-URL-prefix shape as dashboardLink.
+func (s *Service) findingLink(id uuid.UUID) string {
+	return s.opsLink("finding=" + id.String())
+}
+
+func (s *Service) findingsQueueLink() string {
+	return s.opsLink("severity=low")
+}
+
+func (s *Service) opsLink(query string) string {
+	path := "/ops?" + query
+	if s.dashboardBaseURL == "" {
+		return path
+	}
+	return s.dashboardBaseURL + path
+}

--- a/internal/modules/alerting/findings_integration_test.go
+++ b/internal/modules/alerting/findings_integration_test.go
@@ -1,0 +1,102 @@
+//go:build integration
+
+package alerting_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/modules/alerting"
+	"github.com/open-rails/openrails/internal/reconcile"
+)
+
+// TestFindingNotifyDedupeEscalateResolve is the #787 no-mock proof: a finding
+// created through the REAL reconcile.PGStore, notified through the REAL
+// alerting store, deduped across a repeated reconcile pass, re-fired on a
+// genuine escalation, and silenced once resolved.
+func TestFindingNotifyDedupeEscalateResolve(t *testing.T) {
+	pool, appDB := rlsSetup(t)
+	mid := uuid.New()
+	seedMerchant(t, pool, mid)
+
+	alertSvc := alerting.NewService(alerting.Deps{DB: appDB})
+	findingStore := &reconcile.PGStore{DB: appDB}
+
+	subjectKey := "chargeback-" + uuid.NewString()
+
+	upsert := func(t *testing.T, sev reconcile.Severity) reconcile.FindingRecord {
+		t.Helper()
+		var rec reconcile.FindingRecord
+		inConn(t, appDB, mid, func(ctx context.Context) {
+			runID, err := findingStore.CreateRun(ctx, reconcile.ModeAdvisory, []reconcile.Provider{reconcile.ProviderNMI}, nil, nil)
+			require.NoError(t, err)
+			rec, err = findingStore.UpsertFinding(ctx, runID, reconcile.Finding{
+				Provider:          reconcile.ProviderNMI,
+				Type:              reconcile.FindingChargebackActiveSub,
+				SubjectKey:        subjectKey,
+				Severity:          sev,
+				Status:            reconcile.FindingStatusRequiresReview,
+				RecommendedAction: "review the chargeback before any local action",
+			})
+			require.NoError(t, err)
+		})
+		return rec
+	}
+
+	notify := func(t *testing.T, rec reconcile.FindingRecord) {
+		t.Helper()
+		inConn(t, appDB, mid, func(ctx context.Context) {
+			require.NoError(t, alertSvc.NotifyFinding(ctx, rec))
+		})
+	}
+
+	unreadCount := func(t *testing.T) int64 {
+		t.Helper()
+		var n int64
+		inConn(t, appDB, mid, func(ctx context.Context) {
+			var err error
+			n, err = alertSvc.UnreadCount(ctx)
+			require.NoError(t, err)
+		})
+		return n
+	}
+
+	// 1. Finding created (severity=high, requires_review) -> exactly one
+	// notification through the real store.
+	rec := upsert(t, reconcile.SeverityHigh)
+	notify(t, rec)
+	require.Equal(t, int64(1), unreadCount(t), "first requires_review finding must notify exactly once")
+
+	// 2. A repeated reconcile pass re-observes the SAME open finding at the
+	// SAME severity: the dedupe linkage (notified_at/notified_severity, set by
+	// step 1) must block a second notification.
+	rec = upsert(t, reconcile.SeverityHigh)
+	require.NotNil(t, rec.NotifiedAt, "re-observed finding must carry the dedupe linkage from the first notify")
+	notify(t, rec)
+	require.Equal(t, int64(1), unreadCount(t), "re-observing an unchanged open finding must NOT re-notify")
+
+	// 3. Escalation (severity increases while still open) re-fires exactly once
+	// more.
+	rec = upsert(t, reconcile.SeverityCritical)
+	notify(t, rec)
+	require.Equal(t, int64(2), unreadCount(t), "a genuine severity escalation must notify exactly once more")
+
+	// 4. Resolve the finding — the resolution clears the notify linkage
+	// (matching #736's silent alert-clear: resolving never itself pushes a
+	// notification). Re-observing the now-resolved record must not re-fire.
+	var resolved reconcile.FindingRecord
+	inConn(t, appDB, mid, func(ctx context.Context) {
+		ok, err := findingStore.AckFinding(ctx, rec.ID, "chargeback resolved with the processor")
+		require.NoError(t, err)
+		require.True(t, ok)
+		resolved, err = findingStore.GetFinding(ctx, rec.ID)
+		require.NoError(t, err)
+	})
+	require.Equal(t, reconcile.FindingStatusFixed, resolved.Status)
+	require.Nil(t, resolved.NotifiedAt, "resolution must clear the notify linkage")
+	notify(t, resolved)
+	require.Equal(t, int64(2), unreadCount(t), "a resolved finding must never notify")
+}

--- a/internal/modules/alerting/store.go
+++ b/internal/modules/alerting/store.go
@@ -236,6 +236,61 @@ func (s *store) countPaymentMethodsExpiring(ctx context.Context, now time.Time, 
 	})
 }
 
+// --- #787 reconciliation-findings notifications -----------------------------
+
+// markFindingNotified stamps the finding's dedupe linkage after a successful
+// (or attempted — fire-and-forget, matching the rule evaluator's posture)
+// notification push.
+func (s *store) markFindingNotified(ctx context.Context, id uuid.UUID, at time.Time, severity string) error {
+	_, err := s.db.Gen(ctx).MarkReconciliationFindingNotified(ctx, gen.MarkReconciliationFindingNotifiedParams{
+		ID: id, NotifiedAt: at, Severity: severity,
+	})
+	return err
+}
+
+// listArmedFindingsDigestMerchants: merchants with at least one undigested
+// low-severity requires_review finding — the digest sweep's work set.
+// CROSS-MERCHANT (base pool), same posture as listArmedMerchants.
+func (s *store) listArmedFindingsDigestMerchants(ctx context.Context) ([]uuid.UUID, error) {
+	return s.db.GenGlobal().ListArmedFindingsDigestMerchants(ctx)
+}
+
+func (s *store) getFindingDigestWatermark(ctx context.Context) (*time.Time, error) {
+	mid, err := merchant.Require(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s.db.Gen(ctx).GetFindingDigestWatermark(ctx, mid.UUID())
+}
+
+func (s *store) touchFindingDigestWatermark(ctx context.Context, at time.Time) error {
+	mid, err := merchant.Require(ctx)
+	if err != nil {
+		return err
+	}
+	return s.db.Gen(ctx).TouchFindingDigestWatermark(ctx, gen.TouchFindingDigestWatermarkParams{
+		MerchantID: mid.UUID(), LastDigestedAt: at,
+	})
+}
+
+func (s *store) countLowSeverityFindingsPendingDigest(ctx context.Context) (int64, error) {
+	mid, err := merchant.Require(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return s.db.Gen(ctx).CountLowSeverityFindingsPendingDigest(ctx, mid.UUID())
+}
+
+func (s *store) markLowSeverityFindingsDigested(ctx context.Context, at time.Time) (int64, error) {
+	mid, err := merchant.Require(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return s.db.Gen(ctx).MarkLowSeverityFindingsDigested(ctx, gen.MarkLowSeverityFindingsDigestedParams{
+		MerchantID: mid.UUID(), NotifiedAt: at,
+	})
+}
+
 // webhookExpectedRails implements templateEvalDeps for the #786 webhook_silence
 // expectation gate: armed rails with billable subscriptions (rail -> count).
 func (s *store) webhookExpectedRails(ctx context.Context) (map[string]int64, error) {

--- a/internal/reconcile/converge/converge.go
+++ b/internal/reconcile/converge/converge.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/open-rails/openrails/internal/db"
 	"github.com/open-rails/openrails/internal/db/gen"
 	"github.com/open-rails/openrails/internal/modules/subscriptions"
+	"github.com/open-rails/openrails/internal/reconcile"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
 
@@ -117,6 +119,13 @@ type ConvergeEngine struct {
 	// converge); side-effect deps are intentionally nil.
 	lifecycle *subscriptions.SubscriptionLifecycleService
 	passes    []Pass
+
+	// Notifier bridges persisted findings into the #736 operator notification
+	// store (#787). Optional; nil is a no-op (e.g. embedded runtimes with no
+	// alerting service wired). Set directly on the constructed engine, same as
+	// Now — reconcile.FindingNotifier lives in the parent package, which
+	// converge already imports (the LIFE pass's decider).
+	Notifier reconcile.FindingNotifier
 }
 
 // NewConvergeEngine wires the engine with the DERIVE → LIFE → CON passes (each
@@ -198,8 +207,15 @@ func (e *ConvergeEngine) Converge(ctx context.Context, scope Scope) (ConvergeRes
 		if err != nil {
 			return res, err
 		}
-		if perr := e.persist(ctx, q, scope, run.ID, collected[i], status); perr != nil {
+		row, perr := e.persist(ctx, q, scope, run.ID, collected[i], status)
+		if perr != nil {
 			return res, perr
+		}
+		if e.Notifier != nil {
+			if nerr := e.Notifier.NotifyFinding(ctx, reconcile.FindingRecordFromRow(row)); nerr != nil {
+				log.WithContext(ctx).WithError(nerr).WithField("finding_id", row.ID).
+					Warn("converge: finding notification failed; continuing")
+			}
 		}
 		res.Findings++
 		switch status {
@@ -261,9 +277,10 @@ func (e *ConvergeEngine) remediate(ctx context.Context, scope Scope, f ConvergeF
 	}
 }
 
-// persist upserts a finding into the shared ledger. finding_type is the
+// persist upserts a finding into the shared ledger, returning the upserted row
+// so the caller can feed it to a FindingNotifier (#787). finding_type is the
 // self-describing qualified slug; shape/class + finding details ride in evidence.
-func (e *ConvergeEngine) persist(ctx context.Context, q *gen.Queries, scope Scope, runID uuid.UUID, f ConvergeFinding, status string) error {
+func (e *ConvergeEngine) persist(ctx context.Context, q *gen.Queries, scope Scope, runID uuid.UUID, f ConvergeFinding, status string) (gen.OpenrailsReconciliationFinding, error) {
 	meta := map[string]any{
 		"shape": string(f.Shape), "class": string(f.Class),
 	}
@@ -279,13 +296,13 @@ func (e *ConvergeEngine) persist(ctx context.Context, q *gen.Queries, scope Scop
 	}
 	evidence, err := json.Marshal(payload)
 	if err != nil {
-		return fmt.Errorf("converge: marshal evidence %s: %w", f.Type, err)
+		return gen.OpenrailsReconciliationFinding{}, fmt.Errorf("converge: marshal evidence %s: %w", f.Type, err)
 	}
 	var recommended *string
 	if f.RecommendedAction != "" {
 		recommended = &f.RecommendedAction
 	}
-	_, err = q.UpsertReconciliationFinding(ctx, gen.UpsertReconciliationFindingParams{
+	row, err := q.UpsertReconciliationFinding(ctx, gen.UpsertReconciliationFindingParams{
 		MerchantID:        scope.Merchant.UUID(),
 		FindingType:       f.Type,
 		SubjectKey:        f.SubjectKey,
@@ -296,7 +313,7 @@ func (e *ConvergeEngine) persist(ctx context.Context, q *gen.Queries, scope Scop
 		RunID:             &runID,
 	})
 	if err != nil {
-		return fmt.Errorf("converge: upsert finding %s (%s): %w", f.Type, f.SubjectKey, err)
+		return gen.OpenrailsReconciliationFinding{}, fmt.Errorf("converge: upsert finding %s (%s): %w", f.Type, f.SubjectKey, err)
 	}
-	return nil
+	return row, nil
 }

--- a/internal/reconcile/engine.go
+++ b/internal/reconcile/engine.go
@@ -41,6 +41,12 @@ type Engine struct {
 	// unavailable history source is NEVER a run error.
 	History HistoryEventSource
 
+	// Notifier bridges persisted findings into the #736 operator notification
+	// store (#787). Optional; nil is a no-op (e.g. embedded runtimes with no
+	// alerting service wired). Best-effort: a notify failure is logged, never
+	// fails the run — the finding is already durably persisted.
+	Notifier FindingNotifier
+
 	// Now is the clock (defaults to time.Now UTC).
 	Now func() time.Time
 
@@ -392,6 +398,12 @@ func (e *Engine) runProvider(ctx context.Context, runID uuid.UUID, provider Prov
 			return rep, records, planned, appliedChanges, fmt.Errorf("persist finding %s/%s: %w", f.Type, f.SubjectKey, err)
 		}
 		records = append(records, rec)
+		if e.Notifier != nil {
+			if nerr := e.Notifier.NotifyFinding(ctx, rec); nerr != nil {
+				log.WithContext(ctx).WithError(nerr).WithField("finding_id", rec.ID).
+					Warn("reconcile: finding notification failed; continuing")
+			}
+		}
 		if f.Apply != nil {
 			planned = append(planned, mutationRecordsForFinding(provider, rec.ID, f, nil, "planned")...)
 		}

--- a/internal/reconcile/engine_test.go
+++ b/internal/reconcile/engine_test.go
@@ -205,6 +205,8 @@ func (s *memStore) AutoResolveVanished(ctx context.Context, provider Provider, r
 		rec.Status = FindingStatusFixed
 		rec.Resolution = "auto_vanished"
 		rec.ResolvedAt = &now
+		rec.NotifiedAt = nil
+		rec.NotifiedSeverity = ""
 		n++
 	}
 	return n, nil
@@ -221,6 +223,21 @@ func (s *memStore) MarkFindingVanished(ctx context.Context, id uuid.UUID) error 
 	rec.Status = FindingStatusFixed
 	rec.Resolution = "auto_vanished"
 	rec.ResolvedAt = &now
+	rec.NotifiedAt = nil
+	rec.NotifiedSeverity = ""
+	return nil
+}
+
+func (s *memStore) MarkFindingNotified(ctx context.Context, id uuid.UUID, at time.Time, severity Severity) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rec, ok := s.byID[id]
+	if !ok {
+		return fmt.Errorf("no finding %s", id)
+	}
+	t := at
+	rec.NotifiedAt = &t
+	rec.NotifiedSeverity = string(severity)
 	return nil
 }
 
@@ -236,6 +253,8 @@ func (s *memStore) MarkFindingAutoFixed(ctx context.Context, id uuid.UUID, evide
 	rec.Resolution = "enforced"
 	rec.ResolutionEvid = evidence
 	rec.ResolvedAt = &now
+	rec.NotifiedAt = nil
+	rec.NotifiedSeverity = ""
 	return nil
 }
 

--- a/internal/reconcile/findings.go
+++ b/internal/reconcile/findings.go
@@ -246,7 +246,10 @@ var stateRosterFindingTypes = []FindingType{
 	FindingDuplicateSubscriptions,
 }
 
-func severityRank(s Severity) int {
+// SeverityRank orders severities worst-first (critical=0 .. low=3) for sorting
+// and escalation comparisons (a #787 FindingNotifier re-fires only when the
+// rank strictly decreases — a genuine escalation).
+func SeverityRank(s Severity) int {
 	switch s {
 	case SeverityCritical:
 		return 0

--- a/internal/reconcile/notify.go
+++ b/internal/reconcile/notify.go
@@ -1,0 +1,17 @@
+package reconcile
+
+import "context"
+
+// FindingNotifier is the #787 operator-notification seam: both writers of the
+// reconciliation_findings ledger (the pull Engine below, and the Convergence
+// Engine's DERIVE/LIFE/CON passes) call NotifyFinding once per persisted
+// finding row. Findings are event-sourced (one row upserted per pass) rather
+// than a metric-threshold rule, so this bridges directly into the #736
+// notification store instead of going through the alert_rules/evaluator
+// registry. Implementations own the requires_review/severity predicate,
+// dedupe (FindingRecord.NotifiedAt/NotifiedSeverity), the low-severity digest,
+// and channel selection. nil is a valid no-op — embedded runtimes wire no
+// alerting service.
+type FindingNotifier interface {
+	NotifyFinding(ctx context.Context, rec FindingRecord) error
+}

--- a/internal/reconcile/report.go
+++ b/internal/reconcile/report.go
@@ -58,7 +58,7 @@ func RenderRunTable(w io.Writer, run RunRecord, findings []FindingRecord) error 
 	sorted := make([]FindingRecord, len(findings))
 	copy(sorted, findings)
 	sort.SliceStable(sorted, func(i, j int) bool {
-		if a, b := severityRank(sorted[i].Severity), severityRank(sorted[j].Severity); a != b {
+		if a, b := SeverityRank(sorted[i].Severity), SeverityRank(sorted[j].Severity); a != b {
 			return a < b
 		}
 		if sorted[i].Type != sorted[j].Type {

--- a/internal/reconcile/store.go
+++ b/internal/reconcile/store.go
@@ -38,6 +38,13 @@ type FindingRecord struct {
 	Notes             string         `json:"operator_notes,omitempty"`
 	CreatedAt         time.Time      `json:"created_at"`
 	UpdatedAt         time.Time      `json:"updated_at"`
+	// NotifiedAt/NotifiedSeverity are the #787 operator-notification dedupe
+	// linkage: NotifiedAt nil means this open finding has not yet pushed a
+	// notification; NotifiedSeverity is the severity it was notified at, so a
+	// FindingNotifier can detect a genuine escalation vs mere re-observation.
+	// Cleared on every resolution (see the reconciliation.sql resolve queries).
+	NotifiedAt       *time.Time `json:"notified_at,omitempty"`
+	NotifiedSeverity string     `json:"notified_severity,omitempty"`
 }
 
 // RunRecord is a persisted reconciliation run.
@@ -65,6 +72,9 @@ type Store interface {
 	AutoResolveVanished(ctx context.Context, provider Provider, runID uuid.UUID, types []FindingType) (int64, error)
 	MarkFindingVanished(ctx context.Context, id uuid.UUID) error
 	MarkFindingAutoFixed(ctx context.Context, id uuid.UUID, resolutionEvidence map[string]any) error
+	// MarkFindingNotified stamps the #787 dedupe linkage after a FindingNotifier
+	// successfully pushes an operator notification for an OPEN finding.
+	MarkFindingNotified(ctx context.Context, id uuid.UUID, at time.Time, severity Severity) error
 }
 
 // PGStore persists runs + findings via the sqlc layer on a merchant-pinned
@@ -180,7 +190,7 @@ func (s *PGStore) UpsertFinding(ctx context.Context, runID uuid.UUID, f Finding)
 	if err != nil {
 		return FindingRecord{}, err
 	}
-	return findingRecordFromRow(row), nil
+	return FindingRecordFromRow(row), nil
 }
 
 func (s *PGStore) ListActionableFindingsByProvider(ctx context.Context, provider Provider) ([]FindingRecord, error) {
@@ -191,7 +201,7 @@ func (s *PGStore) ListActionableFindingsByProvider(ctx context.Context, provider
 	}
 	out := make([]FindingRecord, 0, len(rows))
 	for _, row := range rows {
-		out = append(out, findingRecordFromRow(row))
+		out = append(out, FindingRecordFromRow(row))
 	}
 	return out, nil
 }
@@ -218,6 +228,13 @@ func (s *PGStore) MarkFindingAutoFixed(ctx context.Context, id uuid.UUID, resolu
 	_, err := s.DB.Gen(ctx).MarkReconciliationFindingAutoFixed(ctx, gen.MarkReconciliationFindingAutoFixedParams{
 		ID:                 id,
 		ResolutionEvidence: marshalEvidence(resolutionEvidence),
+	})
+	return err
+}
+
+func (s *PGStore) MarkFindingNotified(ctx context.Context, id uuid.UUID, at time.Time, severity Severity) error {
+	_, err := s.DB.Gen(ctx).MarkReconciliationFindingNotified(ctx, gen.MarkReconciliationFindingNotifiedParams{
+		ID: id, NotifiedAt: at, Severity: string(severity),
 	})
 	return err
 }
@@ -274,7 +291,7 @@ func (s *PGStore) GetFinding(ctx context.Context, id uuid.UUID) (FindingRecord, 
 	if err != nil {
 		return FindingRecord{}, err
 	}
-	return findingRecordFromRow(row), nil
+	return FindingRecordFromRow(row), nil
 }
 
 func (s *PGStore) ListFindings(ctx context.Context, filter FindingFilter) ([]FindingRecord, error) {
@@ -301,7 +318,7 @@ func (s *PGStore) ListFindings(ctx context.Context, filter FindingFilter) ([]Fin
 	}
 	out := make([]FindingRecord, 0, len(rows))
 	for _, row := range rows {
-		out = append(out, findingRecordFromRow(row))
+		out = append(out, FindingRecordFromRow(row))
 	}
 	return out, nil
 }
@@ -410,7 +427,7 @@ func (s *PGStore) ListQueueFindings(ctx context.Context, filter QueueFilter) ([]
 	var total int64
 	for _, row := range rows {
 		total = row.TotalCount
-		out = append(out, findingRecordFromRow(row.OpenrailsReconciliationFinding))
+		out = append(out, FindingRecordFromRow(row.OpenrailsReconciliationFinding))
 	}
 	return out, total, nil
 }
@@ -575,7 +592,7 @@ func (s *PGStore) AppendFindingNotes(ctx context.Context, id uuid.UUID, note str
 	return err
 }
 
-func findingRecordFromRow(row gen.OpenrailsReconciliationFinding) FindingRecord {
+func FindingRecordFromRow(row gen.OpenrailsReconciliationFinding) FindingRecord {
 	evidence := unmarshalEvidence(row.Evidence)
 	provider, _ := evidence["provider"].(string)
 	requiresReview := row.Status == string(FindingStatusRequiresReview)
@@ -600,6 +617,7 @@ func findingRecordFromRow(row gen.OpenrailsReconciliationFinding) FindingRecord 
 		ResolvedAt:     row.ResolvedAt,
 		CreatedAt:      row.CreatedAt,
 		UpdatedAt:      row.UpdatedAt,
+		NotifiedAt:     row.NotifiedAt,
 	}
 	if row.RecommendedAction != nil {
 		rec.RecommendedAction = *row.RecommendedAction
@@ -612,6 +630,9 @@ func findingRecordFromRow(row gen.OpenrailsReconciliationFinding) FindingRecord 
 	}
 	if row.OperatorNotes != nil {
 		rec.Notes = *row.OperatorNotes
+	}
+	if row.NotifiedSeverity != nil {
+		rec.NotifiedSeverity = *row.NotifiedSeverity
 	}
 	return rec
 }

--- a/internal/river/jobs_converge_sweep.go
+++ b/internal/river/jobs_converge_sweep.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/open-rails/openrails/config"
 	"github.com/open-rails/openrails/internal/db"
+	"github.com/open-rails/openrails/internal/modules/alerting"
 	"github.com/open-rails/openrails/internal/reconcile/converge"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
@@ -42,6 +43,9 @@ type ConvergeSweepWorker struct {
 	DB     *db.DB
 	Config *config.Config
 	Clock  clockwork.Clock
+	// Alerts bridges requires_review findings into the #736 operator
+	// notification store (#787). nil = no-op (no alerting service wired).
+	Alerts *alerting.Service
 }
 
 func (ConvergeSweepWorker) Kind() string { return KindConvergeSweep }
@@ -53,6 +57,12 @@ func (w ConvergeSweepWorker) Work(ctx context.Context, job *river.Job[ConvergeSw
 	}
 	engine := converge.NewConvergeEngine(w.DB)
 	engine.Now = func() time.Time { return clock.Now().UTC() }
+	if w.Alerts != nil {
+		// #787: nil-check before assigning to the interface field — a nil
+		// *alerting.Service boxed into a non-nil FindingNotifier interface
+		// would panic on first use.
+		engine.Notifier = w.Alerts
+	}
 	logger := log.WithContext(ctx).WithField("worker", KindConvergeSweep)
 
 	// Privileged (no-GUC) read of the control-plane merchant directory.

--- a/internal/river/jobs_findings_digest.go
+++ b/internal/river/jobs_findings_digest.go
@@ -1,0 +1,66 @@
+package riverjobs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/riverqueue/river"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/open-rails/openrails/internal/db"
+	"github.com/open-rails/openrails/internal/modules/alerting"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+const KindFindingsDigest = "openrails.findings_digest"
+
+// FindingsDigestArgs triggers one low-severity reconciliation-findings digest
+// pass (#787): select merchants with an undigested low-severity requires_review
+// finding (indexed — work scales with backlog, not the merchant directory),
+// and for each, push ONE digest notification if the #736-style cadence gate is
+// due. Distinct from AlertEvalWorker: findings are not a metric-threshold rule.
+type FindingsDigestArgs struct{}
+
+func (FindingsDigestArgs) Kind() string { return KindFindingsDigest }
+
+// FindingsDigestWorker is the slow-cadence findings-digest sweep. Cross-merchant
+// selection runs on the base pool (same posture as AlertEvalWorker); each
+// merchant's digest check is RLS-scoped inside DigestFindings. One merchant's
+// failure is logged and skipped — never aborts the sweep.
+type FindingsDigestWorker struct {
+	river.WorkerDefaults[FindingsDigestArgs]
+	DB     *db.DB
+	Alerts *alerting.Service
+}
+
+func (FindingsDigestWorker) Kind() string { return KindFindingsDigest }
+
+func (w FindingsDigestWorker) Work(ctx context.Context, _ *river.Job[FindingsDigestArgs]) error {
+	if w.Alerts == nil {
+		return nil
+	}
+	merchantIDs, err := w.Alerts.ArmedFindingsDigestMerchantIDs(ctx)
+	if err != nil {
+		return fmt.Errorf("findings digest: list armed merchants: %w", err)
+	}
+	logger := log.WithContext(ctx).WithField("worker", KindFindingsDigest)
+
+	var swept int
+	var digested int64
+	for _, mid := range merchantIDs {
+		mctx := merchant.WithID(ctx, merchant.ID(mid))
+		stats, err := w.Alerts.DigestFindings(mctx)
+		if err != nil {
+			logger.WithError(err).WithField("merchant_id", mid).
+				Error("findings digest: merchant failed; continuing")
+			continue
+		}
+		swept++
+		digested += stats.Digested
+	}
+	if digested > 0 {
+		logger.WithFields(log.Fields{"merchants": swept, "digested": digested}).
+			Info("findings digest pass completed")
+	}
+	return nil
+}

--- a/internal/river/jobs_provider_refresh.go
+++ b/internal/river/jobs_provider_refresh.go
@@ -21,6 +21,7 @@ import (
 	"github.com/open-rails/openrails/internal/integrations/nmi"
 	solanaint "github.com/open-rails/openrails/internal/integrations/solana"
 	"github.com/open-rails/openrails/internal/merchants"
+	"github.com/open-rails/openrails/internal/modules/alerting"
 	"github.com/open-rails/openrails/internal/modules/subscriptions"
 	"github.com/open-rails/openrails/internal/modules/webhookhealth"
 	"github.com/open-rails/openrails/internal/reconcile"
@@ -263,6 +264,9 @@ type ProviderRefreshWorker struct {
 	SolanaRPC           *solanaint.RPCClient
 	DeferDelete         subscriptions.DeferredDeleteScheduler
 	NotificationService *subscriptions.NotificationService
+	// Alerts bridges requires_review findings into the #736 operator
+	// notification store (#787). nil = no-op (no alerting service wired).
+	Alerts *alerting.Service
 
 	// PullEndpoints overrides provider base URLs on store-armed clients
 	// (fake-provider test seam).
@@ -426,6 +430,12 @@ func (w *ProviderRefreshWorker) runUnknownReconcile(ctx context.Context, mid uui
 func (w *ProviderRefreshWorker) runConvergence(ctx context.Context, mid uuid.UUID) error {
 	engine := converge.NewConvergeEngine(w.DB)
 	engine.Now = func() time.Time { return w.now() }
+	if w.Alerts != nil {
+		// #787: nil-check before assigning to the interface field — a nil
+		// *alerting.Service boxed into a non-nil FindingNotifier interface
+		// would panic on first use.
+		engine.Notifier = w.Alerts
+	}
 	_, err := engine.Converge(ctx, converge.Scope{Merchant: merchant.ID(mid)})
 	return err
 }
@@ -485,6 +495,9 @@ func (w *ProviderRefreshWorker) runProviderEventWindows(ctx context.Context, mid
 
 	engine := reconcile.NewEngine(w.DB, w.Config, fetchers)
 	engine.Now = func() time.Time { return now }
+	if w.Alerts != nil {
+		engine.Notifier = w.Alerts // #787: nil-check, see runConvergence
+	}
 	if w.DeferDelete != nil {
 		// #679: a decider stale-decline cancel from the pull path must durably
 		// queue the deferred NMI delete, same as unknown-resolution.

--- a/migrations/postgres/0014_finding_notifications.up.sql
+++ b/migrations/postgres/0014_finding_notifications.up.sql
@@ -1,0 +1,48 @@
+-- #787: pump requires_review reconciliation findings into the #736 operator
+-- notification store. Findings are event-sourced (one Finding row persisted
+-- per pull/converge pass), NOT a metric-threshold rule, so they get their own
+-- dedupe linkage on the finding row itself rather than an alert_rules entry.
+--
+-- notified_at/notified_severity: set when an OPEN finding pushes an operator
+-- notification (immediate fire, or inclusion in the low-severity digest).
+-- notified_at IS NULL means "not yet notified this open episode" — cleared by
+-- every resolution path (fixed/auto_fixed/ignored) so a finding that reopens
+-- later notifies again. notified_severity records the severity that was
+-- notified, so a later severity INCREASE while still open re-fires (genuine
+-- escalation) but re-observing the same open finding at the same or a lower
+-- severity does not.
+ALTER TABLE openrails.reconciliation_findings
+    ADD COLUMN notified_at timestamp with time zone,
+    ADD COLUMN notified_severity text;
+
+COMMENT ON COLUMN openrails.reconciliation_findings.notified_at IS '#787: last time this OPEN finding pushed an operator notification; NULL = not yet notified this open episode. Cleared to NULL on every resolution so a reopened finding notifies again.';
+COMMENT ON COLUMN openrails.reconciliation_findings.notified_severity IS '#787: severity at last notification; a further increase while still open re-fires, re-observation at the same/lower severity does not.';
+
+-- Armed-merchant scan for the low-severity findings digest (#787): distinct
+-- merchants with at least one undigested low-severity requires_review finding.
+-- Partial index keeps the scan scaled to backlog, never the findings table
+-- on file (#719 only-run-what's-armed).
+CREATE INDEX idx_reconciliation_findings_low_severity_pending_digest
+    ON openrails.reconciliation_findings (merchant_id)
+    WHERE status = 'requires_review' AND severity = 'low' AND notified_at IS NULL;
+
+-- Per-merchant cadence watermark for the low-severity digest — the #736
+-- digest-cadence PATTERN (stored watermark + duration gate) reused outside the
+-- alert_rules/template registry, since findings are not a metric-threshold rule.
+CREATE TABLE openrails.finding_digest_state (
+    merchant_id uuid NOT NULL,
+    last_digested_at timestamp with time zone,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+COMMENT ON TABLE openrails.finding_digest_state IS '#787: one row per merchant recording when the low-severity reconciliation-findings digest last fired.';
+
+ALTER TABLE ONLY openrails.finding_digest_state
+    ADD CONSTRAINT finding_digest_state_pkey PRIMARY KEY (merchant_id);
+ALTER TABLE ONLY openrails.finding_digest_state
+    ADD CONSTRAINT finding_digest_state_merchant_fk FOREIGN KEY (merchant_id) REFERENCES openrails.merchants(id) ON DELETE CASCADE;
+
+ALTER TABLE openrails.finding_digest_state ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ONLY openrails.finding_digest_state FORCE ROW LEVEL SECURITY;
+CREATE POLICY merchant_isolation ON openrails.finding_digest_state USING ((merchant_id = (NULLIF(current_setting('app.merchant_id'::text, true), ''::text))::uuid)) WITH CHECK ((merchant_id = (NULLIF(current_setting('app.merchant_id'::text, true), ''::text))::uuid));
+GRANT SELECT,INSERT,UPDATE,DELETE ON TABLE openrails.finding_digest_state TO openrails_app;


### PR DESCRIPTION
## Summary
- Bridges `requires_review` reconciliation findings (internal/reconcile) into the #736 operator notification store (`internal/modules/alerting`) as a **separate notification source**, not a metric-threshold rule.
- Emit seam: new `reconcile.FindingNotifier` interface, called from both writers of `reconciliation_findings` — the pull `Engine.Run` and the Convergence Engine's `ConvergeEngine.Converge` — right after each finding upsert. `alerting.Service` implements it.
- Predicate: `status == requires_review` (the finding model's own "needs a human" flag). Severity alone isn't used — a high/critical finding the engine can enforce automatically stays `reconcile_required` and self-heals without ever reaching the notifier.
- Dedupe/escalation: `notified_at`/`notified_severity` columns on the finding row (migration `0014`) — set once per open episode, re-fired only on a genuine severity escalation, cleared by every resolution path (fixed/auto_fixed/ignored) so a reopened finding notifies again. Mirrors #736's silent alert-clear: resolving a finding never itself pushes a notification.
- Low-severity `requires_review` findings batch into a new daily digest sweep (`FindingsDigestWorker` / `alerting.Service.DigestFindings`) instead of firing individually — a stored per-merchant cadence watermark reusing the #736 digest-cadence *pattern*, deliberately not the alert_rules/template registry.
- Channel selection: no per-finding rule exists to carry channels, so findings use the existing severity-based `defaultChannels` fallback (critical/high → in_app+email, medium → in_app).
- Embedded runtimes (doujins/hentai0/cozy-art) never wire `alerting`, so `Notifier`/`Alerts` stay nil (no-op) there — zero `pkg/embedded` changes needed.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean on touched files
- [x] `task sqlc` regenerated cleanly (new queries + notified_at/notified_severity columns)
- [x] `internal/reconcile`, `internal/reconcile/converge`, `internal/modules/alerting`, `internal/river` unit tests pass
- [x] `internal/reconcile` and `internal/modules/alerting` integration tests pass (`-tags integration`, testcontainers), except one pre-existing unrelated flake (`TestReconcileAdoptPreservesScheduledProviderActions`, confirmed failing identically on master before this branch — a `uq_prices_merchant_key_current` fixture collision, not caused by this change)
- [x] New integration test `internal/modules/alerting/findings_integration_test.go::TestFindingNotifyDedupeEscalateResolve`: finding created (real `reconcile.PGStore`) → notification emitted once (real `alerting` store) → repeated reconcile pass does not re-emit → escalation fires one more → resolve clears linkage and never re-fires. Verified load-bearing: disabling the dedupe check turned it red, restoring it turned it green.