### PR TITLE
feat(auth): support explicit merchant selection

### DIFF
--- a/internal/http/routes/merchant_selector_test.go
+++ b/internal/http/routes/merchant_selector_test.go
@@ -1,0 +1,211 @@
+package routes
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/open-rails/openrails/pkg/billingauth"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+const selectorTestUserID = "11111111-1111-1111-1111-111111111111"
+
+type merchantSelectorAuth struct {
+	merchant string
+}
+
+func (a merchantSelectorAuth) Authenticate(_ context.Context, _ *http.Request) (billingauth.UserContext, error) {
+	return billingauth.UserContext{UserID: selectorTestUserID, Merchant: a.merchant}, nil
+}
+
+type merchantSelectorChecker struct {
+	allowed       map[string]bool
+	merchantIDs   map[string]merchant.ID
+	inferred      string
+	inferErr      error
+	inferenceRuns int
+}
+
+func (c *merchantSelectorChecker) HasAdminPermission(_ context.Context, merchantRef, userID, _ string) (bool, error) {
+	return userID == selectorTestUserID && c.allowed[merchantRef], nil
+}
+
+func (c *merchantSelectorChecker) MerchantForUser(_ context.Context, userID string) (string, error) {
+	c.inferenceRuns++
+	if userID != selectorTestUserID {
+		return "", nil
+	}
+	return c.inferred, c.inferErr
+}
+
+func (c *merchantSelectorChecker) ResolveMerchantForGroup(_ context.Context, merchantRef string) (merchant.ID, string, error) {
+	id, ok := c.merchantIDs[merchantRef]
+	if !ok {
+		return merchant.ID{}, "", errors.New("merchant not found")
+	}
+	return id, merchantRef, nil
+}
+
+func TestMerchantSelector(t *testing.T) {
+	merchantA := merchant.ID(uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
+	merchantB := merchant.ID(uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
+
+	tests := []struct {
+		name              string
+		authMerchant      string
+		selector          string
+		allowed           map[string]bool
+		merchantIDs       map[string]merchant.ID
+		inferred          string
+		inferErr          error
+		wantMerchant      string
+		wantMerchantID    merchant.ID
+		wantMessage       string
+		wantInferenceRun  int
+		hostMerchantID    merchant.ID
+		contextMerchantID merchant.ID
+	}{
+		{
+			name:           "explicit selection",
+			selector:       " merchant-b ",
+			allowed:        map[string]bool{"merchant-b": true},
+			merchantIDs:    map[string]merchant.ID{"merchant-b": merchantB},
+			wantMerchant:   "merchant-b",
+			wantMerchantID: merchantB,
+		},
+		{
+			name:             "single merchant inference remains",
+			allowed:          map[string]bool{"merchant-a": true},
+			merchantIDs:      map[string]merchant.ID{"merchant-a": merchantA},
+			inferred:         "merchant-a",
+			wantMerchant:     "merchant-a",
+			wantMerchantID:   merchantA,
+			wantInferenceRun: 1,
+		},
+		{
+			name:             "ambiguous membership without selector",
+			allowed:          map[string]bool{},
+			merchantIDs:      map[string]merchant.ID{},
+			inferErr:         errors.New("multiple merchant memberships"),
+			wantMessage:      "merchant_unresolved",
+			wantInferenceRun: 1,
+		},
+		{
+			name:        "selected merchant requires live permission",
+			selector:    "merchant-b",
+			allowed:     map[string]bool{},
+			merchantIDs: map[string]merchant.ID{"merchant-b": merchantB},
+			wantMessage: "permission_required",
+		},
+		{
+			name:        "selected merchant must resolve active",
+			selector:    "merchant-b",
+			allowed:     map[string]bool{"merchant-b": true},
+			merchantIDs: map[string]merchant.ID{},
+			wantMessage: "merchant_unresolved",
+		},
+		{
+			name:           "authenticated merchant cannot be overridden",
+			authMerchant:   "merchant-a",
+			selector:       "merchant-b",
+			allowed:        map[string]bool{"merchant-a": true, "merchant-b": true},
+			merchantIDs:    map[string]merchant.ID{"merchant-a": merchantA, "merchant-b": merchantB},
+			wantMerchant:   "merchant-a",
+			wantMerchantID: merchantA,
+		},
+		{
+			name:           "selected merchant must match host",
+			selector:       "merchant-a",
+			allowed:        map[string]bool{"merchant-a": true},
+			merchantIDs:    map[string]merchant.ID{"merchant-a": merchantA},
+			hostMerchantID: merchantB,
+			wantMessage:    "host_merchant_mismatch",
+		},
+		{
+			name:              "selected merchant must match existing context",
+			selector:          "merchant-a",
+			allowed:           map[string]bool{"merchant-a": true},
+			merchantIDs:       map[string]merchant.ID{"merchant-a": merchantA},
+			contextMerchantID: merchantB,
+			wantMessage:       "merchant_context_mismatch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			checker := &merchantSelectorChecker{
+				allowed:     tt.allowed,
+				merchantIDs: tt.merchantIDs,
+				inferred:    tt.inferred,
+				inferErr:    tt.inferErr,
+			}
+			gate := NewGate(GateOptions{
+				Authenticator:          merchantSelectorAuth{merchant: tt.authMerchant},
+				AdminPermissionChecker: checker,
+			})
+			req, err := http.NewRequest(http.MethodGet, "/v1/merchant/settings", nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			if tt.selector != "" {
+				req.Header.Set(billingauth.MerchantSelectorHeader, tt.selector)
+			}
+
+			ctx := t.Context()
+			if tt.contextMerchantID != (merchant.ID{}) {
+				ctx = merchant.WithID(ctx, tt.contextMerchantID)
+			}
+			if tt.hostMerchantID != (merchant.ID{}) {
+				ctx = merchant.WithHostMerchant(ctx, tt.hostMerchantID)
+			}
+			principal, err := gate.Authorize(ctx, req, "merchant:settings:read")
+			if tt.wantMessage != "" {
+				var gateErr billingauth.GateError
+				if !errors.As(err, &gateErr) {
+					t.Fatalf("Authorize() error = %v, want GateError %q", err, tt.wantMessage)
+				}
+				if gateErr.Status != http.StatusForbidden || gateErr.Message != tt.wantMessage {
+					t.Fatalf("Authorize() GateError = (%d, %q), want (403, %q)", gateErr.Status, gateErr.Message, tt.wantMessage)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Authorize(): %v", err)
+				}
+				if principal.UserContext.Merchant != tt.wantMerchant {
+					t.Fatalf("Authorize() merchant = %q, want %q", principal.UserContext.Merchant, tt.wantMerchant)
+				}
+				if principal.MerchantID != tt.wantMerchantID {
+					t.Fatalf("Authorize() merchant ID = %s, want %s", principal.MerchantID, tt.wantMerchantID)
+				}
+			}
+			if checker.inferenceRuns != tt.wantInferenceRun {
+				t.Fatalf("MerchantForUser() calls = %d, want %d", checker.inferenceRuns, tt.wantInferenceRun)
+			}
+		})
+	}
+}
+
+func TestMerchantSelectorNilRequestUsesMembershipInference(t *testing.T) {
+	merchantA := merchant.ID(uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
+	checker := &merchantSelectorChecker{
+		allowed:     map[string]bool{"merchant-a": true},
+		merchantIDs: map[string]merchant.ID{"merchant-a": merchantA},
+		inferred:    "merchant-a",
+	}
+	gate := NewGate(GateOptions{
+		Authenticator:          merchantSelectorAuth{},
+		AdminPermissionChecker: checker,
+	})
+
+	principal, err := gate.Authorize(t.Context(), nil, "merchant:settings:read")
+	if err != nil {
+		t.Fatalf("Authorize(): %v", err)
+	}
+	if principal.MerchantID != merchantA || principal.UserContext.Merchant != "merchant-a" {
+		t.Fatalf("Authorize() principal = %+v, want inferred merchant-a", principal)
+	}
+}

--- a/internal/http/routes/routes.go
+++ b/internal/http/routes/routes.go
@@ -452,15 +452,20 @@ func (g legacyGate) Authorize(ctx context.Context, req *http.Request, perm strin
 		return billingauth.Principal{}, billingauth.GateError{Status: http.StatusInternalServerError, Message: "authorization unavailable"}
 	}
 	if strings.TrimSpace(uc.Merchant) == "" {
-		resolver, ok := g.AdminPermissionChecker.(merchantUserResolver)
-		if !ok {
-			return billingauth.Principal{}, billingauth.GateError{Status: http.StatusInternalServerError, Message: "merchant resolver unavailable"}
+		if req != nil {
+			uc.Merchant = strings.TrimSpace(req.Header.Get(billingauth.MerchantSelectorHeader))
 		}
-		ref, rerr := resolver.MerchantForUser(ctx, uc.UserID)
-		if rerr != nil || strings.TrimSpace(ref) == "" {
-			return billingauth.Principal{}, billingauth.GateError{Status: http.StatusForbidden, Message: "merchant_unresolved"}
+		if uc.Merchant == "" {
+			resolver, ok := g.AdminPermissionChecker.(merchantUserResolver)
+			if !ok {
+				return billingauth.Principal{}, billingauth.GateError{Status: http.StatusInternalServerError, Message: "merchant resolver unavailable"}
+			}
+			ref, rerr := resolver.MerchantForUser(ctx, uc.UserID)
+			if rerr != nil || strings.TrimSpace(ref) == "" {
+				return billingauth.Principal{}, billingauth.GateError{Status: http.StatusForbidden, Message: "merchant_unresolved"}
+			}
+			uc.Merchant = ref
 		}
-		uc.Merchant = ref
 	}
 	allowed, err := g.AdminPermissionChecker.HasAdminPermission(ctx, uc.Merchant, uc.UserID, perm)
 	if err != nil {
@@ -469,13 +474,13 @@ func (g legacyGate) Authorize(ctx context.Context, req *http.Request, perm strin
 	if !allowed {
 		return billingauth.Principal{}, billingauth.GateError{Status: http.StatusForbidden, Message: "permission_required"}
 	}
+	membershipMID, rerr := g.resolveMerchantForGroup(ctx, uc.Merchant)
+	if rerr != nil {
+		return billingauth.Principal{}, resolveMerchantForGroupGateError(rerr)
+	}
 	mid, ok := merchant.FromContext(ctx)
 	if !ok {
-		var rerr error
-		mid, rerr = g.resolveMerchantForGroup(ctx, uc.Merchant)
-		if rerr != nil {
-			return billingauth.Principal{}, resolveMerchantForGroupGateError(rerr)
-		}
+		mid = membershipMID
 	}
 	// #766: uc.Merchant was resolved from the USER'S group membership, but mid
 	// may instead be the Host-pinned merchant (merchant.WithHostMerchant, set by
@@ -488,13 +493,12 @@ func (g legacyGate) Authorize(ctx context.Context, req *http.Request, perm strin
 	// right signal because it is a no-op unless a Host resolver actually ran, so
 	// single-merchant self-hosters are unaffected.
 	if hostMID, ok := merchant.HostMerchant(ctx); ok {
-		membershipMID, rerr := g.resolveMerchantForGroup(ctx, uc.Merchant)
-		if rerr != nil {
-			return billingauth.Principal{}, resolveMerchantForGroupGateError(rerr)
-		}
 		if hostMID != membershipMID {
 			return billingauth.Principal{}, billingauth.GateError{Status: http.StatusForbidden, Message: "host_merchant_mismatch"}
 		}
+	}
+	if mid != membershipMID {
+		return billingauth.Principal{}, billingauth.GateError{Status: http.StatusForbidden, Message: "merchant_context_mismatch"}
 	}
 	return billingauth.Principal{MerchantID: mid, UserContext: uc}, nil
 }

--- a/pkg/billingauth/user_context.go
+++ b/pkg/billingauth/user_context.go
@@ -18,6 +18,12 @@ import (
 	"github.com/google/uuid"
 )
 
+// MerchantSelectorHeader names the explicit merchant context requested by a
+// human user session. The value is an untrusted routing hint: merchant route
+// gates must still verify the user's live permission for the selected merchant
+// and resolve it to an active merchant before authorizing the request.
+const MerchantSelectorHeader = "X-OpenRails-Merchant"
+
 // UserContext is the identity OpenRails billing reads about the caller. It is
 // the contract between the host's auth system and the library: the host
 // populates whichever fields apply to its identity model and OpenRails treats


### PR DESCRIPTION
## Summary
- accept `X-OpenRails-Merchant` as an explicit merchant hint for authenticated human sessions
- retain live permission, active-merchant, host, and existing-context checks before scoping requests
- preserve single-membership inference and fail closed when ambiguous sessions omit a selector

## Security
The selector is never authority. It is ignored when the authenticator already binds a merchant, checked through `HasAdminPermission`, resolved through the active merchant directory, and rejected on Host or existing-context mismatch.

## Verification
- `go test ./...`
- `go test -race ./internal/http/routes ./pkg/billingauth`
- `go vet ./...`
- `go test -tags=integration ./internal/integrationharness -run ^'$'`\n- `GOTOOLCHAIN=go1.26.5 go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...`\n\nSupports OpenRails SaaS tracker #3.