### PR TITLE
feat(#789): access-ended emails fire on truth, deliver durably

### DIFF
--- a/client.go
+++ b/client.go
@@ -372,6 +372,7 @@ type MerchantProfileInput struct {
 	LogoURL     string `json:"logo_url,omitempty"`
 	FromEmail   string `json:"from_email,omitempty"`
 	SupportURL  string `json:"support_url,omitempty"`
+	SignupURL   string `json:"signup_url,omitempty"`
 }
 
 // MerchantSettings is the merchant-owned admission/policy document installed by

--- a/docs/merchant-provisioning.md
+++ b/docs/merchant-provisioning.md
@@ -144,6 +144,7 @@ merchants:
       logo_url: https://doujins.example/logo.png
       from_email: billing@doujins.example
       support_url: https://doujins.example/support
+      signup_url: https://doujins.example/premium
     accounts:
       mobius:
         nmi:

--- a/embed/provision.go
+++ b/embed/provision.go
@@ -139,7 +139,8 @@ func merchantConfigDeclaresManifestTruth(m MerchantConfig) bool {
 		strings.TrimSpace(m.Profile.DisplayName) != "" ||
 		strings.TrimSpace(m.Profile.LogoURL) != "" ||
 		strings.TrimSpace(m.Profile.FromEmail) != "" ||
-		strings.TrimSpace(m.Profile.SupportURL) != ""
+		strings.TrimSpace(m.Profile.SupportURL) != "" ||
+		strings.TrimSpace(m.Profile.SignupURL) != ""
 }
 
 // ParseMerchantConfig parses a single merchant YAML document into a MerchantConfig.

--- a/internal/app/river_register.go
+++ b/internal/app/river_register.go
@@ -115,6 +115,15 @@ func (r *Runtime) addBillingWorkersToRegistry(ctx context.Context, workers *rive
 	}); err != nil {
 		return fmt.Errorf("add converge sweep worker: %w", err)
 	}
+	// Notification email sweep (#789): delivers undelivered notification_queue
+	// rows (emailed_at NULL) — including the converge NOTIFY pass's access-ended
+	// rows, which are created without inline delivery.
+	if err := addTrackedWorker(r, workers, &riverjobs.NotificationEmailSweepWorker{
+		DB:            r.DB,
+		Notifications: r.NotificationService,
+	}); err != nil {
+		return fmt.Errorf("add notification email sweep worker: %w", err)
+	}
 	if err := addTrackedWorker(r, workers, &riverjobs.CancelSubscriptionWorker{
 		DB:                           r.DB,
 		Config:                       r.Config,
@@ -670,6 +679,20 @@ func (r *Runtime) buildRiverPeriodicJobs(ctx context.Context) ([]*river.Periodic
 			}
 		},
 		&river.PeriodicJobOpts{RunOnStart: true},
+	))
+
+	// Every 10 minutes: notification email sweep (#789) — retry undelivered
+	// notification emails (emailed_at NULL). Cheap no-op when nothing is queued
+	// or no email service is armed.
+	jobs = append(jobs, r.healthPeriodic(
+		10*time.Minute,
+		func() (river.JobArgs, *river.InsertOpts) {
+			return riverjobs.NotificationEmailSweepArgs{}, &river.InsertOpts{
+				Queue:      riverjobs.QueueBilling,
+				UniqueOpts: river.UniqueOpts{ByQueue: true, ByPeriod: 10 * time.Minute},
+			}
+		},
+		&river.PeriodicJobOpts{RunOnStart: false},
 	))
 
 	// Every 15 minutes: metric threshold alerting evaluation (#736). Slow

