### PR TITLE
CI (#790): scope integration job to integration-tagged packages; add -race to unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
         # never compile these files.
         run: go vet -tags integration ./...
       - name: Test
-        run: go test ./...
+        run: go test -race ./...
 
   sqlc:
     runs-on: ubuntu-latest
@@ -118,7 +118,9 @@ jobs:
       - name: Download modules
         run: go mod download
       # Integration tests share one compose-backed Postgres/Garnet stack and
-      # run serially. Testcontainers remain capped fallbacks for direct
-      # package runs, not the normal CI path.
+      # run serially. The script expands ./... to only the packages carrying
+      # the `integration` build tag (#790) so the serial run doesn't repeat
+      # the build job's unit tests. Testcontainers remain capped fallbacks
+      # for direct package runs, not the normal CI path.
       - name: Integration test
         run: bash scripts/test_integration.sh ./...

--- a/scripts/test_integration.sh
+++ b/scripts/test_integration.sh
@@ -1,9 +1,33 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Packages containing files (test or non-test) that carry the `integration`
+# build tag. Running `./...` verbatim would serially re-run every untagged
+# unit test the build job already ran in parallel, so `./...` (and no args)
+# expands to only the tagged packages. Explicit flags/packages pass through.
+integration_packages() {
+  grep -rl --include='*.go' -E '^//go:build (.*[^a-zA-Z0-9_])?integration([^a-zA-Z0-9_].*)?$' . |
+    xargs -n1 dirname | sed -e 's|^\./||' -e 's|^|./|' | sort -u
+}
+
 if [ "$#" -eq 0 ]; then
   set -- ./...
 fi
+
+args=()
+for arg in "$@"; do
+  if [ "$arg" = "./..." ]; then
+    mapfile -t pkgs < <(integration_packages)
+    if [ "${#pkgs[@]}" -eq 0 ]; then
+      echo "test_integration.sh: no packages carry the 'integration' build tag; refusing to test nothing" >&2
+      exit 1
+    fi
+    echo "test_integration.sh: ./... -> ${#pkgs[@]} integration-tagged packages" >&2
+    args+=("${pkgs[@]}")
+  else
+    args+=("$arg")
+  fi
+done
 
 export POSTGRES_HOST_PORT="${POSTGRES_HOST_PORT:-5434}"
 export GARNET_HOST_PORT="${GARNET_HOST_PORT:-6380}"
@@ -13,4 +37,4 @@ docker compose -f docker-compose.yaml up -d --wait postgres garnet
 export OPENRAILS_TEST_DB_DSN="${OPENRAILS_TEST_DB_DSN:-postgresql://admin:admin_password@127.0.0.1:${POSTGRES_HOST_PORT}/openrails_db?sslmode=disable}"
 export OPENRAILS_TEST_REDIS_ADDR="${OPENRAILS_TEST_REDIS_ADDR:-127.0.0.1:${GARNET_HOST_PORT}}"
 
-go test -p 1 -parallel 1 -tags=integration -timeout "${OPENRAILS_INTEGRATION_TIMEOUT:-25m}" "$@"
+go test -p 1 -parallel 1 -tags=integration -timeout "${OPENRAILS_INTEGRATION_TIMEOUT:-25m}" "${args[@]}"


### PR DESCRIPTION
Tracker openrails#790.

The integration job ran `go test -p 1 -parallel 1 -tags=integration ./...` over ALL 102 packages, serially re-running ~256 untagged unit test files the build job already ran in parallel.

## Changes

- **scripts/test_integration.sh**: `./...` (and no args) now expands to only the packages containing files that carry the `integration` build tag (currently 45 of 102), via a word-boundary-safe grep (`stripe_integration` etc. do not match). Packages whose non-test files carry the tag (dbtest, integrationharness, vaulttest) are included; zero tagged matches fails loudly instead of testing nothing. Explicit flags/packages still pass through unchanged, so the live-gated lanes and Taskfile targets keep working.
- **ci.yaml build job**: unit `go test ./...` now runs with `-race`.

## Verification

- Derived package list resolves cleanly: `go list -tags=integration <derived>` = 45 packages.
- `go test -race ./internal/intents/ ./internal/modules/payments/rails/` green.
- Full modified script run locally against the compose stack (in progress at PR-open time; CI is the gate).

Known pre-existing master failures (NOT this PR): TestRootOperatorBoundary_ReachNotMerchantCapability (2fa_enrollment_required) and TestReconcileAdoptPreservesScheduledProviderActions (duplicate price key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)