### PR TITLE
feat(#799): catalog provider links key on the merchant ACCOUNT, not the rail

### DIFF
--- a/internal/db/models/product_catalog.go
+++ b/internal/db/models/product_catalog.go
@@ -218,19 +218,60 @@ const (
 	RailKeyCCBillRecurringBillingOption = "recurring_billing_option_id"
 	RailKeyStripePriceID                = "price_id"
 	RailKeyStripeProductID              = "product_id"
+	// RailKeyRail records the entry's rail inside an ACCOUNT-keyed entry
+	// (#799: prices.rails keys on the merchant's account key, e.g. "mobius";
+	// the rail lives in the entry so several accounts can share one rail).
+	RailKeyRail = "rail"
 )
 
-// GetRailConfig returns the configuration for a specific rail, or nil if not configured
-func (p *Price) GetRailConfig(rail Rail) map[string]string {
-	if p.Rails == nil {
+// RailLinkEntries returns every provider-link entry on the given rail, keyed
+// by account key (#799). An entry matches when its RailKeyRail field names the
+// rail, or its account key IS the rail name — the reserved gateways (stripe,
+// ccbill, solana) are their own account names.
+func RailLinkEntries(rails map[string]map[string]string, rail Rail) map[string]map[string]string {
+	if len(rails) == 0 {
 		return nil
 	}
-	return p.Rails[string(rail)]
+	want := string(rail)
+	var out map[string]map[string]string
+	for key, cfg := range rails {
+		if cfg == nil {
+			continue
+		}
+		if key != want && strings.TrimSpace(cfg[RailKeyRail]) != want {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]map[string]string, 1)
+		}
+		out[key] = cfg
+	}
+	return out
+}
+
+// GetRailConfig returns the rail's single provider-link entry, or nil when the
+// rail is unlinked. Several accounts linked on one rail also yield nil (never
+// guess between accounts) — enumerate RailAccountConfigs there.
+func (p *Price) GetRailConfig(rail Rail) map[string]string {
+	entries := RailLinkEntries(p.Rails, rail)
+	if len(entries) != 1 {
+		return nil
+	}
+	for _, cfg := range entries {
+		return cfg
+	}
+	return nil
+}
+
+// RailAccountConfigs returns every provider-link entry on the rail, keyed by
+// account key.
+func (p *Price) RailAccountConfigs(rail Rail) map[string]map[string]string {
+	return RailLinkEntries(p.Rails, rail)
 }
 
 // HasRail checks if a specific rail is configured for this price
 func (p *Price) HasRail(rail Rail) bool {
-	return p.GetRailConfig(rail) != nil
+	return len(RailLinkEntries(p.Rails, rail)) > 0
 }
 
 // GetNMIConfigForRail returns the NMI plan link for the given rail key (the

--- a/internal/db/models/product_catalog_test.go
+++ b/internal/db/models/product_catalog_test.go
@@ -83,3 +83,39 @@ func TestArchived_Purchasable(t *testing.T) {
 		}
 	}
 }
+
+func TestRailLinkEntries_AccountKeyed(t *testing.T) {
+	// #799: entries key on the ACCOUNT key with the rail stamped inside; a
+	// rail-named key is its own account.
+	p := &Price{Rails: map[string]map[string]string{
+		"mobius": {RailKeyRail: "nmi", RailKeyPlanID: "premium_new"},
+		"stripe": {RailKeyStripePriceID: "price_123"},
+	}}
+
+	nmi := p.RailAccountConfigs(RailNMI)
+	if len(nmi) != 1 || nmi["mobius"][RailKeyPlanID] != "premium_new" {
+		t.Fatalf("nmi entries = %v", nmi)
+	}
+	if cfg := p.GetRailConfig(RailNMI); cfg[RailKeyPlanID] != "premium_new" {
+		t.Fatalf("GetRailConfig(nmi) = %v", cfg)
+	}
+	if cfg := p.GetRailConfig(RailStripe); cfg[RailKeyStripePriceID] != "price_123" {
+		t.Fatalf("GetRailConfig(stripe) = %v", cfg)
+	}
+	if !p.HasRail(RailNMI) || p.HasRail(RailCCBill) {
+		t.Fatalf("HasRail: nmi=%v ccbill=%v", p.HasRail(RailNMI), p.HasRail(RailCCBill))
+	}
+	if planID, ok := p.GetNMIConfigForRail("nmi"); !ok || planID != "premium_new" {
+		t.Fatalf("GetNMIConfigForRail = %q, %v", planID, ok)
+	}
+
+	// Two accounts on one rail: enumeration sees both, the single-entry
+	// accessor refuses to guess.
+	p.Rails["paykings"] = map[string]string{RailKeyRail: "nmi", RailKeyPlanID: "premium_pk"}
+	if got := len(p.RailAccountConfigs(RailNMI)); got != 2 {
+		t.Fatalf("expected 2 nmi entries, got %d", got)
+	}
+	if cfg := p.GetRailConfig(RailNMI); cfg != nil {
+		t.Fatalf("ambiguous GetRailConfig should be nil, got %v", cfg)
+	}
+}