--- a/internal/bootstrap/bootstrap_manifest.go
+++ b/internal/bootstrap/bootstrap_manifest.go
@@ -40,6 +40,9 @@ func validateMerchantManifestShape(m *BillingConfig) error {
 		if profileURL := strings.TrimSpace(t.Profile.SupportURL); profileURL != "" && !validHTTPURL(profileURL) {
 			return fmt.Errorf("merchant %q profile.support_url must be an http or https URL", slug)
 		}
+		if profileURL := strings.TrimSpace(t.Profile.SignupURL); profileURL != "" && !validHTTPURL(profileURL) {
+			return fmt.Errorf("merchant %q profile.signup_url must be an http or https URL", slug)
+		}
 		if t.RemoteApplication != nil {
 			if err := validateManifestRemoteApplication(slug, t.RemoteApplication); err != nil {
 				return err

--- a/internal/bootstrap/merchant_dump.go
+++ b/internal/bootstrap/merchant_dump.go
@@ -87,6 +87,7 @@ func DumpMerchantConfig(ctx context.Context, cfg *config.Config, cp *controlplan
 			LogoURL:     conf.Profile.LogoURL,
 			FromEmail:   conf.Profile.FromEmail,
 			SupportURL:  conf.Profile.SupportURL,
+			SignupURL:   conf.Profile.SignupURL,
 		}
 		if conf.InvoiceCollectionThreshold != nil || conf.InvoiceMonthlyFloor != nil || strings.TrimSpace(conf.InvoiceBillingBoundary) != "" {
 			mt.Invoice = &InvoiceConfig{

--- a/internal/bootstrap/merchant_manifest.go
+++ b/internal/bootstrap/merchant_manifest.go
@@ -297,6 +297,9 @@ func mergeMerchantProfileConfig(dst *MerchantProfileConfig, src MerchantProfileC
 	if strings.TrimSpace(src.SupportURL) != "" {
 		dst.SupportURL = src.SupportURL
 	}
+	if strings.TrimSpace(src.SignupURL) != "" {
+		dst.SignupURL = src.SignupURL
+	}
 }
 
 func mergeInvoiceConfig(dst, src *InvoiceConfig) {
@@ -433,6 +436,7 @@ type MerchantProfileConfig struct {
 	LogoURL     string `yaml:"logo_url,omitempty" koanf:"logo_url"`
 	FromEmail   string `yaml:"from_email,omitempty" koanf:"from_email"`
 	SupportURL  string `yaml:"support_url,omitempty" koanf:"support_url"`
+	SignupURL   string `yaml:"signup_url,omitempty" koanf:"signup_url"`
 }
 
 type RailMerchantAccountConfig map[string]ProviderRailAccountConfig
@@ -802,6 +806,7 @@ func reconcileManifestMerchantConfiguration(ctx context.Context, cfg *config.Con
 				LogoURL:     strings.TrimSpace(mt.Profile.LogoURL),
 				FromEmail:   strings.TrimSpace(mt.Profile.FromEmail),
 				SupportURL:  strings.TrimSpace(mt.Profile.SupportURL),
+				SignupURL:   strings.TrimSpace(mt.Profile.SignupURL),
 			}
 			if conf.Profile.DisplayName == "" {
 				conf.Profile.DisplayName = strings.TrimSpace(mt.DisplayName)
@@ -917,7 +922,8 @@ func hasManifestProfile(p MerchantProfileConfig) bool {
 	return strings.TrimSpace(p.DisplayName) != "" ||
 		strings.TrimSpace(p.LogoURL) != "" ||
 		strings.TrimSpace(p.FromEmail) != "" ||
-		strings.TrimSpace(p.SupportURL) != ""
+		strings.TrimSpace(p.SupportURL) != "" ||
+		strings.TrimSpace(p.SignupURL) != ""
 }
 
 // resolvedManifestRailAccount is the store/DB-independent front half of a

--- a/internal/db/gen/models.go
+++ b/internal/db/gen/models.go
@@ -637,6 +637,8 @@ type OpenrailsNotificationQueue struct {
 	CreatedAt  time.Time
 	MerchantID uuid.UUID
 	CustomerID uuid.UUID
+	// #789: when the notification email was sent; NULL = undelivered (the notification_email_sweep retries).
+	EmailedAt *time.Time
 }
 
 // #690 episode analytics, the mirror of freeloader_episodes: spans where payment coverage existed (subscription paid-through snapshot, or a completed one_off payment with a finite access window for an entitlement-promising product) but no entitlement window covered the time. Open episodes (paid-through still in the future) end at now(). Same approximations: paid-through is the current-period snapshot; window coverage is contiguous-from-the-left (uncovered TAIL only — a wrongly-early revocation shows as the tail from revoked_at to paid-through).

--- a/internal/db/gen/notification_queue.sql.go
+++ b/internal/db/gen/notification_queue.sql.go
@@ -149,7 +149,7 @@ func (q *Queries) DeleteSeenNotificationsBefore(ctx context.Context, cutoff time
 }
 
 const getNotificationByID = `-- name: GetNotificationByID :one
-SELECT id, event_type, data, seen, created_at, merchant_id, customer_id FROM openrails.notification_queue WHERE id = $1
+SELECT id, event_type, data, seen, created_at, merchant_id, customer_id, emailed_at FROM openrails.notification_queue WHERE id = $1
 `
 
 func (q *Queries) GetNotificationByID(ctx context.Context, id uuid.UUID) (OpenrailsNotificationQueue, error) {
@@ -163,6 +163,7 @@ func (q *Queries) GetNotificationByID(ctx context.Context, id uuid.UUID) (Openra
 		&i.CreatedAt,
 		&i.MerchantID,
 		&i.CustomerID,
+		&i.EmailedAt,
 	)
 	return i, err
 }
@@ -199,7 +200,7 @@ func (q *Queries) ListCustomersWithPendingDigest(ctx context.Context, arg ListCu
 }
 
 const listNotificationsByCustomer = `-- name: ListNotificationsByCustomer :many
-SELECT id, event_type, data, seen, created_at, merchant_id, customer_id FROM openrails.notification_queue nq
+SELECT id, event_type, data, seen, created_at, merchant_id, customer_id, emailed_at FROM openrails.notification_queue nq
 WHERE nq.customer_id = $1
 ORDER BY nq.created_at DESC
 `
@@ -221,6 +222,7 @@ func (q *Queries) ListNotificationsByCustomer(ctx context.Context, customerID uu
 			&i.CreatedAt,
 			&i.MerchantID,
 			&i.CustomerID,
+			&i.EmailedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -233,7 +235,7 @@ func (q *Queries) ListNotificationsByCustomer(ctx context.Context, customerID uu
 }
 
 const listNotificationsByEventType = `-- name: ListNotificationsByEventType :many
-SELECT id, event_type, data, seen, created_at, merchant_id, customer_id FROM openrails.notification_queue nq
+SELECT id, event_type, data, seen, created_at, merchant_id, customer_id, emailed_at FROM openrails.notification_queue nq
 WHERE nq.event_type = $1
 ORDER BY nq.created_at DESC
 `
@@ -255,6 +257,7 @@ func (q *Queries) ListNotificationsByEventType(ctx context.Context, eventType st
 			&i.CreatedAt,
 			&i.MerchantID,
 			&i.CustomerID,
+			&i.EmailedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -267,7 +270,7 @@ func (q *Queries) ListNotificationsByEventType(ctx context.Context, eventType st
 }
 
 const listNotificationsFiltered = `-- name: ListNotificationsFiltered :many
-SELECT id, event_type, data, seen, created_at, merchant_id, customer_id FROM openrails.notification_queue nq
+SELECT id, event_type, data, seen, created_at, merchant_id, customer_id, emailed_at FROM openrails.notification_queue nq
 WHERE ($1::uuid IS NULL OR nq.customer_id = $1::uuid)
   AND ($2::text IS NULL OR nq.event_type = $2::text)
   AND ($3::boolean IS NULL OR nq.seen = $3::boolean)
@@ -306,6 +309,7 @@ func (q *Queries) ListNotificationsFiltered(ctx context.Context, arg ListNotific
 			&i.CreatedAt,
 			&i.MerchantID,
 			&i.CustomerID,
+			&i.EmailedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -318,7 +322,7 @@ func (q *Queries) ListNotificationsFiltered(ctx context.Context, arg ListNotific
 }
 
 const listPendingDigestForCustomer = `-- name: ListPendingDigestForCustomer :many
-SELECT id, event_type, data, seen, created_at, merchant_id, customer_id FROM openrails.notification_queue nq
+SELECT id, event_type, data, seen, created_at, merchant_id, customer_id, emailed_at FROM openrails.notification_queue nq
 WHERE nq.customer_id = $1
   AND nq.event_type = $2
   AND nq.created_at >= $3
@@ -355,6 +359,7 @@ func (q *Queries) ListPendingDigestForCustomer(ctx context.Context, arg ListPend
 			&i.CreatedAt,
 			&i.MerchantID,
 			&i.CustomerID,
+			&i.EmailedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -367,7 +372,7 @@ func (q *Queries) ListPendingDigestForCustomer(ctx context.Context, arg ListPend
 }
 
 const listRepairAlerts = `-- name: ListRepairAlerts :many
-SELECT id, event_type, data, seen, created_at, merchant_id, customer_id FROM openrails.notification_queue nq
+SELECT id, event_type, data, seen, created_at, merchant_id, customer_id, emailed_at FROM openrails.notification_queue nq
 WHERE nq.customer_id = $1
   AND nq.event_type = $2
   AND nq.data ->> 'kind' = 'billing_ledger_repair_required'
@@ -407,6 +412,50 @@ func (q *Queries) ListRepairAlerts(ctx context.Context, arg ListRepairAlertsPara
 			&i.CreatedAt,
 			&i.MerchantID,
 			&i.CustomerID,
+			&i.EmailedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listUndeliveredNotifications = `-- name: ListUndeliveredNotifications :many
+SELECT id, event_type, data, seen, created_at, merchant_id, customer_id, emailed_at FROM openrails.notification_queue nq
+WHERE nq.merchant_id = $1::uuid
+  AND nq.emailed_at IS NULL
+ORDER BY nq.created_at
+LIMIT $2::int
+`
+
+type ListUndeliveredNotificationsParams struct {
+	MerchantID uuid.UUID
+	PageLimit  int32
+}
+
+// #789: undelivered rows for the notification email sweep (emailed_at NULL).
+func (q *Queries) ListUndeliveredNotifications(ctx context.Context, arg ListUndeliveredNotificationsParams) ([]OpenrailsNotificationQueue, error) {
+	rows, err := q.db.Query(ctx, listUndeliveredNotifications, arg.MerchantID, arg.PageLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []OpenrailsNotificationQueue
+	for rows.Next() {
+		var i OpenrailsNotificationQueue
+		if err := rows.Scan(
+			&i.ID,
+			&i.EventType,
+			&i.Data,
+			&i.Seen,
+			&i.CreatedAt,
+			&i.MerchantID,
+			&i.CustomerID,
+			&i.EmailedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -419,7 +468,7 @@ func (q *Queries) ListRepairAlerts(ctx context.Context, arg ListRepairAlertsPara
 }
 
 const listUnseenNotificationsByCustomer = `-- name: ListUnseenNotificationsByCustomer :many
-SELECT id, event_type, data, seen, created_at, merchant_id, customer_id FROM openrails.notification_queue nq
+SELECT id, event_type, data, seen, created_at, merchant_id, customer_id, emailed_at FROM openrails.notification_queue nq
 WHERE nq.customer_id = $1 AND nq.seen = false
 ORDER BY nq.created_at DESC
 `
@@ -441,6 +490,7 @@ func (q *Queries) ListUnseenNotificationsByCustomer(ctx context.Context, custome
 			&i.CreatedAt,
 			&i.MerchantID,
 			&i.CustomerID,
+			&i.EmailedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -450,6 +500,25 @@ func (q *Queries) ListUnseenNotificationsByCustomer(ctx context.Context, custome
 		return nil, err
 	}
 	return items, nil
+}
+
+const markNotificationEmailed = `-- name: MarkNotificationEmailed :execrows
+UPDATE openrails.notification_queue
+SET emailed_at = $2::timestamptz
+WHERE id = $1 AND emailed_at IS NULL
+`
+
+type MarkNotificationEmailedParams struct {
+	ID        uuid.UUID
+	EmailedAt time.Time
+}
+
+func (q *Queries) MarkNotificationEmailed(ctx context.Context, arg MarkNotificationEmailedParams) (int64, error) {
+	result, err := q.db.Exec(ctx, markNotificationEmailed, arg.ID, arg.EmailedAt)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const markNotificationSeen = `-- name: MarkNotificationSeen :execrows
@@ -462,6 +531,31 @@ func (q *Queries) MarkNotificationSeen(ctx context.Context, id uuid.UUID) (int64
 		return 0, err
 	}
 	return result.RowsAffected(), nil
+}
+
+const premiumEndedNotificationExistsSince = `-- name: PremiumEndedNotificationExistsSince :one
+SELECT EXISTS (
+    SELECT 1 FROM openrails.notification_queue nq
+    WHERE nq.merchant_id = $1::uuid
+      AND nq.customer_id = $2::uuid
+      AND nq.event_type = 'premium_ended'
+      AND nq.created_at >= $3::timestamptz
+)::boolean AS found
+`
+
+type PremiumEndedNotificationExistsSinceParams struct {
+	MerchantID uuid.UUID
+	CustomerID uuid.UUID
+	Since      time.Time
+}
+
+// #789: dedupe guard for the converge NOTIFY pass — any premium_ended row
+// created at/after the window close means the customer was already told.
+func (q *Queries) PremiumEndedNotificationExistsSince(ctx context.Context, arg PremiumEndedNotificationExistsSinceParams) (bool, error) {
+	row := q.db.QueryRow(ctx, premiumEndedNotificationExistsSince, arg.MerchantID, arg.CustomerID, arg.Since)
+	var found bool
+	err := row.Scan(&found)
+	return found, err
 }
 
 const updateNotification = `-- name: UpdateNotification :execrows

--- a/internal/db/gen/reconciliation.sql.go
+++ b/internal/db/gen/reconciliation.sql.go
@@ -1118,6 +1118,86 @@ func (q *Queries) ListLapsedSubscriptionsWithEvidence(ctx context.Context, arg L
 	return items, nil
 }
 
+const listRecentlyClosedLastEntitlementWindows = `-- name: ListRecentlyClosedLastEntitlementWindows :many
+SELECT DISTINCT ON (e.customer_id)
+       e.id, e.customer_id, e.entitlement,
+       LEAST(COALESCE(e.end_at, 'infinity'::timestamptz), COALESCE(e.revoked_at, 'infinity'::timestamptz)) AS closed_at,
+       e.source_type, e.source_id
+FROM openrails.entitlements e
+WHERE e.merchant_id = $1::uuid
+  AND ($2::uuid IS NULL OR e.customer_id = $2::uuid)
+  AND e.deleted_at IS NULL
+  AND (e.end_at IS NOT NULL OR e.revoked_at IS NOT NULL)
+  AND LEAST(COALESCE(e.end_at, 'infinity'::timestamptz), COALESCE(e.revoked_at, 'infinity'::timestamptz)) > $3::timestamptz
+  AND LEAST(COALESCE(e.end_at, 'infinity'::timestamptz), COALESCE(e.revoked_at, 'infinity'::timestamptz)) <= $4::timestamptz
+  AND NOT EXISTS (
+      SELECT 1 FROM openrails.entitlements live
+      WHERE live.merchant_id = e.merchant_id
+        AND live.customer_id = e.customer_id
+        AND live.entitlement = e.entitlement
+        AND live.deleted_at IS NULL AND live.revoked_at IS NULL
+        AND live.start_at <= $4::timestamptz
+        AND (live.end_at IS NULL OR live.end_at > $4::timestamptz)
+  )
+ORDER BY e.customer_id,
+         LEAST(COALESCE(e.end_at, 'infinity'::timestamptz), COALESCE(e.revoked_at, 'infinity'::timestamptz)) DESC
+`
+
+type ListRecentlyClosedLastEntitlementWindowsParams struct {
+	MerchantID  uuid.UUID
+	CustomerID  *uuid.UUID
+	ClosedAfter time.Time
+	Now         time.Time
+}
+
+type ListRecentlyClosedLastEntitlementWindowsRow struct {
+	ID          uuid.UUID
+	CustomerID  uuid.UUID
+	Entitlement string
+	ClosedAt    *time.Time
+	SourceType  string
+	SourceID    uuid.UUID
+}
+
+// #789 NOTIFY `notify.access_ended` detector: customers whose LAST entitlement
+// window closed inside (closed_after, now] — the close instant is
+// LEAST(end_at, revoked_at) (NULL = infinity; matches idx_entitlements_closed_at)
+// — with NO other live window for the same (customer, entitlement). One row per
+// customer (latest close) — one email per customer, whatever ended the access
+// (dunning, reconcile-driven cancel, grant lapse). customer_id nullable:
+// NULL = merchant-wide sweep.
+func (q *Queries) ListRecentlyClosedLastEntitlementWindows(ctx context.Context, arg ListRecentlyClosedLastEntitlementWindowsParams) ([]ListRecentlyClosedLastEntitlementWindowsRow, error) {
+	rows, err := q.db.Query(ctx, listRecentlyClosedLastEntitlementWindows,
+		arg.MerchantID,
+		arg.CustomerID,
+		arg.ClosedAfter,
+		arg.Now,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListRecentlyClosedLastEntitlementWindowsRow
+	for rows.Next() {
+		var i ListRecentlyClosedLastEntitlementWindowsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.CustomerID,
+			&i.Entitlement,
+			&i.ClosedAt,
+			&i.SourceType,
+			&i.SourceID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listReconciliationFindings = `-- name: ListReconciliationFindings :many
 SELECT id, merchant_id, finding_type, subject_key, severity, status, recommended_action, first_seen_run, last_seen_run, last_seen_at, resolved_at, resolution, operator_notes, created_at, updated_at, evidence, resolved_by, notified_at, notified_severity FROM openrails.reconciliation_findings
 WHERE ($1::text IS NULL OR status = $1::text)

--- a/internal/db/models/merchant_configuration.go
+++ b/internal/db/models/merchant_configuration.go
@@ -33,4 +33,7 @@ type MerchantProfileConfiguration struct {
 	LogoURL     string `json:"logo_url,omitempty"`
 	FromEmail   string `json:"from_email,omitempty"`
 	SupportURL  string `json:"support_url,omitempty"`
+	// SignupURL (#789) is the winback/signup page access-ended and expiry
+	// emails link to. "" ⇒ no CTA rendered.
+	SignupURL string `json:"signup_url,omitempty"`
 }

--- a/internal/db/queries/notification_queue.sql
+++ b/internal/db/queries/notification_queue.sql
@@ -81,6 +81,30 @@ WHERE seen = true AND created_at < sqlc.arg(cutoff)::timestamptz;
 DELETE FROM openrails.notification_queue
 WHERE created_at < sqlc.arg(cutoff)::timestamptz;
 
+-- #789: dedupe guard for the converge NOTIFY pass — any premium_ended row
+-- created at/after the window close means the customer was already told.
+-- name: PremiumEndedNotificationExistsSince :one
+SELECT EXISTS (
+    SELECT 1 FROM openrails.notification_queue nq
+    WHERE nq.merchant_id = sqlc.arg(merchant_id)::uuid
+      AND nq.customer_id = sqlc.arg(customer_id)::uuid
+      AND nq.event_type = 'premium_ended'
+      AND nq.created_at >= sqlc.arg(since)::timestamptz
+)::boolean AS found;
+
+-- #789: undelivered rows for the notification email sweep (emailed_at NULL).
+-- name: ListUndeliveredNotifications :many
+SELECT * FROM openrails.notification_queue nq
+WHERE nq.merchant_id = sqlc.arg(merchant_id)::uuid
+  AND nq.emailed_at IS NULL
+ORDER BY nq.created_at
+LIMIT sqlc.arg(page_limit)::int;
+
+-- name: MarkNotificationEmailed :execrows
+UPDATE openrails.notification_queue
+SET emailed_at = sqlc.arg(emailed_at)::timestamptz
+WHERE id = $1 AND emailed_at IS NULL;
+
 -- name: CountRepairAlerts :one
 SELECT count(*) FROM openrails.notification_queue nq
 WHERE nq.customer_id = $1

--- a/internal/db/queries/reconciliation.sql
+++ b/internal/db/queries/reconciliation.sql
@@ -832,3 +832,34 @@ CROSS JOIN (SELECT count(*) AS total,
 SELECT id FROM openrails.merchants
 WHERE status = 'active' AND deleted_at IS NULL
 ORDER BY id;
+
+-- #789 NOTIFY `notify.access_ended` detector: customers whose LAST entitlement
+-- window closed inside (closed_after, now] — the close instant is
+-- LEAST(end_at, revoked_at) (NULL = infinity; matches idx_entitlements_closed_at)
+-- — with NO other live window for the same (customer, entitlement). One row per
+-- customer (latest close) — one email per customer, whatever ended the access
+-- (dunning, reconcile-driven cancel, grant lapse). customer_id nullable:
+-- NULL = merchant-wide sweep.
+-- name: ListRecentlyClosedLastEntitlementWindows :many
+SELECT DISTINCT ON (e.customer_id)
+       e.id, e.customer_id, e.entitlement,
+       LEAST(COALESCE(e.end_at, 'infinity'::timestamptz), COALESCE(e.revoked_at, 'infinity'::timestamptz)) AS closed_at,
+       e.source_type, e.source_id
+FROM openrails.entitlements e
+WHERE e.merchant_id = sqlc.arg(merchant_id)::uuid
+  AND (sqlc.narg(customer_id)::uuid IS NULL OR e.customer_id = sqlc.narg(customer_id)::uuid)
+  AND e.deleted_at IS NULL
+  AND (e.end_at IS NOT NULL OR e.revoked_at IS NOT NULL)
+  AND LEAST(COALESCE(e.end_at, 'infinity'::timestamptz), COALESCE(e.revoked_at, 'infinity'::timestamptz)) > sqlc.arg(closed_after)::timestamptz
+  AND LEAST(COALESCE(e.end_at, 'infinity'::timestamptz), COALESCE(e.revoked_at, 'infinity'::timestamptz)) <= sqlc.arg(now)::timestamptz
+  AND NOT EXISTS (
+      SELECT 1 FROM openrails.entitlements live
+      WHERE live.merchant_id = e.merchant_id
+        AND live.customer_id = e.customer_id
+        AND live.entitlement = e.entitlement
+        AND live.deleted_at IS NULL AND live.revoked_at IS NULL
+        AND live.start_at <= sqlc.arg(now)::timestamptz
+        AND (live.end_at IS NULL OR live.end_at > sqlc.arg(now)::timestamptz)
+  )
+ORDER BY e.customer_id,
+         LEAST(COALESCE(e.end_at, 'infinity'::timestamptz), COALESCE(e.revoked_at, 'infinity'::timestamptz)) DESC;

--- a/internal/http/handlers/service_admission.go
+++ b/internal/http/handlers/service_admission.go
@@ -361,6 +361,7 @@ type serviceMerchantProfileConfiguration struct {
 	LogoURL     string `json:"logo_url,omitempty"`
 	FromEmail   string `json:"from_email,omitempty"`
 	SupportURL  string `json:"support_url,omitempty"`
+	SignupURL   string `json:"signup_url,omitempty"`
 }
 
 // ServiceGetMerchantSettings returns the merchant-owned policy-sync document.
@@ -454,6 +455,7 @@ func merchantProfileInput(in *serviceMerchantProfileConfiguration) *models.Merch
 		LogoURL:     strings.TrimSpace(in.LogoURL),
 		FromEmail:   strings.TrimSpace(in.FromEmail),
 		SupportURL:  strings.TrimSpace(in.SupportURL),
+		SignupURL:   strings.TrimSpace(in.SignupURL),
 	}
 }
 
@@ -474,6 +476,7 @@ func merchantProfileResponse(in *models.MerchantProfileConfiguration) serviceMer
 		LogoURL:     in.LogoURL,
 		FromEmail:   in.FromEmail,
 		SupportURL:  in.SupportURL,
+		SignupURL:   in.SignupURL,
 	}
 }
 

--- a/internal/modules/subscriptions/email_service.go
+++ b/internal/modules/subscriptions/email_service.go
@@ -147,6 +147,11 @@ func (s *EmailService) storeName(ctx context.Context) string {
 	return name
 }
 
+// signupURL is the merchant's winback/signup page (#789); "" when undeclared.
+func (s *EmailService) signupURL(ctx context.Context) string {
+	return strings.TrimSpace(s.merchantProfile(ctx).SignupURL)
+}
+
 func (s *EmailService) SendSubscriptionConfirmation(ctx context.Context, data SubscriptionEmailData) error {
 	rendered := RenderSubscriptionConfirmationEmail(s.storeName(ctx), data)
 	return s.SendEmail(ctx, data.UserEmail, rendered.Subject, rendered.HTML, rendered.Plain)
@@ -163,7 +168,7 @@ func (s *EmailService) SendSubscriptionCancellation(ctx context.Context, data Su
 }
 
 func (s *EmailService) SendSubscriptionExpired(ctx context.Context, data SubscriptionEmailData) error {
-	rendered := RenderSubscriptionExpiredEmail(s.storeName(ctx), "", data)
+	rendered := RenderSubscriptionExpiredEmail(s.storeName(ctx), s.signupURL(ctx), data)
 	return s.SendEmail(ctx, data.UserEmail, rendered.Subject, rendered.HTML, rendered.Plain)
 }
 
@@ -374,6 +379,12 @@ func (s *EmailService) SendPremiumEnded(ctx context.Context, userID string, reas
 		return nil
 	}
 
+	// access_ended (#789) works for grant-only customers: no subscription row
+	// required, so it resolves the user directly instead of via getEmailData.
+	if reason == PremiumEndReasonAccessEnded {
+		return s.SendAccessEnded(ctx, userID, s.now())
+	}
+
 	emailData, err := s.getEmailData(ctx, userID)
 	if err != nil {
 		if errors.Is(err, errUserEmailUnavailable) {
@@ -395,6 +406,25 @@ func (s *EmailService) SendPremiumEnded(ctx context.Context, userID string, reas
 	default:
 		return s.SendSubscriptionCancellation(ctx, *emailData, reason)
 	}
+}
+
+// SendAccessEnded (#789) sends the neutral access-ended notice. It never needs
+// a subscription row — grant-only customers get it too.
+func (s *EmailService) SendAccessEnded(ctx context.Context, userID string, endedAt time.Time) error {
+	if !s.IsEnabled() {
+		log.WithContext(ctx).Debug("email service not available - skipping access-ended email")
+		return nil
+	}
+	username, email, err := s.getUserEmail(ctx, userID)
+	if err != nil {
+		if errors.Is(err, errUserEmailUnavailable) {
+			log.WithContext(ctx).Debug("email unavailable - skipping access-ended email")
+			return nil
+		}
+		return fmt.Errorf("failed to get user profile: %w", err)
+	}
+	rendered := RenderAccessEndedEmail(s.storeName(ctx), s.signupURL(ctx), username, endedAt)
+	return s.SendEmail(ctx, email, rendered.Subject, rendered.HTML, rendered.Plain)
 }
 
 // SendPaymentFailed sends a payment failure email

--- a/internal/modules/subscriptions/notification_content.go
+++ b/internal/modules/subscriptions/notification_content.go
@@ -3,6 +3,7 @@ package subscriptions
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/open-rails/openrails/internal/shared/moneyutil"
 )
@@ -180,6 +181,50 @@ func RenderSubscriptionExpiredEmail(storeName, customerPortalURL string, data Su
 
 			The %s Team
 		`, data.Username, premiumName, periodEnd, strings.TrimSpace(linkText), storeName),
+	}
+}
+
+// RenderAccessEndedEmail (#789) tells a customer their premium access ended.
+// Neutral copy — these are often long-lapsed users, so no "we tried to charge
+// you" language. A non-empty signupURL renders a "Sign up again" CTA.
+func RenderAccessEndedEmail(storeName, signupURL, username string, endedAt time.Time) EmailContent {
+	endedOn := endedAt.Format("Jan 2, 2006")
+	name := strings.TrimSpace(username)
+	if name == "" {
+		name = "there"
+	}
+	linkHTML := ""
+	linkText := ""
+	if signupURL != "" {
+		linkHTML = fmt.Sprintf(`<p><a href="%s" style="display:inline-block;padding:10px 18px;background:#6c4ad0;color:#ffffff;text-decoration:none;border-radius:4px;">Sign up again</a></p>`, signupURL)
+		linkText = fmt.Sprintf("Sign up again any time: %s", signupURL)
+	}
+
+	return EmailContent{
+		Subject: fmt.Sprintf("Your %s premium access has ended", storeName),
+		HTML: fmt.Sprintf(`
+			<h2>Your Premium Access Has Ended</h2>
+			<p>Hi %s,</p>
+			<p>Your %s premium access ended on <strong>%s</strong>.</p>
+			<p>To keep enjoying premium, sign up again — we'd love to have you back.</p>
+			%s
+			<p>If you have any questions, just reply to this email.</p>
+			<p>The %s Team</p>
+		`, name, storeName, endedOn, linkHTML, storeName),
+		Plain: fmt.Sprintf(`
+			Your Premium Access Has Ended
+
+			Hi %s,
+
+			Your %s premium access ended on %s.
+
+			To keep enjoying premium, sign up again — we'd love to have you back.
+
+			%s
+
+			If you have any questions, just reply to this email.
+			The %s Team
+		`, name, storeName, endedOn, linkText, storeName),
 	}
 }
 

--- a/internal/modules/subscriptions/notification_content_access_ended_test.go
+++ b/internal/modules/subscriptions/notification_content_access_ended_test.go
@@ -1,0 +1,58 @@
+package subscriptions
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRenderAccessEndedEmail(t *testing.T) {
+	endedAt := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+
+	t.Run("with signup url", func(t *testing.T) {
+		c := RenderAccessEndedEmail("Doujins", "https://example.com/signup", "alice", endedAt)
+		if c.Subject != "Your Doujins premium access has ended" {
+			t.Fatalf("subject = %q", c.Subject)
+		}
+		if !strings.Contains(c.HTML, "Hi alice,") {
+			t.Errorf("HTML missing greeting: %q", c.HTML)
+		}
+		if !strings.Contains(c.HTML, "Jul 4, 2026") {
+			t.Errorf("HTML missing ended date: %q", c.HTML)
+		}
+		if !strings.Contains(c.HTML, `href="https://example.com/signup"`) || !strings.Contains(c.HTML, "Sign up again") {
+			t.Errorf("HTML missing signup CTA: %q", c.HTML)
+		}
+		if !strings.Contains(c.Plain, "https://example.com/signup") {
+			t.Errorf("Plain missing signup URL: %q", c.Plain)
+		}
+		// Neutral copy: never charge/dunning language (often long-lapsed users).
+		for _, banned := range []string{"charge", "payment", "renew"} {
+			if strings.Contains(strings.ToLower(c.HTML), banned) {
+				t.Errorf("HTML contains %q — copy must stay neutral", banned)
+			}
+		}
+	})
+
+	t.Run("without signup url", func(t *testing.T) {
+		c := RenderAccessEndedEmail("Doujins", "", "", endedAt)
+		if strings.Contains(c.HTML, "href=") || strings.Contains(c.HTML, "Sign up again</a>") {
+			t.Errorf("HTML must not render CTA without a URL: %q", c.HTML)
+		}
+		if !strings.Contains(c.HTML, "Hi there,") {
+			t.Errorf("HTML missing fallback greeting: %q", c.HTML)
+		}
+	})
+}
+
+func TestParsePremiumEndReasonAccessEnded(t *testing.T) {
+	if got := ParsePremiumEndReason("access_ended"); got != PremiumEndReasonAccessEnded {
+		t.Fatalf("ParsePremiumEndReason(access_ended) = %q", got)
+	}
+	if got := ParsePremiumEndReason(string(PremiumEndReasonAccessEnded)); got != PremiumEndReasonAccessEnded {
+		t.Fatalf("round-trip = %q", got)
+	}
+	if got := ParsePremiumEndReason("bogus"); got != PremiumEndReasonUnknown {
+		t.Fatalf("unknown fallback = %q", got)
+	}
+}

--- a/internal/modules/subscriptions/notification_repo.go
+++ b/internal/modules/subscriptions/notification_repo.go
@@ -146,6 +146,12 @@ func (r *NotificationQueueRepo) GetPendingDigestForUser(ctx context.Context, use
 	return notificationsFromGen(rows)
 }
 
+// MarkEmailed stamps emailed_at once (#789); already-stamped rows are a no-op.
+func (r *NotificationQueueRepo) MarkEmailed(ctx context.Context, id uuid.UUID, at time.Time) error {
+	_, err := r.db.Gen(ctx).MarkNotificationEmailed(ctx, gen.MarkNotificationEmailedParams{ID: id, EmailedAt: at})
+	return err
+}
+
 func (r *NotificationQueueRepo) MarkAsSeen(ctx context.Context, id uuid.UUID) error {
 	rows, err := r.db.Gen(ctx).MarkNotificationSeen(ctx, id)
 	if err != nil {

--- a/internal/modules/subscriptions/notification_service.go
+++ b/internal/modules/subscriptions/notification_service.go
@@ -121,16 +121,38 @@ func (s *NotificationService) CreateAndDeliver(ctx context.Context, notification
 }
 
 func (s *NotificationService) deliverExternalNotifications(ctx context.Context, notification *models.NotificationQueue) error {
-	if err := s.sendEmailNotification(ctx, notification); err != nil {
+	if err := s.DeliverEmail(ctx, notification); err != nil {
 		return fmt.Errorf("failed to send email notification: %w", err)
 	}
 
 	return nil
 }
 
-// DeliverEmail sends the appropriate email for an already-created notification.
+// EmailEnabled reports whether an armed email service is attached.
+func (s *NotificationService) EmailEnabled() bool {
+	return s.emailService.IsEnabled()
+}
+
+// DeliverEmail sends the appropriate email for an already-created notification
+// and stamps emailed_at on success (#789). No armed email service ⇒ the row is
+// left undelivered (emailed_at NULL) so the sweep retries once email is wired;
+// a rendered no-op (unsupported type, user without email) still stamps so the
+// sweep never rescans it.
 func (s *NotificationService) DeliverEmail(ctx context.Context, notification *models.NotificationQueue) error {
-	return s.sendEmailNotification(ctx, notification)
+	if !s.EmailEnabled() {
+		log.WithContext(ctx).Debug("email service not available - leaving notification undelivered")
+		return nil
+	}
+	if err := s.sendEmailNotification(ctx, notification); err != nil {
+		return err
+	}
+	if err := s.repo.MarkEmailed(ctx, notification.ID, time.Now().UTC()); err != nil {
+		// The email already went out; a failed stamp means at most one duplicate
+		// on the next sweep. Log, don't fail the delivery.
+		log.WithContext(ctx).WithError(err).WithField("notification_id", notification.ID).
+			Error("failed to stamp notification emailed_at")
+	}
+	return nil
 }
 
 func (s *NotificationService) sendEmailNotification(ctx context.Context, notification *models.NotificationQueue) error {
@@ -150,6 +172,16 @@ func (s *NotificationService) sendEmailNotification(ctx context.Context, notific
 			if r, ok := notification.Data["reason"].(string); ok {
 				reason = ParsePremiumEndReason(r)
 			}
+		}
+		if reason == PremiumEndReasonAccessEnded {
+			// #789: subscription-row-free path; ended_at rides in the row data.
+			endedAt := time.Now().UTC()
+			if raw, ok := notification.Data["ended_at"].(string); ok {
+				if t, err := time.Parse(time.RFC3339, raw); err == nil {
+					endedAt = t
+				}
+			}
+			return s.emailService.SendAccessEnded(ctx, notification.CustomerID.String(), endedAt)
 		}
 		return s.emailService.SendPremiumEnded(ctx, notification.CustomerID.String(), reason)
 	case models.NotificationPaymentMethodFailed:

--- a/internal/modules/subscriptions/notification_types.go
+++ b/internal/modules/subscriptions/notification_types.go
@@ -16,7 +16,11 @@ const (
 	PremiumEndReasonRefund     PremiumEndReason = "refund"
 	PremiumEndReasonAdmin      PremiumEndReason = "admin"
 	PremiumEndReasonRail       PremiumEndReason = "rail_cancel"
-	PremiumEndReasonUnknown    PremiumEndReason = "unknown"
+	// PremiumEndReasonAccessEnded (#789): the converge NOTIFY pass detected the
+	// customer's last entitlement window closed with no transition-site email —
+	// neutral "access ended" copy, no charge/dunning language.
+	PremiumEndReasonAccessEnded PremiumEndReason = "access_ended"
+	PremiumEndReasonUnknown     PremiumEndReason = "unknown"
 )
 
 func ParsePremiumEndReason(value string) PremiumEndReason {
@@ -33,6 +37,8 @@ func ParsePremiumEndReason(value string) PremiumEndReason {
 		return PremiumEndReasonAdmin
 	case string(PremiumEndReasonRail):
 		return PremiumEndReasonRail
+	case string(PremiumEndReasonAccessEnded):
+		return PremiumEndReasonAccessEnded
 	default:
 		return PremiumEndReasonUnknown
 	}

--- a/internal/reconcile/converge/converge.go
+++ b/internal/reconcile/converge/converge.go
@@ -97,7 +97,8 @@ type ConvergeFinding struct {
 	Repair            func(ctx context.Context) error // AUTO repair; nil = surface only
 }
 
-// Pass is one diagnostic plane. Passes run in DERIVE → LIFE → CON order.
+// Pass is one diagnostic plane. Passes run in DERIVE → LIFE → CON order;
+// the NOTIFY stage (#789) runs after their repairs, on the converged state.
 type Pass interface {
 	Plane() string
 	Run(ctx context.Context, scope Scope) ([]ConvergeFinding, error)
@@ -126,10 +127,15 @@ type ConvergeEngine struct {
 	// Now — reconcile.FindingNotifier lives in the parent package, which
 	// converge already imports (the LIFE pass's decider).
 	Notifier reconcile.FindingNotifier
+
+	// notify (#789) is NOT in passes: it detects on the state the plane repairs
+	// just left behind (a window DERIVE re-projected this run never emails), so
+	// Converge runs it after the remediation loop, not at collection time.
+	notify *notifyPass
 }
 
-// NewConvergeEngine wires the engine with the DERIVE → LIFE → CON passes (each
-// fleshed out across #511 Phase D).
+// NewConvergeEngine wires the engine with the DERIVE → LIFE → CON passes
+// (#511 Phase D) plus the post-repair NOTIFY stage (#789).
 func NewConvergeEngine(database *db.DB) *ConvergeEngine {
 	e := &ConvergeEngine{DB: database, Now: func() time.Time { return time.Now().UTC() }}
 	// Real clock: the LIFE pass passes its own detection instants (now / grace-end)
@@ -138,6 +144,7 @@ func NewConvergeEngine(database *db.DB) *ConvergeEngine {
 	// nil: convergence applies LOCAL state only — converge-not-replay.
 	e.lifecycle = subscriptions.NewSubscriptionLifecycleService(database, nil, nil, nil, nil, nil, nil, clockwork.NewRealClock())
 	e.passes = []Pass{&derivePass{e: e}, &lifePass{e: e}, &conPass{e: e}}
+	e.notify = &notifyPass{e: e}
 	return e
 }
 
@@ -168,8 +175,9 @@ func AfterMutation(ctx context.Context, database *db.DB, merchantID merchant.ID,
 	return NewConvergeEngine(database).Converge(ctx, Scope{Merchant: merchantID, Customer: &customer})
 }
 
-// Converge runs every plane pass for the scope (DERIVE → LIFE → CON), then
-// persists + remediates each finding. It must be called inside a merchant-scoped
+// Converge runs every plane pass for the scope (DERIVE → LIFE → CON), persists
+// + remediates each finding, then runs the post-repair NOTIFY stage (#789) on
+// the converged state. It must be called inside a merchant-scoped
 // connection (RunInMerchantConn) so RLS + the gen queries resolve to the merchant.
 // When the scope is clean (no findings) it does no writes at all — the idempotent
 // no-op that keeps the inline hot path cheap.
@@ -187,57 +195,79 @@ func (e *ConvergeEngine) Converge(ctx context.Context, scope Scope) (ConvergeRes
 		}
 		collected = append(collected, fs...)
 	}
-	if len(collected) == 0 {
-		return res, nil // converged: no run, no writes
-	}
 
 	q := e.DB.Gen(ctx)
 	// A run stamps first_seen_run/last_seen_run on the findings (and drives
 	// auto-vanish). Created lazily — only when there is something to persist.
-	run, err := q.CreateReconciliationRun(ctx, gen.CreateReconciliationRunParams{
-		MerchantID: scope.Merchant.UUID(), Mode: "enforce", Rails: []string{"self"},
-	})
-	if err != nil {
-		return res, fmt.Errorf("converge: create run: %w", err)
-	}
-	res.RunID = &run.ID
-
-	for i := range collected {
-		status, err := e.remediate(ctx, scope, collected[i])
-		if err != nil {
-			return res, err
+	var runID *uuid.UUID
+	apply := func(findings []ConvergeFinding) error {
+		if len(findings) == 0 {
+			return nil
 		}
-		row, perr := e.persist(ctx, q, scope, run.ID, collected[i], status)
-		if perr != nil {
-			return res, perr
+		if runID == nil {
+			run, err := q.CreateReconciliationRun(ctx, gen.CreateReconciliationRunParams{
+				MerchantID: scope.Merchant.UUID(), Mode: "enforce", Rails: []string{"self"},
+			})
+			if err != nil {
+				return fmt.Errorf("converge: create run: %w", err)
+			}
+			runID = &run.ID
+			res.RunID = runID
 		}
-		if e.Notifier != nil {
-			if nerr := e.Notifier.NotifyFinding(ctx, reconcile.FindingRecordFromRow(row)); nerr != nil {
-				log.WithContext(ctx).WithError(nerr).WithField("finding_id", row.ID).
-					Warn("converge: finding notification failed; continuing")
+		for i := range findings {
+			status, err := e.remediate(ctx, scope, findings[i])
+			if err != nil {
+				return err
+			}
+			row, perr := e.persist(ctx, q, scope, *runID, findings[i], status)
+			if perr != nil {
+				return perr
+			}
+			if e.Notifier != nil {
+				if nerr := e.Notifier.NotifyFinding(ctx, reconcile.FindingRecordFromRow(row)); nerr != nil {
+					log.WithContext(ctx).WithError(nerr).WithField("finding_id", row.ID).
+						Warn("converge: finding notification failed; continuing")
+				}
+			}
+			res.Findings++
+			switch status {
+			case "auto_fixed":
+				res.AutoFixed++
+			case "reconcile_required":
+				res.ReconcileRequired++
+			case "requires_review":
+				res.RequiresReview++
+				res.AdminRequired++
+			}
+			if findings[i].Class == ClassOperator {
+				res.Operator++
 			}
 		}
-		res.Findings++
-		switch status {
-		case "auto_fixed":
-			res.AutoFixed++
-		case "reconcile_required":
-			res.ReconcileRequired++
-		case "requires_review":
-			res.RequiresReview++
-			res.AdminRequired++
-		}
-		if collected[i].Class == ClassOperator {
-			res.Operator++
-		}
+		return nil
+	}
+	if err := apply(collected); err != nil {
+		return res, err
 	}
 
+	// NOTIFY (#789) detects on the state the repairs above just converged, so a
+	// window DERIVE re-projected in this very run never emails "access ended".
+	notifyFindings, err := e.notify.Run(ctx, scope)
+	if err != nil {
+		return res, fmt.Errorf("converge %s pass: %w", e.notify.Plane(), err)
+	}
+	if err := apply(notifyFindings); err != nil {
+		return res, err
+	}
+
+	if runID == nil {
+		return res, nil // converged: no run, no writes
+	}
 	summary, _ := json.Marshal(map[string]any{
 		"findings": res.Findings, "auto_fixed": res.AutoFixed,
 		"reconcile_required": res.ReconcileRequired, "requires_review": res.RequiresReview, "operator": res.Operator,
 	})
 	if _, err := q.FinishReconciliationRun(ctx, gen.FinishReconciliationRunParams{
-		ID: run.ID, Status: "completed", Summary: summary,
+		ID: *runID, Status: "completed", Summary: summary,
 	}); err != nil {
 		return res, fmt.Errorf("converge: finish run: %w", err)
 	}

--- a/internal/reconcile/converge/converge_con_integration_test.go
+++ b/internal/reconcile/converge/converge_con_integration_test.go
@@ -47,7 +47,9 @@ func TestConverge_ConReferenceSourceReference(t *testing.T) {
 
 	t.Cleanup(func() {
 		_ = appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
-			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.reconciliation_findings WHERE merchant_id=$1 AND subject_key=$2`, merchantID, "entitlement:"+entID.String())
+			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.reconciliation_findings WHERE merchant_id=$1 AND subject_key = ANY($2)`,
+				merchantID, []string{"entitlement:" + entID.String(), "customer:" + customer.String()})
+			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.notification_queue WHERE merchant_id=$1 AND customer_id=$2`, merchantID, customer)
 			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.entitlements WHERE id=$1`, entID)
 			return nil
 		})
@@ -56,9 +58,11 @@ func TestConverge_ConReferenceSourceReference(t *testing.T) {
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
 		res, err := e.Converge(ctx, Scope{Merchant: dbtest.TestMerchantID, Customer: &customer})
 		require.NoError(t, err)
-		require.Equal(t, 1, res.Findings)
+		// 2 findings: the dangling reference + the #789 NOTIFY access-ended row
+		// (the fixture window closed an hour ago — a real recent lapse).
+		require.Equal(t, 2, res.Findings)
 		require.Equal(t, 1, res.RequiresReview, "dangling reference is surfaced for review, not auto-fixed")
-		require.Equal(t, 0, res.AutoFixed)
+		require.Equal(t, 1, res.AutoFixed)
 
 		var status string
 		require.NoError(t, appDB.Qx(ctx).QueryRow(ctx,

--- a/internal/reconcile/converge/converge_derive1_integration_test.go
+++ b/internal/reconcile/converge/converge_derive1_integration_test.go
@@ -549,8 +549,10 @@ func TestConverge_DeriveGrantMissing_UnknownSubscription(t *testing.T) {
 	t.Cleanup(func() {
 		_ = appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
 			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.reconciliation_findings WHERE merchant_id=$1 AND subject_key = ANY($2)`,
-				merchantID, []string{"subscription:" + subAuto.String(), "subscription:" + subBounded.String(), "subscription:" + subBare.String()})
+				merchantID, []string{"subscription:" + subAuto.String(), "subscription:" + subBounded.String(), "subscription:" + subBare.String(),
+					"customer:" + custAuto.String(), "customer:" + custBounded.String(), "customer:" + custBare.String()})
 			for _, c := range []uuid.UUID{custAuto, custBounded, custBare} {
+				_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.notification_queue WHERE merchant_id=$1 AND customer_id=$2`, merchantID, c)
 				_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.entitlements WHERE merchant_id=$1 AND customer_id=$2`, merchantID, c)
 				_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.grants WHERE merchant_id=$1 AND customer_id=$2`, merchantID, c)
 			}
@@ -598,7 +600,9 @@ func TestConverge_DeriveGrantMissing_UnknownSubscription(t *testing.T) {
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
 		res, err := e.Converge(ctx, Scope{Merchant: dbtest.TestMerchantID, Customer: &custBounded})
 		require.NoError(t, err)
-		require.Equal(t, 1, res.AutoFixed)
+		// 2 auto-fixed: derive.subscription.missing + the #789 NOTIFY access-ended
+		// row for the already-past window it just materialized (grant lapse plane).
+		require.Equal(t, 2, res.AutoFixed)
 		var endAt *time.Time
 		require.NoError(t, appDB.Qx(ctx).QueryRow(ctx,
 			`SELECT end_at FROM openrails.entitlements WHERE merchant_id=$1 AND customer_id=$2 AND entitlement=$3 AND deleted_at IS NULL`,

--- a/internal/reconcile/converge/converge_derive_integration_test.go
+++ b/internal/reconcile/converge/converge_derive_integration_test.go
@@ -126,7 +126,9 @@ func TestConverge_DeriveGrantEffectExcess_TerminatedNotRetracted(t *testing.T) {
 
 	t.Cleanup(func() {
 		_ = appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
-			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.reconciliation_findings WHERE merchant_id=$1 AND subject_key=$2`, merchantID, "grant_effect:"+grantID.String())
+			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.reconciliation_findings WHERE merchant_id=$1 AND subject_key = ANY($2)`,
+				merchantID, []string{"grant_effect:" + grantID.String(), "customer:" + customer.String()})
+			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.notification_queue WHERE merchant_id=$1 AND customer_id=$2`, merchantID, customer)
 			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.entitlements WHERE merchant_id=$1 AND customer_id=$2`, merchantID, customer)
 			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.grants WHERE merchant_id=$1 AND customer_id=$2 AND event<>'grant'`, merchantID, customer)
 			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.grants WHERE merchant_id=$1 AND customer_id=$2`, merchantID, customer)
@@ -138,8 +140,10 @@ func TestConverge_DeriveGrantEffectExcess_TerminatedNotRetracted(t *testing.T) {
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
 		res, err := e.Converge(ctx, Scope{Merchant: dbtest.TestMerchantID, Customer: &customer})
 		require.NoError(t, err)
-		require.Equal(t, 1, res.Findings)
-		require.Equal(t, 1, res.AutoFixed, "terminated grant retraction is AUTO (recorded revoke, not absence)")
+		// 2 findings: the excess retraction + the #789 post-repair NOTIFY
+		// access-ended row for the window this run just revoked.
+		require.Equal(t, 2, res.Findings)
+		require.Equal(t, 2, res.AutoFixed, "terminated grant retraction is AUTO (recorded revoke, not absence)")
 
 		var live bool
 		require.NoError(t, appDB.Qx(ctx).QueryRow(ctx, `

--- a/internal/reconcile/converge/converge_derive_mismatch_integration_test.go
+++ b/internal/reconcile/converge/converge_derive_mismatch_integration_test.go
@@ -175,7 +175,8 @@ func TestConverge_DeriveGrantEffectMismatch_RevokeDirection(t *testing.T) {
 	t.Cleanup(func() {
 		_ = appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
 			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.reconciliation_findings WHERE merchant_id=$1 AND subject_key = ANY($2)`,
-				merchantID, []string{"subscription:" + deadSub.String(), "subscription:" + unknownSub.String()})
+				merchantID, []string{"subscription:" + deadSub.String(), "subscription:" + unknownSub.String(), "customer:" + customer.String()})
+			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.notification_queue WHERE merchant_id=$1 AND customer_id=$2`, merchantID, customer)
 			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.entitlements WHERE customer_id=$1`, customer)
 			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.grants WHERE customer_id=$1`, customer)
 			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.subscriptions WHERE id=ANY($1)`, []uuid.UUID{deadSub, unknownSub})
@@ -188,8 +189,10 @@ func TestConverge_DeriveGrantEffectMismatch_RevokeDirection(t *testing.T) {
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
 		res, err := e.Converge(ctx, Scope{Merchant: dbtest.TestMerchantID, Customer: &customer})
 		require.NoError(t, err)
-		require.Equal(t, 1, res.Findings, "only the terminally-dead sub is flagged")
-		require.Equal(t, 1, res.AutoFixed)
+		// 2 findings: the dead sub's mismatch + the #789 post-repair NOTIFY
+		// access-ended row for the window this very run just bounded.
+		require.Equal(t, 2, res.Findings, "dead-sub mismatch + access-ended notify; unknown sub untouched")
+		require.Equal(t, 2, res.AutoFixed)
 
 		// Repair = the missed #691 closure: the window is BOUNDED at the
 		// entitled bound (GREATEST(paid-through, ended_at)), not revoked.

--- a/internal/reconcile/converge/converge_notify_integration_test.go
+++ b/internal/reconcile/converge/converge_notify_integration_test.go
@@ -1,0 +1,140 @@
+//go:build integration
+
+package converge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// #789 NOTIFY pass: a customer whose last entitlement window closed gets
+// exactly one premium_ended/access_ended notification row (emailed_at NULL);
+// re-running converge never duplicates it; a live replacement window or a
+// pre-existing premium_ended (a transition-site email) suppresses it.
+func TestConvergeNotify_AccessEnded(t *testing.T) {
+	appDB := startReconcilePostgres(t)
+	merchantID := dbtest.TestMerchantID.UUID()
+	baseCtx := merchant.WithID(context.Background(), dbtest.TestMerchantID)
+	e := NewConvergeEngine(appDB)
+	sfx := uuid.NewString()[:8]
+	now := time.Now().UTC()
+
+	type fixture struct {
+		cust uuid.UUID
+		ents []uuid.UUID
+	}
+	var lapsed, replaced, alreadyTold fixture
+
+	seedWindow := func(ctx context.Context, f *fixture, entName string, start time.Time, end *time.Time) {
+		id := uuid.New()
+		_, err := appDB.Qx(ctx).Exec(ctx,
+			`INSERT INTO openrails.entitlements (id, merchant_id, customer_id, entitlement, start_at, end_at, source_id, source_type)
+			 VALUES ($1,$2,$3,$4,$5,$6,$7,'admin')`,
+			id, merchantID, f.cust, entName, start, end, uuid.New())
+		require.NoError(t, err)
+		f.ents = append(f.ents, id)
+	}
+
+	closedAt := now.Add(-2 * 24 * time.Hour)
+	feat := "notify-feat-" + sfx
+	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
+		lapsed.cust = dbtest.EnsureCustomerIDPgx(ctx, t, appDB.Qx(ctx), uuid.NewString())
+		replaced.cust = dbtest.EnsureCustomerIDPgx(ctx, t, appDB.Qx(ctx), uuid.NewString())
+		alreadyTold.cust = dbtest.EnsureCustomerIDPgx(ctx, t, appDB.Qx(ctx), uuid.NewString())
+
+		// (a) one window, ended 2 days ago, no replacement.
+		seedWindow(ctx, &lapsed, feat, now.Add(-30*24*time.Hour), &closedAt)
+		// (b) closed window BUT a live replacement for the same entitlement.
+		seedWindow(ctx, &replaced, feat, now.Add(-30*24*time.Hour), &closedAt)
+		seedWindow(ctx, &replaced, feat, now.Add(-24*time.Hour), nil)
+		// (c) closed window + premium_ended notification created after the close
+		// (the dunning/transition-site email already went out).
+		seedWindow(ctx, &alreadyTold, feat, now.Add(-30*24*time.Hour), &closedAt)
+		_, err := appDB.Qx(ctx).Exec(ctx,
+			`INSERT INTO openrails.notification_queue (id, merchant_id, customer_id, event_type, data)
+			 VALUES ($1,$2,$3,'premium_ended','{"reason":"expired"}'::jsonb)`,
+			uuid.New(), merchantID, alreadyTold.cust)
+		require.NoError(t, err)
+		return nil
+	}))
+	t.Cleanup(func() {
+		_ = appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
+			for _, f := range []fixture{lapsed, replaced, alreadyTold} {
+				_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.notification_queue WHERE merchant_id=$1 AND customer_id=$2`, merchantID, f.cust)
+				_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.entitlements WHERE id=ANY($1)`, f.ents)
+				_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.reconciliation_findings WHERE merchant_id=$1 AND subject_key=$2`, merchantID, "customer:"+f.cust.String())
+			}
+			return nil
+		})
+	})
+
+	countPremiumEnded := func(ctx context.Context, cust uuid.UUID) int {
+		t.Helper()
+		var n int
+		require.NoError(t, appDB.Qx(ctx).QueryRow(ctx,
+			`SELECT count(*) FROM openrails.notification_queue WHERE merchant_id=$1 AND customer_id=$2 AND event_type='premium_ended'`,
+			merchantID, cust).Scan(&n))
+		return n
+	}
+	convergeCustomer := func(ctx context.Context, cust uuid.UUID) {
+		t.Helper()
+		_, err := e.Converge(ctx, Scope{Merchant: dbtest.TestMerchantID, Customer: &cust})
+		require.NoError(t, err)
+	}
+
+	// (a) exactly one access_ended row, undelivered; re-run dedupes.
+	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
+		convergeCustomer(ctx, lapsed.cust)
+		require.Equal(t, 1, countPremiumEnded(ctx, lapsed.cust), "one premium_ended row created")
+
+		var reason, endedAt, source string
+		var emailedAt *time.Time
+		require.NoError(t, appDB.Qx(ctx).QueryRow(ctx,
+			`SELECT data->>'reason', data->>'ended_at', data->>'source', emailed_at FROM openrails.notification_queue
+			 WHERE merchant_id=$1 AND customer_id=$2 AND event_type='premium_ended'`,
+			merchantID, lapsed.cust).Scan(&reason, &endedAt, &source, &emailedAt))
+		require.Equal(t, "access_ended", reason)
+		require.Equal(t, "converge_notify", source)
+		parsed, err := time.Parse(time.RFC3339, endedAt)
+		require.NoError(t, err)
+		require.WithinDuration(t, closedAt, parsed, time.Second)
+		require.Nil(t, emailedAt, "delivery belongs to the sweep — row starts undelivered")
+
+		var status string
+		require.NoError(t, appDB.Qx(ctx).QueryRow(ctx,
+			`SELECT status FROM openrails.reconciliation_findings WHERE merchant_id=$1 AND finding_type='notify.access_ended.missing' AND subject_key=$2`,
+			merchantID, "customer:"+lapsed.cust.String()).Scan(&status))
+		require.Equal(t, "auto_fixed", status)
+
+		convergeCustomer(ctx, lapsed.cust)
+		convergeCustomer(ctx, lapsed.cust)
+		require.Equal(t, 1, countPremiumEnded(ctx, lapsed.cust), "re-running converge never duplicates")
+		return nil
+	}))
+
+	// (b) a live replacement window suppresses the notification entirely.
+	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
+		convergeCustomer(ctx, replaced.cust)
+		require.Equal(t, 0, countPremiumEnded(ctx, replaced.cust), "live window ⇒ access did not end")
+		return nil
+	}))
+
+	// (c) a premium_ended row at/after the close (transition-site email) dedupes.
+	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
+		convergeCustomer(ctx, alreadyTold.cust)
+		require.Equal(t, 1, countPremiumEnded(ctx, alreadyTold.cust), "only the pre-existing dunning notification remains")
+		var reason string
+		require.NoError(t, appDB.Qx(ctx).QueryRow(ctx,
+			`SELECT data->>'reason' FROM openrails.notification_queue WHERE merchant_id=$1 AND customer_id=$2 AND event_type='premium_ended'`,
+			merchantID, alreadyTold.cust).Scan(&reason))
+		require.Equal(t, "expired", reason, "no access_ended row was added")
+		return nil
+	}))
+}

