### PR TITLE
Add atomic customer spend-delegation upsert

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ explicit `customer:*` grants:
 | `customer:payment-methods:update` | Manage a shared customer's payment methods and Stripe portal |
 | `customer:checkout:create` | Pre-pay / load credits onto a shared customer balance |
 | `customer:spend-delegations:read` | Read a shared customer's spend-delegation policy |
-| `customer:spend-delegations:update` | Replace a shared customer's spend-delegation policy |
+| `customer:spend-delegations:update` | Replace or atomically upsert a shared customer's spend-delegation policy |
 
 **3c. Call the self-service API from the browser.** Have your frontend fetch the delegated
 token from your exchange endpoint (cache it, re-fetch on expiry — a ~30-line helper makes

--- a/client.go
+++ b/client.go
@@ -92,7 +92,12 @@ type UsageReportClient interface {
 type PolicySyncClient interface {
 	GetMerchantSettings(ctx context.Context) (*MerchantSettings, error)
 	SetMerchantSettings(ctx context.Context, settings MerchantSettings) error
+	// SetCustomerSpendDelegations explicitly replaces the customer's complete
+	// delegation document.
 	SetCustomerSpendDelegations(ctx context.Context, customerID string, delegations []SpendDelegationInput) error
+	// SetCustomerSpendDelegation atomically upserts one delegation without
+	// reading or replacing unrelated customer delegations.
+	SetCustomerSpendDelegation(ctx context.Context, customerID string, delegation SpendDelegationInput) error
 }
 
 // AdminFundingClient is the small non-hot-path funding/reporting surface used

--- a/embed/client.go
+++ b/embed/client.go
@@ -10,6 +10,9 @@ import (
 
 	"github.com/open-rails/openrails"
 	"github.com/open-rails/openrails/internal/app"
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/modules/admission"
+	"github.com/open-rails/openrails/internal/modules/budgets"
 	"github.com/open-rails/openrails/internal/modules/money"
 	"github.com/open-rails/openrails/pkg/identity"
 	"github.com/open-rails/openrails/pkg/merchant"
@@ -26,11 +29,12 @@ type SingleAdmitter interface {
 }
 
 // localClient is the PERMANENT remainder of the pre-#685 handler-transcribing
-// adapter. Every openrails.Client interface method except one runs through the
+// adapter. Every openrails.Client interface method except customer delegation
+// writes runs through the
 // unified remote implementation over the in-process transport (see
 // unifiedClient in embed.go); what stays here is:
 //
-//   - SetCustomerSpendDelegations — PERMANENTLY transcribed (#685 tail
+//   - SetCustomerSpendDelegation(s) — PERMANENTLY transcribed (#685 tail
 //     decision). Its wire surface is the delegated customer-treasury family
 //     (/v1/customers/*), whose gate semantics are "the credential IS the
 //     customer": CustomerScopeRequired matches :customer_id against the
@@ -131,15 +135,6 @@ func requireCurrency(raw string) (string, error) {
 		return currency, nil
 	}
 	return money.NormalizeCurrency(currency), nil
-}
-
-func firstNonEmpty(vals ...string) string {
-	for _, v := range vals {
-		if strings.TrimSpace(v) != "" {
-			return strings.TrimSpace(v)
-		}
-	}
-	return ""
 }
 
 // wrapInternalErr wraps a 500 StatusError, appending the underlying cause: these
@@ -268,17 +263,11 @@ func (c *localClient) SetCustomerSpendDelegations(ctx context.Context, customerI
 	}
 	next := make([]billingservice.InvokerSpendLimitInput, 0, len(delegations))
 	for _, d := range delegations {
-		windows := make([]billingservice.SpendLimitWindowInput, 0, len(d.Windows))
-		for _, w := range d.Windows {
-			windows = append(windows, billingservice.SpendLimitWindowInput{
-				Key: w.Key, WindowSeconds: w.WindowSeconds, Limit: w.Limit, Currency: w.Currency,
-			})
+		in, err := spendDelegationInput(d)
+		if err != nil {
+			return err
 		}
-		next = append(next, billingservice.InvokerSpendLimitInput{
-			Scope:    d.Scope,
-			ScopeKey: firstNonEmpty(d.ScopeKey, d.RoleID),
-			Windows:  windows,
-		})
+		next = append(next, in)
 	}
 	mctx, err := c.merchantCtx(ctx)
 	if err != nil {
@@ -288,4 +277,59 @@ func (c *localClient) SetCustomerSpendDelegations(ctx context.Context, customerI
 		return wrapInternalErr("set customer spend delegations failed", err)
 	}
 	return nil
+}
+
+// SetCustomerSpendDelegation uses the service/store single-row upsert path;
+// unlike SetCustomerSpendDelegations it never loads or deletes sibling rows.
+func (c *localClient) SetCustomerSpendDelegation(ctx context.Context, customerID string, delegation openrails.SpendDelegationInput) error {
+	payer, err := parseCustomer(customerID, "invalid customer_id")
+	if err != nil {
+		return err
+	}
+	in, err := spendDelegationInput(delegation)
+	if err != nil {
+		return err
+	}
+	mctx, err := c.merchantCtx(ctx)
+	if err != nil {
+		return err
+	}
+	if err := c.svc.SetInvokerSpendLimits(mctx, payer, in); err != nil {
+		return wrapInternalErr("set customer spend delegation failed", err)
+	}
+	return nil
+}
+
+func spendDelegationInput(d openrails.SpendDelegationInput) (billingservice.InvokerSpendLimitInput, error) {
+	scope := budgets.NormalizeScope(d.Scope)
+	scopeKey := strings.TrimSpace(d.ScopeKey)
+	roleID := strings.TrimSpace(d.RoleID)
+	if roleID != "" && scope != budgets.ScopeRole {
+		return billingservice.InvokerSpendLimitInput{}, invalidErr(fmt.Sprintf("role_id is only allowed for scope %q", budgets.ScopeRole))
+	}
+	if scopeKey != "" && roleID != "" && scopeKey != roleID {
+		return billingservice.InvokerSpendLimitInput{}, invalidErr("role_id must match scope_key")
+	}
+	if scopeKey == "" {
+		scopeKey = roleID
+	}
+	windows := make([]models.BudgetWindowPolicy, 0, len(d.Windows))
+	for _, w := range d.Windows {
+		windows = append(windows, models.BudgetWindowPolicy{
+			Key: w.Key, WindowSeconds: w.WindowSeconds, Limit: w.Limit, Currency: w.Currency,
+		})
+	}
+	normalized, err := admission.ValidateInvokerSpendLimit(admission.InvokerSpendLimit{
+		Scope: scope, ScopeKey: scopeKey, Windows: windows,
+	})
+	if err != nil {
+		return billingservice.InvokerSpendLimitInput{}, invalidErr(err.Error())
+	}
+	out := billingservice.InvokerSpendLimitInput{Scope: normalized.Scope, ScopeKey: normalized.ScopeKey}
+	for _, w := range normalized.Windows {
+		out.Windows = append(out.Windows, billingservice.SpendLimitWindowInput{
+			Key: w.Key, WindowSeconds: w.WindowSeconds, Limit: w.Limit, Currency: w.Currency,
+		})
+	}
+	return out, nil
 }

--- a/embed/embed.go
+++ b/embed/embed.go
@@ -137,9 +137,9 @@ func New(ctx context.Context, opts Options, options ...Option) (*Runtime, error)
 // call. Parity with a standalone deployment is structural (one implementation),
 // enforced by conformance_integration_test.go.
 //
-// One interface method (SetCustomerSpendDelegations) is PERMANENTLY served by
-// the transcribed localClient — see unifiedClient and the localClient doc for
-// the authz reasoning. The returned Client also always implements
+// Customer spend-delegation writes are PERMANENTLY served by the transcribed
+// localClient — see unifiedClient and the localClient doc for the authz
+// reasoning. The returned Client also always implements
 // SingleAdmitter (embedded-only single Admit, no wire counterpart) — reach it
 // via a type assertion.
 //
@@ -175,10 +175,10 @@ func (r *Runtime) Client(opts ...ClientOption) openrails.Client {
 
 // unifiedClient is the embedded SDK client (#685): the embedded
 // openrails.Client (the remote implementation over the in-process transport)
-// serves 20/21 interface methods; *localClient keeps the PERMANENT
-// transcription (SetCustomerSpendDelegations — customer-treasury auth surface,
-// see the localClient doc) plus the embedded-only single-Admit extra, which has
-// no /v1/merchant wire counterpart.
+// serves every merchant-authority method; *localClient keeps the PERMANENT
+// customer-treasury spend-delegation transcriptions (see the localClient doc)
+// plus the embedded-only single-Admit extra, which has no /v1/merchant wire
+// counterpart.
 type unifiedClient struct {
 	openrails.Client
 	*localClient
@@ -191,6 +191,12 @@ type unifiedClient struct {
 // forward resolves the embedding conflict.
 func (c *unifiedClient) SetCustomerSpendDelegations(ctx context.Context, customerID string, delegations []openrails.SpendDelegationInput) error {
 	return c.localClient.SetCustomerSpendDelegations(ctx, customerID, delegations)
+}
+
+// SetCustomerSpendDelegation stays transcribed for the same customer-treasury
+// authority boundary as the explicit full-document replacement above.
+func (c *unifiedClient) SetCustomerSpendDelegation(ctx context.Context, customerID string, delegation openrails.SpendDelegationInput) error {
+	return c.localClient.SetCustomerSpendDelegation(ctx, customerID, delegation)
 }
 
 // Verify is the authenticated readiness probe (see openrails.Verify), running

--- a/embed/spend_delegations_integration_test.go
+++ b/embed/spend_delegations_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/open-rails/openrails/config"
 	"github.com/open-rails/openrails/internal/dbtest"
 	"github.com/open-rails/openrails/pkg/embedded"
+	"github.com/open-rails/openrails/pkg/identity"
 )
 
 // Regression: the transcribed SetCustomerSpendDelegations bypasses the
@@ -35,12 +36,36 @@ func TestEmbeddedClientSetCustomerSpendDelegations(t *testing.T) {
 	rt.emb.App().Runtime.SetConfiguredMerchant(dbtest.TestMerchantID)
 
 	client := rt.Client()
-	err = client.SetCustomerSpendDelegations(ctx, customerID.String(), []openrails.SpendDelegationInput{{
+	err = client.SetCustomerSpendDelegations(ctx, customerID.String(), []openrails.SpendDelegationInput{
+		{
+			Scope:    "invoker",
+			ScopeKey: "test-invoker",
+			Windows:  []openrails.SpendLimitWindow{{Key: "day", WindowSeconds: 86400, Limit: 5_000_000, Currency: "USD"}},
+		},
+		{
+			Scope:  "role",
+			RoleID: "test-role",
+			Windows: []openrails.SpendLimitWindow{{
+				Key: "month", WindowSeconds: 2592000, Limit: 9_000_000, Currency: "USD",
+			}},
+		},
+	})
+	require.NoError(t, err, "embedded SetCustomerSpendDelegations must pin the bound merchant itself")
+
+	require.NoError(t, client.SetCustomerSpendDelegation(ctx, customerID.String(), openrails.SpendDelegationInput{
 		Scope:    "invoker",
 		ScopeKey: "test-invoker",
-		Windows:  []openrails.SpendLimitWindow{{Key: "day", WindowSeconds: 86400, Limit: 5_000_000, Currency: "USD"}},
-	}})
-	require.NoError(t, err, "embedded SetCustomerSpendDelegations must pin the bound merchant itself")
+		Windows:  []openrails.SpendLimitWindow{{Key: "day", WindowSeconds: 86400, Limit: 123, Currency: "USD"}},
+	}))
+	stored, err := rt.Service().InvokerSpendLimits(dbtest.WithTestMerchant(ctx), identity.CustomerID(customerID))
+	require.NoError(t, err)
+	require.Len(t, stored, 2, "single embedded upsert must preserve unrelated rows")
+	limits := map[string]int64{}
+	for _, row := range stored {
+		limits[row.Scope+"\x00"+row.ScopeKey] = row.Windows[0].Limit
+	}
+	require.EqualValues(t, 123, limits["invoker\x00test-invoker"])
+	require.EqualValues(t, 9_000_000, limits["role\x00test-role"])
 
 	// Replace-with-empty exercises the delete lane through the same ctx path.
 	require.NoError(t, client.SetCustomerSpendDelegations(ctx, customerID.String(), nil))

--- a/embed/spend_delegations_integration_test.go
+++ b/embed/spend_delegations_integration_test.go
@@ -55,7 +55,9 @@ func TestEmbeddedClientSetCustomerSpendDelegations(t *testing.T) {
 	require.NoError(t, client.SetCustomerSpendDelegation(ctx, customerID.String(), openrails.SpendDelegationInput{
 		Scope:    "invoker",
 		ScopeKey: "test-invoker",
-		Windows:  []openrails.SpendLimitWindow{{Key: "day", WindowSeconds: 86400, Limit: 123, Currency: "USD"}},
+		// Currency is intentionally omitted: spend limits are also valid for
+		// non-monetary units, and the singular upsert must preserve that contract.
+		Windows: []openrails.SpendLimitWindow{{Key: "day", WindowSeconds: 86400, Limit: 123}},
 	}))
 	stored, err := rt.Service().InvokerSpendLimits(dbtest.WithTestMerchant(ctx), identity.CustomerID(customerID))
 	require.NoError(t, err)

--- a/internal/http/handlers/customer_spend_delegations.go
+++ b/internal/http/handlers/customer_spend_delegations.go
@@ -107,6 +107,35 @@ func PutCustomerSpendDelegations(r *httprequest.Request) {
 	r.SuccessJSON(customerSpendDelegationsDocument{Delegations: customerSpendDelegationsFromRows(next)})
 }
 
+// PutCustomerSpendDelegation atomically upserts one addressed delegation and
+// leaves every unrelated payer-owned delegation untouched.
+func PutCustomerSpendDelegation(r *httprequest.Request) {
+	resolved, ok := requireCustomerTreasuryPrincipal(r)
+	if !ok {
+		return
+	}
+
+	var delegation customerSpendDelegation
+	if !r.BindJSON(&delegation) {
+		return
+	}
+	next, err := validateCustomerSpendDelegations([]customerSpendDelegation{delegation})
+	if err != nil {
+		r.ErrorJSON(http.StatusBadRequest, err.Error())
+		return
+	}
+
+	store, payer, ok := customerTreasuryStore(r, resolved)
+	if !ok {
+		return
+	}
+	if err := store.Upsert(r.Request.Context(), payer, next[0]); err != nil {
+		r.ErrorJSON(http.StatusInternalServerError, "spend delegation upsert failed")
+		return
+	}
+	r.SuccessJSON(customerSpendDelegationFromRow(next[0]))
+}
+
 func requireCustomerTreasuryPrincipal(r *httprequest.Request) (*controlplane.ResolvedDelegated, bool) {
 	v, ok := r.Get(middleware.DelegatedContextKey)
 	if !ok {
@@ -149,40 +178,30 @@ func validateCustomerSpendDelegations(in []customerSpendDelegation) ([]admission
 			return nil, fmt.Errorf("delegations[%d].customer_id is not allowed", i)
 		}
 		scope := budgets.NormalizeScope(row.Scope)
-		if scope != budgets.ScopeInvoker && scope != budgets.ScopeRole && scope != budgets.ScopeInvokerTrustLevel {
-			return nil, fmt.Errorf("delegations[%d].scope must be %q, %q, or %q", i, budgets.ScopeInvoker, budgets.ScopeRole, budgets.ScopeInvokerTrustLevel)
-		}
 		scopeKey := strings.TrimSpace(row.ScopeKey)
-		if scopeKey == "" {
-			scopeKey = strings.TrimSpace(row.RoleID)
+		roleID := strings.TrimSpace(row.RoleID)
+		if roleID != "" && scope != budgets.ScopeRole {
+			return nil, fmt.Errorf("delegations[%d].role_id is only allowed for scope %q", i, budgets.ScopeRole)
+		}
+		if scopeKey != "" && roleID != "" && scopeKey != roleID {
+			return nil, fmt.Errorf("delegations[%d].role_id must match scope_key", i)
 		}
 		if scopeKey == "" {
-			return nil, fmt.Errorf("delegations[%d].scope_key required", i)
+			scopeKey = roleID
 		}
-		key := spendDelegationKey(scope, scopeKey)
+		windows := append([]models.BudgetWindowPolicy(nil), row.Windows...)
+		normalized, err := admission.ValidateInvokerSpendLimit(admission.InvokerSpendLimit{
+			Scope: scope, ScopeKey: scopeKey, Windows: windows,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("delegations[%d].%s", i, err)
+		}
+		key := spendDelegationKey(normalized.Scope, normalized.ScopeKey)
 		if _, dup := seen[key]; dup {
 			return nil, fmt.Errorf("duplicate delegation for %s", key)
 		}
 		seen[key] = struct{}{}
-		if len(row.Windows) == 0 {
-			return nil, fmt.Errorf("delegations[%d].windows required", i)
-		}
-		windows := make([]models.BudgetWindowPolicy, 0, len(row.Windows))
-		for j, window := range row.Windows {
-			window.Key = strings.TrimSpace(window.Key)
-			window.Currency = strings.TrimSpace(window.Currency)
-			if window.Key == "" {
-				return nil, fmt.Errorf("delegations[%d].windows[%d].key required", i, j)
-			}
-			if window.WindowSeconds <= 0 {
-				return nil, fmt.Errorf("delegations[%d].windows[%d].window_seconds must be positive", i, j)
-			}
-			if window.Limit < 0 {
-				return nil, fmt.Errorf("delegations[%d].windows[%d].limit must be non-negative", i, j)
-			}
-			windows = append(windows, window)
-		}
-		out = append(out, admission.InvokerSpendLimit{Scope: scope, ScopeKey: scopeKey, Windows: windows})
+		out = append(out, normalized)
 	}
 	sort.Slice(out, func(i, j int) bool {
 		return spendDelegationKey(out[i].Scope, out[i].ScopeKey) < spendDelegationKey(out[j].Scope, out[j].ScopeKey)
@@ -193,20 +212,22 @@ func validateCustomerSpendDelegations(in []customerSpendDelegation) ([]admission
 func customerSpendDelegationsFromRows(rows []admission.InvokerSpendLimit) []customerSpendDelegation {
 	out := make([]customerSpendDelegation, 0, len(rows))
 	for _, row := range rows {
-		delegation := customerSpendDelegation{
-			Scope:    budgets.NormalizeScope(row.Scope),
-			ScopeKey: row.ScopeKey,
-			Windows:  row.Windows,
-		}
-		if delegation.Scope == budgets.ScopeRole {
-			delegation.RoleID = row.ScopeKey
-		}
-		out = append(out, delegation)
+		out = append(out, customerSpendDelegationFromRow(row))
 	}
 	sort.Slice(out, func(i, j int) bool {
 		return spendDelegationKey(out[i].Scope, out[i].ScopeKey) < spendDelegationKey(out[j].Scope, out[j].ScopeKey)
 	})
 	return out
+}
+
+func customerSpendDelegationFromRow(row admission.InvokerSpendLimit) customerSpendDelegation {
+	delegation := customerSpendDelegation{
+		Scope: budgets.NormalizeScope(row.Scope), ScopeKey: row.ScopeKey, Windows: row.Windows,
+	}
+	if delegation.Scope == budgets.ScopeRole {
+		delegation.RoleID = row.ScopeKey
+	}
+	return delegation
 }
 
 func spendDelegationKey(scope, scopeKey string) string {

--- a/internal/http/routes/self.go
+++ b/internal/http/routes/self.go
@@ -124,6 +124,10 @@ func RegisterCustomerTreasuryRoutes(rr router.Router, rt *app.Runtime, delegated
 		h(httphandlers.PutCustomerSpendDelegations),
 		putSpendDelegations...,
 	)
+	group.Handle(http.MethodPut, "/:customer_id/spend-delegations:upsert",
+		h(httphandlers.PutCustomerSpendDelegation),
+		putSpendDelegations...,
+	)
 
 	// Read the payer's money state. `status` is intentionally NOT mounted (it
 	// reports consumer concepts the customer does not own).

--- a/internal/http/routes/self_service_test.go
+++ b/internal/http/routes/self_service_test.go
@@ -217,6 +217,8 @@ func TestCustomerTreasurySpendDelegationsMountedAndGated(t *testing.T) {
 
 	w = doSelf(e, http.MethodPut, "/v1/customers/acme-merchant/spend-delegations", true)
 	require.Equal(t, http.StatusForbidden, w.Code, "read permission must not satisfy update")
+	w = doSelf(e, http.MethodPut, "/v1/customers/acme-merchant/spend-delegations:upsert", true)
+	require.Equal(t, http.StatusForbidden, w.Code, "read permission must not satisfy single-row update")
 }
 
 func TestCustomerTreasurySpendDelegationsRejectBodyCustomerID(t *testing.T) {
@@ -244,4 +246,13 @@ func TestCustomerTreasurySpendDelegationsRejectBodyCustomerID(t *testing.T) {
 	w = doSelfBearerBody(e, http.MethodPut, "/v1/customers/acme-merchant/spend-delegations", "delegated.jwt.token", body)
 	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
 	require.Contains(t, w.Body.String(), "customer_id")
+
+	for _, body := range []string{
+		`{"scope":"invoker","role_id":"role-1","windows":[{"key":"day","window_seconds":86400,"limit":1000,"currency":"USD"}]}`,
+		`{"scope":"invoker","scope_key":"invoker-1","windows":[]}`,
+		`{"scope":"invoker","scope_key":"invoker-1","windows":[{"key":"day","window_seconds":86400,"limit":1000,"currency":"BTC"}]}`,
+	} {
+		w = doSelfBearerBody(e, http.MethodPut, "/v1/customers/acme-merchant/spend-delegations:upsert", "delegated.jwt.token", body)
+		require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	}
 }

--- a/internal/integrationharness/testdata/standalone_route_surface.txt
+++ b/internal/integrationharness/testdata/standalone_route_surface.txt
@@ -167,6 +167,7 @@ POST /v1/webhooks/{provider}/{account_id}
 PUT /v1/customers/{customer_id}/payment-methods/{id}
 PUT /v1/customers/{customer_id}/settings
 PUT /v1/customers/{customer_id}/spend-delegations
+PUT /v1/customers/{customer_id}/spend-delegations:upsert
 PUT /v1/me/payment-methods/{id}
 PUT /v1/me/settings
 PUT /v1/me/subscriptions/{id}/payment-method

--- a/internal/modules/admission/policy.go
+++ b/internal/modules/admission/policy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/open-rails/openrails/internal/db/gen"
 	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/modules/budgets"
+	"github.com/open-rails/openrails/internal/modules/money"
 	"github.com/open-rails/openrails/internal/shared/uuidutil"
 	"github.com/open-rails/openrails/pkg/identity"
 	"github.com/open-rails/openrails/pkg/merchant"
@@ -232,6 +233,44 @@ type InvokerSpendLimit struct {
 	Scope    string
 	ScopeKey string
 	Windows  []models.BudgetWindowPolicy
+}
+
+// ValidateInvokerSpendLimit validates and canonicalizes one payer-owned
+// delegated-spend policy before either transport writes it.
+func ValidateInvokerSpendLimit(p InvokerSpendLimit) (InvokerSpendLimit, error) {
+	p.Scope = budgets.NormalizeScope(p.Scope)
+	switch p.Scope {
+	case budgets.ScopeInvoker, budgets.ScopeRole, budgets.ScopeInvokerTrustLevel:
+	default:
+		return InvokerSpendLimit{}, fmt.Errorf("scope must be %q, %q, or %q", budgets.ScopeInvoker, budgets.ScopeRole, budgets.ScopeInvokerTrustLevel)
+	}
+	p.ScopeKey = strings.TrimSpace(p.ScopeKey)
+	if p.ScopeKey == "" {
+		return InvokerSpendLimit{}, fmt.Errorf("scope_key required")
+	}
+	if len(p.Windows) == 0 {
+		return InvokerSpendLimit{}, fmt.Errorf("windows required")
+	}
+	for i := range p.Windows {
+		window := &p.Windows[i]
+		window.Key = strings.TrimSpace(window.Key)
+		if window.Key == "" {
+			return InvokerSpendLimit{}, fmt.Errorf("windows[%d].key required", i)
+		}
+		if window.WindowSeconds <= 0 {
+			return InvokerSpendLimit{}, fmt.Errorf("windows[%d].window_seconds must be positive", i)
+		}
+		if window.Limit < 0 {
+			return InvokerSpendLimit{}, fmt.Errorf("windows[%d].limit must be non-negative", i)
+		}
+		window.Currency = money.NormalizeCurrency(window.Currency)
+		if window.Currency != "" {
+			if err := money.ValidateCurrency(window.Currency); err != nil {
+				return InvokerSpendLimit{}, fmt.Errorf("windows[%d].currency invalid: %w", i, err)
+			}
+		}
+	}
+	return p, nil
 }
 
 func invokerSpendLimitFromGen(r gen.OpenrailsInvokerSpendLimit) (InvokerSpendLimit, error) {

--- a/internal/river/jobs_provider_refresh.go
+++ b/internal/river/jobs_provider_refresh.go
@@ -170,6 +170,7 @@ func (w *ProviderRefreshSchedulerWorker) Work(ctx context.Context, _ *river.Job[
 	}
 	// Shuffle kills the ListActiveMerchantIDs order bias: no merchant is
 	// systematically last in every window.
+	// #nosec G404 -- this is scheduling fairness, not a security-sensitive random choice.
 	rand.Shuffle(len(merchantIDs), func(i, j int) { merchantIDs[i], merchantIDs[j] = merchantIDs[j], merchantIDs[i] })
 
 	now := w.now()

--- a/pkg/service/admission.go
+++ b/pkg/service/admission.go
@@ -203,10 +203,14 @@ func (s *Service) SetInvokerSpendLimits(ctx context.Context, payer identity.Cust
 	if payer.IsZero() {
 		return fmt.Errorf("payer required")
 	}
-	return admission.NewInvokerSpendLimitStore(s.rt.DB).Upsert(ctx, payer, admission.InvokerSpendLimit{
+	row, err := admission.ValidateInvokerSpendLimit(admission.InvokerSpendLimit{
 		Scope: in.Scope, ScopeKey: in.ScopeKey,
 		Windows: budgetScopeWindowModels(in.Windows),
 	})
+	if err != nil {
+		return err
+	}
+	return admission.NewInvokerSpendLimitStore(s.rt.DB).Upsert(ctx, payer, row)
 }
 
 // InvokerSpendLimits returns the payer's per-invoker spend limits (#473/#517).
@@ -248,10 +252,13 @@ func (s *Service) ReplaceInvokerSpendLimits(ctx context.Context, payer identity.
 	}
 	wanted := make(map[string]admission.InvokerSpendLimit, len(next))
 	for _, in := range next {
-		row := admission.InvokerSpendLimit{
+		row, err := admission.ValidateInvokerSpendLimit(admission.InvokerSpendLimit{
 			Scope:    in.Scope,
 			ScopeKey: strings.TrimSpace(in.ScopeKey),
 			Windows:  budgetScopeWindowModels(in.Windows),
+		})
+		if err != nil {
+			return err
 		}
 		wanted[row.Scope+"\x00"+row.ScopeKey] = row
 	}

--- a/remote.go
+++ b/remote.go
@@ -433,6 +433,15 @@ func (c *remote) SetCustomerSpendDelegations(ctx context.Context, customerID str
 	return c.do(ctx, http.MethodPut, path, map[string]any{"delegations": delegations}, nil)
 }
 
+// SetCustomerSpendDelegation atomically upserts one customer delegation.
+func (c *remote) SetCustomerSpendDelegation(ctx context.Context, customerID string, delegation SpendDelegationInput) error {
+	if strings.TrimSpace(customerID) == "" {
+		return invalidErr("customer_id required")
+	}
+	path := "/v1/customers/" + url.PathEscape(strings.TrimSpace(customerID)) + "/spend-delegations:upsert"
+	return c.do(ctx, http.MethodPut, path, delegation, nil)
+}
+
 // ListActiveEntitlements implements Client (handler
 // ServiceGetExternalSubjectEntitlements, entitlements.go).
 func (c *remote) ListActiveEntitlements(ctx context.Context, subjects []string, at time.Time) (map[string][]EntitlementRecord, error) {

--- a/remote_test.go
+++ b/remote_test.go
@@ -77,6 +77,38 @@ func TestRemoteTrustLevelWireNames(t *testing.T) {
 	}
 }
 
+func TestRemoteSetCustomerSpendDelegation(t *testing.T) {
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("method = %s, want PUT", r.Method)
+		}
+		if r.URL.Path != "/v1/customers/customer-1/spend-delegations:upsert" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	client := NewRemote(srv.URL, WithTokenProvider(func(context.Context) (string, error) {
+		return "test-token", nil
+	}))
+	err := client.SetCustomerSpendDelegation(context.Background(), " customer-1 ", SpendDelegationInput{
+		Scope: "invoker", ScopeKey: "issuer:subject:digest:entitlement",
+		Windows: []SpendLimitWindow{{Key: "month", WindowSeconds: 2592000, Limit: 42, Currency: "USD"}},
+	})
+	if err != nil {
+		t.Fatalf("SetCustomerSpendDelegation: %v", err)
+	}
+	if got["scope"] != "invoker" || got["scope_key"] != "issuer:subject:digest:entitlement" {
+		t.Fatalf("unexpected body: %#v", got)
+	}
+}
+
 // TestRemoteValidationErrorParity asserts that client-side pre-flight argument
 // checks return typed *StatusError values whose errors.Is chain includes
 // ErrInvalid — matching the embedded transport's behavior (#338).
@@ -109,6 +141,12 @@ func TestRemoteValidationErrorParity(t *testing.T) {
 			name: "SetCustomerSpendDelegations empty customer_id",
 			fn: func() error {
 				return client.SetCustomerSpendDelegations(ctx, "", nil)
+			},
+		},
+		{
+			name: "SetCustomerSpendDelegation empty customer_id",
+			fn: func() error {
+				return client.SetCustomerSpendDelegation(ctx, "", SpendDelegationInput{})
 			},
 		},
 		{

--- a/tests/customer_treasury_spend_delegations_test.go
+++ b/tests/customer_treasury_spend_delegations_test.go
@@ -74,6 +74,29 @@ func TestCustomerTreasurySpendDelegationsHTTPFullReplacement(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.status, resp.body)
 	require.Len(t, decodeDelegations(t, resp.body), 3)
 
+	resp = requestCustomerTreasuryJSON(t, srv, http.MethodPut, "/v1/customers/"+dbtest.TestMerchantSlug+"/spend-delegations:upsert", map[string]any{
+		"scope":     "invoker",
+		"scope_key": invokerKey,
+		"windows": []map[string]any{
+			{"key": "day", "window_seconds": 86400, "limit": 321, "currency": "USD"},
+		},
+	})
+	require.Equal(t, http.StatusOK, resp.status, resp.body)
+
+	svc, err := billingservice.New(suite.App.Runtime)
+	require.NoError(t, err)
+	payer := identity.CustomerID(dbtest.TestMerchantID.UUID())
+	stored, err := svc.InvokerSpendLimits(dbtest.WithTestMerchant(context.Background()), payer)
+	require.NoError(t, err)
+	require.Len(t, stored, 3, "single upsert must preserve unrelated role and invoker-tier rows")
+	limits := map[string]int64{}
+	for _, row := range stored {
+		limits[row.Scope+"\x00"+row.ScopeKey] = row.Windows[0].Limit
+	}
+	require.EqualValues(t, 321, limits["invoker\x00"+invokerKey])
+	require.EqualValues(t, 9000, limits["role\x00"+roleKey])
+	require.EqualValues(t, 15000, limits["invoker_tier\x00"+trustLevelKey])
+
 	secondDoc := map[string]any{"delegations": []map[string]any{
 		{
 			"scope":     "role",
@@ -86,10 +109,7 @@ func TestCustomerTreasurySpendDelegationsHTTPFullReplacement(t *testing.T) {
 	resp = requestCustomerTreasuryJSON(t, srv, http.MethodPut, "/v1/customers/"+dbtest.TestMerchantSlug+"/spend-delegations", secondDoc)
 	require.Equal(t, http.StatusOK, resp.status, resp.body)
 
-	svc, err := billingservice.New(suite.App.Runtime)
-	require.NoError(t, err)
-	payer := identity.CustomerID(dbtest.TestMerchantID.UUID())
-	stored, err := svc.InvokerSpendLimits(dbtest.WithTestMerchant(context.Background()), payer)
+	stored, err = svc.InvokerSpendLimits(dbtest.WithTestMerchant(context.Background()), payer)
 	require.NoError(t, err)
 	require.Len(t, stored, 1)
 	require.Equal(t, "role", stored[0].Scope)


### PR DESCRIPTION
## What

- add `SetCustomerSpendDelegation` across embedded and remote clients
- expose an authorized singular-upsert route
- reuse the existing atomic store upsert so unrelated invoker and role grants are preserved
- keep optional-currency behavior and cover it in integration tests

## Why

Tensorhub entitlement documents need to refresh one document-bound spend grant without replacing other grants belonging to the same customer. The existing bulk replacement API was too broad for concurrent delegated applications.

## Impact

This is additive. Existing bulk replacement behavior is unchanged. The new path uses the same permission gate, merchant/customer scope, validation, and database uniqueness guarantees.

## Validation

- `go test ./...`
- `go vet ./...`
- focused HTTP, embedded PostgreSQL, remote, and route-surface tests
- `go test -tags=integration ./embed -run TestEmbeddedClientSetCustomerSpendDelegations -count=1`
- independent security/correctness review
- `git diff --check`