### PR TITLE
refactor: adopt authkitmigrate one-call API

### DIFF
--- a/internal/migrate/migrator.go
+++ b/internal/migrate/migrator.go
@@ -9,7 +9,7 @@ import (
 
 	_ "github.com/jackc/pgx/v5/stdlib" // database/sql driver "pgx"
 
-	authkitpostgres "github.com/open-rails/authkit/migrations/postgres"
+	"github.com/open-rails/authkit/authkitmigrate"
 	"github.com/open-rails/migratekit"
 	"github.com/open-rails/openrails/config"
 	"github.com/open-rails/openrails/internal/db"
@@ -47,12 +47,12 @@ func RunPostgres(ctx context.Context, cfg *config.Config) error {
 
 	// ---------- 1. AuthKit Migrations (profiles schema) ----------
 	log.Info("Running AuthKit migrations (profiles schema)...")
-	authMigrations, err := migratekit.LoadFromFS(authkitpostgres.FS)
+	authPool, err := db.NewPGXPoolWithRetry(ctx, cfg.DB.GetConnectionString())
 	if err != nil {
-		return fmt.Errorf("authkit: load migrations: %w", err)
+		return fmt.Errorf("authkit: create pgx pool: %w", err)
 	}
-	authMigrator := migratekit.NewPostgres(sqlDB, "authkit")
-	if err := authMigrator.ApplyMigrations(ctx, authMigrations); err != nil {
+	defer authPool.Close()
+	if _, err := authkitmigrate.New(authPool, &authkitmigrate.Config{}).Migrate(ctx); err != nil {
 		return fmt.Errorf("authkit: apply migrations: %w", err)
 	}
 	log.Info("✓ AuthKit migrations completed successfully")


### PR DESCRIPTION
## Summary
- Swaps the hand-rolled migratekit.LoadFromFS(authkitpostgres.FS) + migratekit.NewPostgres(sqlDB, "authkit").ApplyMigrations dance in internal/migrate/migrator.go (RunPostgres) for authkitmigrate.New(pool, &authkitmigrate.Config{}).Migrate(ctx).
- Same tracking key ("authkit"), same profiles schema, same idempotent up-only behavior. build_runtime.go's validateDatabase was audited too but only validates OpenRails' own migrations (no authkit MigrationSource there), so it's untouched — no other authkit-migration-FS call sites found in this repo.

## Test plan
- [x] go build ./... and go vet ./... green
- [x] go test ./... (unit) green
- [x] go test -tags integration ./... green apart from the two pre-existing standing-red master tests tracked in #792 (TestRootOperatorBoundary_ReachNotMerchantCapability, TestReconcileAdoptPreservesScheduledProviderActions) — both predate this change and are unrelated (MFA-enrollment fixture gap / test-DB fixture key collision)
- [x] internal/dbtest.SharedPostgresDSN (used by dozens of integration suites) directly drives internal/migrate.RunPostgres against a real testcontainer Postgres on every integration run, exercising the new authkit path end-to-end