### PR TITLE
Add machine-authenticated spend delegation sync

### DIFF
--- a/client.go
+++ b/client.go
@@ -508,8 +508,9 @@ type SpendLimitWindow struct {
 	Currency      string `json:"currency,omitempty"`
 }
 
-// SpendDelegationInput is one payer-owned delegation in
-// /v1/customers/:customer_id/spend-delegations.
+// SpendDelegationInput is one payer-owned spend delegation. Machine clients use
+// the merchant service surface; customers manage the same policy through their
+// customer-owned treasury surface.
 type SpendDelegationInput struct {
 	Scope    string             `json:"scope"`
 	ScopeKey string             `json:"scope_key,omitempty"`

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -355,7 +355,7 @@ Credential examples:
 |-------|---------------------|
 | `GET /v1/merchant/customers/{customer_id}/entitlements`, `GET /v1/merchant/users/{user_id}/product-access`, `GET /v1/merchant/invokers/{invoker}/credits`, `GET /v1/merchant/trust-level`, `GET /v1/merchant/credit-limit`, `GET /v1/merchant/credits/balance` | `merchant:customer-settings:read` |
 | `POST /v1/merchant/customers/entitlements:batch` | `merchant:customer-settings:read` |
-| `PUT /v1/merchant/credit-limit`, `POST /v1/merchant/credits/deposit` | `merchant:customer-settings:update` |
+| `PUT /v1/merchant/credit-limit`, `POST /v1/merchant/credits/deposit`, `PUT /v1/merchant/customers/{customer_id}/spend-delegations`, `PUT /v1/merchant/customers/{customer_id}/spend-delegations:upsert` | `merchant:customer-settings:update` |
 | `POST /v1/merchant/admissions`, `POST /v1/merchant/admissions/{id}/capture`, `POST /v1/merchant/admissions/{id}/release`, `POST /v1/merchant/wasted-spend` | `merchant:admissions:create` |
 | `GET /v1/merchant/settings` | `merchant:settings:read` |
 | `PUT /v1/merchant/settings` | `merchant:settings:update` |
@@ -533,6 +533,14 @@ Lists payment history for one customer. Requires `merchant:payments:read`.
 ### POST /v1/merchant/customers/{customer_id}/payments/off-channel
 Records an off-channel/manual purchase and grants product entitlements through
 the normal checkout purchase path. Requires `merchant:customer-settings:update`.
+
+### PUT /v1/merchant/customers/{customer_id}/spend-delegations
+Atomically replaces the customer's complete payer-owned spend-delegation policy.
+Requires `merchant:customer-settings:update`.
+
+### PUT /v1/merchant/customers/{customer_id}/spend-delegations:upsert
+Atomically upserts one customer spend delegation without changing sibling grants.
+Requires `merchant:customer-settings:update`.
 
 ### POST /v1/merchant/customers/{customer_id}/entitlements
 Manually grants an entitlement through the grant ledger. Requires

--- a/embed/client.go
+++ b/embed/client.go
@@ -2,6 +2,7 @@ package embed
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -10,9 +11,6 @@ import (
 
 	"github.com/open-rails/openrails"
 	"github.com/open-rails/openrails/internal/app"
-	"github.com/open-rails/openrails/internal/db/models"
-	"github.com/open-rails/openrails/internal/modules/admission"
-	"github.com/open-rails/openrails/internal/modules/budgets"
 	"github.com/open-rails/openrails/internal/modules/money"
 	"github.com/open-rails/openrails/pkg/identity"
 	"github.com/open-rails/openrails/pkg/merchant"
@@ -244,18 +242,14 @@ func (c *localClient) SetCustomerSpendDelegations(ctx context.Context, customerI
 	}
 	next := make([]billingservice.InvokerSpendLimitInput, 0, len(delegations))
 	for _, d := range delegations {
-		in, err := spendDelegationInput(d)
-		if err != nil {
-			return err
-		}
-		next = append(next, in)
+		next = append(next, spendDelegationInput(d))
 	}
 	mctx, err := c.merchantCtx(ctx)
 	if err != nil {
 		return err
 	}
 	if err := c.svc.ReplaceInvokerSpendLimits(mctx, payer, next); err != nil {
-		return wrapInternalErr("set customer spend delegations failed", err)
+		return spendDelegationWriteError("set customer spend delegations failed", err)
 	}
 	return nil
 }
@@ -267,50 +261,33 @@ func (c *localClient) SetCustomerSpendDelegation(ctx context.Context, customerID
 	if err != nil {
 		return err
 	}
-	in, err := spendDelegationInput(delegation)
-	if err != nil {
-		return err
-	}
+	in := spendDelegationInput(delegation)
 	mctx, err := c.merchantCtx(ctx)
 	if err != nil {
 		return err
 	}
 	if err := c.svc.SetInvokerSpendLimits(mctx, payer, in); err != nil {
-		return wrapInternalErr("set customer spend delegation failed", err)
+		return spendDelegationWriteError("set customer spend delegation failed", err)
 	}
 	return nil
 }
 
-func spendDelegationInput(d openrails.SpendDelegationInput) (billingservice.InvokerSpendLimitInput, error) {
-	scope := budgets.NormalizeScope(d.Scope)
-	scopeKey := strings.TrimSpace(d.ScopeKey)
-	roleID := strings.TrimSpace(d.RoleID)
-	if roleID != "" && scope != budgets.ScopeRole {
-		return billingservice.InvokerSpendLimitInput{}, invalidErr(fmt.Sprintf("role_id is only allowed for scope %q", budgets.ScopeRole))
+func spendDelegationInput(d openrails.SpendDelegationInput) billingservice.InvokerSpendLimitInput {
+	out := billingservice.InvokerSpendLimitInput{
+		Scope: d.Scope, ScopeKey: d.ScopeKey, RoleID: d.RoleID,
+		Windows: make([]billingservice.SpendLimitWindowInput, 0, len(d.Windows)),
 	}
-	if scopeKey != "" && roleID != "" && scopeKey != roleID {
-		return billingservice.InvokerSpendLimitInput{}, invalidErr("role_id must match scope_key")
-	}
-	if scopeKey == "" {
-		scopeKey = roleID
-	}
-	windows := make([]models.BudgetWindowPolicy, 0, len(d.Windows))
 	for _, w := range d.Windows {
-		windows = append(windows, models.BudgetWindowPolicy{
-			Key: w.Key, WindowSeconds: w.WindowSeconds, Limit: w.Limit, Currency: w.Currency,
-		})
-	}
-	normalized, err := admission.ValidateInvokerSpendLimit(admission.InvokerSpendLimit{
-		Scope: scope, ScopeKey: scopeKey, Windows: windows,
-	})
-	if err != nil {
-		return billingservice.InvokerSpendLimitInput{}, invalidErr(err.Error())
-	}
-	out := billingservice.InvokerSpendLimitInput{Scope: normalized.Scope, ScopeKey: normalized.ScopeKey}
-	for _, w := range normalized.Windows {
 		out.Windows = append(out.Windows, billingservice.SpendLimitWindowInput{
 			Key: w.Key, WindowSeconds: w.WindowSeconds, Limit: w.Limit, Currency: w.Currency,
 		})
 	}
-	return out, nil
+	return out
+}
+
+func spendDelegationWriteError(message string, err error) error {
+	if errors.Is(err, billingservice.ErrInvalidInvokerSpendLimit) {
+		return invalidErr(err.Error())
+	}
+	return wrapInternalErr(message, err)
 }

--- a/embed/client.go
+++ b/embed/client.go
@@ -28,29 +28,13 @@ type SingleAdmitter interface {
 	Admit(ctx context.Context, req openrails.AdmitRequest) (*openrails.AdmitResponse, error)
 }
 
-// localClient is the PERMANENT remainder of the pre-#685 handler-transcribing
-// adapter. Every openrails.Client interface method except customer delegation
-// writes runs through the
-// unified remote implementation over the in-process transport (see
-// unifiedClient in embed.go); what stays here is:
+// localClient is the direct embedded remainder of the pre-#685 adapter. Most
+// openrails.Client methods run through the unified remote implementation over
+// the in-process transport (see unifiedClient in embed.go); what stays here is:
 //
-//   - SetCustomerSpendDelegation(s) — PERMANENTLY transcribed (#685 tail
-//     decision). Its wire surface is the delegated customer-treasury family
-//     (/v1/customers/*), whose gate semantics are "the credential IS the
-//     customer": CustomerScopeRequired matches :customer_id against the
-//     delegated principal's OWN resolved identity and the handler derives the
-//     payer FROM the principal (a body customer_id is rejected). The host
-//     principal is the MERCHANT — one fixed identity — while this method takes
-//     an arbitrary customerID per call; routing it in-process would require
-//     synthesizing a per-request ResolvedDelegated whose identity is copied
-//     from the very path segment the gate exists to check (fabrication, not
-//     auth), with a merchant.ID holding a non-merchant UUID. The wire also
-//     deliberately offers NO merchant-credential route for this operation
-//     (#666 retired the merchant-side service routes; every /v1/customers
-//     route is gated on customer:* perms because the balance may be shared) —
-//     an in-process mapping would mint embedded-only authority with no
-//     standalone equivalent. The transcription states what this really is:
-//     direct engine access by the process owner.
+//   - SetCustomerSpendDelegation(s), implemented directly through pkg/service.
+//     Standalone mode exposes equivalent merchant-authenticated service routes;
+//     `/v1/customers/*` remains the distinct customer-owned browser surface.
 //   - Embedded-only extra with NO wire counterpart: single Admit (the batch
 //     route is the surviving HTTP surface, #666), reachable via type assertion
 //     to SingleAdmitter by hosts that need it. (SetCreditAccountSettings, ListCreditTransactions,
@@ -250,12 +234,9 @@ func admitResponseFromResult(res *billingservice.AdmitResult) *openrails.AdmitRe
 	return out
 }
 
-// SetCustomerSpendDelegations transcribes the customer treasury spend-delegations
-// replace operation for embedded hosts (#567). PERMANENTLY transcribed — see the
-// localClient doc: the /v1/customers/* gate requires a credential that IS the
-// customer, which a host (merchant) principal cannot honestly satisfy for an
-// arbitrary customerID; the wire deliberately has no merchant-credential
-// equivalent for this operation.
+// SetCustomerSpendDelegations applies the spend-delegation replacement directly
+// for embedded hosts. Standalone callers reach the equivalent merchant-machine
+// route; both paths pin the merchant and share the same service/store semantics.
 func (c *localClient) SetCustomerSpendDelegations(ctx context.Context, customerID string, delegations []openrails.SpendDelegationInput) error {
 	payer, err := parseCustomer(customerID, "invalid customer_id")
 	if err != nil {

--- a/embed/embed.go
+++ b/embed/embed.go
@@ -137,9 +137,9 @@ func New(ctx context.Context, opts Options, options ...Option) (*Runtime, error)
 // call. Parity with a standalone deployment is structural (one implementation),
 // enforced by conformance_integration_test.go.
 //
-// Customer spend-delegation writes are PERMANENTLY served by the transcribed
-// localClient — see unifiedClient and the localClient doc for the authz
-// reasoning. The returned Client also always implements
+// Customer spend-delegation writes use localClient's direct service path; the
+// remote client uses equivalent merchant-machine routes. The returned Client
+// also always implements
 // SingleAdmitter (embedded-only single Admit, no wire counterpart) — reach it
 // via a type assertion.
 //
@@ -175,26 +175,23 @@ func (r *Runtime) Client(opts ...ClientOption) openrails.Client {
 
 // unifiedClient is the embedded SDK client (#685): the embedded
 // openrails.Client (the remote implementation over the in-process transport)
-// serves every merchant-authority method; *localClient keeps the PERMANENT
-// customer-treasury spend-delegation transcriptions (see the localClient doc)
-// plus the embedded-only single-Admit extra, which has no /v1/merchant wire
-// counterpart.
+// serves merchant-authority methods; *localClient keeps direct service
+// implementations for spend-delegation sync plus the embedded-only single-Admit
+// extra, which has no /v1/merchant wire counterpart.
 type unifiedClient struct {
 	openrails.Client
 	*localClient
 }
 
-// SetCustomerSpendDelegations stays transcribed PERMANENTLY: its HTTP surface
-// is the delegated customer-treasury family (/v1/customers/*), whose gate
-// requires a credential that IS the customer — a mapping the merchant host
-// principal cannot honestly satisfy (see the localClient doc). Explicit
-// forward resolves the embedding conflict.
+// SetCustomerSpendDelegations uses the direct embedded service path. The remote
+// client uses the equivalent merchant-machine HTTP route. Explicit forwarding
+// resolves the embedding conflict.
 func (c *unifiedClient) SetCustomerSpendDelegations(ctx context.Context, customerID string, delegations []openrails.SpendDelegationInput) error {
 	return c.localClient.SetCustomerSpendDelegations(ctx, customerID, delegations)
 }
 
-// SetCustomerSpendDelegation stays transcribed for the same customer-treasury
-// authority boundary as the explicit full-document replacement above.
+// SetCustomerSpendDelegation preserves singular-upsert semantics in both
+// embedded and standalone modes.
 func (c *unifiedClient) SetCustomerSpendDelegation(ctx context.Context, customerID string, delegation openrails.SpendDelegationInput) error {
 	return c.localClient.SetCustomerSpendDelegation(ctx, customerID, delegation)
 }

--- a/embed/spend_delegations_integration_test.go
+++ b/embed/spend_delegations_integration_test.go
@@ -69,6 +69,25 @@ func TestEmbeddedClientSetCustomerSpendDelegations(t *testing.T) {
 	require.EqualValues(t, 123, limits["invoker\x00test-invoker"])
 	require.EqualValues(t, 9_000_000, limits["role\x00test-role"])
 
+	err = client.SetCustomerSpendDelegations(ctx, customerID.String(), []openrails.SpendDelegationInput{
+		{
+			Scope: " role ", RoleID: " test-role ",
+			Windows: []openrails.SpendLimitWindow{{Key: "day", WindowSeconds: 86400, Limit: 1}},
+		},
+		{
+			Scope: "role", ScopeKey: "test-role",
+			Windows: []openrails.SpendLimitWindow{{Key: "day", WindowSeconds: 86400, Limit: 2}},
+		},
+	})
+	require.ErrorIs(t, err, openrails.ErrInvalid)
+	var embeddedStatus *openrails.StatusError
+	require.ErrorAs(t, err, &embeddedStatus)
+	require.Equal(t, 400, embeddedStatus.Status)
+	require.Contains(t, err.Error(), "duplicate delegation for role")
+	stored, err = rt.Service().InvokerSpendLimits(dbtest.WithTestMerchant(ctx), identity.CustomerID(customerID))
+	require.NoError(t, err)
+	require.Len(t, stored, 2, "rejected embedded duplicate document must not mutate policy")
+
 	// Replace-with-empty exercises the delete lane through the same ctx path.
 	require.NoError(t, client.SetCustomerSpendDelegations(ctx, customerID.String(), nil))
 }

--- a/internal/db/gen/admission_support.sql.go
+++ b/internal/db/gen/admission_support.sql.go
@@ -12,6 +12,27 @@ import (
 	"github.com/google/uuid"
 )
 
+const deleteAllInvokerSpendLimits = `-- name: DeleteAllInvokerSpendLimits :execrows
+DELETE FROM openrails.invoker_spend_limits
+WHERE merchant_id = $1 AND customer_id = $2
+`
+
+type DeleteAllInvokerSpendLimitsParams struct {
+	MerchantID uuid.UUID
+	CustomerID uuid.UUID
+}
+
+// Full-document replacement removes the exact merchant+payer set before
+// inserting the canonical replacement. This also purges legacy non-canonical
+// scope_key values that cannot be addressed safely by normalized key deletes.
+func (q *Queries) DeleteAllInvokerSpendLimits(ctx context.Context, arg DeleteAllInvokerSpendLimitsParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteAllInvokerSpendLimits, arg.MerchantID, arg.CustomerID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const deleteInvokerSpendLimit = `-- name: DeleteInvokerSpendLimit :execrows
 DELETE FROM openrails.invoker_spend_limits
 WHERE merchant_id = $1 AND customer_id = $2

--- a/internal/db/queries/admission_support.sql
+++ b/internal/db/queries/admission_support.sql
@@ -50,6 +50,13 @@ DELETE FROM openrails.invoker_spend_limits
 WHERE merchant_id = $1 AND customer_id = $2
   AND scope = $3 AND scope_key = $4;
 
+-- name: DeleteAllInvokerSpendLimits :execrows
+-- Full-document replacement removes the exact merchant+payer set before
+-- inserting the canonical replacement. This also purges legacy non-canonical
+-- scope_key values that cannot be addressed safely by normalized key deletes.
+DELETE FROM openrails.invoker_spend_limits
+WHERE merchant_id = $1 AND customer_id = $2;
+
 -- name: ListInvokerSpendLimits :many
 -- ALL invoker spend limits for a payer (the admit path reads every scope to
 -- compose the verdict).

--- a/internal/http/handlers/customer_spend_delegations.go
+++ b/internal/http/handlers/customer_spend_delegations.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -16,6 +16,7 @@ import (
 	"github.com/open-rails/openrails/internal/modules/admission"
 	"github.com/open-rails/openrails/internal/modules/budgets"
 	"github.com/open-rails/openrails/pkg/identity"
+	billingservice "github.com/open-rails/openrails/pkg/service"
 )
 
 type customerSpendDelegationsDocument struct {
@@ -75,16 +76,16 @@ func PutCustomerSpendDelegations(r *httprequest.Request) {
 		return
 	}
 
-	store, payer, ok := customerTreasuryStore(r, resolved)
+	svc, payer, ok := customerTreasurySpendDelegationService(r, resolved)
 	if !ok {
 		return
 	}
-	if err := replaceCustomerSpendDelegations(r.Request.Context(), store, payer, next); err != nil {
-		r.ErrorJSON(http.StatusInternalServerError, "spend delegation replace failed")
+	if err := svc.ReplaceInvokerSpendLimits(r.Request.Context(), payer, next); err != nil {
+		customerSpendDelegationWriteError(r, err, "spend delegation replace failed")
 		return
 	}
 
-	r.SuccessJSON(customerSpendDelegationsDocument{Delegations: customerSpendDelegationsFromRows(next)})
+	r.SuccessJSON(customerSpendDelegationsDocument{Delegations: customerSpendDelegationsFromInputs(next)})
 }
 
 // PutCustomerSpendDelegation atomically upserts one addressed delegation and
@@ -105,15 +106,15 @@ func PutCustomerSpendDelegation(r *httprequest.Request) {
 		return
 	}
 
-	store, payer, ok := customerTreasuryStore(r, resolved)
+	svc, payer, ok := customerTreasurySpendDelegationService(r, resolved)
 	if !ok {
 		return
 	}
-	if err := store.Upsert(r.Request.Context(), payer, next[0]); err != nil {
-		r.ErrorJSON(http.StatusInternalServerError, "spend delegation upsert failed")
+	if err := svc.SetInvokerSpendLimits(r.Request.Context(), payer, next[0]); err != nil {
+		customerSpendDelegationWriteError(r, err, "spend delegation upsert failed")
 		return
 	}
-	r.SuccessJSON(customerSpendDelegationFromRow(next[0]))
+	r.SuccessJSON(customerSpendDelegationFromInput(next[0]))
 }
 
 // ServicePutCustomerSpendDelegations is the merchant-machine counterpart of
@@ -133,15 +134,15 @@ func ServicePutCustomerSpendDelegations(r *httprequest.Request) {
 		r.ErrorJSON(http.StatusBadRequest, err.Error())
 		return
 	}
-	store, payer, ok := serviceCustomerSpendDelegationStore(r)
+	svc, payer, ok := serviceCustomerSpendDelegationService(r)
 	if !ok {
 		return
 	}
-	if err := replaceCustomerSpendDelegations(r.Request.Context(), store, payer, next); err != nil {
-		r.ErrorJSON(http.StatusInternalServerError, "spend delegation replace failed")
+	if err := svc.ReplaceInvokerSpendLimits(r.Request.Context(), payer, next); err != nil {
+		customerSpendDelegationWriteError(r, err, "spend delegation replace failed")
 		return
 	}
-	r.SuccessJSON(customerSpendDelegationsDocument{Delegations: customerSpendDelegationsFromRows(next)})
+	r.SuccessJSON(customerSpendDelegationsDocument{Delegations: customerSpendDelegationsFromInputs(next)})
 }
 
 // ServicePutCustomerSpendDelegation atomically reasserts one payer grant for a
@@ -156,18 +157,18 @@ func ServicePutCustomerSpendDelegation(r *httprequest.Request) {
 		r.ErrorJSON(http.StatusBadRequest, err.Error())
 		return
 	}
-	store, payer, ok := serviceCustomerSpendDelegationStore(r)
+	svc, payer, ok := serviceCustomerSpendDelegationService(r)
 	if !ok {
 		return
 	}
-	if err := store.Upsert(r.Request.Context(), payer, next[0]); err != nil {
-		r.ErrorJSON(http.StatusInternalServerError, "spend delegation upsert failed")
+	if err := svc.SetInvokerSpendLimits(r.Request.Context(), payer, next[0]); err != nil {
+		customerSpendDelegationWriteError(r, err, "spend delegation upsert failed")
 		return
 	}
-	r.SuccessJSON(customerSpendDelegationFromRow(next[0]))
+	r.SuccessJSON(customerSpendDelegationFromInput(next[0]))
 }
 
-func serviceCustomerSpendDelegationStore(r *httprequest.Request) (*admission.InvokerSpendLimitStore, identity.CustomerID, bool) {
+func serviceCustomerSpendDelegationService(r *httprequest.Request) (*billingservice.Service, identity.CustomerID, bool) {
 	payer, err := parseServiceCustomerID(r.Param("customer_id"))
 	if err != nil || payer == nil {
 		r.ErrorJSON(http.StatusBadRequest, "invalid customer_id")
@@ -176,36 +177,29 @@ func serviceCustomerSpendDelegationStore(r *httprequest.Request) (*admission.Inv
 	if !requireServiceCustomerScope(r, *payer) {
 		return nil, identity.CustomerID(uuid.Nil), false
 	}
-	if r.State == nil || r.State.DB == nil {
-		r.ErrorJSON(http.StatusInternalServerError, "billing service unavailable")
-		return nil, identity.CustomerID(uuid.Nil), false
-	}
-	return admission.NewInvokerSpendLimitStore(r.State.DB), *payer, true
+	svc, ok := customerSpendDelegationService(r)
+	return svc, *payer, ok
 }
 
-func replaceCustomerSpendDelegations(ctx context.Context, store *admission.InvokerSpendLimitStore, payer identity.CustomerID, next []admission.InvokerSpendLimit) error {
-	existing, err := store.LoadAll(ctx, payer)
+func customerSpendDelegationService(r *httprequest.Request) (*billingservice.Service, bool) {
+	if r.State == nil || r.State.DB == nil {
+		r.ErrorJSON(http.StatusInternalServerError, "billing service unavailable")
+		return nil, false
+	}
+	svc, err := billingservice.New(r.State)
 	if err != nil {
-		return err
+		r.ErrorJSON(http.StatusInternalServerError, "billing service unavailable")
+		return nil, false
 	}
-	wanted := make(map[string]admission.InvokerSpendLimit, len(next))
-	for _, row := range next {
-		wanted[spendDelegationKey(row.Scope, row.ScopeKey)] = row
+	return svc, true
+}
+
+func customerSpendDelegationWriteError(r *httprequest.Request, err error, internalMessage string) {
+	if errors.Is(err, billingservice.ErrInvalidInvokerSpendLimit) {
+		r.ErrorJSON(http.StatusBadRequest, err.Error())
+		return
 	}
-	for _, row := range existing {
-		if _, keep := wanted[spendDelegationKey(row.Scope, row.ScopeKey)]; keep {
-			continue
-		}
-		if err := store.Delete(ctx, payer, row.Scope, row.ScopeKey); err != nil {
-			return err
-		}
-	}
-	for _, row := range next {
-		if err := store.Upsert(ctx, payer, row); err != nil {
-			return err
-		}
-	}
-	return nil
+	r.ErrorJSON(http.StatusInternalServerError, internalMessage)
 }
 
 func requireCustomerTreasuryPrincipal(r *httprequest.Request) (*controlplane.ResolvedDelegated, bool) {
@@ -242,43 +236,32 @@ func customerTreasuryStore(r *httprequest.Request, resolved *controlplane.Resolv
 	return admission.NewInvokerSpendLimitStore(r.State.DB), identity.CustomerID(resolved.MerchantID.UUID()), true
 }
 
-func validateCustomerSpendDelegations(in []customerSpendDelegation) ([]admission.InvokerSpendLimit, error) {
-	out := make([]admission.InvokerSpendLimit, 0, len(in))
-	seen := make(map[string]struct{}, len(in))
+func customerTreasurySpendDelegationService(r *httprequest.Request, resolved *controlplane.ResolvedDelegated) (*billingservice.Service, identity.CustomerID, bool) {
+	if resolved == nil || resolved.MerchantID.IsZero() {
+		r.ErrorJSON(http.StatusUnauthorized, "delegated principal invalid")
+		return nil, identity.CustomerID(uuid.Nil), false
+	}
+	svc, ok := customerSpendDelegationService(r)
+	return svc, identity.CustomerID(resolved.MerchantID.UUID()), ok
+}
+
+func validateCustomerSpendDelegations(in []customerSpendDelegation) ([]billingservice.InvokerSpendLimitInput, error) {
+	out := make([]billingservice.InvokerSpendLimitInput, 0, len(in))
 	for i, row := range in {
 		if strings.TrimSpace(row.CustomerID) != "" {
 			return nil, fmt.Errorf("delegations[%d].customer_id is not allowed", i)
 		}
-		scope := budgets.NormalizeScope(row.Scope)
-		scopeKey := strings.TrimSpace(row.ScopeKey)
-		roleID := strings.TrimSpace(row.RoleID)
-		if roleID != "" && scope != budgets.ScopeRole {
-			return nil, fmt.Errorf("delegations[%d].role_id is only allowed for scope %q", i, budgets.ScopeRole)
+		windows := make([]billingservice.SpendLimitWindowInput, 0, len(row.Windows))
+		for _, window := range row.Windows {
+			windows = append(windows, billingservice.SpendLimitWindowInput{
+				Key: window.Key, WindowSeconds: window.WindowSeconds, Limit: window.Limit, Currency: window.Currency,
+			})
 		}
-		if scopeKey != "" && roleID != "" && scopeKey != roleID {
-			return nil, fmt.Errorf("delegations[%d].role_id must match scope_key", i)
-		}
-		if scopeKey == "" {
-			scopeKey = roleID
-		}
-		windows := append([]models.BudgetWindowPolicy(nil), row.Windows...)
-		normalized, err := admission.ValidateInvokerSpendLimit(admission.InvokerSpendLimit{
-			Scope: scope, ScopeKey: scopeKey, Windows: windows,
+		out = append(out, billingservice.InvokerSpendLimitInput{
+			Scope: row.Scope, ScopeKey: row.ScopeKey, RoleID: row.RoleID, Windows: windows,
 		})
-		if err != nil {
-			return nil, fmt.Errorf("delegations[%d].%s", i, err)
-		}
-		key := spendDelegationKey(normalized.Scope, normalized.ScopeKey)
-		if _, dup := seen[key]; dup {
-			return nil, fmt.Errorf("duplicate delegation for %s", key)
-		}
-		seen[key] = struct{}{}
-		out = append(out, normalized)
 	}
-	sort.Slice(out, func(i, j int) bool {
-		return spendDelegationKey(out[i].Scope, out[i].ScopeKey) < spendDelegationKey(out[j].Scope, out[j].ScopeKey)
-	})
-	return out, nil
+	return billingservice.ValidateInvokerSpendLimitInputs(out)
 }
 
 func customerSpendDelegationsFromRows(rows []admission.InvokerSpendLimit) []customerSpendDelegation {
@@ -295,6 +278,30 @@ func customerSpendDelegationsFromRows(rows []admission.InvokerSpendLimit) []cust
 func customerSpendDelegationFromRow(row admission.InvokerSpendLimit) customerSpendDelegation {
 	delegation := customerSpendDelegation{
 		Scope: budgets.NormalizeScope(row.Scope), ScopeKey: row.ScopeKey, Windows: row.Windows,
+	}
+	if delegation.Scope == budgets.ScopeRole {
+		delegation.RoleID = row.ScopeKey
+	}
+	return delegation
+}
+
+func customerSpendDelegationsFromInputs(rows []billingservice.InvokerSpendLimitInput) []customerSpendDelegation {
+	out := make([]customerSpendDelegation, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, customerSpendDelegationFromInput(row))
+	}
+	return out
+}
+
+func customerSpendDelegationFromInput(row billingservice.InvokerSpendLimitInput) customerSpendDelegation {
+	windows := make([]models.BudgetWindowPolicy, 0, len(row.Windows))
+	for _, window := range row.Windows {
+		windows = append(windows, models.BudgetWindowPolicy{
+			Key: window.Key, WindowSeconds: window.WindowSeconds, Limit: window.Limit, Currency: window.Currency,
+		})
+	}
+	delegation := customerSpendDelegation{
+		Scope: row.Scope, ScopeKey: row.ScopeKey, Windows: windows,
 	}
 	if delegation.Scope == budgets.ScopeRole {
 		delegation.RoleID = row.ScopeKey

--- a/internal/http/handlers/customer_spend_delegations.go
+++ b/internal/http/handlers/customer_spend_delegations.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"sort"
@@ -78,30 +79,9 @@ func PutCustomerSpendDelegations(r *httprequest.Request) {
 	if !ok {
 		return
 	}
-	existing, err := store.LoadAll(r.Request.Context(), payer)
-	if err != nil {
-		r.ErrorJSON(http.StatusInternalServerError, "spend delegation lookup failed")
+	if err := replaceCustomerSpendDelegations(r.Request.Context(), store, payer, next); err != nil {
+		r.ErrorJSON(http.StatusInternalServerError, "spend delegation replace failed")
 		return
-	}
-
-	wanted := make(map[string]admission.InvokerSpendLimit, len(next))
-	for _, row := range next {
-		wanted[spendDelegationKey(row.Scope, row.ScopeKey)] = row
-	}
-	for _, row := range existing {
-		if _, keep := wanted[spendDelegationKey(row.Scope, row.ScopeKey)]; keep {
-			continue
-		}
-		if err := store.Delete(r.Request.Context(), payer, row.Scope, row.ScopeKey); err != nil {
-			r.ErrorJSON(http.StatusInternalServerError, "spend delegation replace failed")
-			return
-		}
-	}
-	for _, row := range next {
-		if err := store.Upsert(r.Request.Context(), payer, row); err != nil {
-			r.ErrorJSON(http.StatusInternalServerError, "spend delegation replace failed")
-			return
-		}
 	}
 
 	r.SuccessJSON(customerSpendDelegationsDocument{Delegations: customerSpendDelegationsFromRows(next)})
@@ -134,6 +114,98 @@ func PutCustomerSpendDelegation(r *httprequest.Request) {
 		return
 	}
 	r.SuccessJSON(customerSpendDelegationFromRow(next[0]))
+}
+
+// ServicePutCustomerSpendDelegations is the merchant-machine counterpart of
+// PutCustomerSpendDelegations. Route authentication pins the merchant; the
+// path names a payable customer within that merchant.
+func ServicePutCustomerSpendDelegations(r *httprequest.Request) {
+	var doc customerSpendDelegationsDocument
+	if !r.BindJSON(&doc) {
+		return
+	}
+	if strings.TrimSpace(doc.CustomerID) != "" {
+		r.ErrorJSON(http.StatusBadRequest, "customer_id is not allowed in the body; it is taken from the path scope")
+		return
+	}
+	next, err := validateCustomerSpendDelegations(doc.Delegations)
+	if err != nil {
+		r.ErrorJSON(http.StatusBadRequest, err.Error())
+		return
+	}
+	store, payer, ok := serviceCustomerSpendDelegationStore(r)
+	if !ok {
+		return
+	}
+	if err := replaceCustomerSpendDelegations(r.Request.Context(), store, payer, next); err != nil {
+		r.ErrorJSON(http.StatusInternalServerError, "spend delegation replace failed")
+		return
+	}
+	r.SuccessJSON(customerSpendDelegationsDocument{Delegations: customerSpendDelegationsFromRows(next)})
+}
+
+// ServicePutCustomerSpendDelegation atomically reasserts one payer grant for a
+// merchant-authenticated machine caller without touching sibling grants.
+func ServicePutCustomerSpendDelegation(r *httprequest.Request) {
+	var delegation customerSpendDelegation
+	if !r.BindJSON(&delegation) {
+		return
+	}
+	next, err := validateCustomerSpendDelegations([]customerSpendDelegation{delegation})
+	if err != nil {
+		r.ErrorJSON(http.StatusBadRequest, err.Error())
+		return
+	}
+	store, payer, ok := serviceCustomerSpendDelegationStore(r)
+	if !ok {
+		return
+	}
+	if err := store.Upsert(r.Request.Context(), payer, next[0]); err != nil {
+		r.ErrorJSON(http.StatusInternalServerError, "spend delegation upsert failed")
+		return
+	}
+	r.SuccessJSON(customerSpendDelegationFromRow(next[0]))
+}
+
+func serviceCustomerSpendDelegationStore(r *httprequest.Request) (*admission.InvokerSpendLimitStore, identity.CustomerID, bool) {
+	payer, err := parseServiceCustomerID(r.Param("customer_id"))
+	if err != nil || payer == nil {
+		r.ErrorJSON(http.StatusBadRequest, "invalid customer_id")
+		return nil, identity.CustomerID(uuid.Nil), false
+	}
+	if !requireServiceCustomerScope(r, *payer) {
+		return nil, identity.CustomerID(uuid.Nil), false
+	}
+	if r.State == nil || r.State.DB == nil {
+		r.ErrorJSON(http.StatusInternalServerError, "billing service unavailable")
+		return nil, identity.CustomerID(uuid.Nil), false
+	}
+	return admission.NewInvokerSpendLimitStore(r.State.DB), *payer, true
+}
+
+func replaceCustomerSpendDelegations(ctx context.Context, store *admission.InvokerSpendLimitStore, payer identity.CustomerID, next []admission.InvokerSpendLimit) error {
+	existing, err := store.LoadAll(ctx, payer)
+	if err != nil {
+		return err
+	}
+	wanted := make(map[string]admission.InvokerSpendLimit, len(next))
+	for _, row := range next {
+		wanted[spendDelegationKey(row.Scope, row.ScopeKey)] = row
+	}
+	for _, row := range existing {
+		if _, keep := wanted[spendDelegationKey(row.Scope, row.ScopeKey)]; keep {
+			continue
+		}
+		if err := store.Delete(ctx, payer, row.Scope, row.ScopeKey); err != nil {
+			return err
+		}
+	}
+	for _, row := range next {
+		if err := store.Upsert(ctx, payer, row); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func requireCustomerTreasuryPrincipal(r *httprequest.Request) (*controlplane.ResolvedDelegated, bool) {

--- a/internal/http/routes/merchant_action_routes_test.go
+++ b/internal/http/routes/merchant_action_routes_test.go
@@ -46,6 +46,7 @@ func TestRegisterMerchantActionRoutesPermissions(t *testing.T) {
 		}),
 	}
 	RegisterMerchantActionRoutes(router.NewMux(mux, "/billing/v1/merchant", nil), nil, opts)
+	RegisterServiceRoutes(router.NewMux(mux, "/billing/v1/merchant", nil), nil, opts)
 	RegisterCatalogRoutes(router.NewMux(mux, "/billing/v1/merchant/catalog", nil), nil, opts)
 	RegisterPaymentProviderRoutes(router.NewMux(mux, "/billing/v1/merchant/payment-providers", nil), nil, opts)
 
@@ -95,6 +96,18 @@ func TestRegisterMerchantActionRoutesPermissions(t *testing.T) {
 			name:   "off channel payment",
 			method: http.MethodPost,
 			path:   "/billing/v1/merchant/customers/11111111-1111-1111-1111-111111111111/payments/off-channel",
+			perm:   controlplane.PermMerchantCustomerSettingsUpdate,
+		},
+		{
+			name:   "replace customer spend delegations",
+			method: http.MethodPut,
+			path:   "/billing/v1/merchant/customers/11111111-1111-1111-1111-111111111111/spend-delegations",
+			perm:   controlplane.PermMerchantCustomerSettingsUpdate,
+		},
+		{
+			name:   "upsert customer spend delegation",
+			method: http.MethodPut,
+			path:   "/billing/v1/merchant/customers/11111111-1111-1111-1111-111111111111/spend-delegations:upsert",
 			perm:   controlplane.PermMerchantCustomerSettingsUpdate,
 		},
 		{

--- a/internal/http/routes/routes.go
+++ b/internal/http/routes/routes.go
@@ -203,6 +203,14 @@ func RegisterServiceRoutes(rr router.Router, rt *app.Runtime, opts Options) {
 		h(httphandlers.ServiceGetCustomerEntitlements),
 		readMW...,
 	)
+	customers.Handle(http.MethodPut, "/spend-delegations",
+		h(httphandlers.ServicePutCustomerSpendDelegations),
+		writeMW...,
+	)
+	customers.Handle(http.MethodPut, "/spend-delegations:upsert",
+		h(httphandlers.ServicePutCustomerSpendDelegation),
+		writeMW...,
+	)
 
 	entitlements := group.Group("/entitlements")
 	entitlements.Handle(http.MethodGet, "/:entitlement/customers",

--- a/internal/integrationharness/testdata/standalone_route_surface.txt
+++ b/internal/integrationharness/testdata/standalone_route_surface.txt
@@ -172,6 +172,8 @@ PUT /v1/me/payment-methods/{id}
 PUT /v1/me/settings
 PUT /v1/me/subscriptions/{id}/payment-method
 PUT /v1/merchant/credit-limit
+PUT /v1/merchant/customers/{customer_id}/spend-delegations
+PUT /v1/merchant/customers/{customer_id}/spend-delegations:upsert
 PUT /v1/merchant/dashboard
 PUT /v1/merchant/payment-providers/{provider}
 PUT /v1/merchant/settings

--- a/internal/modules/admission/policy.go
+++ b/internal/modules/admission/policy.go
@@ -389,22 +389,11 @@ func (s *InvokerSpendLimitStore) delete(ctx context.Context, tenantID uuid.UUID,
 // failed delete/upsert rolls the transaction back to the prior document.
 func (s *InvokerSpendLimitStore) Replace(ctx context.Context, payer identity.CustomerID, next []InvokerSpendLimit) error {
 	return s.withPayerWriteTx(ctx, payer, func(ctx context.Context, txStore *InvokerSpendLimitStore, tenantID uuid.UUID) error {
-		existing, err := txStore.loadAll(ctx, tenantID, payer)
-		if err != nil {
+		if _, err := txStore.db.Gen(ctx).DeleteAllInvokerSpendLimits(ctx, gen.DeleteAllInvokerSpendLimitsParams{
+			MerchantID: tenantID,
+			CustomerID: payer.UUID(),
+		}); err != nil {
 			return err
-		}
-		wanted := make(map[string]struct{}, len(next))
-		for _, row := range next {
-			wanted[budgets.NormalizeScope(row.Scope)+"\x00"+strings.TrimSpace(row.ScopeKey)] = struct{}{}
-		}
-		for _, row := range existing {
-			key := budgets.NormalizeScope(row.Scope) + "\x00" + strings.TrimSpace(row.ScopeKey)
-			if _, keep := wanted[key]; keep {
-				continue
-			}
-			if err := txStore.delete(ctx, tenantID, payer, row.Scope, row.ScopeKey); err != nil {
-				return err
-			}
 		}
 		for _, row := range next {
 			if err := txStore.upsert(ctx, tenantID, payer, row); err != nil {

--- a/internal/modules/admission/policy.go
+++ b/internal/modules/admission/policy.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/open-rails/openrails/internal/db"
 	"github.com/open-rails/openrails/internal/db/gen"
@@ -290,70 +291,127 @@ func (s *InvokerSpendLimitStore) LoadAll(ctx context.Context, payer identity.Cus
 	if terr != nil {
 		return nil, terr
 	}
-	tenantID := tid.UUID()
 	var out []InvokerSpendLimit
 	err := s.db.RunInMerchantConn(ctx, func(ctx context.Context) error {
-		rows, e := s.db.Gen(ctx).ListInvokerSpendLimits(ctx, gen.ListInvokerSpendLimitsParams{
-			MerchantID: tenantID, CustomerID: payer.UUID(),
-		})
-		if e != nil {
-			return e
-		}
-		for _, r := range rows {
-			p, derr := invokerSpendLimitFromGen(r)
-			if derr != nil {
-				return derr
-			}
-			out = append(out, p)
-		}
-		return nil
+		var err error
+		out, err = s.loadAll(ctx, tid.UUID(), payer)
+		return err
 	})
 	return out, err
 }
 
-// Upsert writes one invoker spend limit (payer-set).
-func (s *InvokerSpendLimitStore) Upsert(ctx context.Context, payer identity.CustomerID, p InvokerSpendLimit) error {
-	tid, terr := merchant.Require(ctx) // #336/#474: no default merchant
-	if terr != nil {
-		return terr
+func (s *InvokerSpendLimitStore) loadAll(ctx context.Context, tenantID uuid.UUID, payer identity.CustomerID) ([]InvokerSpendLimit, error) {
+	var out []InvokerSpendLimit
+	rows, err := s.db.Gen(ctx).ListInvokerSpendLimits(ctx, gen.ListInvokerSpendLimitsParams{
+		MerchantID: tenantID, CustomerID: payer.UUID(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		p, err := invokerSpendLimitFromGen(r)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+// withPayerWriteTx serializes every spend-delegation write for one
+// merchant+payer and keeps the lock for the full transaction. Replace therefore
+// cannot interleave its read/delete/upsert sequence with a singular upsert.
+func (s *InvokerSpendLimitStore) withPayerWriteTx(ctx context.Context, payer identity.CustomerID, fn func(context.Context, *InvokerSpendLimitStore, uuid.UUID) error) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("admission: invoker spend-limit store not initialized")
+	}
+	tid, err := merchant.Require(ctx)
+	if err != nil {
+		return err
 	}
 	tenantID := tid.UUID()
+	lockKey := tid.String() + ":" + payer.UUID().String()
+	return s.db.MerchantTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, lockKey); err != nil {
+			return fmt.Errorf("admission: lock invoker spend limits: %w", err)
+		}
+		txdb := s.db.NewWithPgxTx(tx)
+		if _, err := db.EnsureCustomerID(ctx, txdb.Qx(ctx), tenantID, payer.UUID().String()); err != nil {
+			return err
+		}
+		return fn(ctx, NewInvokerSpendLimitStore(txdb), tenantID)
+	})
+}
+
+// Upsert writes one invoker spend limit (payer-set) under the same serialized
+// transaction boundary used by Replace.
+func (s *InvokerSpendLimitStore) Upsert(ctx context.Context, payer identity.CustomerID, p InvokerSpendLimit) error {
+	return s.withPayerWriteTx(ctx, payer, func(ctx context.Context, txStore *InvokerSpendLimitStore, tenantID uuid.UUID) error {
+		return txStore.upsert(ctx, tenantID, payer, p)
+	})
+}
+
+func (s *InvokerSpendLimitStore) upsert(ctx context.Context, tenantID uuid.UUID, payer identity.CustomerID, p InvokerSpendLimit) error {
 	now := time.Now().UTC()
 	windowsJSON, err := json.Marshal(p.Windows)
 	if err != nil {
 		return fmt.Errorf("admission: encode invoker spend-limit windows: %w", err)
 	}
-	return s.db.RunInMerchantConn(ctx, func(ctx context.Context) error {
-		if _, err := db.EnsureCustomerID(ctx, s.db.Qx(ctx), tenantID, payer.UUID().String()); err != nil {
-			return err
-		}
-		return s.db.Gen(ctx).UpsertInvokerSpendLimit(ctx, gen.UpsertInvokerSpendLimitParams{
-			ID:            uuidutil.NewV7(),
-			MerchantID:    tenantID,
-			CustomerID:    payer.UUID(),
-			Scope:         budgets.NormalizeScope(p.Scope), // #491: store canonical invoker
-			ScopeKey:      p.ScopeKey,
-			Windows:       windowsJSON,
-			PolicyVersion: 1,
-			CreatedAt:     now,
-			UpdatedAt:     now,
-		})
+	return s.db.Gen(ctx).UpsertInvokerSpendLimit(ctx, gen.UpsertInvokerSpendLimitParams{
+		ID:            uuidutil.NewV7(),
+		MerchantID:    tenantID,
+		CustomerID:    payer.UUID(),
+		Scope:         budgets.NormalizeScope(p.Scope), // #491: store canonical invoker
+		ScopeKey:      p.ScopeKey,
+		Windows:       windowsJSON,
+		PolicyVersion: 1,
+		CreatedAt:     now,
+		UpdatedAt:     now,
 	})
 }
 
 // Delete removes one invoker spend limit.
 func (s *InvokerSpendLimitStore) Delete(ctx context.Context, payer identity.CustomerID, scope, scopeKey string) error {
-	tid, terr := merchant.Require(ctx) // #336/#474: no default merchant
-	if terr != nil {
-		return terr
-	}
-	tenantID := tid.UUID()
-	return s.db.RunInMerchantConn(ctx, func(ctx context.Context) error {
-		_, err := s.db.Gen(ctx).DeleteInvokerSpendLimit(ctx, gen.DeleteInvokerSpendLimitParams{
-			MerchantID: tenantID, CustomerID: payer.UUID(),
-			Scope: budgets.NormalizeScope(scope), ScopeKey: scopeKey,
-		})
-		return err
+	return s.withPayerWriteTx(ctx, payer, func(ctx context.Context, txStore *InvokerSpendLimitStore, tenantID uuid.UUID) error {
+		return txStore.delete(ctx, tenantID, payer, scope, scopeKey)
+	})
+}
+
+func (s *InvokerSpendLimitStore) delete(ctx context.Context, tenantID uuid.UUID, payer identity.CustomerID, scope, scopeKey string) error {
+	_, err := s.db.Gen(ctx).DeleteInvokerSpendLimit(ctx, gen.DeleteInvokerSpendLimitParams{
+		MerchantID: tenantID, CustomerID: payer.UUID(),
+		Scope: budgets.NormalizeScope(scope), ScopeKey: strings.TrimSpace(scopeKey),
+	})
+	return err
+}
+
+// Replace atomically replaces the complete payer-owned policy document. Any
+// failed delete/upsert rolls the transaction back to the prior document.
+func (s *InvokerSpendLimitStore) Replace(ctx context.Context, payer identity.CustomerID, next []InvokerSpendLimit) error {
+	return s.withPayerWriteTx(ctx, payer, func(ctx context.Context, txStore *InvokerSpendLimitStore, tenantID uuid.UUID) error {
+		existing, err := txStore.loadAll(ctx, tenantID, payer)
+		if err != nil {
+			return err
+		}
+		wanted := make(map[string]struct{}, len(next))
+		for _, row := range next {
+			wanted[budgets.NormalizeScope(row.Scope)+"\x00"+strings.TrimSpace(row.ScopeKey)] = struct{}{}
+		}
+		for _, row := range existing {
+			key := budgets.NormalizeScope(row.Scope) + "\x00" + strings.TrimSpace(row.ScopeKey)
+			if _, keep := wanted[key]; keep {
+				continue
+			}
+			if err := txStore.delete(ctx, tenantID, payer, row.Scope, row.ScopeKey); err != nil {
+				return err
+			}
+		}
+		for _, row := range next {
+			if err := txStore.upsert(ctx, tenantID, payer, row); err != nil {
+				return err
+			}
+		}
+		return nil
 	})
 }
 

--- a/pkg/service/admission.go
+++ b/pkg/service/admission.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -12,6 +14,7 @@ import (
 	"github.com/open-rails/openrails/internal/modules/abuse"
 	"github.com/open-rails/openrails/internal/modules/admission"
 	"github.com/open-rails/openrails/internal/modules/admission/spendgate"
+	"github.com/open-rails/openrails/internal/modules/budgets"
 	"github.com/open-rails/openrails/internal/modules/merchantconfig"
 	"github.com/open-rails/openrails/internal/modules/money"
 	"github.com/open-rails/openrails/internal/modules/ratelimit"
@@ -182,7 +185,22 @@ type SpendLimitWindowInput struct {
 type InvokerSpendLimitInput struct {
 	Scope    string                  `json:"scope"`
 	ScopeKey string                  `json:"scope_key,omitempty"`
+	RoleID   string                  `json:"role_id,omitempty"`
 	Windows  []SpendLimitWindowInput `json:"windows"`
+}
+
+// ErrInvalidInvokerSpendLimit identifies caller-owned spend-delegation input
+// errors so HTTP and embedded transports can map the shared service result to
+// the same 400/ErrInvalid contract.
+var ErrInvalidInvokerSpendLimit = errors.New("invalid invoker spend limit")
+
+type invokerSpendLimitValidationError struct{ message string }
+
+func (e *invokerSpendLimitValidationError) Error() string { return e.message }
+func (e *invokerSpendLimitValidationError) Unwrap() error { return ErrInvalidInvokerSpendLimit }
+
+func invalidInvokerSpendLimit(message string) error {
+	return &invokerSpendLimitValidationError{message: message}
 }
 
 func budgetScopeWindowModels(ws []SpendLimitWindowInput) []models.BudgetWindowPolicy {
@@ -191,6 +209,71 @@ func budgetScopeWindowModels(ws []SpendLimitWindowInput) []models.BudgetWindowPo
 		out = append(out, models.BudgetWindowPolicy{Key: w.Key, WindowSeconds: w.WindowSeconds, Limit: w.Limit, Currency: w.Currency})
 	}
 	return out
+}
+
+func spendLimitWindowInputs(ws []models.BudgetWindowPolicy) []SpendLimitWindowInput {
+	out := make([]SpendLimitWindowInput, 0, len(ws))
+	for _, w := range ws {
+		out = append(out, SpendLimitWindowInput{
+			Key: w.Key, WindowSeconds: w.WindowSeconds, Limit: w.Limit, Currency: w.Currency,
+		})
+	}
+	return out
+}
+
+func invokerSpendLimitKey(scope, scopeKey string) string {
+	return budgets.NormalizeScope(scope) + "\x00" + strings.TrimSpace(scopeKey)
+}
+
+// ValidateInvokerSpendLimitInputs validates and canonicalizes a complete
+// payer-owned spend-delegation document. Duplicate detection happens after
+// scope, scope_key, and role_id aliases are normalized, so every transport has
+// identical replacement semantics.
+func ValidateInvokerSpendLimitInputs(in []InvokerSpendLimitInput) ([]InvokerSpendLimitInput, error) {
+	out := make([]InvokerSpendLimitInput, 0, len(in))
+	seen := make(map[string]struct{}, len(in))
+	for i, item := range in {
+		scope := budgets.NormalizeScope(item.Scope)
+		scopeKey := strings.TrimSpace(item.ScopeKey)
+		roleID := strings.TrimSpace(item.RoleID)
+		if roleID != "" && scope != budgets.ScopeRole {
+			return nil, invalidInvokerSpendLimit(fmt.Sprintf("delegations[%d].role_id is only allowed for scope %q", i, budgets.ScopeRole))
+		}
+		if scopeKey != "" && roleID != "" && scopeKey != roleID {
+			return nil, invalidInvokerSpendLimit(fmt.Sprintf("delegations[%d].role_id must match scope_key", i))
+		}
+		if scopeKey == "" {
+			scopeKey = roleID
+		}
+		row, err := admission.ValidateInvokerSpendLimit(admission.InvokerSpendLimit{
+			Scope: scope, ScopeKey: scopeKey, Windows: budgetScopeWindowModels(item.Windows),
+		})
+		if err != nil {
+			return nil, invalidInvokerSpendLimit(fmt.Sprintf("delegations[%d].%s", i, err))
+		}
+		key := invokerSpendLimitKey(row.Scope, row.ScopeKey)
+		if _, duplicate := seen[key]; duplicate {
+			return nil, invalidInvokerSpendLimit(fmt.Sprintf("duplicate delegation for %s", key))
+		}
+		seen[key] = struct{}{}
+		normalized := InvokerSpendLimitInput{
+			Scope: row.Scope, ScopeKey: row.ScopeKey, Windows: spendLimitWindowInputs(row.Windows),
+		}
+		if row.Scope == budgets.ScopeRole {
+			normalized.RoleID = row.ScopeKey
+		}
+		out = append(out, normalized)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return invokerSpendLimitKey(out[i].Scope, out[i].ScopeKey) < invokerSpendLimitKey(out[j].Scope, out[j].ScopeKey)
+	})
+	return out, nil
+}
+
+func invokerSpendLimitRow(in InvokerSpendLimitInput) admission.InvokerSpendLimit {
+	return admission.InvokerSpendLimit{
+		Scope: in.Scope, ScopeKey: in.ScopeKey, Windows: budgetScopeWindowModels(in.Windows),
+	}
 }
 
 // SetInvokerSpendLimits upserts a SUBJECT-owned budget-scope policy (#473): the
@@ -203,14 +286,11 @@ func (s *Service) SetInvokerSpendLimits(ctx context.Context, payer identity.Cust
 	if payer.IsZero() {
 		return fmt.Errorf("payer required")
 	}
-	row, err := admission.ValidateInvokerSpendLimit(admission.InvokerSpendLimit{
-		Scope: in.Scope, ScopeKey: in.ScopeKey,
-		Windows: budgetScopeWindowModels(in.Windows),
-	})
+	next, err := ValidateInvokerSpendLimitInputs([]InvokerSpendLimitInput{in})
 	if err != nil {
 		return err
 	}
-	return admission.NewInvokerSpendLimitStore(s.rt.DB).Upsert(ctx, payer, row)
+	return admission.NewInvokerSpendLimitStore(s.rt.DB).Upsert(ctx, payer, invokerSpendLimitRow(next[0]))
 }
 
 // InvokerSpendLimits returns the payer's per-invoker spend limits (#473/#517).
@@ -245,37 +325,15 @@ func (s *Service) ReplaceInvokerSpendLimits(ctx context.Context, payer identity.
 	if payer.IsZero() {
 		return fmt.Errorf("payer required")
 	}
-	store := admission.NewInvokerSpendLimitStore(s.rt.DB)
-	existing, err := store.LoadAll(ctx, payer)
+	normalized, err := ValidateInvokerSpendLimitInputs(next)
 	if err != nil {
 		return err
 	}
-	wanted := make(map[string]admission.InvokerSpendLimit, len(next))
-	for _, in := range next {
-		row, err := admission.ValidateInvokerSpendLimit(admission.InvokerSpendLimit{
-			Scope:    in.Scope,
-			ScopeKey: strings.TrimSpace(in.ScopeKey),
-			Windows:  budgetScopeWindowModels(in.Windows),
-		})
-		if err != nil {
-			return err
-		}
-		wanted[row.Scope+"\x00"+row.ScopeKey] = row
+	rows := make([]admission.InvokerSpendLimit, 0, len(normalized))
+	for _, in := range normalized {
+		rows = append(rows, invokerSpendLimitRow(in))
 	}
-	for _, row := range existing {
-		if _, keep := wanted[row.Scope+"\x00"+row.ScopeKey]; keep {
-			continue
-		}
-		if err := store.Delete(ctx, payer, row.Scope, row.ScopeKey); err != nil {
-			return err
-		}
-	}
-	for _, row := range wanted {
-		if err := store.Upsert(ctx, payer, row); err != nil {
-			return err
-		}
-	}
-	return nil
+	return admission.NewInvokerSpendLimitStore(s.rt.DB).Replace(ctx, payer, rows)
 }
 
 // TrustLevelBudgetWindowInput / PayerSpendLimitInput configure a trust level's

--- a/pkg/service/admission_validation_test.go
+++ b/pkg/service/admission_validation_test.go
@@ -1,0 +1,36 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateInvokerSpendLimitInputsRejectsNormalizedDuplicates(t *testing.T) {
+	roleID := "22222222-2222-2222-2222-222222222222"
+	windows := []SpendLimitWindowInput{{Key: "day", WindowSeconds: 86400, Limit: 1000}}
+
+	_, err := ValidateInvokerSpendLimitInputs([]InvokerSpendLimitInput{
+		{Scope: " role ", RoleID: " " + roleID + " ", Windows: windows},
+		{Scope: "role", ScopeKey: roleID, Windows: windows},
+	})
+
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrInvalidInvokerSpendLimit))
+	require.Contains(t, err.Error(), "duplicate delegation for role\x00"+roleID)
+}
+
+func TestValidateInvokerSpendLimitInputsCanonicalizesRoleAliases(t *testing.T) {
+	roleID := "22222222-2222-2222-2222-222222222222"
+	next, err := ValidateInvokerSpendLimitInputs([]InvokerSpendLimitInput{{
+		Scope: " role ", ScopeKey: " " + roleID + " ", RoleID: roleID,
+		Windows: []SpendLimitWindowInput{{Key: " day ", WindowSeconds: 86400, Limit: 1000, Currency: " usd "}},
+	}})
+
+	require.NoError(t, err)
+	require.Equal(t, []InvokerSpendLimitInput{{
+		Scope: "role", ScopeKey: roleID, RoleID: roleID,
+		Windows: []SpendLimitWindowInput{{Key: "day", WindowSeconds: 86400, Limit: 1000, Currency: "USD"}},
+	}}, next)
+}

--- a/remote.go
+++ b/remote.go
@@ -423,13 +423,14 @@ func (c *remote) SetMerchantSettings(ctx context.Context, settings MerchantSetti
 	return c.do(ctx, http.MethodPut, "/v1/merchant/settings", settings, nil)
 }
 
-// SetCustomerSpendDelegations implements PolicySyncClient over the customer
-// treasury surface (#567 — mounted on /v1/customers).
+// SetCustomerSpendDelegations implements PolicySyncClient over the
+// machine-authenticated merchant surface. The /v1/customers counterpart is
+// reserved for a customer-owned delegated browser principal.
 func (c *remote) SetCustomerSpendDelegations(ctx context.Context, customerID string, delegations []SpendDelegationInput) error {
 	if strings.TrimSpace(customerID) == "" {
 		return invalidErr("customer_id required")
 	}
-	path := "/v1/customers/" + url.PathEscape(strings.TrimSpace(customerID)) + "/spend-delegations"
+	path := "/v1/merchant/customers/" + url.PathEscape(strings.TrimSpace(customerID)) + "/spend-delegations"
 	return c.do(ctx, http.MethodPut, path, map[string]any{"delegations": delegations}, nil)
 }
 
@@ -438,7 +439,7 @@ func (c *remote) SetCustomerSpendDelegation(ctx context.Context, customerID stri
 	if strings.TrimSpace(customerID) == "" {
 		return invalidErr("customer_id required")
 	}
-	path := "/v1/customers/" + url.PathEscape(strings.TrimSpace(customerID)) + "/spend-delegations:upsert"
+	path := "/v1/merchant/customers/" + url.PathEscape(strings.TrimSpace(customerID)) + "/spend-delegations:upsert"
 	return c.do(ctx, http.MethodPut, path, delegation, nil)
 }
 

--- a/remote_test.go
+++ b/remote_test.go
@@ -83,7 +83,7 @@ func TestRemoteSetCustomerSpendDelegation(t *testing.T) {
 		if r.Method != http.MethodPut {
 			t.Errorf("method = %s, want PUT", r.Method)
 		}
-		if r.URL.Path != "/v1/customers/customer-1/spend-delegations:upsert" {
+		if r.URL.Path != "/v1/merchant/customers/customer-1/spend-delegations:upsert" {
 			t.Errorf("path = %s", r.URL.Path)
 		}
 		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
@@ -105,6 +105,38 @@ func TestRemoteSetCustomerSpendDelegation(t *testing.T) {
 		t.Fatalf("SetCustomerSpendDelegation: %v", err)
 	}
 	if got["scope"] != "invoker" || got["scope_key"] != "issuer:subject:digest:entitlement" {
+		t.Fatalf("unexpected body: %#v", got)
+	}
+}
+
+func TestRemoteSetCustomerSpendDelegationsUsesMerchantMachineRoute(t *testing.T) {
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("method = %s, want PUT", r.Method)
+		}
+		if r.URL.Path != "/v1/merchant/customers/customer-1/spend-delegations" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	client := NewRemote(srv.URL, WithTokenProvider(func(context.Context) (string, error) {
+		return "test-token", nil
+	}))
+	err := client.SetCustomerSpendDelegations(context.Background(), " customer-1 ", []SpendDelegationInput{{
+		Scope: "invoker", ScopeKey: "invoker-1",
+		Windows: []SpendLimitWindow{{Key: "month", WindowSeconds: 2592000, Limit: 42, Currency: "USD"}},
+	}})
+	if err != nil {
+		t.Fatalf("SetCustomerSpendDelegations: %v", err)
+	}
+	if rows, ok := got["delegations"].([]any); !ok || len(rows) != 1 {
 		t.Fatalf("unexpected body: %#v", got)
 	}
 }

--- a/tests/customer_treasury_spend_delegations_test.go
+++ b/tests/customer_treasury_spend_delegations_test.go
@@ -150,6 +150,63 @@ EXECUTE FUNCTION openrails.%s()`, functionName, triggerName, failingKey, functio
 		"failed replacement must roll back deletes and upserts")
 }
 
+func TestReplaceInvokerSpendLimitsPurgesLegacyPaddedScopeKeys(t *testing.T) {
+	suite := setupTestSuite(t)
+	ctx := dbtest.WithTestMerchant(context.Background())
+	payerID := suite.ensureCustomer(ctx, uuid.NewString())
+	payer := identity.CustomerID(payerID)
+	svc, err := billingservice.New(suite.App.Runtime)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = suite.Pool.Exec(ctx, "DELETE FROM openrails.invoker_spend_limits WHERE customer_id = $1", payerID)
+	})
+
+	canonical := billingservice.InvokerSpendLimitInput{
+		Scope: "invoker_tier", ScopeKey: "gold",
+		Windows: []billingservice.SpendLimitWindowInput{{Key: "day", WindowSeconds: 86400, Limit: 222}},
+	}
+	require.NoError(t, svc.SetInvokerSpendLimits(ctx, payer, canonical))
+	tag, err := suite.Pool.Exec(ctx, `
+UPDATE openrails.invoker_spend_limits
+SET scope_key = 'gold '
+WHERE merchant_id = $1 AND customer_id = $2
+  AND scope = 'invoker_tier' AND scope_key = 'gold'`, dbtest.TestMerchantID.UUID(), payerID)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, tag.RowsAffected())
+
+	loadScopeKeys := func() []string {
+		rows, err := suite.Pool.Query(ctx, `
+SELECT scope_key
+FROM openrails.invoker_spend_limits
+WHERE merchant_id = $1 AND customer_id = $2
+ORDER BY scope_key`, dbtest.TestMerchantID.UUID(), payerID)
+		require.NoError(t, err)
+		defer rows.Close()
+		var keys []string
+		for rows.Next() {
+			var key string
+			require.NoError(t, rows.Scan(&key))
+			keys = append(keys, key)
+		}
+		require.NoError(t, rows.Err())
+		return keys
+	}
+
+	require.Equal(t, []string{"gold "}, loadScopeKeys(), "fixture must contain the padded legacy key")
+	require.NoError(t, svc.ReplaceInvokerSpendLimits(ctx, payer, []billingservice.InvokerSpendLimitInput{canonical}))
+	require.Equal(t, []string{"gold"}, loadScopeKeys(), "canonical replacement must leave exactly its requested set")
+
+	tag, err = suite.Pool.Exec(ctx, `
+UPDATE openrails.invoker_spend_limits
+SET scope_key = 'gold '
+WHERE merchant_id = $1 AND customer_id = $2
+  AND scope = 'invoker_tier' AND scope_key = 'gold'`, dbtest.TestMerchantID.UUID(), payerID)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, tag.RowsAffected())
+	require.NoError(t, svc.ReplaceInvokerSpendLimits(ctx, payer, nil))
+	require.Empty(t, loadScopeKeys(), "empty replacement must revoke padded legacy rows")
+}
+
 func TestReplaceAndSetInvokerSpendLimitsSerialize(t *testing.T) {
 	suite := setupTestSuite(t)
 	ctx := dbtest.WithTestMerchant(context.Background())

--- a/tests/customer_treasury_spend_delegations_test.go
+++ b/tests/customer_treasury_spend_delegations_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	openrails "github.com/open-rails/openrails"
 	"github.com/open-rails/openrails/internal/controlplane"
 	"github.com/open-rails/openrails/internal/dbtest"
 	"github.com/open-rails/openrails/internal/http/middleware"
@@ -23,6 +24,62 @@ import (
 	"github.com/open-rails/openrails/pkg/identity"
 	billingservice "github.com/open-rails/openrails/pkg/service"
 )
+
+func TestMerchantServiceJWTSpendDelegationRemoteClient(t *testing.T) {
+	suite := setupTestSuite(t)
+	ctx := dbtest.WithTestMerchant(context.Background())
+	payerID := suite.ensureCustomer(ctx, uuid.NewString())
+	payer := identity.CustomerID(payerID)
+	_, err := suite.Pool.Exec(ctx, "DELETE FROM openrails.invoker_spend_limits WHERE customer_id = $1", payerID)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = suite.Pool.Exec(ctx, "DELETE FROM openrails.invoker_spend_limits WHERE customer_id = $1", payerID)
+	})
+
+	mux := http.NewServeMux()
+	resolver := stubServiceCredentialResolver{
+		serviceJWT: true,
+		permissions: []string{
+			controlplane.PermMerchantCustomerSettingsUpdate,
+		},
+	}
+	httproutes.RegisterServiceRoutes(
+		httprouter.NewMux(mux, "/v1/merchant", suite.App.Runtime),
+		suite.App.Runtime,
+		httproutes.Options{Gate: httproutes.NewGate(httproutes.GateOptions{ServiceCredentialResolver: resolver})},
+	)
+	router := middleware.ChainHTTP(mux, middleware.ResolveMerchantHTTP(middleware.StaticMerchant(dbtest.TestMerchantID)))
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+	client := openrails.NewRemote(srv.URL, openrails.WithTokenProvider(func(context.Context) (string, error) {
+		return "eyJ.service.jwt", nil
+	}))
+
+	first := openrails.SpendDelegationInput{
+		Scope: "invoker", ScopeKey: "document-bound-invoker",
+		Windows: []openrails.SpendLimitWindow{{Key: "day", WindowSeconds: 86400, Limit: 1000, Currency: "USD"}},
+	}
+	second := openrails.SpendDelegationInput{
+		Scope: "role", ScopeKey: uuid.NewString(),
+		Windows: []openrails.SpendLimitWindow{{Key: "week", WindowSeconds: 604800, Limit: 9000, Currency: "USD"}},
+	}
+	require.NoError(t, client.SetCustomerSpendDelegation(ctx, payerID.String(), first))
+	require.NoError(t, client.SetCustomerSpendDelegation(ctx, payerID.String(), second))
+	first.Windows[0].Limit = 321
+	require.NoError(t, client.SetCustomerSpendDelegation(ctx, payerID.String(), first))
+
+	svc, err := billingservice.New(suite.App.Runtime)
+	require.NoError(t, err)
+	stored, err := svc.InvokerSpendLimits(ctx, payer)
+	require.NoError(t, err)
+	require.Len(t, stored, 2, "singular machine upsert must preserve sibling grants")
+
+	require.NoError(t, client.SetCustomerSpendDelegations(ctx, payerID.String(), []openrails.SpendDelegationInput{second}))
+	stored, err = svc.InvokerSpendLimits(ctx, payer)
+	require.NoError(t, err)
+	require.Len(t, stored, 1, "full replacement must remove omitted grants")
+	require.Equal(t, "role", stored[0].Scope)
+}
 
 func TestCustomerTreasurySpendDelegationsHTTPFullReplacement(t *testing.T) {
 	suite := setupTestSuite(t)

--- a/tests/customer_treasury_spend_delegations_test.go
+++ b/tests/customer_treasury_spend_delegations_test.go
@@ -6,10 +6,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -79,6 +82,148 @@ func TestMerchantServiceJWTSpendDelegationRemoteClient(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, stored, 1, "full replacement must remove omitted grants")
 	require.Equal(t, "role", stored[0].Scope)
+
+	err = client.SetCustomerSpendDelegations(ctx, payerID.String(), []openrails.SpendDelegationInput{
+		{
+			Scope: " role ", RoleID: " " + second.ScopeKey + " ", Windows: second.Windows,
+		},
+		second,
+	})
+	require.ErrorIs(t, err, openrails.ErrInvalid)
+	var remoteStatus *openrails.StatusError
+	require.ErrorAs(t, err, &remoteStatus)
+	require.Equal(t, http.StatusBadRequest, remoteStatus.Status)
+	require.Contains(t, err.Error(), "duplicate delegation for role")
+	stored, err = svc.InvokerSpendLimits(ctx, payer)
+	require.NoError(t, err)
+	require.Len(t, stored, 1, "rejected remote duplicate document must not mutate policy")
+}
+
+func TestReplaceInvokerSpendLimitsRollsBackOnWriteFailure(t *testing.T) {
+	suite := setupTestSuite(t)
+	ctx := dbtest.WithTestMerchant(context.Background())
+	payerID := suite.ensureCustomer(ctx, uuid.NewString())
+	payer := identity.CustomerID(payerID)
+	svc, err := billingservice.New(suite.App.Runtime)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = suite.Pool.Exec(ctx, "DELETE FROM openrails.invoker_spend_limits WHERE customer_id = $1", payerID)
+	})
+
+	original := billingservice.InvokerSpendLimitInput{
+		Scope: "invoker", ScopeKey: "rollback-original",
+		Windows: []billingservice.SpendLimitWindowInput{{Key: "day", WindowSeconds: 86400, Limit: 111}},
+	}
+	require.NoError(t, svc.SetInvokerSpendLimits(ctx, payer, original))
+
+	failingKey := "rollback-failure-" + uuid.NewString()
+	suffix := strings.Split(uuid.NewString(), "-")[0]
+	functionName := "fail_invoker_spend_" + suffix
+	triggerName := "fail_invoker_spend_" + suffix
+	_, err = suite.Pool.Exec(ctx, fmt.Sprintf(`
+CREATE FUNCTION openrails.%s() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE EXCEPTION 'injected invoker spend-limit write failure';
+END
+$$;
+CREATE TRIGGER %s
+BEFORE INSERT OR UPDATE ON openrails.invoker_spend_limits
+FOR EACH ROW WHEN (NEW.scope_key = '%s')
+EXECUTE FUNCTION openrails.%s()`, functionName, triggerName, failingKey, functionName))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = suite.Pool.Exec(context.Background(), fmt.Sprintf(
+			"DROP TRIGGER IF EXISTS %s ON openrails.invoker_spend_limits; DROP FUNCTION IF EXISTS openrails.%s()",
+			triggerName, functionName,
+		))
+	})
+
+	err = svc.ReplaceInvokerSpendLimits(ctx, payer, []billingservice.InvokerSpendLimitInput{{
+		Scope: "invoker", ScopeKey: failingKey,
+		Windows: []billingservice.SpendLimitWindowInput{{Key: "day", WindowSeconds: 86400, Limit: 999}},
+	}})
+	require.ErrorContains(t, err, "injected invoker spend-limit write failure")
+
+	stored, err := svc.InvokerSpendLimits(ctx, payer)
+	require.NoError(t, err)
+	require.Equal(t, []billingservice.InvokerSpendLimitInput{original}, stored,
+		"failed replacement must roll back deletes and upserts")
+}
+
+func TestReplaceAndSetInvokerSpendLimitsSerialize(t *testing.T) {
+	suite := setupTestSuite(t)
+	ctx := dbtest.WithTestMerchant(context.Background())
+	payerID := suite.ensureCustomer(ctx, uuid.NewString())
+	payer := identity.CustomerID(payerID)
+	svc, err := billingservice.New(suite.App.Runtime)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = suite.Pool.Exec(ctx, "DELETE FROM openrails.invoker_spend_limits WHERE customer_id = $1", payerID)
+	})
+
+	blocker, err := suite.Pool.Acquire(ctx)
+	require.NoError(t, err)
+	tx, err := blocker.Begin(ctx)
+	require.NoError(t, err)
+	released := false
+	t.Cleanup(func() {
+		if !released {
+			_ = tx.Rollback(context.Background())
+			blocker.Release()
+		}
+	})
+	lockKey := dbtest.TestMerchantID.String() + ":" + payerID.String()
+	_, err = tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, lockKey)
+	require.NoError(t, err)
+
+	replacement := billingservice.InvokerSpendLimitInput{
+		Scope: "role", ScopeKey: uuid.NewString(),
+		Windows: []billingservice.SpendLimitWindowInput{{Key: "week", WindowSeconds: 604800, Limit: 700}},
+	}
+	singular := billingservice.InvokerSpendLimitInput{
+		Scope: "invoker", ScopeKey: "serialized-upsert",
+		Windows: []billingservice.SpendLimitWindowInput{{Key: "day", WindowSeconds: 86400, Limit: 300}},
+	}
+	replaceDone := make(chan error, 1)
+	go func() {
+		replaceDone <- svc.ReplaceInvokerSpendLimits(ctx, payer, []billingservice.InvokerSpendLimitInput{replacement})
+	}()
+
+	waiters := func(want int) bool {
+		var got int
+		err := suite.Pool.QueryRow(ctx, `
+SELECT count(*)
+FROM pg_stat_activity
+WHERE datname = current_database()
+  AND wait_event_type = 'Lock'
+  AND query LIKE '%pg_advisory_xact_lock(hashtextextended%'`).Scan(&got)
+		return err == nil && got >= want
+	}
+	require.Eventually(t, func() bool { return waiters(1) }, 5*time.Second, 20*time.Millisecond,
+		"replacement must wait on the payer-scoped write lock")
+
+	upsertDone := make(chan error, 1)
+	go func() {
+		upsertDone <- svc.SetInvokerSpendLimits(ctx, payer, singular)
+	}()
+	require.Eventually(t, func() bool { return waiters(2) }, 5*time.Second, 20*time.Millisecond,
+		"singular upsert must queue behind replacement on the same lock")
+
+	require.NoError(t, tx.Commit(ctx))
+	blocker.Release()
+	released = true
+	require.NoError(t, <-replaceDone)
+	require.NoError(t, <-upsertDone)
+
+	stored, err := svc.InvokerSpendLimits(ctx, payer)
+	require.NoError(t, err)
+	require.Len(t, stored, 2, "queued replace then upsert must commit in that serial order")
+	limits := map[string]int64{}
+	for _, row := range stored {
+		limits[row.Scope+"\x00"+row.ScopeKey] = row.Windows[0].Limit
+	}
+	require.EqualValues(t, 700, limits["role\x00"+replacement.ScopeKey])
+	require.EqualValues(t, 300, limits["invoker\x00"+singular.ScopeKey])
 }
 
 func TestCustomerTreasurySpendDelegationsHTTPFullReplacement(t *testing.T) {


### PR DESCRIPTION
## Summary
- add merchant-service replace and singular-upsert routes for payer spend delegations
- move the remote unified client off the browser/customer-only treasury route
- preserve embedded direct-service behavior and prove service-JWT transport parity
- make full-document replacement atomic and serialize it with singular updates per merchant + payer
- canonicalize and reject duplicate policy entries identically across HTTP, remote SDK, and embedded calls

## Security boundary
The machine route is gated by `merchant:customer-settings:update`, pins the authenticated merchant, and keeps singular upserts isolated from sibling grants. `/v1/customers/*` remains customer-owned delegated-browser auth only. OpenRails receives generic spend-delegation records; it has no AuthKit- or Cozy-specific policy knowledge.

## Correctness
Replacement validates before mutation, then deletes the exact merchant+payer set and inserts only the canonical requested document inside one merchant-scoped transaction. It shares a transaction-scoped payer lock with singular upserts. A failed write rolls the complete replacement back. Tests cover concurrency, rollback, normalized duplicates, remote/embedded parity, and revocation of legacy padded scope keys.

## Validation
- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off task sqlc`
- full integration suite across all 45 tagged packages
- independent adversarial review and post-fix re-review
- `git diff --check`

Tracker: openrails #807