--- a/internal/intents/solana_sunset.go
+++ b/internal/intents/solana_sunset.go
@@ -133,7 +133,7 @@ func (h *SolanaSunsetPlanHandler) CheckRelevance(ctx context.Context, intent gen
 		if !pr.IsPurchasable() {
 			continue
 		}
-		cfg := pr.Rails[string(models.RailSolana)]
+		cfg := pr.GetRailConfig(models.RailSolana)
 		if cfg != nil && strings.TrimSpace(cfg["plan_pda"]) == pda {
 			return SupersededBy("a purchasable local price references this plan again; sunsetting it would be wrong"), nil
 		}

--- a/internal/modules/catalog/extras.go
+++ b/internal/modules/catalog/extras.go
@@ -49,7 +49,7 @@ func BuildExtrasIndex(products []*models.Product, prices []*models.Price) Extras
 		if key := keyByProductID[pr.ProductID.String()]; key != "" {
 			ix.PriceContentKeys[OpenRailsPriceContentKey(key, pr.Currency, pr.Amount, pr.RecurringCycleDays())] = struct{}{}
 		}
-		if stripe := pr.Rails["stripe"]; stripe != nil {
+		if stripe := pr.GetRailConfig(models.RailStripe); stripe != nil {
 			if id := strings.TrimSpace(stripe[models.RailKeyStripePriceID]); id != "" {
 				ix.StripePriceIDs[id] = struct{}{}
 			}

--- a/internal/reconcile/diff.go
+++ b/internal/reconcile/diff.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/open-rails/openrails/internal/db/models"
 )
 
 // localIndex precomputes the lookups the diff checks share.
@@ -66,23 +68,29 @@ type planLink struct {
 var planLinkIDKeys = []string{"plan_id", "price_id", "recurring_billing_option_id", "plan_pda"}
 
 // buildPlanIndex maps remote plan ids onto local prices via the catalog
-// provider_links blobs, restricted to the provider's local rail names.
+// provider_links blobs, restricted to the provider's local rail names. Blobs
+// are ACCOUNT-keyed (#799: entry key = merchant account key, rail recorded in
+// the entry; a rail-named key is its own account) — two accounts carrying the
+// same plan id on one price dedup to a single link.
 func buildPlanIndex(provider Provider, prices []LocalPrice) map[string][]planLink {
 	idx := map[string][]planLink{}
 	names := localRailNames(provider)
 	for i := range prices {
 		p := &prices[i]
 		for _, name := range names {
-			cfg := p.Rails[name]
-			if cfg == nil {
-				continue
-			}
-			for _, key := range planLinkIDKeys {
-				id := strings.TrimSpace(cfg[key])
-				if id == "" {
-					continue
+			seen := map[string]struct{}{}
+			for _, cfg := range models.RailLinkEntries(p.Rails, models.Rail(name)) {
+				for _, key := range planLinkIDKeys {
+					id := strings.TrimSpace(cfg[key])
+					if id == "" {
+						continue
+					}
+					if _, dup := seen[id]; dup {
+						continue
+					}
+					seen[id] = struct{}{}
+					idx[id] = append(idx[id], planLink{price: p, railName: name})
 				}
-				idx[id] = append(idx[id], planLink{price: p, railName: name})
 			}
 		}
 	}

--- a/internal/reconcile/engine_test.go
+++ b/internal/reconcile/engine_test.go
@@ -1358,9 +1358,9 @@ func materializeFixture() (*fakeLocal, *RemoteSnapshot, LocalPrice) {
 		Amount:    999,
 		Currency:  "usd",
 		Rails: map[string]map[string]string{
-			// #630: the provider-link key is the gateway rail (nmi), not the
-			// provider-account name (mobius).
-			"nmi": {"plan_id": "plan-gold"},
+			// #799: the provider-link key is the merchant's ACCOUNT key with
+			// the rail recorded inside the entry.
+			"mobius": {"rail": "nmi", "plan_id": "plan-gold"},
 		},
 	}
 	local.state.Prices = []LocalPrice{price}

--- a/internal/river/jobs_catalog_reconciliation.go
+++ b/internal/river/jobs_catalog_reconciliation.go
@@ -224,7 +224,7 @@ func computeStripeDriftJob(
 				priceByContentKey[ck] = pr
 			}
 		}
-		stripe := pr.Rails["stripe"]
+		stripe := pr.GetRailConfig(models.RailStripe)
 		if stripe == nil {
 			continue
 		}
@@ -401,13 +401,12 @@ func computeNMIDriftJob(plans []nmiPlanJob, priceRows []*models.Price, now time.
 	priceByPlanID := make(map[string]string)
 	for _, pr := range priceRows {
 		priceByID[pr.ID.String()] = pr
-		nmiLink := pr.Rails[string(models.RailNMI)]
-		if nmiLink == nil {
-			continue
-		}
-		if planID := strings.TrimSpace(nmiLink[models.RailKeyPlanID]); planID != "" {
-			planIDByOpenRailsPrice[pr.ID.String()] = planID
-			priceByPlanID[planID] = pr.ID.String()
+		// Account-keyed (#799): register every NMI account's plan link.
+		for _, nmiLink := range pr.RailAccountConfigs(models.RailNMI) {
+			if planID := strings.TrimSpace(nmiLink[models.RailKeyPlanID]); planID != "" {
+				planIDByOpenRailsPrice[pr.ID.String()] = planID
+				priceByPlanID[planID] = pr.ID.String()
+			}
 		}
 	}
 

--- a/pkg/embedded/catalog_dump.go
+++ b/pkg/embedded/catalog_dump.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/open-rails/openrails/config"
 	"github.com/open-rails/openrails/internal/db"
+	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/pkg/catalog"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
@@ -456,6 +457,12 @@ func providerLinks(raw []byte) map[string]map[string]string {
 	_ = json.Unmarshal(raw, &links)
 	if len(links) == 0 {
 		return nil
+	}
+	// The stored blob is account-keyed with the rail stamped inside each entry
+	// (#799); the manifest derives the rail from the account key, so the stamp
+	// is storage detail, not manifest content.
+	for _, cfg := range links {
+		delete(cfg, models.RailKeyRail)
 	}
 	return links
 }

--- a/pkg/service/catalog_drift.go
+++ b/pkg/service/catalog_drift.go
@@ -506,7 +506,7 @@ func buildSnapshotFromRows(productRows []*models.Product, priceRows []*models.Pr
 				snap.priceByContentKey[ck] = pr
 			}
 		}
-		if stripe := pr.Rails["stripe"]; stripe != nil {
+		if stripe := pr.GetRailConfig(models.RailStripe); stripe != nil {
 			if id := strings.TrimSpace(stripe[models.RailKeyStripePriceID]); id != "" {
 				snap.stripePriceIDs[id] = pr.ID.String()
 			}
@@ -515,7 +515,8 @@ func buildSnapshotFromRows(productRows []*models.Product, priceRows []*models.Pr
 				snap.stripeProductIDs[id] = pr.ProductID.String()
 			}
 		}
-		if nmiLink := pr.Rails[string(models.RailNMI)]; nmiLink != nil {
+		// Account-keyed (#799): any NMI account's plan link registers the price.
+		for _, nmiLink := range pr.RailAccountConfigs(models.RailNMI) {
 			if planID := strings.TrimSpace(nmiLink[models.RailKeyPlanID]); planID != "" {
 				snap.nmiPlanIDByOpenRailsPrice[pr.ID.String()] = planID
 			}
@@ -685,7 +686,7 @@ func (s *Service) computeSolanaCatalogDrift(ctx context.Context, snap localCatal
 	var events []models.CatalogDriftEvent
 	scanned := 0
 	for _, pr := range snap.priceByID {
-		cfg := pr.Rails[string(models.RailSolana)]
+		cfg := pr.GetRailConfig(models.RailSolana)
 		if len(cfg) == 0 {
 			continue
 		}

--- a/pkg/service/catalog_extras.go
+++ b/pkg/service/catalog_extras.go
@@ -366,7 +366,7 @@ func computeSolanaSunsetExtras(ctx context.Context, reader solanaPlanReader, sna
 	}
 	byPDA := map[string]*pdaState{}
 	for _, pr := range snap.priceByID {
-		cfg := pr.Rails[string(models.RailSolana)]
+		cfg := pr.GetRailConfig(models.RailSolana)
 		if cfg == nil {
 			continue
 		}

--- a/pkg/service/catalog_providers.go
+++ b/pkg/service/catalog_providers.go
@@ -172,6 +172,15 @@ func (s *Service) providerAdapters() map[string]providerAdapter {
 	}
 }
 
+func sortedAdapterNames(adapters map[string]providerAdapter) []string {
+	names := make([]string, 0, len(adapters))
+	for name := range adapters {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
 // priceCycleToken renders the provider-cadence component of a price content key.
 // A recurring price (cycle > 0) renders the day count for day-granularity
 // providers; a one-time price (nil or
@@ -263,6 +272,39 @@ func (s *Service) resolveProviders(ctx context.Context, product *models.Product,
 	}
 	sort.Strings(names)
 
+	// The manifest speaks the operator's ACCOUNT vocabulary ("mobius"), not
+	// rail names: resolve each declared name to its rail via the merchant's
+	// declared accounts (a rail name itself also resolves — the reserved
+	// gateways are their own account names). Unknown names fail loudly:
+	// silently dropping cost doujins its NMI plan links. Several accounts on
+	// one rail are fine — rails[] is keyed by the ACCOUNT key and each entry
+	// records its rail (#799).
+	type attachTarget struct {
+		declared  string // manifest name = ProviderLinks key = rails[]/states[] key
+		rail      string // adapters index; recorded in the entry's RailKeyRail
+		accountID string // rail-native account id; pins Attach/AutoCreate (#641)
+		adapter   providerAdapter
+	}
+	accountRails := s.merchantAccountRails(ctx)
+	targets := make([]attachTarget, 0, len(names))
+	for _, name := range names {
+		t := attachTarget{declared: name, rail: name}
+		var ok bool
+		t.adapter, ok = adapters[name]
+		if !ok {
+			if acct, found := accountRails[name]; found {
+				t.rail, t.accountID = acct.rail, acct.accountID
+				t.adapter, ok = adapters[acct.rail]
+			}
+		}
+		if !ok {
+			return nil, nil, nil, fmt.Errorf(
+				"unknown provider %q in providers/provider_links: not a rail (%s) or a declared merchant account key",
+				name, strings.Join(sortedAdapterNames(adapters), ", "))
+		}
+		targets = append(targets, t)
+	}
+
 	// The price substance (product key + immutable money terms) is the same for the
 	// Attach (link-validation) and AutoCreate (mint) paths. lookup_key + content
 	// keys are derived from the product key + money terms, not the row UUIDs, so
@@ -288,28 +330,40 @@ func (s *Service) resolveProviders(ctx context.Context, product *models.Product,
 		RemoteWritesDisabled: remoteWritesDisabled,
 	}
 
-	for _, name := range names {
-		adapter, ok := adapters[name]
-		if !ok {
-			// Unknown provider: silently drop. Matches pre-#208 catalog tolerance.
-			continue
+	// stampRail records the entry's rail inside account-keyed entries so
+	// readers can scan by rail (RailLinkEntries); a rail-named key is already
+	// self-describing.
+	stampRail := func(ids map[string]string, t attachTarget) map[string]string {
+		if ids == nil {
+			ids = map[string]string{}
 		}
-		link := req.ProviderLinks[name]
+		if t.declared != t.rail {
+			ids[models.RailKeyRail] = t.rail
+		}
+		return ids
+	}
+
+	for _, t := range targets {
+		link := req.ProviderLinks[t.declared]
+		// Pin provider calls to THIS account's credentials (#641); empty means
+		// the rail's armed default.
+		tctx := pctx
+		tctx.TargetAccountID = t.accountID
 		// Try the user-supplied attach path first. Attach VERIFIES the linked
 		// remote object exists and matches the price substance (pctx) — a wrong
 		// or missing link is a loud error, never a silent accept — and no provider
 		// object is created when a valid link is supplied.
 		if len(normalizeLinkMap(link)) > 0 {
-			ids, attachErr := adapter.Attach(ctx, link, pctx)
+			ids, attachErr := t.adapter.Attach(ctx, link, tctx)
 			if errors.Is(attachErr, errRemoteWritesDisabled) {
 				// The link verified as MISSING remotely and creating it is blocked
 				// by the operating mode: defer, don't fail the apply. The slot
 				// converges on a later apply once writes are allowed.
-				template := adapter.PendingActionTemplate(priceID)
+				template := t.adapter.PendingActionTemplate(priceID)
 				if template.Provider == "" {
-					template.Provider = name
+					template.Provider = t.rail
 				}
-				states[name] = ProviderState{
+				states[t.declared] = ProviderState{
 					Status:     ProviderStatusPendingManualLink,
 					SyncStatus: SyncStatusNeverSynced,
 					Message:    remoteWritesDisabledMessage,
@@ -318,13 +372,11 @@ func (s *Service) resolveProviders(ctx context.Context, product *models.Product,
 				continue
 			}
 			if attachErr != nil {
-				return nil, nil, nil, fmt.Errorf("%s: %w", name, attachErr)
+				return nil, nil, nil, fmt.Errorf("%s: %w", t.declared, attachErr)
 			}
-			if ids == nil {
-				ids = map[string]string{}
-			}
-			rails[name] = ids
-			states[name] = ProviderState{
+			ids = stampRail(ids, t)
+			rails[t.declared] = ids
+			states[t.declared] = ProviderState{
 				Status:     ProviderStatusLinked,
 				IDs:        copyStringMap(ids),
 				LookupKey:  ids[providerLookupKey],
@@ -337,11 +389,11 @@ func (s *Service) resolveProviders(ctx context.Context, product *models.Product,
 		// the find-half of find-or-create is not worth a special case here; the
 		// slot converges on a later apply.
 		if pctx.RemoteWritesDisabled {
-			template := adapter.PendingActionTemplate(priceID)
+			template := t.adapter.PendingActionTemplate(priceID)
 			if template.Provider == "" {
-				template.Provider = name
+				template.Provider = t.rail
 			}
-			states[name] = ProviderState{
+			states[t.declared] = ProviderState{
 				Status:     ProviderStatusPendingManualLink,
 				SyncStatus: SyncStatusNeverSynced,
 				Message:    remoteWritesDisabledMessage,
@@ -349,27 +401,25 @@ func (s *Service) resolveProviders(ctx context.Context, product *models.Product,
 			pending = append(pending, template)
 			continue
 		}
-		ids, createErr := adapter.AutoCreate(ctx, pctx)
+		ids, createErr := t.adapter.AutoCreate(ctx, tctx)
 		switch {
 		case errors.Is(createErr, errPendingManualLink):
-			template := adapter.PendingActionTemplate(priceID)
-			states[name] = ProviderState{
+			template := t.adapter.PendingActionTemplate(priceID)
+			states[t.declared] = ProviderState{
 				Status:     ProviderStatusPendingManualLink,
 				SyncStatus: SyncStatusNeverSynced,
 				Message:    template.Hint,
 			}
 			if template.Provider == "" {
-				template.Provider = name
+				template.Provider = t.rail
 			}
 			pending = append(pending, template)
 		case createErr != nil:
-			return nil, nil, nil, fmt.Errorf("%s: %w", name, createErr)
+			return nil, nil, nil, fmt.Errorf("%s: %w", t.declared, createErr)
 		default:
-			if ids == nil {
-				ids = map[string]string{}
-			}
-			rails[name] = ids
-			states[name] = ProviderState{
+			ids = stampRail(ids, t)
+			rails[t.declared] = ids
+			states[t.declared] = ProviderState{
 				Status:     ProviderStatusLinked,
 				IDs:        copyStringMap(ids),
 				LookupKey:  ids[providerLookupKey],
@@ -377,15 +427,62 @@ func (s *Service) resolveProviders(ctx context.Context, product *models.Product,
 			}
 		}
 	}
-	// Keep every non-archived account in sync (best-effort); archived is skipped.
+	// Keep every non-archived account in sync (best-effort); archived is
+	// skipped. Once per RAIL — the sync itself enumerates the rail's accounts.
 	if !remoteWritesDisabled {
-		for _, name := range names {
-			if adapter, ok := adapters[name]; ok {
-				s.syncSecondaryCatalogAccounts(ctx, name, pctx, adapter)
+		syncedRails := map[string]struct{}{}
+		for _, t := range targets {
+			if _, done := syncedRails[t.rail]; done {
+				continue
 			}
+			syncedRails[t.rail] = struct{}{}
+			s.syncSecondaryCatalogAccounts(ctx, t.rail, pctx, t.adapter)
 		}
 	}
 	return rails, states, pending, nil
+}
+
+// railAccountRef is one declared merchant account: its rail plus the
+// rail-native account id (pins provider calls to that account's credentials).
+type railAccountRef struct {
+	rail      string
+	accountID string
+}
+
+// merchantAccountRails maps the ctx merchant's declared account keys
+// (rail_merchant_accounts.display_name — the manifest `accounts.<key>` name,
+// e.g. "mobius") to their rails. Best-effort: no merchant ctx / DB means only
+// rail names resolve.
+func (s *Service) merchantAccountRails(ctx context.Context) map[string]railAccountRef {
+	out := map[string]railAccountRef{}
+	if s.rt == nil || s.rt.DB == nil {
+		return out
+	}
+	mid, err := merchant.Require(ctx)
+	if err != nil {
+		return out
+	}
+	rows, err := s.rt.DB.Gen(ctx).ListRailMerchantAccountsForMerchant(ctx, gen.ListRailMerchantAccountsForMerchantParams{
+		MerchantID: mid.UUID(),
+	})
+	if err != nil {
+		log.WithContext(ctx).WithError(err).Warn("catalog: list declared rail accounts failed; only rail names resolve")
+		return out
+	}
+	for _, row := range rows {
+		if row.Archived || row.DisplayName == nil {
+			continue
+		}
+		name := strings.ToLower(strings.TrimSpace(*row.DisplayName))
+		if name == "" {
+			continue
+		}
+		out[name] = railAccountRef{
+			rail:      strings.ToLower(strings.TrimSpace(row.Rail)),
+			accountID: strings.TrimSpace(row.AccountID),
+		}
+	}
+	return out
 }
 
 // syncSecondaryCatalogAccounts best-effort find-or-creates the price in each

--- a/pkg/service/catalog_providers_test.go
+++ b/pkg/service/catalog_providers_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -226,7 +227,9 @@ func TestResolveProviders_AllPending(t *testing.T) {
 	}
 }
 
-func TestResolveProviders_UnknownProviderDropped(t *testing.T) {
+func TestResolveProviders_UnknownProviderErrors(t *testing.T) {
+	// An unknown provider name (e.g. an account name like "mobius" instead of
+	// its rail) must fail loudly — silent dropping loses provider links.
 	s := newUnconfiguredService()
 	productID := uuid.New()
 	req := CreatePriceRequest{
@@ -235,12 +238,9 @@ func TestResolveProviders_UnknownProviderDropped(t *testing.T) {
 		Currency:   "usd",
 		Providers:  []string{"paypal"}, // not in dispatch table
 	}
-	rails, states, pending, err := s.resolveProviders(context.Background(), &models.Product{ID: productID}, req, uuid.New())
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	if len(rails) != 0 || len(states) != 0 || len(pending) != 0 {
-		t.Fatalf("expected unknown provider to be dropped, got rails=%v states=%v pending=%v", rails, states, pending)
+	_, _, _, err := s.resolveProviders(context.Background(), &models.Product{ID: productID}, req, uuid.New())
+	if err == nil || !strings.Contains(err.Error(), `unknown provider "paypal"`) {
+		t.Fatalf("expected unknown-provider error, got %v", err)
 	}
 }
 

--- a/pkg/service/service_definition_catalog.go
+++ b/pkg/service/service_definition_catalog.go
@@ -296,7 +296,7 @@ func (s *Service) lookupStripeProductID(ctx context.Context, productID uuid.UUID
 		return ""
 	}
 	for _, p := range priceList {
-		if id := strings.TrimSpace(p.Rails["stripe"][models.RailKeyStripeProductID]); id != "" {
+		if id := strings.TrimSpace(p.GetRailConfig(models.RailStripe)[models.RailKeyStripeProductID]); id != "" {
 			return id
 		}
 	}
@@ -757,7 +757,12 @@ func (s *Service) UpdatePrice(ctx context.Context, priceID uuid.UUID, req Update
 		if !s.catalogRemoteWritesDisabled() {
 			adapters := s.providerAdapters()
 			for provider, ids := range updated.Rails {
-				adapter, ok := adapters[strings.ToLower(strings.TrimSpace(provider))]
+				// Account-keyed entry (#799): rail from the entry, key as fallback.
+				rail := strings.ToLower(strings.TrimSpace(ids[models.RailKeyRail]))
+				if rail == "" {
+					rail = strings.ToLower(strings.TrimSpace(provider))
+				}
+				adapter, ok := adapters[rail]
 				if !ok {
 					continue
 				}

--- a/pkg/service/service_definition_catalog_admin.go
+++ b/pkg/service/service_definition_catalog_admin.go
@@ -229,7 +229,7 @@ func (s *Service) propagatePriceActiveToStripe(ctx context.Context, price *model
 		return
 	}
 	var stripePriceID string
-	if m := price.Rails["stripe"]; m != nil {
+	if m := price.GetRailConfig(models.RailStripe); m != nil {
 		stripePriceID = strings.TrimSpace(m[models.RailKeyStripePriceID])
 	}
 	if stripePriceID == "" {
@@ -346,7 +346,13 @@ func (s *Service) VerifyPriceSync(ctx context.Context, priceID uuid.UUID) (map[s
 	adapters := s.providerAdapters()
 	out := make(map[string]ProviderState, len(p.Rails))
 	for name, ids := range p.Rails {
-		adapter, ok := adapters[strings.ToLower(strings.TrimSpace(name))]
+		// Account-keyed entry (#799): the rail lives in the entry; a rail-named
+		// key is its own account.
+		rail := strings.ToLower(strings.TrimSpace(ids[models.RailKeyRail]))
+		if rail == "" {
+			rail = strings.ToLower(strings.TrimSpace(name))
+		}
+		adapter, ok := adapters[rail]
 		if !ok {
 			// Unknown providers stay visible but uncomputed.
 			out[name] = ProviderState{


### PR DESCRIPTION
A merchant can hold several accounts on one rail (mobius + paykings on nmi); `payment_methods`/`subscriptions`/`payments` already carry `rail_merchant_account_id`, but `prices.rails` was rail-keyed and could not represent which account owns a provider object. The catalog apply also silently dropped unknown provider names — doujins' `mobius`-keyed NMI plan links never persisted, which is why PS-1 could never auto-adopt re-signed paying subscribers (found in the freeloader false-positive investigation).

## Changes
- `prices.rails` entries key on the manifest ACCOUNT name with the rail stamped inside each entry (`RailKeyRail`); rail-named keys are their own accounts, so existing stripe/ccbill/solana blobs keep their shape.
- `resolveProviders` resolves account names → rail adapter via `rail_merchant_accounts.display_name`, pins Attach/AutoCreate to that account's credentials (`TargetAccountID`, #641), and errors loudly on unknown names.
- Readers converted to scan-by-rail (`models.RailLinkEntries` / `GetRailConfig` / `RailAccountConfigs`): reconcile PS-1 plan index, catalog drift (service + river job), archive propagation, `?verify` adapter dispatch, solana sunset/extras.
- Catalog dump strips the rail stamp — manifests round-trip account-keyed.
- `GetRailConfig` returns nil (never guesses) when several accounts link one rail.

## Testing
- Full unit suite green repo-wide (`go test ./internal/... ./pkg/...`), vet clean, changed files gofmt-clean.
- New: `TestRailLinkEntries_AccountKeyed` (both key forms + ambiguity); reconcile PS-1 materialize fixture now uses the account-keyed form end-to-end.
- Integration suite not run (box load 66 at the time); the doujins `migrate legacy run` catalog push is the live verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)