--- a/internal/reconcile/converge/converge_passes.go
+++ b/internal/reconcile/converge/converge_passes.go
@@ -17,6 +17,7 @@ import (
 	"github.com/open-rails/openrails/internal/modules/subscriptions"
 	"github.com/open-rails/openrails/internal/reconcile"
 	"github.com/open-rails/openrails/internal/reconcile/recommend"
+	"github.com/open-rails/openrails/internal/shared/uuidutil"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
 
@@ -710,6 +711,80 @@ func stuckIntentFinding(si *gen.OpenrailsRailIntent, now time.Time) ConvergeFind
 		f.Severity = "low"
 	}
 	return f
+}
+
+// accessEndedLookback bounds the NOTIFY access-ended scan: a window closed
+// longer ago than this is stale news, never emailed.
+const accessEndedLookback = 30 * 24 * time.Hour
+
+// notifyPass — NOTIFY plane (#789): whatever plane closed a customer's LAST
+// entitlement window (dunning, reconcile-driven cancel, grant lapse), the
+// customer is told exactly once. The pass only CREATES notification_queue rows
+// (emailed_at NULL); delivery belongs to the notification email sweep — the
+// converge engine carries no EmailService. Dedupe: any premium_ended row at or
+// after the close means a transition site already told them.
+type notifyPass struct{ e *ConvergeEngine }
+
+func (*notifyPass) Plane() string { return "NOTIFY" }
+func (p *notifyPass) Run(ctx context.Context, scope Scope) ([]ConvergeFinding, error) {
+	if scope.Customer == nil && scope.Subscription != nil {
+		return nil, nil // subscription-scope rides on its customer/merchant run
+	}
+	q := p.e.DB.Gen(ctx)
+	now := p.e.Now()
+	closed, err := q.ListRecentlyClosedLastEntitlementWindows(ctx, gen.ListRecentlyClosedLastEntitlementWindowsParams{
+		MerchantID: scope.Merchant.UUID(), CustomerID: scope.Customer,
+		ClosedAfter: now.Add(-accessEndedLookback), Now: now,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("notify: scan recently closed entitlement windows: %w", err)
+	}
+	var out []ConvergeFinding
+	repo := subscriptions.NewNotificationQueueRepo(p.e.DB)
+	for i := range closed {
+		c := closed[i]
+		if c.ClosedAt == nil {
+			continue // WHERE guarantees a bound; guard the pointer anyway
+		}
+		closedAt := c.ClosedAt.UTC()
+		already, err := q.PremiumEndedNotificationExistsSince(ctx, gen.PremiumEndedNotificationExistsSinceParams{
+			MerchantID: scope.Merchant.UUID(), CustomerID: c.CustomerID, Since: closedAt,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("notify: check premium_ended dedupe: %w", err)
+		}
+		if already {
+			continue
+		}
+		cust, entName := c.CustomerID, c.Entitlement
+		out = append(out, ConvergeFinding{
+			Type:       "notify.access_ended.missing",
+			Shape:      ShapeMissing,
+			Class:      ClassAuto,
+			Severity:   "low",
+			SubjectKey: "customer:" + cust.String(),
+			Provider:   "self",
+			Evidence: map[string]any{
+				"customer_id": cust.String(), "entitlement": entName,
+				"ended_at": closedAt.Format(time.RFC3339), "source_type": c.SourceType, "source_id": c.SourceID.String(),
+			},
+			Repair: func(ctx context.Context) error {
+				ctx = merchant.WithID(ctx, scope.Merchant)
+				return repo.Create(ctx, &models.NotificationQueue{
+					ID:         uuidutil.NewV7(),
+					CustomerID: cust,
+					EventType:  models.NotificationPremiumEnded,
+					Data: map[string]any{
+						"reason":      string(subscriptions.PremiumEndReasonAccessEnded),
+						"ended_at":    closedAt.Format(time.RFC3339),
+						"entitlement": entName,
+						"source":      "converge_notify",
+					},
+				})
+			},
+		})
+	}
+	return out, nil
 }
 
 // conPass — CON plane: residual internal consistency (duplicate /

--- a/internal/river/jobs_notification_email.go
+++ b/internal/river/jobs_notification_email.go
@@ -1,0 +1,94 @@
+package riverjobs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/riverqueue/river"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/open-rails/openrails/internal/db"
+	"github.com/open-rails/openrails/internal/db/gen"
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/modules/subscriptions"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+const KindNotificationEmailSweep = "openrails.notification_email_sweep"
+
+// notificationEmailSweepBatch bounds one merchant's per-sweep delivery batch;
+// the remainder rides the next tick.
+const notificationEmailSweepBatch = 200
+
+type NotificationEmailSweepArgs struct{}
+
+func (NotificationEmailSweepArgs) Kind() string { return KindNotificationEmailSweep }
+
+// NotificationEmailSweepWorker (#789) delivers undelivered notification_queue
+// rows (emailed_at NULL) through the SAME NotificationService.DeliverEmail path
+// the inline dispatch uses — DeliverEmail stamps emailed_at on success, no-ops
+// (and stamps) unsupported types, and leaves failures NULL for the next sweep.
+// It is the delivery half of the converge NOTIFY pass, which only creates rows.
+// Mirrors ConvergeSweepWorker: privileged merchant list, per-merchant
+// RunInMerchantConn, one merchant's failure never aborts the rest.
+type NotificationEmailSweepWorker struct {
+	river.WorkerDefaults[NotificationEmailSweepArgs]
+	DB            *db.DB
+	Notifications *subscriptions.NotificationService
+}
+
+func (NotificationEmailSweepWorker) Kind() string { return KindNotificationEmailSweep }
+
+func (w NotificationEmailSweepWorker) Work(ctx context.Context, job *river.Job[NotificationEmailSweepArgs]) error {
+	logger := log.WithContext(ctx).WithField("worker", KindNotificationEmailSweep)
+	if w.Notifications == nil || !w.Notifications.EmailEnabled() {
+		logger.Debug("email service not armed - leaving notifications undelivered")
+		return nil
+	}
+
+	// Privileged (no-GUC) read of the control-plane merchant directory.
+	merchantIDs, err := w.DB.Gen(ctx).ListActiveMerchantIDs(ctx)
+	if err != nil {
+		return fmt.Errorf("notification email sweep: list merchants: %w", err)
+	}
+
+	var delivered, failed int
+	for _, mid := range merchantIDs {
+		mctx := merchant.WithID(ctx, merchant.ID(mid))
+		if err := w.DB.RunInMerchantConn(mctx, func(ctx context.Context) error {
+			rows, err := w.DB.Gen(ctx).ListUndeliveredNotifications(ctx, gen.ListUndeliveredNotificationsParams{
+				MerchantID: mid, PageLimit: notificationEmailSweepBatch,
+			})
+			if err != nil {
+				return fmt.Errorf("list undelivered notifications: %w", err)
+			}
+			for i := range rows {
+				n, err := models.NotificationFromGen(rows[i])
+				if err != nil {
+					failed++
+					logger.WithError(err).WithField("notification_id", rows[i].ID).
+						Error("notification email sweep: decode row; skipping")
+					continue
+				}
+				if err := w.Notifications.DeliverEmail(ctx, n); err != nil {
+					failed++
+					logger.WithError(err).WithFields(log.Fields{
+						"notification_id": n.ID, "event_type": n.EventType,
+					}).Error("notification email sweep: delivery failed; will retry next sweep")
+					continue
+				}
+				delivered++
+			}
+			return nil
+		}); err != nil {
+			// One merchant's failure must not abort the rest of the sweep.
+			logger.WithError(err).WithField("merchant_id", mid).
+				Error("notification email sweep: merchant failed; continuing")
+		}
+	}
+	if delivered > 0 || failed > 0 {
+		logger.WithFields(log.Fields{"delivered": delivered, "failed": failed}).
+			Info("notification email sweep completed")
+	}
+	return nil
+}

--- a/internal/river/jobs_notification_email_integration_test.go
+++ b/internal/river/jobs_notification_email_integration_test.go
@@ -1,0 +1,58 @@
+//go:build integration
+
+package riverjobs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/internal/modules/subscriptions"
+)
+
+// #789: with no armed email service the sweep must leave undelivered rows
+// exactly as they are (emailed_at NULL) without erroring — they are retried
+// once email is wired, never stamped as sent.
+func TestNotificationEmailSweep_NoEmailServiceLeavesRowsUndelivered(t *testing.T) {
+	dsn := dbtest.SharedPostgresDSN(t)
+	dbi := dbtest.OpenAppDB(t, dsn)
+	merchantID := dbtest.TestMerchantID.UUID()
+	baseCtx := dbtest.WithTestMerchant(context.Background())
+	dbtest.EnsureTestMerchant(baseCtx, t, dbi.Pool())
+
+	notifID := uuid.New()
+	var customer uuid.UUID
+	require.NoError(t, dbi.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
+		customer = dbtest.EnsureCustomerIDPgx(ctx, t, dbi.Qx(ctx), uuid.NewString())
+		_, err := dbi.Qx(ctx).Exec(ctx,
+			`INSERT INTO openrails.notification_queue (id, merchant_id, customer_id, event_type, data)
+			 VALUES ($1,$2,$3,'premium_ended','{"reason":"access_ended","source":"converge_notify"}'::jsonb)`,
+			notifID, merchantID, customer)
+		return err
+	}))
+	t.Cleanup(func() {
+		_ = dbi.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
+			_, _ = dbi.Qx(ctx).Exec(ctx, `DELETE FROM openrails.notification_queue WHERE id=$1`, notifID)
+			return nil
+		})
+	})
+
+	worker := NotificationEmailSweepWorker{
+		DB:            dbi,
+		Notifications: subscriptions.NewNotificationService(dbi, nil), // no email service
+	}
+	require.NoError(t, worker.Work(context.Background(), &river.Job[NotificationEmailSweepArgs]{}))
+
+	require.NoError(t, dbi.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
+		var emailedAt *time.Time
+		require.NoError(t, dbi.Qx(ctx).QueryRow(ctx,
+			`SELECT emailed_at FROM openrails.notification_queue WHERE id=$1`, notifID).Scan(&emailedAt))
+		require.Nil(t, emailedAt, "no email service ⇒ row stays undelivered for a later sweep")
+		return nil
+	}))
+}

