### PR TITLE
fix(docker): match Go builder to module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN npm run build -- --outDir /out --emptyOutDir
 
 
 # Stage 2: build
-FROM golang:1.26.4-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates


### PR DESCRIPTION
Align the Docker build stage with the Go 1.26.5 minimum declared by go.mod. This fixes the deterministic Docker smoke failure on master (runs 29306997445, 29288540365, and 29245836334).\n\nValidation: local full docker build completed successfully.