### PR TITLE
feat(checkout): expose ready payment rails

### DIFF
--- a/internal/modules/checkout/rail_options.go
+++ b/internal/modules/checkout/rail_options.go
@@ -1,0 +1,202 @@
+package checkout
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/modules/catalog"
+	"github.com/open-rails/openrails/internal/railresolve"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// CheckoutRailOption is a locally ready payment-provider choice for a price.
+// Selector is the exact value checkout accepts; Rail is the canonical gateway.
+type CheckoutRailOption struct {
+	Selector string
+	Rail     string
+	Mode     string
+}
+
+var checkoutRailOptionOrder = []string{
+	string(models.RailStripe),
+	string(models.RailNMI),
+	string(models.RailCCBill),
+	string(models.RailSolana),
+}
+
+// ListCheckoutRailOptions returns payment providers that this runtime can use
+// for new checkout against priceRef. It performs no remote provider probes and
+// no writes; readiness means the active local account, required credentials,
+// price link, checkout mode, and runtime services are all present.
+func (s *CheckoutSessionService) ListCheckoutRailOptions(ctx context.Context, priceRef string) ([]CheckoutRailOption, error) {
+	priceRef = strings.TrimSpace(priceRef)
+	if priceRef == "" {
+		return nil, fmt.Errorf("price reference is required")
+	}
+	if s == nil || s.priceService == nil || s.productService == nil {
+		return nil, fmt.Errorf("checkout rail options unavailable")
+	}
+	checkoutService, ok := s.checkoutService.(*CheckoutService)
+	if !ok || checkoutService == nil || checkoutService.Rails == nil {
+		return nil, fmt.Errorf("checkout rail options unavailable")
+	}
+	if s.config == nil || s.config.IsProviderReadOnly() {
+		return []CheckoutRailOption{}, nil
+	}
+	merchantID, err := merchant.Require(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolve checkout merchant: %w", err)
+	}
+
+	price, err := catalog.ResolveReference(ctx, s.priceService, priceRef)
+	if err != nil {
+		return nil, fmt.Errorf("resolve checkout price: %w", err)
+	}
+	if price.MerchantID != merchantID.UUID() {
+		return nil, fmt.Errorf("resolve checkout price: price not found")
+	}
+	if !price.IsPurchasable() {
+		return []CheckoutRailOption{}, nil
+	}
+	product, err := s.productService.GetByID(ctx, price.ProductID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve checkout product: %w", err)
+	}
+	if product.MerchantID != merchantID.UUID() {
+		return nil, fmt.Errorf("resolve checkout product: product not found")
+	}
+	if !product.IsPurchasable() {
+		return []CheckoutRailOption{}, nil
+	}
+	return s.listCheckoutRailOptionsForPrice(ctx, checkoutService, price)
+}
+
+func (s *CheckoutSessionService) listCheckoutRailOptionsForPrice(ctx context.Context, checkoutService *CheckoutService, price *models.Price) ([]CheckoutRailOption, error) {
+	options := make([]CheckoutRailOption, 0, len(checkoutRailOptionOrder))
+	var resolutionErr error
+	for _, requestedRail := range checkoutRailOptionOrder {
+		target, err := checkoutService.resolveRailTarget(ctx, requestedRail)
+		if err != nil {
+			resolutionErr = errors.Join(resolutionErr, fmt.Errorf("resolve checkout rail %s: %w", requestedRail, err))
+			continue
+		}
+		accountID := ""
+		if target.Scope != nil {
+			accountID = target.Scope.AccountID
+		}
+		providerConfig, err := checkoutService.Rails.RailConfig(ctx, target.Rail, accountID)
+		if err != nil {
+			if errors.Is(err, railresolve.ErrRailNotArmed) {
+				continue
+			}
+			resolutionErr = errors.Join(resolutionErr, fmt.Errorf("resolve checkout rail config %s: %w", requestedRail, err))
+			continue
+		}
+
+		mode := checkoutModeForRail(price, target.Rail)
+		if !s.checkoutRailOptionReady(price, target, providerConfig, mode) {
+			continue
+		}
+		options = append(options, CheckoutRailOption{
+			Selector: target.Rail,
+			Rail:     target.Rail,
+			Mode:     string(mode),
+		})
+	}
+	if len(options) == 0 && resolutionErr != nil {
+		return nil, resolutionErr
+	}
+	return options, nil
+}
+
+func checkoutModeForRail(price *models.Price, rail string) models.CheckoutSessionMode {
+	_ = rail
+	if price != nil && price.AutoRenew {
+		return models.CheckoutSessionModeSubscription
+	}
+	return models.CheckoutSessionModeOneOff
+}
+
+func (s *CheckoutSessionService) checkoutRailOptionReady(price *models.Price, target railTarget, providerConfig *config.PSPConfig, mode models.CheckoutSessionMode) bool {
+	if price == nil || providerConfig == nil {
+		return false
+	}
+	switch target.Rail {
+	case string(models.RailStripe):
+		if providerConfig.Stripe == nil || strings.TrimSpace(providerConfig.Stripe.SecretKey) == "" || stripePaidIntroUnsupported(price) {
+			return false
+		}
+		targetPriceID := strings.TrimSpace(checkoutPSPLinkForTarget(price, target)[models.RailKeyStripePriceID])
+		executionPriceID, err := getStripePriceID(price)
+		return err == nil && targetPriceID != "" && targetPriceID == executionPriceID
+	case string(models.RailNMI):
+		if providerConfig.NMI == nil || strings.TrimSpace(providerConfig.NMI.SecurityKey) == "" {
+			return false
+		}
+		if checkoutPSPLinkForTarget(price, target) == nil {
+			return false
+		}
+		if mode == models.CheckoutSessionModeSubscription {
+			_, err := requireNMIPlanForTarget(price, target)
+			return err == nil
+		}
+		return true
+	case string(models.RailCCBill):
+		if mode != models.CheckoutSessionModeSubscription || providerConfig.CCBill == nil {
+			return false
+		}
+		if _, _, err := config.SplitCCBillAccountID(providerConfig.EffectiveAccountID()); err != nil {
+			return false
+		}
+		link := checkoutPSPLinkForTarget(price, target)
+		targetForm := strings.TrimSpace(link[models.RailKeyCCBillFormName])
+		targetFlexID := strings.TrimSpace(link[models.RailKeyCCBillFlexID])
+		executionForm, executionFlexID, ok := price.GetCCBillFlexForm()
+		return ok && targetForm != "" && targetFlexID != "" &&
+			targetForm == executionForm && targetFlexID == executionFlexID
+	case string(models.RailSolana):
+		if providerConfig.Solana == nil || len(providerConfig.Solana.Tokens) == 0 {
+			return false
+		}
+		if checkoutPSPLinkForTarget(price, target) == nil {
+			return false
+		}
+		if mode == models.CheckoutSessionModeSubscription {
+			if s.solanaPrepareSubscribe == nil || s.solanaEnroll == nil {
+				return false
+			}
+			targetTerms, targetErr := parseSolanaPlanTerms(checkoutPSPLinkForTarget(price, target))
+			executionTerms, executionErr := parseSolanaPlanTerms(price.PSPLinkForRail(models.RailSolana))
+			return targetErr == nil && executionErr == nil && targetTerms == executionTerms
+		}
+		return s.solanaPayService != nil || s.solanaTransactionService != nil
+	default:
+		return false
+	}
+}
+
+// checkoutPSPLinkForTarget resolves the price link for the same account chosen
+// for credentials. A rail-named fallback preserves single-account manifests.
+func checkoutPSPLinkForTarget(price *models.Price, target railTarget) map[string]string {
+	if price == nil {
+		return nil
+	}
+	lookup := func(key string) map[string]string {
+		link := price.PSPLinks[key]
+		if link == nil || !strings.EqualFold(strings.TrimSpace(link[models.RailKeyRail]), target.Rail) {
+			return nil
+		}
+		return link
+	}
+	if link := lookup(target.PSP); link != nil {
+		return link
+	}
+	if target.Scope == nil && target.PSP != target.Rail {
+		return lookup(target.Rail)
+	}
+	return nil
+}

