### PR TITLE
refactor: rail-field-only matching for provider links; drop key-name fallback

### DIFF
--- a/internal/db/models/product_catalog.go
+++ b/internal/db/models/product_catalog.go
@@ -218,16 +218,14 @@ const (
 	RailKeyCCBillRecurringBillingOption = "recurring_billing_option_id"
 	RailKeyStripePriceID                = "price_id"
 	RailKeyStripeProductID              = "product_id"
-	// RailKeyRail records the entry's rail inside an ACCOUNT-keyed entry
-	// (#799: prices.rails keys on the merchant's account key, e.g. "mobius";
-	// the rail lives in the entry so several accounts can share one rail).
+	// RailKeyRail is the rail (gateway) an entry's provider objects live on.
+	// prices.rails keys on the merchant's ACCOUNT key (e.g. "mobius") so
+	// several accounts can share one rail; every entry records its rail here.
 	RailKeyRail = "rail"
 )
 
 // RailLinkEntries returns every provider-link entry on the given rail, keyed
-// by account key (#799). An entry matches when its RailKeyRail field names the
-// rail, or its account key IS the rail name — the reserved gateways (stripe,
-// ccbill, solana) are their own account names.
+// by account key. Only the entry's RailKeyRail field decides membership.
 func RailLinkEntries(rails map[string]map[string]string, rail Rail) map[string]map[string]string {
 	if len(rails) == 0 {
 		return nil
@@ -235,10 +233,7 @@ func RailLinkEntries(rails map[string]map[string]string, rail Rail) map[string]m
 	want := string(rail)
 	var out map[string]map[string]string
 	for key, cfg := range rails {
-		if cfg == nil {
-			continue
-		}
-		if key != want && strings.TrimSpace(cfg[RailKeyRail]) != want {
+		if cfg == nil || strings.TrimSpace(cfg[RailKeyRail]) != want {
 			continue
 		}
 		if out == nil {
@@ -274,8 +269,10 @@ func (p *Price) HasRail(rail Rail) bool {
 	return len(RailLinkEntries(p.Rails, rail)) > 0
 }
 
-// GetNMIConfigForRail returns the NMI plan link for the given rail key (the
-// gateway rail, e.g. "nmi").
+// GetNMIConfigForRail returns the NMI plan link for the given rail (e.g.
+// "nmi"), whichever account key carries it. Several accounts on the rail is
+// ambiguous and reports no link — the caller fails loudly rather than
+// charging a plan on the wrong account.
 func (p *Price) GetNMIConfigForRail(railName string) (planID string, ok bool) {
 	config := p.GetRailConfig(Rail(railName))
 	if config == nil {
@@ -339,11 +336,18 @@ func (p *Price) GetStripeConfig() (priceID string, ok bool) {
 	return priceID, priceID != ""
 }
 
-// SetRailConfig sets the configuration for a specific rail
+// SetRailConfig sets the rail's provider-link entry under the rail-named
+// account key, stamping the rail into the entry (readers match on RailKeyRail
+// only). Account-named entries are written by the catalog apply, which knows
+// the account key.
 func (p *Price) SetRailConfig(rail Rail, config map[string]string) {
 	if p.Rails == nil {
 		p.Rails = make(map[string]map[string]string)
 	}
+	if config == nil {
+		config = map[string]string{}
+	}
+	config[RailKeyRail] = string(rail)
 	p.Rails[string(rail)] = config
 }
 

--- a/internal/db/models/product_catalog_test.go
+++ b/internal/db/models/product_catalog_test.go
@@ -85,11 +85,10 @@ func TestArchived_Purchasable(t *testing.T) {
 }
 
 func TestRailLinkEntries_AccountKeyed(t *testing.T) {
-	// #799: entries key on the ACCOUNT key with the rail stamped inside; a
-	// rail-named key is its own account.
+	// Entries key on the ACCOUNT key with the rail stamped inside.
 	p := &Price{Rails: map[string]map[string]string{
 		"mobius": {RailKeyRail: "nmi", RailKeyPlanID: "premium_new"},
-		"stripe": {RailKeyStripePriceID: "price_123"},
+		"stripe": {RailKeyRail: "stripe", RailKeyStripePriceID: "price_123"},
 	}}
 
 	nmi := p.RailAccountConfigs(RailNMI)

--- a/internal/intents/catalog_archive_test.go
+++ b/internal/intents/catalog_archive_test.go
@@ -243,7 +243,7 @@ func TestStripeArchive_RelevanceFlipsWhenObjectJoinsCatalog(t *testing.T) {
 		linked := &models.Price{
 			ID: uuid.New(), ProductID: productID, Amount: 900, Currency: "usd", AccessDurationHours: &cycle, AutoRenew: true,
 			Rails: map[string]map[string]string{
-				"stripe": {models.RailKeyStripePriceID: "price_x"},
+				"stripe": {models.RailKeyRail: "stripe", models.RailKeyStripePriceID: "price_x"},
 			},
 		}
 		h.LoadCatalog = stubCatalog(nil, []*models.Price{linked})

--- a/internal/intents/solana_sunset_test.go
+++ b/internal/intents/solana_sunset_test.go
@@ -232,7 +232,7 @@ func TestSolanaSunset_RelevanceFlipsWhenPlanRejoinsCatalog(t *testing.T) {
 			ID: uuid.New(), ProductID: uuid.New(), Amount: 2300, Currency: "usd",
 			AccessDurationHours: &cycle, AutoRenew: true, Archived: archived,
 			Rails: map[string]map[string]string{
-				string(models.RailSolana): {"plan_pda": fx.pda},
+				string(models.RailSolana): {models.RailKeyRail: "solana", "plan_pda": fx.pda},
 			},
 		}
 	}

--- a/internal/modules/checkout/merchant_rail_secrets_test.go
+++ b/internal/modules/checkout/merchant_rail_secrets_test.go
@@ -226,6 +226,7 @@ func TestCheckoutCCBillSubscriptionUsesMerchantSecret(t *testing.T) {
 		ID: uuid.New(),
 		Rails: map[string]map[string]string{
 			"ccbill": {
+				models.RailKeyRail:           "ccbill",
 				models.RailKeyCCBillFormName: "premium",
 				models.RailKeyCCBillFlexID:   "flex-123",
 			},

--- a/internal/modules/checkout/nmi_provider_test.go
+++ b/internal/modules/checkout/nmi_provider_test.go
@@ -8,48 +8,50 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRequireNMIPlanForRail_UsesProviderSpecificConfig(t *testing.T) {
+func TestRequireNMIPlanForRail_ResolvesAccountKeyedEntry(t *testing.T) {
+	// Entries key on the merchant's account name; the rail lives in the entry.
 	price := &models.Price{
 		ID: uuid.New(),
 		Rails: map[string]map[string]string{
 			"acme": {
+				models.RailKeyRail:   "nmi",
 				models.RailKeyPlanID: "plan_acme_123",
 			},
 		},
 	}
 
-	planID, err := requireNMIPlanForRail(price, "acme")
+	planID, err := requireNMIPlanForRail(price, "nmi")
 	require.NoError(t, err)
 	require.Equal(t, "plan_acme_123", planID)
 }
 
-func TestRequireNMIPlanForRail_RejectsProviderFromDifferentRailSlot(t *testing.T) {
+func TestRequireNMIPlanForRail_RejectsEntryOnAnotherRail(t *testing.T) {
 	price := &models.Price{
 		ID: uuid.New(),
 		Rails: map[string]map[string]string{
 			"mobius": {
-				models.RailKeyPlanID:   "mobius_plan_456",
-				models.RailKeyProvider: "acme",
+				models.RailKeyRail:   "ccbill",
+				models.RailKeyPlanID: "mobius_plan_456",
 			},
 		},
 	}
 
-	_, err := requireNMIPlanForRail(price, "acme")
+	_, err := requireNMIPlanForRail(price, "nmi")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing NMI plan configuration")
 }
 
-func TestRequireNMIPlanForRail_RejectsMissingProviderConfig(t *testing.T) {
+func TestRequireNMIPlanForRail_RejectsAmbiguousAccounts(t *testing.T) {
+	// Two accounts on the rail: never guess which account's plan to charge.
 	price := &models.Price{
 		ID: uuid.New(),
 		Rails: map[string]map[string]string{
-			"mobius": {
-				models.RailKeyPlanID: "plan_mobius_only",
-			},
+			"mobius":   {models.RailKeyRail: "nmi", models.RailKeyPlanID: "plan_mobius"},
+			"paykings": {models.RailKeyRail: "nmi", models.RailKeyPlanID: "plan_paykings"},
 		},
 	}
 
-	_, err := requireNMIPlanForRail(price, "acme")
+	_, err := requireNMIPlanForRail(price, "nmi")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing NMI plan configuration")
 }

--- a/internal/modules/checkout/upgrade_adopt_integration_test.go
+++ b/internal/modules/checkout/upgrade_adopt_integration_test.go
@@ -261,7 +261,7 @@ func newUpgradeAdoptFixture(t *testing.T) *upgradeAdoptFixture {
 	newPrice := &models.Price{
 		ID: newPriceID, ProductID: newProductID, Amount: 5_000_000, Currency: "USD",
 		AutoRenew: true, AccessDurationHours: &hours,
-		Rails: map[string]map[string]string{"nmi": {models.RailKeyPlanID: planID}},
+		Rails: map[string]map[string]string{"nmi": {models.RailKeyRail: "nmi", models.RailKeyPlanID: planID}},
 	}
 	newProduct := &models.Product{ID: newProductID, Key: "upg-new-" + sfx, DisplayName: "Upgrade New"}
 

--- a/internal/reconcile/ccbill_test.go
+++ b/internal/reconcile/ccbill_test.go
@@ -127,7 +127,7 @@ func TestCCBillPlanIndexUsesRecurringBillingOption(t *testing.T) {
 		ID:        priceID,
 		ProductID: productID,
 		Rails: map[string]map[string]string{
-			"ccbill": {"recurring_billing_option_id": "0000007498"},
+			"ccbill": {"rail": "ccbill", "recurring_billing_option_id": "0000007498"},
 		},
 	}})
 

--- a/internal/reconcile/diff.go
+++ b/internal/reconcile/diff.go
@@ -69,9 +69,8 @@ var planLinkIDKeys = []string{"plan_id", "price_id", "recurring_billing_option_i
 
 // buildPlanIndex maps remote plan ids onto local prices via the catalog
 // provider_links blobs, restricted to the provider's local rail names. Blobs
-// are ACCOUNT-keyed (#799: entry key = merchant account key, rail recorded in
-// the entry; a rail-named key is its own account) — two accounts carrying the
-// same plan id on one price dedup to a single link.
+// key on the merchant's ACCOUNT key with the rail recorded in each entry —
+// two accounts carrying the same plan id on one price dedup to a single link.
 func buildPlanIndex(provider Provider, prices []LocalPrice) map[string][]planLink {
 	idx := map[string][]planLink{}
 	names := localRailNames(provider)

--- a/internal/reconcile/engine_test.go
+++ b/internal/reconcile/engine_test.go
@@ -1358,8 +1358,8 @@ func materializeFixture() (*fakeLocal, *RemoteSnapshot, LocalPrice) {
 		Amount:    999,
 		Currency:  "usd",
 		Rails: map[string]map[string]string{
-			// #799: the provider-link key is the merchant's ACCOUNT key with
-			// the rail recorded inside the entry.
+			// The provider-link key is the merchant's ACCOUNT key with the
+			// rail recorded inside the entry.
 			"mobius": {"rail": "nmi", "plan_id": "plan-gold"},
 		},
 	}

--- a/internal/reconcile/solana_test.go
+++ b/internal/reconcile/solana_test.go
@@ -954,7 +954,7 @@ func TestDiffSolanaDiscoveredSubscriptionNeverMaterializes(t *testing.T) {
 		PaymentMethods: []LocalPaymentMethod{{ID: uuid.New(), CustomerID: customerID, Rail: "solana", VaultID: wallet}},
 		Prices: []LocalPrice{{
 			ID: priceID, ProductID: uuid.New(), Amount: 9_990_000, Currency: "usd",
-			Rails: map[string]map[string]string{"solana": {"plan_pda": planPDA, "provider": "solana"}},
+			Rails: map[string]map[string]string{"solana": {"rail": "solana", "plan_pda": planPDA, "provider": "solana"}},
 		}},
 	}
 	remote := func(raw json.RawMessage) *RemoteSnapshot {

--- a/internal/river/jobs_catalog_reconciliation.go
+++ b/internal/river/jobs_catalog_reconciliation.go
@@ -401,7 +401,7 @@ func computeNMIDriftJob(plans []nmiPlanJob, priceRows []*models.Price, now time.
 	priceByPlanID := make(map[string]string)
 	for _, pr := range priceRows {
 		priceByID[pr.ID.String()] = pr
-		// Account-keyed (#799): register every NMI account's plan link.
+		// Register every NMI account's plan link.
 		for _, nmiLink := range pr.RailAccountConfigs(models.RailNMI) {
 			if planID := strings.TrimSpace(nmiLink[models.RailKeyPlanID]); planID != "" {
 				planIDByOpenRailsPrice[pr.ID.String()] = planID

--- a/pkg/embedded/catalog_dump.go
+++ b/pkg/embedded/catalog_dump.go
@@ -458,8 +458,8 @@ func providerLinks(raw []byte) map[string]map[string]string {
 	if len(links) == 0 {
 		return nil
 	}
-	// The stored blob is account-keyed with the rail stamped inside each entry
-	// (#799); the manifest derives the rail from the account key, so the stamp
+	// The stored blob is account-keyed with the rail stamped inside each
+	// entry; the manifest derives the rail from the account key, so the stamp
 	// is storage detail, not manifest content.
 	for _, cfg := range links {
 		delete(cfg, models.RailKeyRail)

--- a/pkg/service/catalog_drift.go
+++ b/pkg/service/catalog_drift.go
@@ -515,7 +515,7 @@ func buildSnapshotFromRows(productRows []*models.Product, priceRows []*models.Pr
 				snap.stripeProductIDs[id] = pr.ProductID.String()
 			}
 		}
-		// Account-keyed (#799): any NMI account's plan link registers the price.
+		// Any NMI account's plan link registers the price.
 		for _, nmiLink := range pr.RailAccountConfigs(models.RailNMI) {
 			if planID := strings.TrimSpace(nmiLink[models.RailKeyPlanID]); planID != "" {
 				snap.nmiPlanIDByOpenRailsPrice[pr.ID.String()] = planID

--- a/pkg/service/catalog_drift_test.go
+++ b/pkg/service/catalog_drift_test.go
@@ -87,7 +87,7 @@ func prod(id uuid.UUID, name, desc string, active bool) *models.Product {
 func price(id, productID uuid.UUID, _ string, amount int64, currency string, active bool, stripePriceID, stripeProductID string) *models.Price {
 	p := &models.Price{ID: id, ProductID: productID, Amount: amount, Currency: currency, Archived: !active}
 	if stripePriceID != "" || stripeProductID != "" {
-		p.Rails = map[string]map[string]string{"stripe": {}}
+		p.Rails = map[string]map[string]string{"stripe": {models.RailKeyRail: "stripe"}}
 		if stripePriceID != "" {
 			p.Rails["stripe"][models.RailKeyStripePriceID] = stripePriceID
 		}
@@ -104,7 +104,7 @@ func nmiPrice(id, productID uuid.UUID, _ string, amount int64, planID string) *m
 	p := &models.Price{ID: id, ProductID: productID, Amount: amount, Currency: "usd"}
 	if planID != "" {
 		p.Rails = map[string]map[string]string{
-			string(models.RailNMI): {models.RailKeyPlanID: planID, models.RailKeyProvider: "mobius"},
+			"mobius": {models.RailKeyRail: string(models.RailNMI), models.RailKeyPlanID: planID, models.RailKeyProvider: "mobius"},
 		}
 	}
 	return p

--- a/pkg/service/catalog_extras_test.go
+++ b/pkg/service/catalog_extras_test.go
@@ -41,10 +41,12 @@ func extrasTestSnapshot() localCatalogSnapshot {
 		AutoRenew:           true,
 		Rails: map[string]map[string]string{
 			"stripe": {
+				models.RailKeyRail:            "stripe",
 				models.RailKeyStripePriceID:   "price_local",
 				models.RailKeyStripeProductID: "prod_local",
 			},
-			string(models.RailNMI): {
+			"mobius": {
+				models.RailKeyRail:   string(models.RailNMI),
 				models.RailKeyPlanID: "premium-usd-23000000-30",
 			},
 		},
@@ -442,7 +444,7 @@ func TestComputeSolanaSunsetExtras(t *testing.T) {
 			ID: uuid.New(), ProductID: productID, Amount: 23_000_000, Currency: "usd",
 			AccessDurationHours: &cycleHours, AutoRenew: true, Archived: archived,
 			Rails: map[string]map[string]string{
-				string(models.RailSolana): {"plan_pda": pda},
+				string(models.RailSolana): {models.RailKeyRail: string(models.RailSolana), "plan_pda": pda},
 			},
 		}
 	}

--- a/pkg/service/catalog_providers.go
+++ b/pkg/service/catalog_providers.go
@@ -275,14 +275,14 @@ func (s *Service) resolveProviders(ctx context.Context, product *models.Product,
 	// The manifest speaks the operator's ACCOUNT vocabulary ("mobius"), not
 	// rail names: resolve each declared name to its rail via the merchant's
 	// declared accounts (a rail name itself also resolves — the reserved
-	// gateways are their own account names). Unknown names fail loudly:
-	// silently dropping cost doujins its NMI plan links. Several accounts on
-	// one rail are fine — rails[] is keyed by the ACCOUNT key and each entry
-	// records its rail (#799).
+	// gateways are their own account names). Unknown names fail loudly: a
+	// silently dropped name loses its provider links. Several accounts on one
+	// rail are fine — rails[] is keyed by the ACCOUNT key and each entry
+	// records its rail.
 	type attachTarget struct {
 		declared  string // manifest name = ProviderLinks key = rails[]/states[] key
 		rail      string // adapters index; recorded in the entry's RailKeyRail
-		accountID string // rail-native account id; pins Attach/AutoCreate (#641)
+		accountID string // rail-native account id; pins Attach/AutoCreate to the account
 		adapter   providerAdapter
 	}
 	accountRails := s.merchantAccountRails(ctx)
@@ -330,23 +330,19 @@ func (s *Service) resolveProviders(ctx context.Context, product *models.Product,
 		RemoteWritesDisabled: remoteWritesDisabled,
 	}
 
-	// stampRail records the entry's rail inside account-keyed entries so
-	// readers can scan by rail (RailLinkEntries); a rail-named key is already
-	// self-describing.
+	// Every entry records its rail; readers match on RailKeyRail only.
 	stampRail := func(ids map[string]string, t attachTarget) map[string]string {
 		if ids == nil {
 			ids = map[string]string{}
 		}
-		if t.declared != t.rail {
-			ids[models.RailKeyRail] = t.rail
-		}
+		ids[models.RailKeyRail] = t.rail
 		return ids
 	}
 
 	for _, t := range targets {
 		link := req.ProviderLinks[t.declared]
-		// Pin provider calls to THIS account's credentials (#641); empty means
-		// the rail's armed default.
+		// Pin provider calls to THIS account's credentials; empty means the
+		// rail's armed default.
 		tctx := pctx
 		tctx.TargetAccountID = t.accountID
 		// Try the user-supplied attach path first. Attach VERIFIES the linked

--- a/pkg/service/service_definition_catalog.go
+++ b/pkg/service/service_definition_catalog.go
@@ -756,13 +756,9 @@ func (s *Service) UpdatePrice(ctx context.Context, priceID uuid.UUID, req Update
 		mutable := mutableUpdate{IsActive: &active}
 		if !s.catalogRemoteWritesDisabled() {
 			adapters := s.providerAdapters()
-			for provider, ids := range updated.Rails {
-				// Account-keyed entry (#799): rail from the entry, key as fallback.
-				rail := strings.ToLower(strings.TrimSpace(ids[models.RailKeyRail]))
-				if rail == "" {
-					rail = strings.ToLower(strings.TrimSpace(provider))
-				}
-				adapter, ok := adapters[rail]
+			for _, ids := range updated.Rails {
+				// Entries are account-keyed; the rail lives in the entry.
+				adapter, ok := adapters[strings.ToLower(strings.TrimSpace(ids[models.RailKeyRail]))]
 				if !ok {
 					continue
 				}

--- a/pkg/service/service_definition_catalog_admin.go
+++ b/pkg/service/service_definition_catalog_admin.go
@@ -346,13 +346,8 @@ func (s *Service) VerifyPriceSync(ctx context.Context, priceID uuid.UUID) (map[s
 	adapters := s.providerAdapters()
 	out := make(map[string]ProviderState, len(p.Rails))
 	for name, ids := range p.Rails {
-		// Account-keyed entry (#799): the rail lives in the entry; a rail-named
-		// key is its own account.
-		rail := strings.ToLower(strings.TrimSpace(ids[models.RailKeyRail]))
-		if rail == "" {
-			rail = strings.ToLower(strings.TrimSpace(name))
-		}
-		adapter, ok := adapters[rail]
+		// Entries are account-keyed; the rail lives in the entry.
+		adapter, ok := adapters[strings.ToLower(strings.TrimSpace(ids[models.RailKeyRail]))]
 		if !ok {
 			// Unknown providers stay visible but uncomputed.
 			out[name] = ProviderState{
@@ -653,7 +648,7 @@ func (s *Service) recreateStripePrice(ctx context.Context, prices *catalog.Price
 	}
 	newRails := cloneRails(local.Rails)
 	if newRails["stripe"] == nil {
-		newRails["stripe"] = map[string]string{}
+		newRails["stripe"] = map[string]string{models.RailKeyRail: string(models.RailStripe)}
 	}
 	newRails["stripe"][models.RailKeyStripePriceID] = newPriceID
 	if err := prices.UpdateRails(ctx, priceID, newRails); err != nil {

--- a/tests/entitlements_dunning_nmi_state_machine_test.go
+++ b/tests/entitlements_dunning_nmi_state_machine_test.go
@@ -60,6 +60,7 @@ func TestEntitlementsDunningStateMachine_NMI_SucceedsAfterRetries(t *testing.T) 
 		AccessDurationHours: &billingDays, AutoRenew: true,
 		Rails: map[string]map[string]string{
 			string(models.RailNMI): {
+				models.RailKeyRail:   string(models.RailNMI),
 				models.RailKeyPlanID: "plan_test_999",
 			},
 		},

--- a/tests/stripe_checkout_e2e_test.go
+++ b/tests/stripe_checkout_e2e_test.go
@@ -159,6 +159,7 @@ func seedStripeSubscriptionPrice(t *testing.T, suite *TestContainerSuite, stripe
 		AccessDurationHours: intPtr(720),
 		Rails: map[string]map[string]string{
 			string(models.RailStripe): {
+				models.RailKeyRail:          string(models.RailStripe),
 				models.RailKeyStripePriceID: stripePriceID,
 			},
 		},


### PR DESCRIPTION
Hard cut on the account-keyed `prices.rails` blob (follow-up to #149): every entry records its rail — `SetRailConfig` and the catalog apply stamp it — and readers match ONLY on the entry's rail field. No key-name fallback: a key that happens to equal a rail name means nothing.

- Checkout's NMI plan lookup scans the rail and fails loudly when several accounts link it (never charges a plan on a guessed account).
- Adapter dispatch (`?verify`, archive propagation) resolves from the entry's rail field only.
- Test fixtures updated to carry the rail field; checkout NMI lookup tests rewritten for the account-keyed model.
- Code comments no longer cite tracker issue numbers.

Unit suite green repo-wide (65 packages), vet clean incl. integration-tagged packages, changed files gofmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)