### PR TITLE
fix(tests): repair the two standing-red master integration fixtures (#792)

### DIFF
--- a/internal/controlplane/bootstrap_integration_test.go
+++ b/internal/controlplane/bootstrap_integration_test.go
@@ -100,6 +100,21 @@ func applyBootstrapTestSchema(t *testing.T, ctx context.Context, pool *pgxpool.P
 	dbtest.EnsureTestMerchant(ctx, t, pool)
 }
 
+// enrollTestMFA marks userID as MFA-enrolled directly in the DB (a settings
+// row + a default email factor — exactly what authkit's userHasEnabledMFA
+// checks), so granting MFA-required root roles (authkit v0.84.0 #49) succeeds
+// in fixtures that have no session to enroll 2FA through the real HTTP flow.
+func enrollTestMFA(ctx context.Context, t *testing.T, pool *pgxpool.Pool, userID string) {
+	t.Helper()
+	_, err := pool.Exec(ctx,
+		`INSERT INTO profiles.mfa_settings (user_id, enabled) VALUES ($1::uuid, true)
+		 ON CONFLICT (user_id) DO UPDATE SET enabled = true`, userID)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx,
+		`INSERT INTO profiles.mfa_factors (user_id, method, is_default) VALUES ($1::uuid, 'email', true)`, userID)
+	require.NoError(t, err)
+}
+
 func newTestControlPlane(t *testing.T, pool *pgxpool.Pool) *ControlPlane {
 	t.Helper()
 	cfg := &config.Config{
@@ -364,6 +379,9 @@ func TestRootOperatorBoundary_ReachNotMerchantCapability(t *testing.T) {
 
 	rootOperator, err := cp.Core().CreateUser(ctx, "root-operator@example.test", "rootoperator")
 	require.NoError(t, err)
+	// authkit v0.84.0 #49: assigning an MFA-required root role fails closed
+	// unless the subject already has 2FA enrolled.
+	enrollTestMFA(ctx, t, pool, rootOperator.ID)
 	require.NoError(t, cp.Core().Genesis().AssignGroupRole(ctx, authcore.RootPersona, "", rootOperator.ID, authcore.SubjectKindUser, authcore.OwnerRoleName))
 
 	canModerateMerchant, err := cp.Core().Can(ctx, rootOperator.ID, authcore.SubjectKindUser, authcore.RootPersona, "", "root:merchants:delete")

--- a/internal/reconcile/integration_test.go
+++ b/internal/reconcile/integration_test.go
@@ -580,9 +580,13 @@ func TestReconcileAdoptPreservesScheduledProviderActions(t *testing.T) {
 		}
 		exec(`INSERT INTO openrails.products (id, key, display_name, merchant_id) VALUES ($1,$2,$2,$3)`, productID, "sa-prod-"+suffix, merchantID)
 		// Two prices for the SAME product (the scheduled downgrade target), so the
-		// subscriptions_price_product_merchant composite FK is satisfied.
-		exec(`INSERT INTO openrails.prices (id, product_id, amount, currency, merchant_id) VALUES ($1,$2,9990000,'usd',$3),($4,$2,4990000,'usd',$3)`,
-			priceID, productID, merchantID, schedPriceID)
+		// subscriptions_price_product_merchant composite FK is satisfied. Both
+		// default to auto_renew=false/access_duration_hours=NULL, so the
+		// trg_prices_default_key trigger would derive the SAME "<product>-onetime"
+		// key for both and collide on uq_prices_merchant_key_current (#774) —
+		// supply distinct explicit keys, per insertPriceIfAbsent in tests/seed_data.go.
+		exec(`INSERT INTO openrails.prices (id, product_id, amount, currency, key, merchant_id) VALUES ($1,$2,9990000,'usd',$3,$4),($5,$2,4990000,'usd',$6,$4)`,
+			priceID, productID, "sa-price-"+suffix+"-current", merchantID, schedPriceID, "sa-price-"+suffix+"-scheduled")
 		exec(`INSERT INTO openrails.subscriptions
 		        (id, price_id, product_id, status, rail, rail_subscription_id,
 		         current_period_starts_at, current_period_ends_at, started_at,


### PR DESCRIPTION
Fixes the two integration tests that have kept master CI red (tracker #792). Both reproduce on clean master; both are TEST-FIXTURE bugs, no product code touched.

## 1. TestRootOperatorBoundary_ReachNotMerchantCapability (internal/controlplane)

Failed with `2fa_enrollment_required`: authkit v0.84.0 (#49 login gate) fails closed when assigning an MFA-required root role to a user without enrolled 2FA — the fixture granted `root` owner to a fresh user who never enrolled.

Fix: new `enrollTestMFA` test helper (hentai0's pattern) inserts the exact DB state authkit's `userHasEnabledMFA` checks — an enabled `profiles.mfa_settings` row plus a default email `profiles.mfa_factors` row — before the Genesis role grant. The gate itself is untouched.

## 2. TestReconcileAdoptPreservesScheduledProviderActions (internal/reconcile)

Failed with `duplicate key value violates unique constraint "uq_prices_merchant_key_current"`.

**Verdict: fixture bug, not a product bug in price convergence/adopt.** The violation fires on the fixture's own seed INSERT (integration_test.go seed block), before any reconcile/adopt code runs: it inserts two prices for the same product with no explicit `key`, both defaulting to `auto_renew=false` / `access_duration_hours=NULL`, so the `trg_prices_default_key` trigger derives the SAME `<product>-onetime` key for both rows — colliding on the #774 partial unique index within a single statement. Product convergence code is not on the failing path at all.

Fix: distinct explicit keys (`sa-price-<suffix>-current` / `-scheduled`), per the documented `insertPriceIfAbsent` pattern in tests/seed_data.go.

## Verification

- Both tests reproduced red on clean master, green after.
- `go build ./...`, `go vet ./...`, full unit `go test ./...` green.
- Full integration suite (`scripts/test_integration.sh ./...`, 44 tagged packages) green; `./tests` hit its 25m timeout once while ANOTHER worker's integration run contended for the shared Postgres (stuck live NMI HTTP call), and passes in 9s standalone — unrelated to this change.
- Re-verified both target tests after rebasing onto 421c1f62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)