### PR TITLE
security: disable pnpmfile execution

### DIFF
--- a/web/admin/pnpm-workspace.yaml
+++ b/web/admin/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
 
 pmOnFail: error
 ignoreScripts: true
+ignorePnpmfile: true
 verifyDepsBeforeRun: error
 enablePrePostScripts: false
 dangerouslyAllowAllBuilds: false


### PR DESCRIPTION
Disables automatic .pnpmfile.mjs/.cjs execution during dependency installation. pnpm documents that ignoreScripts does not cover pnpmfile hooks. No dependency or lockfile changes.