--- a/internal/modules/checkout/rail_options_test.go
+++ b/internal/modules/checkout/rail_options_test.go
@@ -1,0 +1,357 @@
+package checkout
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/merchants"
+	"github.com/open-rails/openrails/internal/modules/solana/recurring"
+	"github.com/open-rails/openrails/internal/railresolve"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckoutModeForRail(t *testing.T) {
+	t.Parallel()
+
+	recurringPrice := &models.Price{AutoRenew: true}
+	solanaRecurringPrice := &models.Price{
+		AutoRenew: true,
+		PSPLinks: map[string]map[string]string{
+			"solana": {
+				models.RailKeyRail:  "solana",
+				"plan_id":           "1",
+				"amount_base_units": "100",
+				"period_hours":      "720",
+				"mint_symbol":       "USDC",
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		price    *models.Price
+		rail     string
+		expected models.CheckoutSessionMode
+	}{
+		{name: "recurring card price", price: recurringPrice, rail: "stripe", expected: models.CheckoutSessionModeSubscription},
+		{name: "solana recurring price without plan stays recurring", price: recurringPrice, rail: "solana", expected: models.CheckoutSessionModeSubscription},
+		{name: "solana with plan is recurring", price: solanaRecurringPrice, rail: "solana", expected: models.CheckoutSessionModeSubscription},
+		{name: "one off price", price: &models.Price{}, rail: "nmi", expected: models.CheckoutSessionModeOneOff},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, checkoutModeForRail(tt.price, tt.rail))
+		})
+	}
+}
+
+func TestCheckoutRailOptionReady(t *testing.T) {
+	t.Parallel()
+
+	stripePrice := railOptionPrice(true, "stripe", map[string]string{
+		models.RailKeyStripePriceID: "price_test",
+	})
+	nmiPrice := railOptionPrice(true, "mobius", map[string]string{
+		models.RailKeyRail:   "nmi",
+		models.RailKeyPlanID: "plan_test",
+	})
+	ccbillPrice := railOptionPrice(true, "ccbill", map[string]string{
+		models.RailKeyCCBillFormName: "form_test",
+		models.RailKeyCCBillFlexID:   "flex_test",
+	})
+	solanaPrice := railOptionPrice(true, "solana", map[string]string{
+		"plan_id":           "1",
+		"amount_base_units": "100",
+		"period_hours":      "720",
+		"mint_symbol":       "USDC",
+	})
+
+	solanaReady := &CheckoutSessionService{
+		solanaPrepareSubscribe: &recurring.PrepareSubscribeService{},
+		solanaEnroll:           &recurring.EnrollService{},
+	}
+
+	tests := []struct {
+		name           string
+		service        *CheckoutSessionService
+		price          *models.Price
+		target         railTarget
+		providerConfig *config.PSPConfig
+		mode           models.CheckoutSessionMode
+		expected       bool
+	}{
+		{
+			name:    "stripe recurring ready",
+			service: &CheckoutSessionService{},
+			price:   stripePrice,
+			target:  railTarget{PSP: "stripe", Rail: "stripe"},
+			providerConfig: &config.PSPConfig{
+				Rail:   models.RailStripe,
+				Stripe: &config.StripeRailConfig{SecretKey: "sk_test_value"},
+			},
+			mode:     models.CheckoutSessionModeSubscription,
+			expected: true,
+		},
+		{
+			name:    "stripe missing price link",
+			service: &CheckoutSessionService{},
+			price:   &models.Price{ID: uuid.New(), AutoRenew: true},
+			target:  railTarget{PSP: "stripe", Rail: "stripe"},
+			providerConfig: &config.PSPConfig{
+				Rail:   models.RailStripe,
+				Stripe: &config.StripeRailConfig{SecretKey: "sk_test_value"},
+			},
+			mode: models.CheckoutSessionModeSubscription,
+		},
+		{
+			name:    "stripe ambiguous account links",
+			service: &CheckoutSessionService{},
+			price: &models.Price{ID: uuid.New(), AutoRenew: true, PSPLinks: map[string]map[string]string{
+				"stripe": {models.RailKeyRail: "stripe", models.RailKeyStripePriceID: "price_active"},
+				"old":    {models.RailKeyRail: "stripe", models.RailKeyStripePriceID: "price_stale"},
+			}},
+			target: railTarget{PSP: "stripe", Rail: "stripe"},
+			providerConfig: &config.PSPConfig{
+				Rail:   models.RailStripe,
+				Stripe: &config.StripeRailConfig{SecretKey: "sk_test_value"},
+			},
+			mode: models.CheckoutSessionModeSubscription,
+		},
+		{
+			name:    "nmi recurring ready for exact provider",
+			service: &CheckoutSessionService{},
+			price:   nmiPrice,
+			target:  railTarget{PSP: "mobius", Rail: "nmi"},
+			providerConfig: &config.PSPConfig{
+				Rail: models.RailNMI,
+				NMI:  &config.NMIRailConfig{SecurityKey: "security_test"},
+			},
+			mode:     models.CheckoutSessionModeSubscription,
+			expected: true,
+		},
+		{
+			name:    "nmi recurring missing exact provider plan",
+			service: &CheckoutSessionService{},
+			price:   nmiPrice,
+			target:  railTarget{PSP: "other", Rail: "nmi"},
+			providerConfig: &config.PSPConfig{
+				Rail: models.RailNMI,
+				NMI:  &config.NMIRailConfig{SecurityKey: "security_test"},
+			},
+			mode: models.CheckoutSessionModeSubscription,
+		},
+		{
+			name:    "ccbill recurring ready",
+			service: &CheckoutSessionService{},
+			price:   ccbillPrice,
+			target:  railTarget{PSP: "ccbill", Rail: "ccbill"},
+			providerConfig: &config.PSPConfig{
+				Rail:      models.RailCCBill,
+				AccountID: "945280-0000",
+				CCBill:    &config.CCBillRailConfig{},
+			},
+			mode:     models.CheckoutSessionModeSubscription,
+			expected: true,
+		},
+		{
+			name:    "ccbill one off unsupported",
+			service: &CheckoutSessionService{},
+			price:   ccbillPrice,
+			target:  railTarget{PSP: "ccbill", Rail: "ccbill"},
+			providerConfig: &config.PSPConfig{
+				Rail:      models.RailCCBill,
+				AccountID: "945280-0000",
+				CCBill:    &config.CCBillRailConfig{},
+			},
+			mode: models.CheckoutSessionModeOneOff,
+		},
+		{
+			name:    "solana recurring ready",
+			service: solanaReady,
+			price:   solanaPrice,
+			target:  railTarget{PSP: "solana", Rail: "solana"},
+			providerConfig: &config.PSPConfig{
+				Rail: models.RailSolana,
+				Solana: &config.SolanaRailConfig{Tokens: map[string]config.TokenConfig{
+					"USDC": {Mint: "mint_test"},
+				}},
+			},
+			mode:     models.CheckoutSessionModeSubscription,
+			expected: true,
+		},
+		{
+			name:    "solana recurring services unavailable",
+			service: &CheckoutSessionService{},
+			price:   solanaPrice,
+			target:  railTarget{PSP: "solana", Rail: "solana"},
+			providerConfig: &config.PSPConfig{
+				Rail: models.RailSolana,
+				Solana: &config.SolanaRailConfig{Tokens: map[string]config.TokenConfig{
+					"USDC": {Mint: "mint_test"},
+				}},
+			},
+			mode: models.CheckoutSessionModeSubscription,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, tt.service.checkoutRailOptionReady(tt.price, tt.target, tt.providerConfig, tt.mode))
+		})
+	}
+}
+
+func TestListCheckoutRailOptionsForPrice_ReturnsExecutableSelectors(t *testing.T) {
+	t.Parallel()
+
+	price := &models.Price{
+		ID:        uuid.New(),
+		AutoRenew: true,
+		PSPLinks: map[string]map[string]string{
+			"stripe": {
+				models.RailKeyRail:          "stripe",
+				models.RailKeyStripePriceID: "price_test",
+			},
+			"nmi": {
+				models.RailKeyRail:   "nmi",
+				models.RailKeyPlanID: "plan_test",
+			},
+			"ccbill": {
+				models.RailKeyRail:           "ccbill",
+				models.RailKeyCCBillFormName: "form_test",
+				models.RailKeyCCBillFlexID:   "flex_test",
+			},
+		},
+	}
+	rails := railresolve.FixedSet{
+		"stripe": {
+			Rail:      models.RailStripe,
+			AccountID: "acct_stripe",
+			Stripe:    &config.StripeRailConfig{SecretKey: "sk_test_value"},
+		},
+		"nmi": {
+			Rail:      models.RailNMI,
+			AccountID: "acct_nmi",
+			NMI:       &config.NMIRailConfig{SecurityKey: "security_test"},
+		},
+		"ccbill": {
+			Rail:      models.RailCCBill,
+			AccountID: "945280-0000",
+			CCBill:    &config.CCBillRailConfig{},
+		},
+	}
+	checkoutService := &CheckoutService{
+		Config: &config.Config{ProviderWriteMode: config.ProviderWriteModeFull},
+		Rails:  rails,
+	}
+	svc := &CheckoutSessionService{
+		config:          &config.Config{ProviderWriteMode: config.ProviderWriteModeFull},
+		checkoutService: checkoutService,
+	}
+
+	options, err := svc.listCheckoutRailOptionsForPrice(context.Background(), checkoutService, price)
+	require.NoError(t, err)
+	require.Equal(t, []CheckoutRailOption{
+		{Selector: "stripe", Rail: "stripe", Mode: "subscription"},
+		{Selector: "nmi", Rail: "nmi", Mode: "subscription"},
+		{Selector: "ccbill", Rail: "ccbill", Mode: "subscription"},
+	}, options)
+
+	for _, option := range options {
+		mode, err := svc.resolveMode(option.Mode, option.Selector, price)
+		require.NoError(t, err, option.Selector)
+		require.Equal(t, models.CheckoutSessionModeSubscription, mode, option.Selector)
+
+		payment := &CheckoutSessionPaymentRequest{Rail: option.Selector}
+		switch option.Rail {
+		case "nmi":
+			payment.PaymentToken = "token_test"
+		case "ccbill":
+			payment.Email = "buyer@example.test"
+			payment.FirstName = "Test"
+			payment.LastName = "Buyer"
+			payment.Address1 = "1 Test Street"
+			payment.City = "Testville"
+			payment.Zip = "12345"
+			payment.Country = "US"
+		}
+		require.NoError(t, svc.validatePayment(context.Background(), option.Selector, payment, &UserIdentity{ID: uuid.NewString()}), option.Selector)
+	}
+}
+
+func TestCheckoutPSPLinkForTarget(t *testing.T) {
+	t.Parallel()
+
+	active := map[string]string{models.RailKeyRail: "nmi", models.RailKeyPlanID: "active-plan"}
+	stale := map[string]string{models.RailKeyRail: "nmi", models.RailKeyPlanID: "stale-plan"}
+	price := &models.Price{PSPLinks: map[string]map[string]string{
+		"mobius": active,
+		"other":  stale,
+	}}
+
+	assert.Equal(t, active, checkoutPSPLinkForTarget(price, railTarget{PSP: "mobius", Rail: "nmi"}))
+	assert.Equal(t, stale, checkoutPSPLinkForTarget(price, railTarget{PSP: "other", Rail: "nmi"}))
+	assert.Nil(t, checkoutPSPLinkForTarget(price, railTarget{PSP: "missing", Rail: "nmi"}))
+
+	railFallback := &models.Price{PSPLinks: map[string]map[string]string{"nmi": active}}
+	assert.Equal(t, active, checkoutPSPLinkForTarget(railFallback, railTarget{PSP: "mobius", Rail: "nmi"}))
+	assert.Nil(t, checkoutPSPLinkForTarget(railFallback, railTarget{
+		PSP:   "mobius",
+		Rail:  "nmi",
+		Scope: &merchants.PSPScope{Key: "mobius", Rail: "nmi"},
+	}))
+}
+
+func TestCheckoutSessionServiceRequireProviderWrites(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		mode      string
+		nilConfig bool
+		expectErr bool
+	}{
+		{name: "readonly blocks checkout", mode: config.ProviderWriteModeReadOnly, expectErr: true},
+		{name: "missing config blocks checkout", nilConfig: true, expectErr: true},
+		{name: "limited allows user checkout", mode: config.ProviderWriteModeLimited},
+		{name: "full allows checkout", mode: config.ProviderWriteModeFull},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var cfg *config.Config
+			if !tt.nilConfig {
+				cfg = &config.Config{ProviderWriteMode: tt.mode}
+			}
+			svc := &CheckoutSessionService{config: cfg}
+			err := svc.requireProviderWrites()
+			if tt.expectErr {
+				require.ErrorIs(t, err, ErrCheckoutSessionValidation)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+
+	// The gate must run before session persistence or provider interaction.
+	svc := &CheckoutSessionService{config: &config.Config{ProviderWriteMode: config.ProviderWriteModeReadOnly}}
+	_, err := svc.CreateSession(context.Background(), &CheckoutSessionCreateRequest{}, &UserIdentity{ID: uuid.NewString()})
+	require.ErrorIs(t, err, ErrCheckoutSessionValidation)
+}
+
+func railOptionPrice(autoRenew bool, provider string, link map[string]string) *models.Price {
+	if link[models.RailKeyRail] == "" {
+		link[models.RailKeyRail] = provider
+	}
+	return &models.Price{
+		ID:        uuid.New(),
+		AutoRenew: autoRenew,
+		PSPLinks:  map[string]map[string]string{provider: link},
+	}
+}

--- a/internal/modules/checkout/service.go
+++ b/internal/modules/checkout/service.go
@@ -3013,7 +3013,7 @@ func requireNMIPlanForTarget(price *models.Price, target railTarget) (string, er
 	if id, ok := lookup(target.PSP); ok {
 		return id, nil
 	}
-	if target.PSP != target.Rail {
+	if target.Scope == nil && target.PSP != target.Rail {
 		if id, ok := lookup(target.Rail); ok {
 			return id, nil
 		}

--- a/internal/modules/checkout/session_idempotency_test.go
+++ b/internal/modules/checkout/session_idempotency_test.go
@@ -20,6 +20,49 @@ func TestCheckoutSessionRequestFingerprintChangesWithRequest(t *testing.T) {
 	require.NotEqual(t, checkoutSessionRequestFingerprint(base), checkoutSessionRequestFingerprint(other))
 }
 
+func TestCheckoutSessionRequestFingerprintIncludesRedirectURLs(t *testing.T) {
+	t.Parallel()
+
+	base := CheckoutSessionCreateRequest{
+		PriceID:    "price_11111111-1111-1111-1111-111111111111",
+		Payment:    CheckoutSessionPaymentRequest{Rail: "stripe"},
+		SuccessURL: "https://app.example.test/billing?checkout=success",
+		CancelURL:  "https://app.example.test/billing?checkout=cancelled",
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*CheckoutSessionCreateRequest)
+	}{
+		{
+			name: "success url changes",
+			mutate: func(req *CheckoutSessionCreateRequest) {
+				req.SuccessURL = "https://other.example.test/billing?checkout=success"
+			},
+		},
+		{
+			name: "cancel url changes",
+			mutate: func(req *CheckoutSessionCreateRequest) {
+				req.CancelURL = "https://other.example.test/billing?checkout=cancelled"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			changed := base
+			tt.mutate(&changed)
+			require.NotEqual(t, checkoutSessionRequestFingerprint(&base), checkoutSessionRequestFingerprint(&changed))
+		})
+	}
+
+	trimmed := base
+	trimmed.SuccessURL = "  " + base.SuccessURL + "  "
+	trimmed.CancelURL = "  " + base.CancelURL + "  "
+	require.Equal(t, checkoutSessionRequestFingerprint(&base), checkoutSessionRequestFingerprint(&trimmed))
+}
+
 func TestValidatePaymentRejectsStripeSavedPaymentMethod(t *testing.T) {
 	svc := &CheckoutSessionService{}
 	err := svc.validatePayment(context.Background(), "stripe", &CheckoutSessionPaymentRequest{

--- a/internal/modules/checkout/session_service.go
+++ b/internal/modules/checkout/session_service.go
@@ -275,12 +275,22 @@ func (s *CheckoutSessionService) Clock() clockwork.Clock {
 	return s.clock
 }
 
+func (s *CheckoutSessionService) requireProviderWrites() error {
+	if s == nil || s.config == nil || s.config.IsProviderReadOnly() {
+		return fmt.Errorf("%w: provider writes are disabled", ErrCheckoutSessionValidation)
+	}
+	return nil
+}
+
 func (s *CheckoutSessionService) CreateSession(ctx context.Context, req *CheckoutSessionCreateRequest, user *UserIdentity) (*CheckoutSessionResponse, error) {
 	if user == nil || strings.TrimSpace(user.ID) == "" {
 		return nil, fmt.Errorf("%w: user is required", ErrCheckoutSessionValidation)
 	}
 	if req == nil {
 		return nil, fmt.Errorf("%w: request is required", ErrCheckoutSessionValidation)
+	}
+	if err := s.requireProviderWrites(); err != nil {
+		return nil, err
 	}
 
 	fingerprint := checkoutSessionRequestFingerprint(req)
@@ -330,15 +340,19 @@ func checkoutSessionRequestFingerprint(req *CheckoutSessionCreateRequest) string
 		return ""
 	}
 	payload, _ := json.Marshal(struct {
-		PriceID  string
-		Mode     string
-		Payment  CheckoutSessionPaymentRequest
-		Metadata map[string]string
+		PriceID    string
+		Mode       string
+		Payment    CheckoutSessionPaymentRequest
+		Metadata   map[string]string
+		SuccessURL string
+		CancelURL  string
 	}{
-		PriceID:  strings.TrimSpace(req.PriceID),
-		Mode:     strings.TrimSpace(req.Mode),
-		Payment:  req.Payment,
-		Metadata: normalizeMetadata(req.Metadata),
+		PriceID:    strings.TrimSpace(req.PriceID),
+		Mode:       strings.TrimSpace(req.Mode),
+		Payment:    req.Payment,
+		Metadata:   normalizeMetadata(req.Metadata),
+		SuccessURL: strings.TrimSpace(req.SuccessURL),
+		CancelURL:  strings.TrimSpace(req.CancelURL),
 	})
 	sum := sha256.Sum256(payload)
 	return hex.EncodeToString(sum[:])
@@ -2214,6 +2228,9 @@ func solanaLifecycleLabel(verb, productName string, state map[string]any) string
 // BuildSolanaPayTransaction builds a Solana transaction for the given checkout session and wallet account.
 // This implements the POST endpoint of the Solana Pay Transaction Request spec.
 func (s *CheckoutSessionService) BuildSolanaPayTransaction(ctx context.Context, sessionID uuid.UUID, account string) (*solanamodule.PayTransactionResponse, error) {
+	if err := s.requireProviderWrites(); err != nil {
+		return nil, err
+	}
 	if s.repo == nil {
 		return nil, ErrCheckoutSessionNotFound
 	}

--- a/pkg/service/service_user.go
+++ b/pkg/service/service_user.go
@@ -119,6 +119,44 @@ func (s *Service) GetPrices(ctx context.Context, opts GetPricesOptions) (*Pagina
 
 // -------------------------------- Checkout Sessions --------------------------------
 
+// ListCheckoutRailOptions returns the locally ready payment-provider choices
+// for a price. It does not probe remote providers or mutate billing state.
+func (s *Service) ListCheckoutRailOptions(ctx context.Context, priceRef string) ([]CheckoutRailOption, error) {
+	checkoutSessions, err := s.requireCheckoutSessionService()
+	if err != nil {
+		return nil, err
+	}
+	priceRef = strings.TrimSpace(priceRef)
+	if priceRef == "" {
+		return nil, fmt.Errorf("price reference is required")
+	}
+	rt, err := s.runtime()
+	if err != nil {
+		return nil, err
+	}
+	if rt.DB == nil {
+		return nil, fmt.Errorf("billing service: database unavailable")
+	}
+	var options []checkout.CheckoutRailOption
+	err = rt.DB.RunInMerchantConn(ctx, func(scopedCtx context.Context) error {
+		var listErr error
+		options, listErr = checkoutSessions.ListCheckoutRailOptions(scopedCtx, priceRef)
+		return listErr
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list checkout rail options: %w", err)
+	}
+	result := make([]CheckoutRailOption, 0, len(options))
+	for _, option := range options {
+		result = append(result, CheckoutRailOption{
+			Selector: option.Selector,
+			Rail:     option.Rail,
+			Mode:     option.Mode,
+		})
+	}
+	return result, nil
+}
+
 // CreateCheckoutSession creates a new checkout session.
 func (s *Service) CreateCheckoutSession(ctx context.Context, userID string, req CreateCheckoutSessionRequest) (*CheckoutSession, error) {
 	checkoutSessions, err := s.requireCheckoutSessionService()
@@ -135,6 +173,8 @@ func (s *Service) CreateCheckoutSession(ctx context.Context, userID string, req 
 		Mode:           req.Mode,
 		Metadata:       req.Metadata,
 		IdempotencyKey: req.IdempotencyKey,
+		SuccessURL:     req.SuccessURL,
+		CancelURL:      req.CancelURL,
 		Payment: checkout.CheckoutSessionPaymentRequest{
 			Rail:            req.Payment.Rail,
 			PaymentMethodID: req.Payment.PaymentMethodID,
@@ -157,7 +197,19 @@ func (s *Service) CreateCheckoutSession(ctx context.Context, userID string, req 
 	}
 
 	user := &checkout.UserIdentity{ID: userID}
-	resp, err := checkoutSessions.CreateSession(ctx, svcReq, user)
+	rt, err := s.runtime()
+	if err != nil {
+		return nil, err
+	}
+	if rt.DB == nil {
+		return nil, fmt.Errorf("billing service: database unavailable")
+	}
+	var resp *checkout.CheckoutSessionResponse
+	err = rt.DB.RunInMerchantConn(ctx, func(scopedCtx context.Context) error {
+		var createErr error
+		resp, createErr = checkoutSessions.CreateSession(scopedCtx, svcReq, user)
+		return createErr
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +232,19 @@ func (s *Service) GetCheckoutSession(ctx context.Context, userID string, session
 	}
 
 	user := &checkout.UserIdentity{ID: userID}
-	resp, err := checkoutSessions.GetSession(ctx, sessionID, user)
+	rt, err := s.runtime()
+	if err != nil {
+		return nil, err
+	}
+	if rt.DB == nil {
+		return nil, fmt.Errorf("billing service: database unavailable")
+	}
+	var resp *checkout.CheckoutSessionResponse
+	err = rt.DB.RunInMerchantConn(ctx, func(scopedCtx context.Context) error {
+		var getErr error
+		resp, getErr = checkoutSessions.GetSession(scopedCtx, sessionID, user)
+		return getErr
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +275,19 @@ func (s *Service) ConfirmCheckoutSession(ctx context.Context, userID string, ses
 	}
 
 	user := &checkout.UserIdentity{ID: userID}
-	resp, err := checkoutSessions.ConfirmSession(ctx, sessionID, svcReq, user)
+	rt, err := s.runtime()
+	if err != nil {
+		return nil, err
+	}
+	if rt.DB == nil {
+		return nil, fmt.Errorf("billing service: database unavailable")
+	}
+	var resp *checkout.CheckoutSessionResponse
+	err = rt.DB.RunInMerchantConn(ctx, func(scopedCtx context.Context) error {
+		var confirmErr error
+		resp, confirmErr = checkoutSessions.ConfirmSession(scopedCtx, sessionID, svcReq, user)
+		return confirmErr
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -89,6 +89,15 @@ type RecurringInfo struct {
 
 // -------------------------------- Checkout Sessions --------------------------------
 
+// CheckoutRailOption is a locally ready payment-provider choice for a price.
+// Selector is the exact value accepted by CheckoutPayment.Rail; Rail is the
+// canonical gateway and Mode is "one_off" or "subscription".
+type CheckoutRailOption struct {
+	Selector string
+	Rail     string
+	Mode     string
+}
+
 // CreateCheckoutSessionRequest specifies checkout session creation parameters.
 type CreateCheckoutSessionRequest struct {
 	PriceID        string
@@ -96,6 +105,8 @@ type CreateCheckoutSessionRequest struct {
 	Payment        CheckoutPayment
 	Metadata       map[string]string
 	IdempotencyKey string
+	SuccessURL     string // Required for Stripe hosted checkout
+	CancelURL      string // Required for Stripe hosted checkout
 }
 
 // CheckoutPayment specifies payment details for checkout.


### PR DESCRIPTION
## Summary
- expose locally checkout-ready rail options through the embedded service API
- enforce merchant RLS and provider write posture for checkout session facade calls
- forward Stripe return URLs and include them in idempotency matching

## Verification
- go test ./...
- go test -race ./internal/modules/checkout ./pkg/service
- focused review and adversarial audit: clean