### PR TITLE
feat: checkout picks the payment PROVIDER (account), not just the rail

### DIFF
--- a/internal/db/models/product_catalog.go
+++ b/internal/db/models/product_catalog.go
@@ -269,19 +269,6 @@ func (p *Price) HasRail(rail Rail) bool {
 	return len(RailLinkEntries(p.Rails, rail)) > 0
 }
 
-// GetNMIConfigForRail returns the NMI plan link for the given rail (e.g.
-// "nmi"), whichever account key carries it. Several accounts on the rail is
-// ambiguous and reports no link — the caller fails loudly rather than
-// charging a plan on the wrong account.
-func (p *Price) GetNMIConfigForRail(railName string) (planID string, ok bool) {
-	config := p.GetRailConfig(Rail(railName))
-	if config == nil {
-		return "", false
-	}
-	planID = config[RailKeyPlanID]
-	return planID, planID != ""
-}
-
 // GetCCBillFlexForm returns the CCBill flexform configuration (form name + flex ID)
 func (p *Price) GetCCBillFlexForm() (formName, flexID string, ok bool) {
 	config := p.GetRailConfig(RailCCBill)

--- a/internal/db/models/product_catalog_test.go
+++ b/internal/db/models/product_catalog_test.go
@@ -104,9 +104,6 @@ func TestRailLinkEntries_AccountKeyed(t *testing.T) {
 	if !p.HasRail(RailNMI) || p.HasRail(RailCCBill) {
 		t.Fatalf("HasRail: nmi=%v ccbill=%v", p.HasRail(RailNMI), p.HasRail(RailCCBill))
 	}
-	if planID, ok := p.GetNMIConfigForRail("nmi"); !ok || planID != "premium_new" {
-		t.Fatalf("GetNMIConfigForRail = %q, %v", planID, ok)
-	}
 
 	// Two accounts on one rail: enumeration sees both, the single-entry
 	// accessor refuses to guess.

--- a/internal/merchants/credentials.go
+++ b/internal/merchants/credentials.go
@@ -166,6 +166,7 @@ type railMerchantAccountSecretScope struct {
 	rail        string
 	environment string
 	accountID   string
+	displayName string
 	settings    map[string]any
 }
 
@@ -198,6 +199,7 @@ func (s railMerchantAccountSecretScope) exported() RailMerchantAccountScope {
 		Rail:        s.rail,
 		Environment: s.environment,
 		AccountID:   s.accountID,
+		DisplayName: s.displayName,
 		Settings:    settings,
 	}
 }
@@ -291,7 +293,47 @@ func (s *Service) activeRailMerchantAccountSecretScope(ctx context.Context, id m
 		accountID:   row.AccountID,
 		settings:    railMerchantAccountSettings(row.Evidence),
 	}
+	if row.DisplayName != nil {
+		scope.displayName = strings.TrimSpace(*row.DisplayName)
+	}
 	return scope, true, nil
+}
+
+// RailMerchantAccountScopeByKey resolves a declared, non-archived account by
+// its manifest account KEY (display_name, e.g. "mobius") for the given
+// environment. This is how the payment-provider vocabulary used by the catalog
+// and checkout resolves to a concrete account.
+func (s *Service) RailMerchantAccountScopeByKey(ctx context.Context, id merchant.ID, key, environment string) (RailMerchantAccountScope, bool, error) {
+	if s == nil || s.pool == nil || id.IsZero() || strings.TrimSpace(key) == "" {
+		return RailMerchantAccountScope{}, false, nil
+	}
+	environment = normalizeProviderSecretEnvironment(environment)
+	if environment == "" {
+		return RailMerchantAccountScope{}, false, fmt.Errorf("provider account environment must be live or test")
+	}
+	var scope railMerchantAccountSecretScope
+	var evidence []byte
+	err := s.pool.MerchantTx(ctx, id, func(ctx context.Context, tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+				SELECT id, rail, environment, account_id, COALESCE(display_name, ''), evidence
+				  FROM openrails.rail_merchant_accounts
+				 WHERE merchant_id = $1::uuid
+				   AND lower(display_name) = lower($2)
+				   AND environment = $3
+				   AND archived = false
+				 ORDER BY created_at DESC, id DESC
+				 LIMIT 1
+			`, id.String(), strings.TrimSpace(key), environment).
+			Scan(&scope.id, &scope.rail, &scope.environment, &scope.accountID, &scope.displayName, &evidence)
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return RailMerchantAccountScope{}, false, nil
+	}
+	if err != nil {
+		return RailMerchantAccountScope{}, false, fmt.Errorf("load provider account by key %s/%s: %w", key, environment, err)
+	}
+	scope.settings = railMerchantAccountSettings(evidence)
+	return scope.exported(), true, nil
 }
 
 // railMerchantAccountSecretScopeByAccountID resolves the secret scope for a specific
@@ -306,13 +348,13 @@ func (s *Service) railMerchantAccountSecretScopeByAccountID(ctx context.Context,
 	var evidence []byte
 	err := s.pool.MerchantTx(ctx, id, func(ctx context.Context, tx pgx.Tx) error {
 		return tx.QueryRow(ctx, `
-				SELECT rail, environment, account_id, evidence
+				SELECT rail, environment, account_id, COALESCE(display_name, ''), evidence
 				  FROM openrails.rail_merchant_accounts
 				 WHERE merchant_id = $1::uuid
 				   AND rail = lower($2)
 				   AND account_id = $3
 				 LIMIT 1
-			`, id.String(), rail, strings.TrimSpace(accountID)).Scan(&scope.rail, &scope.environment, &scope.accountID, &evidence)
+			`, id.String(), rail, strings.TrimSpace(accountID)).Scan(&scope.rail, &scope.environment, &scope.accountID, &scope.displayName, &evidence)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
 		return railMerchantAccountSecretScope{}, false, nil

--- a/internal/merchants/secrets.go
+++ b/internal/merchants/secrets.go
@@ -233,6 +233,9 @@ type RailMerchantAccountScope struct {
 	Rail        string
 	Environment string
 	AccountID   string
+	// DisplayName is the manifest account KEY ("mobius") — the
+	// payment-provider vocabulary catalog links and checkout use.
+	DisplayName string
 	Settings    map[string]any
 }
 
@@ -240,6 +243,13 @@ type RailMerchantAccountScope struct {
 // requiring a particular secret key.
 type RailMerchantAccountScopeResolver interface {
 	ActiveRailMerchantAccountScope(ctx context.Context, merchantID merchant.ID, rail, environment string) (RailMerchantAccountScope, bool, error)
+}
+
+// RailMerchantAccountKeyResolver resolves a declared account by its manifest
+// account key (display_name) — the payment-provider name checkout requests
+// and catalog provider_links use.
+type RailMerchantAccountKeyResolver interface {
+	RailMerchantAccountScopeByKey(ctx context.Context, merchantID merchant.ID, key, environment string) (RailMerchantAccountScope, bool, error)
 }
 
 // MerchantSecretStore is the per-merchant secrets abstraction (issue #225). Every

--- a/internal/modules/checkout/merchant_rail_secrets.go
+++ b/internal/modules/checkout/merchant_rail_secrets.go
@@ -87,76 +87,144 @@ func (s *CheckoutService) railMerchantAccountEnvironment() string {
 	return config.ExpectedProviderEnvironment(s != nil && s.Config != nil && s.Config.IsTestMode())
 }
 
-// ResolveRailMerchantAccountID resolves the ACTIVE provider account for new work
-// on the given rail (#704). Returns nil when no resolver is wired or no active
-// account exists — provenance is only ever stamped with a REAL resolved account,
-// never invented. Resolution failures are logged and swallowed: stamping is
-// metadata and must not block a sale.
-func (s *CheckoutService) ResolveRailMerchantAccountID(ctx context.Context, rail string) *uuid.UUID {
+// railTarget is a resolved checkout destination: the payment PROVIDER (the
+// merchant's account key, e.g. "mobius") plus the rail it runs on. Checkout
+// requests name the provider; a bare rail name resolves through arming to THE
+// active provider on that rail, so the provider is always picked.
+type railTarget struct {
+	Provider string // account key: catalog provider_links key, plan lookup key
+	Rail     string // gateway rail: dispatch, row vocabulary (subscriptions.rail)
+	Scope    *merchants.RailMerchantAccountScope
+}
+
+// knownRails are the gateway rails checkout can dispatch to.
+var knownRails = map[string]struct{}{
+	string(models.RailNMI):    {},
+	string(models.RailCCBill): {},
+	string(models.RailStripe): {},
+	string(models.RailSolana): {},
+}
+
+// resolveRailTarget resolves a requested checkout provider name. The name is
+// either a declared account key ("mobius"), or a rail name — reserved gateways
+// (stripe/ccbill/solana) are their own account names, and a bare rail resolves
+// to its active armed account. Unknown names fail loudly.
+func (s *CheckoutService) resolveRailTarget(ctx context.Context, requested string) (railTarget, error) {
+	name := strings.ToLower(strings.TrimSpace(requested))
+	if name == "" {
+		return railTarget{}, errors.New("rail is required")
+	}
+	_, isRail := knownRails[name]
+
+	// Declared account key wins (a rail-named account resolves identically).
+	if keys, ok := s.ProviderSecrets.(merchants.RailMerchantAccountKeyResolver); ok {
+		if tid, err := merchant.Require(ctx); err == nil {
+			scope, found, err := keys.RailMerchantAccountScopeByKey(ctx, tid, name, s.railMerchantAccountEnvironment())
+			if err != nil {
+				return railTarget{}, fmt.Errorf("resolve payment provider %q: %w", name, err)
+			}
+			if found {
+				return railTarget{Provider: name, Rail: scope.Rail, Scope: &scope}, nil
+			}
+		}
+	}
+
+	if !isRail {
+		return railTarget{}, fmt.Errorf("unknown payment provider %q: not a declared account key or a rail (nmi, ccbill, stripe, solana)", name)
+	}
+
+	// Bare rail: arming picks the provider. The active account's key becomes
+	// the provider so plan links resolve; an unwired resolver leaves the rail
+	// name (single-account deployments declare links under it).
+	target := railTarget{Provider: name, Rail: name}
+	if scopes, ok := s.ProviderSecrets.(merchants.RailMerchantAccountScopeResolver); ok {
+		if tid, err := merchant.Require(ctx); err == nil {
+			scope, found, err := scopes.ActiveRailMerchantAccountScope(ctx, tid, name, s.railMerchantAccountEnvironment())
+			if err != nil {
+				log.WithContext(ctx).WithError(err).WithField("rail", name).Debug("checkout: provider-account resolution failed; proceeding rail-scoped")
+			} else if found {
+				target.Scope = &scope
+				if key := strings.ToLower(strings.TrimSpace(scope.DisplayName)); key != "" {
+					target.Provider = key
+				}
+			}
+		}
+	}
+	return target, nil
+}
+
+// ResolveRailMerchantAccountID resolves the provider account for new work on
+// the given provider/rail name for provenance stamping. Returns nil when no resolver
+// is wired or nothing is armed — provenance is only ever stamped with a REAL
+// resolved account, never invented. Resolution failures are logged and
+// swallowed: stamping is metadata and must not block a sale.
+func (s *CheckoutService) ResolveRailMerchantAccountID(ctx context.Context, name string) *uuid.UUID {
 	if s == nil || s.ProviderSecrets == nil {
 		return nil
 	}
-	scopes, ok := s.ProviderSecrets.(merchants.RailMerchantAccountScopeResolver)
-	if !ok {
+	target, err := s.resolveRailTarget(ctx, name)
+	if err != nil || target.Scope == nil || target.Scope.ID == uuid.Nil {
 		return nil
 	}
-	rail = strings.ToLower(strings.TrimSpace(rail))
-	if rail == "" {
-		return nil
-	}
-	tid, err := merchant.Require(ctx)
-	if err != nil {
-		return nil
-	}
-	scope, found, err := scopes.ActiveRailMerchantAccountScope(ctx, tid, rail, s.railMerchantAccountEnvironment())
-	if err != nil {
-		log.WithContext(ctx).WithError(err).WithField("rail", rail).Debug("checkout: provider-account resolution failed; leaving provenance unstamped")
-		return nil
-	}
-	if !found || scope.ID == uuid.Nil {
-		return nil
-	}
-	id := scope.ID
+	id := target.Scope.ID
 	return &id
 }
 
 // stampRailMerchantAccount pins resolved account provenance into ctx so the
 // payment / subscription / payment-method writes downstream of this checkout
 // flow stamp rail_merchant_account_id (#704).
-func (s *CheckoutService) stampRailMerchantAccount(ctx context.Context, rail string) context.Context {
-	if id := s.ResolveRailMerchantAccountID(ctx, rail); id != nil {
+func (s *CheckoutService) stampRailMerchantAccount(ctx context.Context, name string) context.Context {
+	if id := s.ResolveRailMerchantAccountID(ctx, name); id != nil {
 		return db.WithRailMerchantAccountID(ctx, *id)
 	}
 	return ctx
 }
 
-// resolveNMIClient arms the ctx merchant's NMI client from the armed rail
-// state (#788): the active scoped account's security_key. Fail closed — a
-// missing scope/secret errors; there is no boot-config fallback.
+// resolveNMIClient arms the ctx merchant's NMI client for the given provider
+// name (account key or bare rail): the resolved account's security_key. Fail
+// closed — a missing scope/secret errors; there is no boot-config fallback.
 func (s *CheckoutService) resolveNMIClient(ctx context.Context, provider string) (*nmi.NMIClient, error) {
 	if s.ResolveNMIClientOverride != nil {
 		return s.ResolveNMIClientOverride(ctx, provider)
 	}
-	provider = strings.ToLower(strings.TrimSpace(provider))
-	if provider == "" {
-		return nil, errors.New("rail is required")
-	}
-	if !rails.IsNMI(models.Rail(provider)) {
-		return nil, fmt.Errorf("missing client")
-	}
 	if !s.scopedProviderSecretsEnabled() {
 		return nil, fmt.Errorf("merchant rail resolution is not configured")
 	}
-	// Environment follows test_mode (#681), same as the CCBill leg.
-	value, ok, err := s.merchantProviderSecret(ctx, string(models.RailNMI), s.railMerchantAccountEnvironment(), "security_key")
+	target, err := s.resolveRailTarget(ctx, provider)
 	if err != nil {
-		return nil, fmt.Errorf("load merchant NMI secret: %w", err)
+		return nil, err
 	}
-	if !ok {
-		return nil, fmt.Errorf("missing scoped merchant NMI secret for provider account")
+	if !rails.IsNMI(models.Rail(target.Rail)) {
+		return nil, fmt.Errorf("missing client")
+	}
+	var value string
+	if target.Scope != nil {
+		// Pinned to the resolved account's own secret.
+		name, err := merchants.RailMerchantAccountSecretName(target.Scope.Rail, target.Scope.Environment, target.Scope.AccountID, "security_key")
+		if err != nil {
+			return nil, err
+		}
+		v, ok, err := s.merchantSecret(ctx, name)
+		if err != nil {
+			return nil, fmt.Errorf("load merchant NMI secret: %w", err)
+		}
+		if !ok {
+			return nil, fmt.Errorf("missing scoped merchant NMI secret for provider account")
+		}
+		value = v
+	} else {
+		// Environment follows test_mode, same as the CCBill leg.
+		v, ok, err := s.merchantProviderSecret(ctx, string(models.RailNMI), s.railMerchantAccountEnvironment(), "security_key")
+		if err != nil {
+			return nil, fmt.Errorf("load merchant NMI secret: %w", err)
+		}
+		if !ok {
+			return nil, fmt.Errorf("missing scoped merchant NMI secret for provider account")
+		}
+		value = v
 	}
 	proc := &config.RailMerchantAccountConfig{Rail: models.RailNMI, NMI: &config.NMIRailConfig{SecurityKey: value}}
-	client, err := nmi.NewClient(provider, proc.ToNMIProviderSettings(), s.Config != nil && s.Config.IsTestMode())
+	client, err := nmi.NewClient(target.Provider, proc.ToNMIProviderSettings(), s.Config != nil && s.Config.IsTestMode())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/modules/checkout/nmi_provider_test.go
+++ b/internal/modules/checkout/nmi_provider_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRequireNMIPlanForRail_ResolvesAccountKeyedEntry(t *testing.T) {
+func TestRequireNMIPlanForTarget_ResolvesProviderEntry(t *testing.T) {
 	// Entries key on the merchant's account name; the rail lives in the entry.
 	price := &models.Price{
 		ID: uuid.New(),
@@ -20,12 +20,47 @@ func TestRequireNMIPlanForRail_ResolvesAccountKeyedEntry(t *testing.T) {
 		},
 	}
 
-	planID, err := requireNMIPlanForRail(price, "nmi")
+	planID, err := requireNMIPlanForTarget(price, railTarget{Provider: "acme", Rail: "nmi"})
 	require.NoError(t, err)
 	require.Equal(t, "plan_acme_123", planID)
 }
 
-func TestRequireNMIPlanForRail_RejectsEntryOnAnotherRail(t *testing.T) {
+func TestRequireNMIPlanForTarget_FallsBackToRailNamedEntry(t *testing.T) {
+	// A manifest that declared the link under the rail name still resolves
+	// when the provider is an account key.
+	price := &models.Price{
+		ID: uuid.New(),
+		Rails: map[string]map[string]string{
+			"nmi": {
+				models.RailKeyRail:   "nmi",
+				models.RailKeyPlanID: "plan_rail_default",
+			},
+		},
+	}
+
+	planID, err := requireNMIPlanForTarget(price, railTarget{Provider: "mobius", Rail: "nmi"})
+	require.NoError(t, err)
+	require.Equal(t, "plan_rail_default", planID)
+}
+
+func TestRequireNMIPlanForTarget_NeverCrossesProviders(t *testing.T) {
+	// Another provider's plan on the same rail is NOT this provider's plan.
+	price := &models.Price{
+		ID: uuid.New(),
+		Rails: map[string]map[string]string{
+			"paykings": {
+				models.RailKeyRail:   "nmi",
+				models.RailKeyPlanID: "plan_paykings",
+			},
+		},
+	}
+
+	_, err := requireNMIPlanForTarget(price, railTarget{Provider: "mobius", Rail: "nmi"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "missing NMI plan configuration")
+}
+
+func TestRequireNMIPlanForTarget_RejectsEntryOnAnotherRail(t *testing.T) {
 	price := &models.Price{
 		ID: uuid.New(),
 		Rails: map[string]map[string]string{
@@ -36,22 +71,7 @@ func TestRequireNMIPlanForRail_RejectsEntryOnAnotherRail(t *testing.T) {
 		},
 	}
 
-	_, err := requireNMIPlanForRail(price, "nmi")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "missing NMI plan configuration")
-}
-
-func TestRequireNMIPlanForRail_RejectsAmbiguousAccounts(t *testing.T) {
-	// Two accounts on the rail: never guess which account's plan to charge.
-	price := &models.Price{
-		ID: uuid.New(),
-		Rails: map[string]map[string]string{
-			"mobius":   {models.RailKeyRail: "nmi", models.RailKeyPlanID: "plan_mobius"},
-			"paykings": {models.RailKeyRail: "nmi", models.RailKeyPlanID: "plan_paykings"},
-		},
-	}
-
-	_, err := requireNMIPlanForRail(price, "nmi")
+	_, err := requireNMIPlanForTarget(price, railTarget{Provider: "mobius", Rail: "nmi"})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing NMI plan configuration")
 }

--- a/internal/modules/checkout/nmi_sale_intent.go
+++ b/internal/modules/checkout/nmi_sale_intent.go
@@ -39,7 +39,11 @@ func NMISaleIdempotencyKey(checkoutIdempotencyKey string) string {
 // and the async verifier need to charge AND locally register the purchase
 // without the originating HTTP request.
 type NMISalePayload struct {
-	Provider        string `json:"provider"`
+	// Provider is the RAIL ("nmi") — local row vocabulary.
+	Provider string `json:"provider"`
+	// ProviderAccount is the payment provider (account key, e.g. "mobius")
+	// this charge runs through; "" resolves the rail's active account.
+	ProviderAccount string `json:"provider_account,omitempty"`
 	CustomerVaultID string `json:"customer_vault_id"`
 	// BillingID targets the exact stored card in the vault (#682); "" charges
 	// the vault's priority-1 entry (always correct for one-card-per-vault).
@@ -126,7 +130,7 @@ func (h *NMISaleIntentHandler) Execute(ctx context.Context, intent gen.Openrails
 	if err != nil {
 		return intents.Terminal(err.Error())
 	}
-	client, err := h.Sale.nmiClient(ctx, strings.ToLower(intent.Rail))
+	client, err := h.Sale.nmiClient(ctx, nmiIntentClientName(p.ProviderAccount, intent.Rail))
 	if err != nil {
 		return intents.Parked(fmt.Sprintf("nmi client not configured for provider %q: %v", intent.Rail, err))
 	}
@@ -197,7 +201,7 @@ func (h *NMISaleIntentHandler) Verify(ctx context.Context, intent gen.OpenrailsR
 	if err != nil {
 		return intents.Terminal(err.Error())
 	}
-	client, err := h.Sale.nmiClient(ctx, strings.ToLower(intent.Rail))
+	client, err := h.Sale.nmiClient(ctx, nmiIntentClientName(p.ProviderAccount, intent.Rail))
 	if err != nil {
 		return intents.Ambiguous(fmt.Sprintf("nmi client not configured for provider %q; cannot verify", intent.Rail))
 	}

--- a/internal/modules/checkout/nmi_sale_service.go
+++ b/internal/modules/checkout/nmi_sale_service.go
@@ -77,9 +77,11 @@ func NewCheckoutNMISaleService(
 // A crash/timeout at ANY point leaves a pending/unknown intent the scheduled
 // executor/verifier resolves against the SAME order id — never a blind retry
 // under a fresh key, never a charged-but-unrecorded sale.
-func (s *CheckoutNMISaleService) Process(ctx context.Context, req *CheckoutRequest, user *UserIdentity, price *models.Price, product *models.Product, idempotencyKey string, provider string) (*CheckoutResponse, error) {
+func (s *CheckoutNMISaleService) Process(ctx context.Context, req *CheckoutRequest, user *UserIdentity, price *models.Price, product *models.Product, idempotencyKey string, target railTarget) (*CheckoutResponse, error) {
 	const idempOp = "nmi_sale"
-	provider = strings.TrimSpace(strings.ToLower(provider))
+	// Rows and intents speak rail vocabulary; the provider (account key) pins
+	// the NMI client.
+	provider := target.Rail
 	if provider == "" {
 		return nil, errors.New("rail is required")
 	}
@@ -87,8 +89,8 @@ func (s *CheckoutNMISaleService) Process(ctx context.Context, req *CheckoutReque
 		return nil, errors.New("checkout sale intent executor not wired")
 	}
 	// Fail fast on misconfiguration instead of parking a user-facing checkout.
-	if _, err := s.nmiClient(ctx, provider); err != nil {
-		return nil, fmt.Errorf("NMI provider '%s' is not configured: %w", provider, err)
+	if _, err := s.nmiClient(ctx, target.Provider); err != nil {
+		return nil, fmt.Errorf("NMI provider '%s' is not configured: %w", target.Provider, err)
 	}
 	if _, err := customerIDFromUser(user.ID); err != nil {
 		return nil, err
@@ -141,6 +143,7 @@ func (s *CheckoutNMISaleService) Process(ctx context.Context, req *CheckoutReque
 		PriceID:    &price.ID,
 		Payload: NMISalePayload{
 			Provider:            provider,
+			ProviderAccount:     target.Provider,
 			CustomerVaultID:     customerVaultID,
 			BillingID:           vaultBillingID,
 			AmountMicros:        price.Amount,

--- a/internal/modules/checkout/nmi_subscription_intent.go
+++ b/internal/modules/checkout/nmi_subscription_intent.go
@@ -40,7 +40,11 @@ func NMISubscriptionCreateIdempotencyKey(checkoutIdempotencyKey string) string {
 // verifier need to create the remote subscription AND register it locally
 // without the originating HTTP request.
 type NMISubscriptionCreatePayload struct {
-	Provider        string `json:"provider"`
+	// Provider is the RAIL ("nmi") — local row vocabulary.
+	Provider string `json:"provider"`
+	// ProviderAccount is the payment provider (account key, e.g. "mobius")
+	// this create charges through; "" resolves the rail's active account.
+	ProviderAccount string `json:"provider_account,omitempty"`
 	PlanID          string `json:"plan_id"`
 	CustomerVaultID string `json:"customer_vault_id"`
 	// BillingID binds the subscription to ONE stored card in the vault (#682
@@ -139,9 +143,9 @@ func (h *NMISubscriptionCreateIntentHandler) Execute(ctx context.Context, intent
 	if err != nil {
 		return intents.Terminal(err.Error())
 	}
-	client, err := h.Checkout.resolveNMIClient(ctx, strings.ToLower(intent.Rail))
+	client, err := h.Checkout.resolveNMIClient(ctx, nmiIntentClientName(p.ProviderAccount, intent.Rail))
 	if err != nil {
-		return intents.Parked(fmt.Sprintf("nmi client not configured for provider %q: %v", intent.Rail, err))
+		return intents.Parked(fmt.Sprintf("nmi client not configured for provider %q: %v", nmiIntentClientName(p.ProviderAccount, intent.Rail), err))
 	}
 	if client.ReadOnly {
 		return intents.Parked("nmi client is read-only (mode=readonly)")
@@ -212,9 +216,9 @@ func (h *NMISubscriptionCreateIntentHandler) Verify(ctx context.Context, intent 
 	if err != nil {
 		return intents.Terminal(err.Error())
 	}
-	client, err := h.Checkout.resolveNMIClient(ctx, strings.ToLower(intent.Rail))
+	client, err := h.Checkout.resolveNMIClient(ctx, nmiIntentClientName(p.ProviderAccount, intent.Rail))
 	if err != nil {
-		return intents.Ambiguous(fmt.Sprintf("nmi client not configured for provider %q; cannot verify", intent.Rail))
+		return intents.Ambiguous(fmt.Sprintf("nmi client not configured for provider %q; cannot verify", nmiIntentClientName(p.ProviderAccount, intent.Rail)))
 	}
 	orderID := nmiSaleIntentOrderID(intent.ID, p.E2ERunID)
 	if outcome, resolved := h.verifyAtProvider(ctx, intent.MerchantID, client, p, orderID); resolved {
@@ -305,6 +309,15 @@ func findUnregisteredRemoteSubscriptions(ctx context.Context, subs railSubscript
 		cursor = next
 	}
 	return candidates, nil
+}
+
+// nmiIntentClientName picks the client-resolution name for an NMI intent: the
+// payload's pinned payment provider, else the intent's rail (active account).
+func nmiIntentClientName(providerAccount, rail string) string {
+	if name := strings.ToLower(strings.TrimSpace(providerAccount)); name != "" {
+		return name
+	}
+	return strings.ToLower(strings.TrimSpace(rail))
 }
 
 // subscriptionMetadataString reads one string key off a subscription's raw

--- a/internal/modules/checkout/service.go
+++ b/internal/modules/checkout/service.go
@@ -35,7 +35,6 @@ import (
 	"github.com/open-rails/openrails/internal/modules/subscriptions"
 	"github.com/open-rails/openrails/internal/railresolve"
 	"github.com/open-rails/openrails/internal/shared/moneyutil"
-	"github.com/open-rails/openrails/internal/shared/normalize"
 	"github.com/open-rails/openrails/internal/shared/timeutil"
 	"github.com/open-rails/openrails/internal/shared/uuidutil"
 	"github.com/open-rails/openrails/pkg/api"
@@ -415,19 +414,23 @@ func (s *CheckoutService) processSubscription(
 	coverage *CoverageInfo,
 	rail string,
 ) (*CheckoutResponse, error) {
-	// Route to rail-specific handler based on config type detection
-	// This allows adding new NMI providers via config without code changes
+	// The requested name is a payment PROVIDER (account key, e.g. "mobius") or
+	// a rail; dispatch on the resolved rail, hand the provider to the leg.
+	target, err := s.resolveRailTarget(ctx, rail)
+	if err != nil {
+		return nil, err
+	}
 	switch {
-	case rail == "ccbill":
+	case target.Rail == "ccbill":
 		return s.processCCBillSubscription(ctx, req, user, price)
-	case rails.IsNMI(models.Rail(rail)):
-		return s.processNMISubscription(ctx, req, user, price, product, coverage, rail)
-	case rail == "stripe":
+	case rails.IsNMI(models.Rail(target.Rail)):
+		return s.processNMISubscription(ctx, req, user, price, product, coverage, target)
+	case target.Rail == "stripe":
 		return s.processStripeSubscription(ctx, req, user, price, coverage)
-	case rail == "solana":
+	case target.Rail == "solana":
 		return nil, errors.New("solana does not support recurring subscriptions; use a one-time price instead")
 	default:
-		return nil, fmt.Errorf("unsupported rail: %s", rail)
+		return nil, fmt.Errorf("unsupported rail: %s", target.Rail)
 	}
 }
 
@@ -441,19 +444,23 @@ func (s *CheckoutService) processOneTimePurchase(
 	coverage *CoverageInfo,
 	rail string,
 ) (*CheckoutResponse, error) {
-	// Route to rail-specific handler based on config type detection
-	// This allows adding new NMI providers via config without code changes
+	// The requested name is a payment PROVIDER (account key) or a rail;
+	// dispatch on the resolved rail, hand the provider to the leg.
+	target, err := s.resolveRailTarget(ctx, rail)
+	if err != nil {
+		return nil, err
+	}
 	switch {
-	case rails.IsNMI(models.Rail(rail)):
-		return s.processNMISale(ctx, req, user, price, product, coverage, rail)
-	case rail == "solana":
+	case rails.IsNMI(models.Rail(target.Rail)):
+		return s.processNMISale(ctx, req, user, price, product, coverage, target)
+	case target.Rail == "solana":
 		return s.processSolanaPurchase(ctx, req, user, price, product, coverage)
-	case rail == "ccbill":
+	case target.Rail == "ccbill":
 		return nil, errors.New("ccbill does not support one-time purchases; use a subscription price instead")
-	case rail == "stripe":
+	case target.Rail == "stripe":
 		return s.processStripePayment(ctx, req, user, price)
 	default:
-		return nil, fmt.Errorf("unsupported rail for one-time purchases: %s", rail)
+		return nil, fmt.Errorf("unsupported rail for one-time purchases: %s", target.Rail)
 	}
 }
 
@@ -601,20 +608,19 @@ func (s *CheckoutService) processNMISubscription(
 	price *models.Price,
 	product *models.Product,
 	coverage *CoverageInfo,
-	rail string,
+	target railTarget,
 ) (*CheckoutResponse, error) {
-	provider := normalize.Lower(rail)
-	if provider == "" {
-		return nil, errors.New("rail is required")
-	}
-	nmiPlanID, err := requireNMIPlanForRail(price, provider)
+	// Rows and intents speak rail vocabulary; the provider (account key) picks
+	// the plan link and pins the NMI client.
+	provider := target.Rail
+	nmiPlanID, err := requireNMIPlanForTarget(price, target)
 	if err != nil {
 		return nil, err
 	}
 
 	// Fail fast on misconfiguration instead of parking a user-facing checkout.
-	if _, err := s.resolveNMIClient(ctx, provider); err != nil {
-		return nil, fmt.Errorf("NMI provider '%s' is not configured: %w", provider, err)
+	if _, err := s.resolveNMIClient(ctx, target.Provider); err != nil {
+		return nil, fmt.Errorf("NMI provider '%s' is not configured: %w", target.Provider, err)
 	}
 
 	// Get idempotency key (client-provided or generated)
@@ -716,6 +722,7 @@ func (s *CheckoutService) processNMISubscription(
 		PriceID:    &price.ID,
 		Payload: NMISubscriptionCreatePayload{
 			Provider:               provider,
+			ProviderAccount:        target.Provider,
 			PlanID:                 nmiPlanID,
 			CustomerVaultID:        customerVaultID,
 			BillingID:              vaultBillingID,
@@ -1166,18 +1173,14 @@ func (s *CheckoutService) processNMISale(
 	price *models.Price,
 	product *models.Product,
 	coverage *CoverageInfo,
-	rail string,
+	target railTarget,
 ) (*CheckoutResponse, error) {
 	_ = coverage
 	if s.NMISaleService == nil {
 		return nil, errors.New("NMI sale service unavailable")
 	}
 	idempotencyKey := s.getIdempotencyKey(req, user.ID, price.ID, "nmi_sale")
-	provider := normalize.Lower(rail)
-	if provider == "" {
-		return nil, errors.New("rail is required")
-	}
-	return s.NMISaleService.Process(ctx, req, user, price, product, idempotencyKey, provider)
+	return s.NMISaleService.Process(ctx, req, user, price, product, idempotencyKey, target)
 }
 
 // processSolanaPurchase handles Solana one-time purchases
@@ -1662,7 +1665,7 @@ func (s *CheckoutService) processUpgrade(
 	newPrice *models.Price,
 	newProduct *models.Product,
 	existingSub *models.Subscription,
-	rail string,
+	target railTarget,
 ) (*CheckoutResponse, error) {
 	now := s.now()
 
@@ -1674,18 +1677,18 @@ func (s *CheckoutService) processUpgrade(
 	}
 
 	// CCBill handles upgrades via their own Package Upgrade flow
-	if rail == "ccbill" {
+	if target.Rail == "ccbill" {
 		return s.processCCBillUpgrade(ctx, user, newPrice, existingSub)
 	}
 
 	// Solana doesn't support subscriptions
-	if rail == "solana" {
+	if target.Rail == "solana" {
 		return nil, errors.New("solana does not support subscription upgrades")
 	}
 
 	// Only NMI-backed rails support programmatic upgrades
-	if !rails.IsNMI(models.Rail(rail)) {
-		return nil, fmt.Errorf("unsupported rail for upgrades: %s", rail)
+	if !rails.IsNMI(models.Rail(target.Rail)) {
+		return nil, fmt.Errorf("unsupported rail for upgrades: %s", target.Rail)
 	}
 
 	// Get idempotency key (client-provided or generated)
@@ -1775,19 +1778,14 @@ func (s *CheckoutService) processUpgrade(
 		return nil, err
 	}
 
-	provider := normalize.Lower(rail)
-	if provider == "" {
-		err := errors.New("rail is required for upgrades")
-		_ = s.IdempotencyService.Fail(ctx, idempOp, idempotencyKey, err)
-		return nil, err
-	}
+	provider := target.Rail
 	if existingSub.CurrentPeriodEndsAt == nil || existingSub.CurrentPeriodEndsAt.IsZero() {
 		err := errors.New("existing subscription missing current period end")
 		_ = s.IdempotencyService.Fail(ctx, idempOp, idempotencyKey, err)
 		return nil, err
 	}
 
-	nmiPlanID, err := requireNMIPlanForRail(newPrice, provider)
+	nmiPlanID, err := requireNMIPlanForTarget(newPrice, target)
 	if err != nil {
 		_ = s.IdempotencyService.Fail(ctx, idempOp, idempotencyKey, err)
 		return nil, err
@@ -1801,9 +1799,9 @@ func (s *CheckoutService) processUpgrade(
 	newPeriodEnd := now.Add(time.Duration(cycleHours) * time.Hour)
 	startDate, _ := buildNMIFutureStartDate(newPeriodEnd, now)
 
-	client, err := s.resolveNMIClient(ctx, provider)
+	client, err := s.resolveNMIClient(ctx, target.Provider)
 	if err != nil {
-		err := fmt.Errorf("NMI provider '%s' is not configured: %w", provider, err)
+		err := fmt.Errorf("NMI provider '%s' is not configured: %w", target.Provider, err)
 		_ = s.IdempotencyService.Fail(ctx, idempOp, idempotencyKey, err)
 		return nil, err
 	}
@@ -2212,10 +2210,10 @@ func (s *CheckoutService) processDowngrade(
 	newPrice *models.Price,
 	newProduct *models.Product,
 	existingSub *models.Subscription,
-	rail string,
+	target railTarget,
 ) (*CheckoutResponse, error) {
 	// CCBill handles downgrades via their own flow
-	if rail == "ccbill" {
+	if target.Rail == "ccbill" {
 		return &CheckoutResponse{
 			Status:  "blocked",
 			Message: "CCBill subscription downgrades are not supported. Please cancel your current subscription and wait for it to expire, then subscribe to the lower tier.",
@@ -2223,22 +2221,17 @@ func (s *CheckoutService) processDowngrade(
 	}
 
 	// Solana doesn't support subscriptions
-	if rail == "solana" {
+	if target.Rail == "solana" {
 		return nil, errors.New("solana does not support subscription downgrades")
 	}
 
 	// Only NMI-backed rails support programmatic downgrades
-	if !rails.IsNMI(models.Rail(rail)) {
-		return nil, fmt.Errorf("unsupported rail for downgrades: %s", rail)
-	}
-
-	provider := normalize.Lower(rail)
-	if provider == "" {
-		return nil, errors.New("rail is required for downgrades")
+	if !rails.IsNMI(models.Rail(target.Rail)) {
+		return nil, fmt.Errorf("unsupported rail for downgrades: %s", target.Rail)
 	}
 
 	// Validate the new price has NMI configuration
-	if _, err := requireNMIPlanForRail(newPrice, provider); err != nil {
+	if _, err := requireNMIPlanForTarget(newPrice, target); err != nil {
 		return nil, err
 	}
 
@@ -2849,14 +2842,17 @@ func (s *CheckoutService) processTierChangeNMI(
 		checkoutReq.PaymentMethodID = api.FormatPaymentMethodID(*existingSub.PaymentMethodID)
 	}
 
-	// Route to existing methods which handle the heavy lifting
+	// Route to existing methods which handle the heavy lifting. The existing
+	// subscription's rail resolves through arming to its payment provider.
+	target, err := s.resolveRailTarget(ctx, string(existingSub.Rail))
+	if err != nil {
+		return nil, err
+	}
 	var checkoutResp *CheckoutResponse
-	var err error
-
 	if action == "upgrade" {
-		checkoutResp, err = s.processUpgrade(ctx, checkoutReq, user, newPrice, newProduct, existingSub, string(existingSub.Rail))
+		checkoutResp, err = s.processUpgrade(ctx, checkoutReq, user, newPrice, newProduct, existingSub, target)
 	} else {
-		checkoutResp, err = s.processDowngrade(ctx, checkoutReq, user, newPrice, newProduct, existingSub, string(existingSub.Rail))
+		checkoutResp, err = s.processDowngrade(ctx, checkoutReq, user, newPrice, newProduct, existingSub, target)
 	}
 
 	if err != nil {
@@ -2975,19 +2971,32 @@ func (s *CheckoutService) mapCheckoutToTierChangeResponse(resp *CheckoutResponse
 	return tierResp
 }
 
-func requireNMIPlanForRail(price *models.Price, provider string) (string, error) {
-	provider = normalize.Lower(provider)
-	if provider == "" {
-		return "", errors.New("rail is required")
-	}
+// requireNMIPlanForTarget returns the NMI plan the resolved payment provider
+// charges for this price: the provider's own link entry (by account key), or
+// the rail-named entry when the manifest declared it under the rail. Never a
+// rail-wide scan — with several accounts on a rail, each provider's plan is
+// its own.
+func requireNMIPlanForTarget(price *models.Price, target railTarget) (string, error) {
 	if price == nil {
 		return "", errors.New("price is required")
 	}
-	planID, ok := price.GetNMIConfigForRail(provider)
-	if !ok || strings.TrimSpace(planID) == "" {
-		return "", fmt.Errorf("price %s is missing NMI plan configuration for rail %s", price.ID, provider)
+	lookup := func(key string) (string, bool) {
+		cfg := price.Rails[key]
+		if cfg == nil || !strings.EqualFold(strings.TrimSpace(cfg[models.RailKeyRail]), target.Rail) {
+			return "", false
+		}
+		id := strings.TrimSpace(cfg[models.RailKeyPlanID])
+		return id, id != ""
 	}
-	return planID, nil
+	if id, ok := lookup(target.Provider); ok {
+		return id, nil
+	}
+	if target.Provider != target.Rail {
+		if id, ok := lookup(target.Rail); ok {
+			return id, nil
+		}
+	}
+	return "", fmt.Errorf("price %s is missing NMI plan configuration for payment provider %s (rail %s)", price.ID, target.Provider, target.Rail)
 }
 
 // captureStoredCredentialRef persists a stored-credential sequence anchor for

--- a/internal/modules/checkout/upgrade_adopt_integration_test.go
+++ b/internal/modules/checkout/upgrade_adopt_integration_test.go
@@ -286,7 +286,7 @@ func TestUpgradeAmbiguousCreateLanded_AdoptsInline(t *testing.T) {
 	fx := newUpgradeAdoptFixture(t)
 	fx.gateway.createMode.Store("ambiguousLanded")
 
-	resp, err := fx.svc.processUpgrade(fx.ctx, fx.req, fx.user, fx.newPrice, fx.newProduct, fx.existingSub, "nmi")
+	resp, err := fx.svc.processUpgrade(fx.ctx, fx.req, fx.user, fx.newPrice, fx.newProduct, fx.existingSub, railTarget{Provider: "nmi", Rail: "nmi"})
 	require.NoError(t, err, "landed-but-lost create must be adopted, not failed")
 	require.Equal(t, "success", resp.Status)
 	require.EqualValues(t, 1, fx.gateway.createCalls.Load(), "never a second blind create")
@@ -312,7 +312,7 @@ func TestUpgradeAmbiguousCreateLost_RetryRecreatesSameOrderID(t *testing.T) {
 	fx := newUpgradeAdoptFixture(t)
 	fx.gateway.createMode.Store("ambiguousLost")
 
-	_, err := fx.svc.processUpgrade(fx.ctx, fx.req, fx.user, fx.newPrice, fx.newProduct, fx.existingSub, "nmi")
+	_, err := fx.svc.processUpgrade(fx.ctx, fx.req, fx.user, fx.newPrice, fx.newProduct, fx.existingSub, railTarget{Provider: "nmi", Rail: "nmi"})
 	require.Error(t, err)
 	require.True(t, errors.Is(err, ErrCheckoutProcessing), "unresolved ambiguity is processing, never a decline: %v", err)
 	require.EqualValues(t, 1, fx.gateway.createCalls.Load())
@@ -327,7 +327,7 @@ func TestUpgradeAmbiguousCreateLost_RetryRecreatesSameOrderID(t *testing.T) {
 	// Provider recovers; the retry (same idempotency key ⇒ retryAfterFailure)
 	// scans the roster first, then re-creates under the ORIGINAL order id.
 	fx.gateway.createMode.Store("approve")
-	resp, err := fx.svc.processUpgrade(fx.ctx, fx.req, fx.user, fx.newPrice, fx.newProduct, fx.existingSub, "nmi")
+	resp, err := fx.svc.processUpgrade(fx.ctx, fx.req, fx.user, fx.newPrice, fx.newProduct, fx.existingSub, railTarget{Provider: "nmi", Rail: "nmi"})
 	require.NoError(t, err)
 	require.Equal(t, "success", resp.Status)
 	require.EqualValues(t, 2, fx.gateway.createCalls.Load())


### PR DESCRIPTION
Completes the account-keyed provider-links work (#149/#150): checkout's wire value now names a **payment provider** — a declared account key (`mobius`, `paykings`) or a rail name, which resolves through arming to *the* active provider on that rail. The provider is always picked, explicitly or by arming.

## Changes
- One resolution seam: `resolveRailTarget` maps the requested name → (provider key, rail, account scope) via `rail_merchant_accounts.display_name`. Dispatch runs on the resolved rail; rows/intents keep rail vocabulary (`subscriptions.rail`/`rail_intents.rail` = `nmi`).
- Per-provider plan lookup (`requireNMIPlanForTarget`): the provider's own link entry, rail-named entry as fallback. Two NMI accounts with distinct plan links on one price no longer collide — each charges its own plan.
- NMI client resolution pins to the resolved account's `security_key`; intent payloads carry `provider_account` so executors/verifiers re-resolve the same account across crashes/retries.
- Provenance stamping uses the resolved account; `merchants.RailMerchantAccountScopeByKey` + `DisplayName` on the scope are the new resolution surface.
- `models.GetNMIConfigForRail` deleted — checkout owns provider-aware lookup.

## Known seam (loud, not silent)
Vault creation still resolves the rail's ACTIVE account. An explicit non-active provider fails at charge time (vault not found at NMI) — a decline, never money on the wrong account. Vault pinning is the follow-up.

## Testing
Unit suite green repo-wide (65 packages), integration-tagged vet clean, changed files gofmt-clean. New `requireNMIPlanForTarget` tests: provider entry, rail-named fallback, never-cross-providers, wrong-rail rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)