### PR TITLE
feat(#797): host usage reporting — RecordUsage on the unified Client + FinalizeInvoice service export

### DIFF
--- a/client.go
+++ b/client.go
@@ -78,6 +78,15 @@ type AdmissionClient interface {
 	ReportWastedSpend(ctx context.Context, report WastedSpendReport) (*WastedSpendResponse, error)
 }
 
+// UsageReportClient reports metered usage events outside the admission
+// hold/capture cycle (#797): the host records a usage_events row (optionally
+// host-priced via Amount; 0 = free/metered-only) that the rate-card rating
+// sweep aggregates into arrears invoice lines. Gauge meters (GB-month style)
+// report unit-second segment quantities in Dimensions.
+type UsageReportClient interface {
+	RecordUsage(ctx context.Context, report UsageReport) error
+}
+
 // PolicySyncClient installs merchant-owned admission policy in one settings
 // document.
 type PolicySyncClient interface {
@@ -146,6 +155,7 @@ type CustomerLookupClient interface {
 // smaller interfaces above.
 type Client interface {
 	AdmissionClient
+	UsageReportClient
 	PolicySyncClient
 	AdminFundingClient
 	CustomerLookupClient
@@ -435,6 +445,28 @@ type WastedSpendReport struct {
 	// SourceID is the idempotency key for this report within the Source namespace.
 	SourceID string `json:"source_id"`
 	Reason   string `json:"reason,omitempty"`
+}
+
+// UsageReport is one host-reported metered usage event (#797). CustomerID is
+// the billed payer; Source+SourceID form the idempotency key within
+// (payer, event_type) — replays are accepted and never double-record or
+// double-charge. Amount is the host-priced cost in the currency's internal
+// precision; 0 records a free/metered-only event (dimensions still aggregate
+// through rate-card rating). OccurredAtUnix (seconds; 0 = now) places the
+// event in its rating window — gauge segment reporters set it to segment end.
+type UsageReport struct {
+	CustomerID string           `json:"customer_id"`
+	Invoker    string           `json:"invoker"`
+	Currency   string           `json:"currency,omitempty"`
+	EventType  string           `json:"event_type"`
+	Dimensions map[string]int64 `json:"dimensions,omitempty"`
+	Amount     int64            `json:"amount"`
+	Resource   string           `json:"resource,omitempty"`
+	Metadata   map[string]any   `json:"metadata,omitempty"`
+	Source     string           `json:"source"`
+	SourceID   string           `json:"source_id"`
+	// OccurredAtUnix is the event time as a unix timestamp in seconds (0 = now).
+	OccurredAtUnix int64 `json:"occurred_at_unix,omitempty"`
 }
 
 // WastedSpendResponse reports how OpenRails handled a wasted-spend report.

--- a/embed/usage_report_integration_test.go
+++ b/embed/usage_report_integration_test.go
@@ -1,0 +1,127 @@
+//go:build integration
+
+package embed_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/open-rails/openrails"
+	"github.com/open-rails/openrails/embed"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/internal/integrationharness"
+	"github.com/open-rails/openrails/internal/modules/money"
+	"github.com/open-rails/openrails/pkg/identity"
+	"github.com/open-rails/openrails/pkg/pricing"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRecordUsage_UnifiedClient_RatesIntoInvoice proves #797 end to end on
+// BOTH transports: host-reported usage lands in openrails.usage_events through
+// the unified client (idempotent on source+source_id), and the pkg/service
+// FinalizeInvoice export rates it through a gauge rate card into an invoice.
+func TestRecordUsage_UnifiedClient_RatesIntoInvoice(t *testing.T) {
+	ctx := context.Background()
+	currency := money.DefaultCurrency
+
+	h := integrationharness.New(t, ctx)
+	embedded := h.StartEmbeddedHost(currency)
+	standalone := h.StartStandalone(currency)
+	pool := h.Pool()
+
+	embeddedClient := embedded.Runtime().Client(embed.WithCurrency(currency))
+	standaloneClient := standalone.Client()
+
+	merchantID := dbtest.TestMerchantID.UUID()
+	meterKey := "gb-seconds-" + uuid.NewString()
+	productID := uuid.New()
+	payerID := uuid.New()
+	payer := identity.CustomerID(payerID)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, "DELETE FROM openrails.usage_events WHERE customer_id = $1", payerID)
+		_, _ = pool.Exec(ctx, "DELETE FROM openrails.invoice_items WHERE customer_id = $1", payerID)
+		_, _ = pool.Exec(ctx, "DELETE FROM openrails.invoices WHERE customer_id = $1", payerID)
+		_, _ = pool.Exec(ctx, "DELETE FROM openrails.catalog_rate_cards WHERE merchant_id = $1 AND product_id = $2", merchantID, productID)
+		_, _ = pool.Exec(ctx, "DELETE FROM openrails.catalog_meters WHERE key = $1", meterKey)
+		_, _ = pool.Exec(ctx, "DELETE FROM openrails.products WHERE id = $1", productID)
+	})
+
+	// Arrears so rated usage becomes an open receivable.
+	svc := embedded.Runtime().Service()
+	mode := money.BillingModeArrears
+	require.NoError(t, svc.SetCreditAccountSettings(dbtest.WithTestMerchant(ctx), payer, currency,
+		money.AccountSettingsInput{BillingMode: &mode}))
+
+	from := time.Now().Add(-time.Hour)
+	to := time.Now().Add(time.Hour)
+	occurred := time.Now().UTC().Truncate(time.Second)
+
+	// Two gauge segment events via the EMBEDDED unified client; the first is
+	// replayed and must not double-record.
+	report := openrails.UsageReport{
+		CustomerID:     payerID.String(),
+		Invoker:        "usage-report-test",
+		Currency:       currency,
+		EventType:      meterKey,
+		Dimensions:     map[string]int64{meterKey: 1800},
+		Amount:         0,
+		Source:         "usage-report-test",
+		SourceID:       uuid.NewString(),
+		OccurredAtUnix: occurred.Unix(),
+	}
+	require.NoError(t, embeddedClient.RecordUsage(ctx, report))
+	require.NoError(t, embeddedClient.RecordUsage(ctx, report), "idempotent replay must succeed")
+	second := report
+	second.SourceID = uuid.NewString()
+	second.Dimensions = map[string]int64{meterKey: 5400}
+	require.NoError(t, embeddedClient.RecordUsage(ctx, second))
+
+	// One more via the STANDALONE client (same wire, real HTTP + AuthKit).
+	third := report
+	third.SourceID = uuid.NewString()
+	third.Dimensions = map[string]int64{meterKey: 3600}
+	require.NoError(t, standaloneClient.RecordUsage(ctx, third))
+
+	var eventCount int
+	var totalUnits int64
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT count(*), COALESCE(SUM((dimensions ->> $2)::bigint), 0)
+		FROM openrails.usage_events
+		WHERE customer_id = $1 AND event_type = $2`, payerID, meterKey).Scan(&eventCount, &totalUnits))
+	require.Equal(t, 3, eventCount, "replay must not create a fourth event")
+	require.Equal(t, int64(1800+5400+3600), totalUnits)
+
+	// Gauge rate card: 500_000 micros per 3600 unit-seconds.
+	rateMicros, divideBy := int64(500_000), int64(3600)
+	_, err := pool.Exec(ctx, `INSERT INTO openrails.products (id, key, display_name, merchant_id) VALUES ($1, $2, $3, $4)`,
+		productID, "usage-report-"+uuid.NewString(), "Usage Report Product", merchantID)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `INSERT INTO openrails.catalog_meters (merchant_id, key, kind) VALUES ($1, $2, 'gauge')`,
+		merchantID, meterKey)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+INSERT INTO openrails.catalog_rate_cards (merchant_id, product_id, ordinal, meter_key, payment_term, price)
+VALUES ($1, $2, 1, $3, 'in_arrears', jsonb_build_object(
+    'model', 'per_unit',
+    'currency', 'usd',
+    'per_unit', jsonb_build_object('unit_amount', $4::bigint, 'divide_by', $5::bigint)))`,
+		merchantID, productID, meterKey, rateMicros, divideBy)
+	require.NoError(t, err)
+
+	expected, err := pricing.ChargeModel{Kind: pricing.ModelPerUnit, UnitAmount: rateMicros, DivideBy: divideBy}.Rate(totalUnits)
+	require.NoError(t, err)
+	require.Greater(t, expected, int64(0))
+
+	inv, err := svc.FinalizeInvoice(dbtest.WithTestMerchant(ctx), payer, currency, from, to)
+	require.NoError(t, err)
+	require.Equal(t, "open", inv.Status)
+	require.Equal(t, expected, inv.AmountDue, "invoice must equal reported unit-seconds x rate")
+
+	// Re-finalize the same window: idempotent (per-period watermark).
+	inv2, err := svc.FinalizeInvoice(dbtest.WithTestMerchant(ctx), payer, currency, from, to)
+	require.NoError(t, err)
+	require.Equal(t, inv.ID, inv2.ID)
+	require.Equal(t, expected, inv2.AmountDue)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-rails/openrails
 
-go 1.26.4
+go 1.26.5
 
 // Keep the npm tree (which ships stray .go files) out of ./... package
 // patterns WITHOUT a nested go.mod — a nested module would prune web/admin

--- a/internal/http/handlers/service_credits.go
+++ b/internal/http/handlers/service_credits.go
@@ -210,6 +210,73 @@ type serviceUsageRollupRequest struct {
 	GroupBy    string `json:"group_by" binding:"required"`
 }
 
+type serviceRecordUsageRequest struct {
+	CustomerID     string           `json:"customer_id" binding:"required"`
+	Invoker        string           `json:"invoker"`
+	Currency       string           `json:"currency"`
+	EventType      string           `json:"event_type" binding:"required"`
+	Dimensions     map[string]int64 `json:"dimensions"`
+	Amount         int64            `json:"amount"`
+	Resource       string           `json:"resource"`
+	Metadata       map[string]any   `json:"metadata"`
+	Source         string           `json:"source" binding:"required"`
+	SourceID       string           `json:"source_id" binding:"required"`
+	OccurredAtUnix int64            `json:"occurred_at_unix"`
+}
+
+// ServiceRecordUsage records one host-reported metered usage event (#797): a
+// usage_events row (plus a ledger debit for a non-zero amount) that the
+// rate-card rating sweep aggregates into arrears invoice lines. Idempotent on
+// (payer, event_type, source, source_id). Operator API key, admissions:create.
+func ServiceRecordUsage(r *httprequest.Request) {
+	var req serviceRecordUsageRequest
+	if !r.BindJSON(&req) {
+		return
+	}
+	if req.Amount < 0 {
+		r.ErrorJSON(http.StatusBadRequest, "amount must be >= 0")
+		return
+	}
+	payer, err := parseServiceCustomerID(req.CustomerID)
+	if err != nil || payer == nil {
+		r.ErrorJSON(http.StatusBadRequest, "customer_id required")
+		return
+	}
+	if !requireServiceCustomerScope(r, *payer) {
+		return
+	}
+	currency, ok := serviceRequiredCurrency(r, req.Currency)
+	if !ok {
+		return
+	}
+	svc, err := billingservice.New(r.State)
+	if err != nil {
+		r.ErrorJSON(http.StatusInternalServerError, "billing service unavailable")
+		return
+	}
+	var occurredAt time.Time
+	if req.OccurredAtUnix > 0 {
+		occurredAt = time.Unix(req.OccurredAtUnix, 0).UTC()
+	}
+	if err := svc.RecordUsage(r.Request.Context(), billingservice.RecordUsageInput{
+		CustomerID: *payer,
+		Invoker:    req.Invoker,
+		Currency:   currency,
+		EventType:  req.EventType,
+		Dimensions: req.Dimensions,
+		Amount:     req.Amount,
+		Resource:   req.Resource,
+		Metadata:   req.Metadata,
+		Source:     req.Source,
+		SourceID:   req.SourceID,
+		OccurredAt: occurredAt,
+	}); err != nil {
+		r.ErrorJSON(http.StatusBadRequest, err.Error())
+		return
+	}
+	r.SuccessJSON(map[string]any{"currency": currency, "recorded": true})
+}
+
 type serviceEndpointRevenueRequest struct {
 	Resource string `json:"resource" binding:"required"`
 	Currency string `json:"currency"`

--- a/internal/http/routes/routes.go
+++ b/internal/http/routes/routes.go
@@ -235,6 +235,7 @@ func RegisterServiceRoutes(rr router.Router, rt *app.Runtime, opts Options) {
 	admissions.Handle(http.MethodPost, "/:id/release", h(httphandlers.ServiceReleaseHold), admissionMW...)
 
 	usage := group.Group("/usage")
+	usage.Handle(http.MethodPost, "/report", h(httphandlers.ServiceRecordUsage), admissionMW...)
 	usage.Handle(http.MethodPost, "/rollup", h(httphandlers.ServiceUsageRollup), usageReadMW...)
 	usage.Handle(http.MethodPost, "/resource-revenue", h(httphandlers.ServiceResourceRevenue), usageReadMW...)
 

--- a/internal/integrationharness/testdata/standalone_route_surface.txt
+++ b/internal/integrationharness/testdata/standalone_route_surface.txt
@@ -153,6 +153,7 @@ POST /v1/merchant/subscriptions/{id}/cancel
 POST /v1/merchant/subscriptions/{id}/reprice
 POST /v1/merchant/subscriptions/{id}/resume
 POST /v1/merchant/team/invites
+POST /v1/merchant/usage/report
 POST /v1/merchant/usage/resource-revenue
 POST /v1/merchant/usage/rollup
 POST /v1/merchant/wasted-spend

--- a/pkg/service/usage.go
+++ b/pkg/service/usage.go
@@ -1,0 +1,94 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/open-rails/openrails/internal/modules/money"
+	"github.com/open-rails/openrails/pkg/identity"
+)
+
+// RecordUsageInput is one host-reported metered usage event (#797).
+// Source+SourceID form the idempotency key within (payer, event_type):
+// replays return success without double-recording or double-charging.
+// Amount is the host-priced cost in the currency's internal precision;
+// 0 records a free/metered-only event whose Dimensions still aggregate
+// through rate-card rating (gauge meters report unit-second quantities).
+type RecordUsageInput struct {
+	CustomerID identity.CustomerID
+	Invoker    string
+	Currency   string
+	EventType  string
+	Dimensions map[string]int64
+	Amount     int64
+	Resource   string
+	Metadata   map[string]any
+	Source     string
+	SourceID   string
+	// OccurredAt places the event in its rating window (zero = now).
+	OccurredAt time.Time
+}
+
+// RecordUsage durably records a metered usage event (and debits the ledger for
+// a non-zero Amount) via money.RecordUsage (#289/#797). Idempotent on
+// (merchant, payer, event_type, source, source_id).
+func (s *Service) RecordUsage(ctx context.Context, in RecordUsageInput) error {
+	if s == nil || s.rt == nil {
+		return fmt.Errorf("service not initialized")
+	}
+	if in.CustomerID.IsZero() {
+		return fmt.Errorf("payer required")
+	}
+	cur, err := requireCurrency(in.Currency)
+	if err != nil {
+		return err
+	}
+	metadata := in.Metadata
+	if in.Resource = strings.TrimSpace(in.Resource); in.Resource != "" {
+		if metadata == nil {
+			metadata = map[string]any{}
+		}
+		if _, ok := metadata["resource"]; !ok {
+			metadata["resource"] = in.Resource
+		}
+	}
+	payer := in.CustomerID
+	_, err = s.moneyService().RecordUsage(ctx, money.RecordUsageParams{
+		Payer:      &payer,
+		Invoker:    strings.TrimSpace(in.Invoker),
+		Currency:   cur,
+		EventType:  strings.TrimSpace(in.EventType),
+		Dimensions: in.Dimensions,
+		Amount:     in.Amount,
+		Source:     strings.TrimSpace(in.Source),
+		SourceID:   strings.TrimSpace(in.SourceID),
+		Metadata:   metadata,
+		OccurredAt: in.OccurredAt,
+	})
+	return err
+}
+
+// FinalizeInvoice closes the rating window [from, to) for one payer: the
+// metered rating sweep rates reported usage through the catalog rate cards
+// (allowances + per-period watermarks) and the resulting statement is
+// finalized as an invoice (#797 public export). Idempotent per window.
+func (s *Service) FinalizeInvoice(ctx context.Context, payer identity.CustomerID, currency string, from, to time.Time) (*InvoiceDTO, error) {
+	if s == nil || s.rt == nil {
+		return nil, fmt.Errorf("service not initialized")
+	}
+	if payer.IsZero() {
+		return nil, fmt.Errorf("payer required")
+	}
+	cur, err := requireCurrency(currency)
+	if err != nil {
+		return nil, err
+	}
+	inv, err := s.moneyService().FinalizeInvoice(ctx, payer, cur, from, to)
+	if err != nil {
+		return nil, err
+	}
+	dto := invoiceToDTO(inv)
+	return &dto, nil
+}

--- a/remote.go
+++ b/remote.go
@@ -346,6 +346,28 @@ func (c *remote) ReportWastedSpend(ctx context.Context, report WastedSpendReport
 	return &out, nil
 }
 
+// RecordUsage implements Client (handler ServiceRecordUsage, #797).
+func (c *remote) RecordUsage(ctx context.Context, report UsageReport) error {
+	currency := normalizeCurrency(report.Currency)
+	if currency == "" {
+		currency = normalizeCurrency(c.currency)
+	}
+	body := map[string]any{
+		"customer_id":      strings.TrimSpace(report.CustomerID),
+		"invoker":          report.Invoker,
+		"currency":         currency,
+		"event_type":       report.EventType,
+		"dimensions":       report.Dimensions,
+		"amount":           report.Amount,
+		"resource":         report.Resource,
+		"metadata":         report.Metadata,
+		"source":           report.Source,
+		"source_id":        report.SourceID,
+		"occurred_at_unix": report.OccurredAtUnix,
+	}
+	return c.do(ctx, http.MethodPost, "/v1/merchant/usage/report", body, nil)
+}
+
 // SetCreditLimit implements Client (handler ServiceSetCreditLimit, #489).
 func (c *remote) SetCreditLimit(ctx context.Context, customerID, currency string, creditLimit int64) error {
 	body := map[string]any{


### PR DESCRIPTION
Implements openrails-tracker #797.

- `UsageReportClient.RecordUsage` folded into the unified `Client` (both transports; remote hits new `POST /v1/merchant/usage/report`, admissions:create permission)
- handler `ServiceRecordUsage` -> `pkg/service.RecordUsage` -> `money.RecordUsage` (idempotent on payer/event_type/source/source_id; amount 0 = metered-only)
- `pkg/service.FinalizeInvoice` export so embedded hosts/tests can close a rating window (metered sweep + watermarks)
- integration test: report via embedded AND standalone clients -> gauge rate card -> finalized invoice; idempotent replay + re-finalize

Consumer: tensorhub th#660 storage GB-month metering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)