### PR TITLE
feat(embed): expose merchant display-name updates

### DIFF
--- a/internal/merchants/lifecycle.go
+++ b/internal/merchants/lifecycle.go
@@ -185,6 +185,27 @@ func (s *Service) GetBySlug(ctx context.Context, slug string) (*Merchant, error)
 	return s.merchantBySlug(ctx, normalizeSlug(slug))
 }
 
+// SetDisplayName sets the human-readable name for an active merchant. An empty
+// name is a no-op so repair calls cannot clear an existing value by omission.
+func (s *Service) SetDisplayName(ctx context.Context, id merchant.ID, displayName string) error {
+	displayName = strings.TrimSpace(displayName)
+	if displayName == "" {
+		return nil
+	}
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE openrails.merchants
+		   SET display_name = $2, updated_at = current_timestamp
+		 WHERE id = $1::uuid AND status = 'active' AND deleted_at IS NULL
+	`, id.String(), displayName)
+	if err != nil {
+		return fmt.Errorf("merchants: set display name: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrMerchantNotFound
+	}
+	return nil
+}
+
 // SearchMerchants returns active merchant directory rows whose slug matches the
 // (case-insensitive) query substring. It is the cross-merchant search backing
 // the platform-superadmin API (issue #226); the CALLER is responsible for

--- a/internal/merchants/lifecycle_integration_test.go
+++ b/internal/merchants/lifecycle_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
@@ -35,6 +36,7 @@ CREATE TABLE IF NOT EXISTS openrails.merchants (
     slug             TEXT NOT NULL UNIQUE,
     status           TEXT NOT NULL DEFAULT 'active',
     permission_group_id  TEXT,
+    display_name     TEXT,
     created_at       TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
     updated_at       TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
     deleted_at       TIMESTAMPTZ
@@ -284,6 +286,37 @@ func TestProvision_Idempotent(t *testing.T) {
 
 	_, _, err = svc.Provision(ctx, ProvisionRequest{Slug: "noown"})
 	require.ErrorIs(t, err, ErrPermissionGroupRequired, "control-plane provisioning must not create an ownerless merchant")
+}
+
+func TestSetDisplayName(t *testing.T) {
+	ctx := context.Background()
+	svc := newSvc(t)
+	tn, _, err := svc.Provision(ctx, ProvisionRequest{Slug: "named", PermissionGroupID: "group-named"})
+	require.NoError(t, err)
+
+	require.NoError(t, svc.SetDisplayName(ctx, tn.ID, "  Named Merchant  "))
+	var displayName *string
+	require.NoError(t, svc.pool.QueryRow(ctx,
+		`SELECT display_name FROM openrails.merchants WHERE id = $1::uuid`, tn.ID.String()).Scan(&displayName))
+	require.NotNil(t, displayName)
+	require.Equal(t, "Named Merchant", *displayName)
+
+	require.NoError(t, svc.SetDisplayName(ctx, tn.ID, "Repaired Name"))
+	require.NoError(t, svc.SetDisplayName(ctx, tn.ID, "  "))
+	require.NoError(t, svc.pool.QueryRow(ctx,
+		`SELECT display_name FROM openrails.merchants WHERE id = $1::uuid`, tn.ID.String()).Scan(&displayName))
+	require.NotNil(t, displayName)
+	require.Equal(t, "Repaired Name", *displayName)
+
+	require.ErrorIs(t, svc.SetDisplayName(ctx, merchant.ID(uuid.New()), "Missing"), ErrMerchantNotFound)
+	_, err = svc.pool.Exec(ctx,
+		`UPDATE openrails.merchants SET status = 'deleted' WHERE id = $1::uuid`, tn.ID.String())
+	require.NoError(t, err)
+	require.ErrorIs(t, svc.SetDisplayName(ctx, tn.ID, "Deleted"), ErrMerchantNotFound)
+	_, err = svc.pool.Exec(ctx,
+		`UPDATE openrails.merchants SET status = 'active', deleted_at = current_timestamp WHERE id = $1::uuid`, tn.ID.String())
+	require.NoError(t, err)
+	require.ErrorIs(t, svc.SetDisplayName(ctx, tn.ID, "Soft Deleted"), ErrMerchantNotFound)
 }
 
 func TestDelete_RequiresExport(t *testing.T) {

--- a/pkg/embedded/controlplane/profile.go
+++ b/pkg/embedded/controlplane/profile.go
@@ -1,0 +1,33 @@
+package controlplane
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-rails/openrails/internal/app"
+	"github.com/open-rails/openrails/internal/merchants"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// ErrMerchantNotFound indicates that no active merchant matched the requested
+// directory update.
+var ErrMerchantNotFound = merchants.ErrMerchantNotFound
+
+// SetMerchantDisplayName sets an active merchant's human-readable directory
+// name through the attached control plane. Empty names are ignored so hosts can
+// safely retry provisioning without clearing a previously stored name. This is
+// a privileged host seam; callers must authorize the merchant ID before use.
+func SetMerchantDisplayName(ctx context.Context, a *app.App, id merchant.ID, displayName string) error {
+	cp := Get(a)
+	if cp == nil {
+		return fmt.Errorf("control plane set merchant display name: no control plane attached (call Attach first)")
+	}
+	dir, err := merchants.NewDirectoryService(cp.Pool())
+	if err != nil {
+		return fmt.Errorf("control plane set merchant display name: build merchant directory service: %w", err)
+	}
+	if err := dir.SetDisplayName(ctx, id, displayName); err != nil {
+		return fmt.Errorf("control plane set merchant display name: %w", err)
+	}
+	return nil
+}

--- a/pkg/embedded/controlplane/provision_integration_test.go
+++ b/pkg/embedded/controlplane/provision_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/open-rails/openrails/permissions"
 	"github.com/open-rails/openrails/pkg/embedded"
 	embcp "github.com/open-rails/openrails/pkg/embedded/controlplane"
+	"github.com/open-rails/openrails/pkg/merchant"
 )
 
 func TestMain(m *testing.M) { dbtest.RunMain(m) }
@@ -183,11 +184,27 @@ func TestHostedPosture_RegisterVerifyProvision(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(pool.Close)
 	var rowID, rowGroupID string
+	var rowDisplayName *string
 	require.NoError(t, pool.QueryRow(ctx,
-		`SELECT id::text, permission_group_id FROM openrails.merchants WHERE slug = $1 AND deleted_at IS NULL`,
-		slug).Scan(&rowID, &rowGroupID))
+		`SELECT id::text, permission_group_id, display_name FROM openrails.merchants WHERE slug = $1 AND deleted_at IS NULL`,
+		slug).Scan(&rowID, &rowGroupID, &rowDisplayName))
 	require.Equal(t, res1.MerchantID.String(), rowID)
 	require.Equal(t, res1.GroupID, rowGroupID)
+	require.Nil(t, rowDisplayName)
+
+	require.NoError(t, embcp.SetMerchantDisplayName(ctx, e.App(), res1.MerchantID, "  SaaS Merchant  "))
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT display_name FROM openrails.merchants WHERE id = $1::uuid`, res1.MerchantID.String()).Scan(&rowDisplayName))
+	require.NotNil(t, rowDisplayName)
+	require.Equal(t, "SaaS Merchant", *rowDisplayName)
+	require.NoError(t, embcp.SetMerchantDisplayName(ctx, e.App(), res1.MerchantID, "Repaired Merchant"))
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT display_name FROM openrails.merchants WHERE id = $1::uuid`, res1.MerchantID.String()).Scan(&rowDisplayName))
+	require.NotNil(t, rowDisplayName)
+	require.Equal(t, "Repaired Merchant", *rowDisplayName)
+	require.ErrorIs(t,
+		embcp.SetMerchantDisplayName(ctx, e.App(), merchant.ID(uuid.New()), "Missing"),
+		embcp.ErrMerchantNotFound)
 
 	// The owner holds the merchant owner role (= merchant:*), never platform authority.
 	canRead, err := cp.Core().Can(ctx, user.ID, authcore.SubjectKindUser, "merchant", slug, permissions.MerchantSettingsRead)


### PR DESCRIPTION
## Summary
- add an ID-bound directory setter for active merchant display names
- expose the setter through the embedded control-plane host seam with an errors.Is-able not-found sentinel
- preserve existing names on empty retry input and reject inactive or soft-deleted merchants

## Verification
- `go test ./internal/merchants ./pkg/embedded/controlplane`
- `go test -race ./internal/merchants ./pkg/embedded/controlplane`
- `go vet ./internal/merchants ./pkg/embedded/controlplane`
- `go test -tags=integration -run ^'$' ./internal/merchants ./pkg/embedded/controlplane`\n- focused integration execution attempted but Docker is unavailable locally\n- focused review and adversarial security audit: clean\n\nSupports open-rails/openrails-saas#3.