--- a/migrations/postgres/0015_access_ended_notifications.up.sql
+++ b/migrations/postgres/0015_access_ended_notifications.up.sql
@@ -1,0 +1,23 @@
+-- #789 access-ended notifications: delivery state on notification_queue +
+-- the entitlement close-instant index the converge NOTIFY pass scans.
+--
+-- emailed_at — when the row's email was actually sent (NULL = undelivered;
+-- the notification email sweep retries NULLs). Historical rows are assumed
+-- delivered inline by the old fire-and-forget path.
+ALTER TABLE openrails.notification_queue ADD COLUMN emailed_at timestamp with time zone;
+UPDATE openrails.notification_queue SET emailed_at = created_at;
+
+COMMENT ON COLUMN openrails.notification_queue.emailed_at IS '#789: when the notification email was sent; NULL = undelivered (the notification_email_sweep retries).';
+
+CREATE INDEX idx_notification_queue_undelivered ON openrails.notification_queue (merchant_id, created_at) WHERE emailed_at IS NULL;
+
+-- The NOTIFY plane's findings (notify.access_ended.missing) join the ledger.
+ALTER TABLE openrails.reconciliation_findings DROP CONSTRAINT chk_reconciliation_findings_type;
+ALTER TABLE openrails.reconciliation_findings
+    ADD CONSTRAINT chk_reconciliation_findings_type CHECK ((finding_type ~ '^(pull|derive|life|consistency|notify)\.[a-z0-9_]+(\.[a-z0-9_]+)?$'::text));
+
+-- Window CLOSE instant = LEAST(end_at, revoked_at) treating NULL as infinity;
+-- must match ListRecentlyClosedLastEntitlementWindows exactly.
+CREATE INDEX idx_entitlements_closed_at ON openrails.entitlements
+    (merchant_id, (LEAST(COALESCE(end_at, 'infinity'::timestamp with time zone), COALESCE(revoked_at, 'infinity'::timestamp with time zone))))
+    WHERE end_at IS NOT NULL OR revoked_at IS NOT NULL;


