### PR TITLE
security: quarantine pnpm dependency updates

### DIFF
--- a/web/admin/pnpm-workspace.yaml
+++ b/web/admin/pnpm-workspace.yaml
@@ -4,6 +4,14 @@ packages:
 pmOnFail: error
 ignoreScripts: true
 ignorePnpmfile: true
+strictDepBuilds: true
 verifyDepsBeforeRun: error
 enablePrePostScripts: false
 dangerouslyAllowAllBuilds: false
+
+minimumReleaseAge: 1440
+minimumReleaseAgeStrict: true
+minimumReleaseAgeIgnoreMissingTime: false
+trustPolicy: no-downgrade
+trustLockfile: false
+blockExoticSubdeps: true


### PR DESCRIPTION
## Summary\n\n- fail closed on unreviewed dependency build scripts\n- quarantine newly published packages for 24 hours and reject trust downgrades\n- revalidate lockfile entries and block exotic transitive dependency sources\n\n## Validation\n\n- parsed and asserted every policy value with pnpm 11\n- [ERR_PNPM_NO_PKG_MANIFEST] No package.json found in /home/fidika/cozy/.worktrees/pnpm-policy-openrails\n- no project lifecycle scripts or Vite code executed