### PR DESCRIPTION
Tracker: open-rails-tracker #789.

Users who lose premium access were emailed only from ad-hoc transition sites (user cancel, admin revoke, dunning, CCBill webhooks). Reconcile-driven cancels (`ResolveUnknownSubscription`) and grant lapses were silent, and email delivery was fire-and-forget (no state on `notification_queue`).

## Design
- **NOTIFY converge stage** (runs post-repair so same-run re-projections never false-fire): a customer whose LAST live entitlement window closed within the 30-day lookback, with no `premium_ended` notification at/after the close instant, gets exactly one queued `access_ended` notification. Transition-site emails act as natural suppressors — one email per access loss, any plane, any ordering.
- **Durable delivery**: migration 0014 adds `notification_queue.emailed_at` (historical rows backfilled = created_at); `DeliverEmail` stamps on success; new `notification_email_sweep` river job (10-min periodic, per-merchant RunInMerchantConn) retries undelivered rows. Unarmed email service leaves rows undelivered for later; unsupported/no-op renders stamp so the sweep never rescans them.
- **Winback CTA**: merchant profile gains `signup_url` (manifest → models → emails); new `RenderAccessEndedEmail` with neutral copy + sign-up-again button; `SendSubscriptionExpired`'s hardcoded empty portal URL now uses it; the `access_ended` path resolves email without a subscription row (grant-only customers).

## Tests
Converge NOTIFY integration (dedupe on re-run, live-window suppression, transition-site suppression), sweep-with-unarmed-email integration, render/reason unit tests. Full `./internal/reconcile/converge`, `./internal/river`, `./internal/modules/subscriptions`, `./tests`, `./embed`, `./pkg/service` integration suites green; `sqlc generate` + `vet` clean.

Doujins/hentai0 note: hosts pick this up via the next lockstep version bump + `profile.signup_url` in their merchant manifests (doujins tracker #779 cutover interlock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)