### PR TITLE
fix(checkout): make session retries crash-safe

### DIFF
--- a/internal/http/middleware/idempotency_neutral.go
+++ b/internal/http/middleware/idempotency_neutral.go
@@ -110,7 +110,7 @@ func IdempotencyHTTP(svc *idempotency.IdempotencyService) HTTPMiddleware {
 				target += "?" + r.URL.RawQuery
 			}
 			operation := "http:" + r.Method + " " + target
-			storeKey := mid.String() + ":" + key
+			storeKey := mid.String() + ":" + hashIdempotencyKey(key)
 			fp := fingerprint(r.Method, target, body)
 			ctx := r.Context()
 
@@ -189,6 +189,11 @@ func IdempotencyHTTP(svc *idempotency.IdempotencyService) HTTPMiddleware {
 			}
 		})
 	}
+}
+
+func hashIdempotencyKey(key string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(key)))
+	return hex.EncodeToString(sum[:])
 }
 
 // fingerprint hashes the request identity. target is path plus query string (#579)

--- a/internal/modules/checkout/contracts.go
+++ b/internal/modules/checkout/contracts.go
@@ -42,6 +42,7 @@ type CheckoutRequest struct {
 
 	IdempotencyKey    string            `json:"-"`
 	CheckoutSessionID string            `json:"-"`
+	CheckoutStartedAt time.Time         `json:"-"`
 	Email             string            `json:"email,omitempty"`
 	FirstName         string            `json:"first_name,omitempty"`
 	LastName          string            `json:"last_name,omitempty"`

--- a/internal/modules/checkout/pan_firewall.go
+++ b/internal/modules/checkout/pan_firewall.go
@@ -27,10 +27,14 @@ func RejectPANShapedFields(req *CheckoutRequest) error {
 		"state":              req.State,
 		"zip":                req.Zip,
 		"country":            req.Country,
+		"last_four":          req.LastFour,
 		"expiry_date":        req.ExpiryDate,
 		"card_type":          req.CardType,
 	}
 	for key, value := range req.Metadata {
+		if looksLikePAN(key) {
+			return fmt.Errorf("metadata key contains a card-number-shaped value: raw PANs must never reach OpenRails (SAQ A) — collect cards via the vault's browser SDK")
+		}
 		fields["metadata."+key] = value
 	}
 	for name, value := range fields {

--- a/internal/modules/checkout/service.go
+++ b/internal/modules/checkout/service.go
@@ -1249,7 +1249,11 @@ func (s *CheckoutService) processStripeSubscription(
 	if stripePaidIntroUnsupported(price) {
 		return nil, errors.New("stripe paid introductory pricing is not supported")
 	}
-	trialEnd := stripeCheckoutTrialEnd(price, coverage, s.now())
+	trialAnchor := req.CheckoutStartedAt
+	if trialAnchor.IsZero() {
+		trialAnchor = s.now()
+	}
+	trialEnd := stripeCheckoutTrialEnd(price, coverage, trialAnchor)
 	urlStr, err := s.createStripeCheckoutSession(ctx, stripeCheckoutParams{
 		Mode:              "subscription",
 		PriceID:           stripePriceID,
@@ -1261,6 +1265,7 @@ func (s *CheckoutService) processStripeSubscription(
 		InternalPriceID:   price.ID.String(),
 		TrialEnd:          trialEnd,
 		CheckoutSessionID: req.CheckoutSessionID,
+		IdempotencyKey:    req.IdempotencyKey,
 	})
 	if err != nil {
 		return nil, err
@@ -1323,6 +1328,7 @@ func (s *CheckoutService) processStripePayment(
 		CustomerEmail:     userEmail(user),
 		InternalPriceID:   price.ID.String(),
 		CheckoutSessionID: req.CheckoutSessionID,
+		IdempotencyKey:    req.IdempotencyKey,
 	})
 	if err != nil {
 		return nil, err
@@ -1562,6 +1568,7 @@ type stripeCheckoutParams struct {
 	InternalPriceID   string
 	TrialEnd          int64
 	CheckoutSessionID string
+	IdempotencyKey    string
 }
 
 func (s *CheckoutService) createStripeCheckoutSession(ctx context.Context, params stripeCheckoutParams) (string, error) {
@@ -1606,6 +1613,7 @@ func (s *CheckoutService) createStripeCheckoutSession(ctx context.Context, param
 	}
 	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(stripeProc.Stripe.SecretKey))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	stripeapi.SetIdempotencyKey(req, stripeCheckoutIdempotencyKey(params.IdempotencyKey))
 
 	client := stripeapi.Client(s.Config, 0)
 	resp, err := client.Do(req)
@@ -1631,6 +1639,15 @@ func (s *CheckoutService) createStripeCheckoutSession(ctx context.Context, param
 		return "", errors.New("stripe checkout returned empty URL")
 	}
 	return out.URL, nil
+}
+
+func stripeCheckoutIdempotencyKey(key string) string {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(key))
+	return "openrails-checkout-" + hex.EncodeToString(sum[:])
 }
 
 func parseStripeError(body []byte) string {

--- a/internal/modules/checkout/session_checkout_returnurls_test.go
+++ b/internal/modules/checkout/session_checkout_returnurls_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -46,11 +47,13 @@ func TestInitializeCheckoutSession_ThreadsStripeReturnURLs(t *testing.T) {
 
 	exec := &captureCheckoutExecutor{}
 	svc := &CheckoutSessionService{checkoutService: exec}
+	startedAt := time.Date(2026, time.July, 17, 12, 0, 0, 0, time.UTC)
 
 	session := &models.CheckoutSession{
-		ID:      uuid.New(),
-		PriceID: uuid.New(),
-		Rail:    models.RailStripe,
+		ID:        uuid.New(),
+		PriceID:   uuid.New(),
+		Rail:      models.RailStripe,
+		CreatedAt: startedAt,
 	}
 	payment := &CheckoutSessionPaymentRequest{Rail: string(models.RailStripe)}
 	user := &UserIdentity{ID: uuid.New().String()}
@@ -66,5 +69,8 @@ func TestInitializeCheckoutSession_ThreadsStripeReturnURLs(t *testing.T) {
 	}
 	if exec.captured.CancelURL != wantCancel {
 		t.Errorf("CancelURL not threaded: got %q, want %q", exec.captured.CancelURL, wantCancel)
+	}
+	if !exec.captured.CheckoutStartedAt.Equal(startedAt) {
+		t.Errorf("CheckoutStartedAt not threaded: got %v, want %v", exec.captured.CheckoutStartedAt, startedAt)
 	}
 }

--- a/internal/modules/checkout/session_service.go
+++ b/internal/modules/checkout/session_service.go
@@ -752,7 +752,6 @@ func rejectCheckoutSessionPAN(req *CheckoutSessionCreateRequest) error {
 		"new_price_id":         req.NewPriceID,
 		"price_id":             req.PriceID,
 		"mode":                 req.Mode,
-		"idempotency_key":      req.IdempotencyKey,
 	}
 	if err := RejectPANShapedFields(&CheckoutRequest{Metadata: extraFields}); err != nil {
 		return fmt.Errorf("%w: invalid checkout input: %v", ErrCheckoutSessionValidation, err)

--- a/internal/modules/checkout/session_service.go
+++ b/internal/modules/checkout/session_service.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/mail"
 	"strconv"
@@ -14,6 +15,7 @@ import (
 
 	safecast "github.com/ccoveille/go-safecast/v2"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jonboulle/clockwork"
 	"github.com/open-rails/openrails/config"
 	"github.com/open-rails/openrails/internal/db"
@@ -38,9 +40,11 @@ import (
 )
 
 const (
-	checkoutSessionIdempotencyOp = "checkout_session_create"
-	defaultCheckoutSessionTTL    = 15 * time.Minute
-	redirectCheckoutSessionTTL   = 24 * time.Hour
+	checkoutSessionIdempotencyOp  = "checkout_session_create"
+	checkoutSessionFingerprintKey = "_openrails_request_fingerprint"
+	checkoutSessionPendingLease   = 30 * time.Second
+	defaultCheckoutSessionTTL     = 15 * time.Minute
+	redirectCheckoutSessionTTL    = 24 * time.Hour
 )
 
 // Idempotency types are the idempotency module's own (#666 — the copy that
@@ -63,6 +67,7 @@ type checkoutSessionIdempotencyResult struct {
 
 type sessionIdempotencyStore interface {
 	Begin(ctx context.Context, operation, key string) (*IdempotencyRecord, bool, error)
+	TryTakeoverPending(ctx context.Context, operation, key string, olderThan time.Duration) (bool, error)
 	Fail(ctx context.Context, operation, key string, operationErr error) error
 	Complete(ctx context.Context, operation, key string, result json.RawMessage) error
 }
@@ -292,6 +297,9 @@ func (s *CheckoutSessionService) CreateSession(ctx context.Context, req *Checkou
 	if err := s.requireProviderWrites(); err != nil {
 		return nil, err
 	}
+	if looksLikePAN(req.IdempotencyKey) {
+		return nil, fmt.Errorf("%w: idempotency key contains invalid card input", ErrCheckoutSessionValidation)
+	}
 
 	fingerprint := checkoutSessionRequestFingerprint(req)
 	req.IdempotencyKey = scopeIdempotencyKey(user.ID, req.IdempotencyKey)
@@ -311,7 +319,22 @@ func (s *CheckoutSessionService) CreateSession(ctx context.Context, req *Checkou
 				}
 				return cached, nil
 			case IdempotencyStatusPending:
-				return nil, ErrCheckoutSessionPending
+				if s.now().Sub(rec.CreatedAt) < checkoutSessionPendingLease {
+					return nil, ErrCheckoutSessionPending
+				}
+				taken, err := s.idempotencyService.TryTakeoverPending(
+					ctx,
+					checkoutSessionIdempotencyOp,
+					req.IdempotencyKey,
+					checkoutSessionPendingLease,
+				)
+				if err != nil {
+					return nil, fmt.Errorf("take over stale checkout session request: %w", err)
+				}
+				if !taken {
+					return nil, ErrCheckoutSessionPending
+				}
+				claimed = true
 			case IdempotencyStatusFailed:
 				return nil, fmt.Errorf("%w: previous request failed: %s", ErrCheckoutSessionConflict, rec.Error)
 			}
@@ -322,7 +345,10 @@ func (s *CheckoutSessionService) CreateSession(ctx context.Context, req *Checkou
 	resp, err := s.createSessionWithValidation(ctx, req, user)
 	if err != nil {
 		if claimed && s.idempotencyService != nil && strings.TrimSpace(req.IdempotencyKey) != "" {
-			_ = s.idempotencyService.Fail(ctx, checkoutSessionIdempotencyOp, req.IdempotencyKey, err)
+			isDeterministic := errors.Is(err, ErrCheckoutSessionValidation) || errors.Is(err, ErrCheckoutSessionConflict)
+			if isDeterministic {
+				_ = s.idempotencyService.Fail(ctx, checkoutSessionIdempotencyOp, req.IdempotencyKey, err)
+			}
 		}
 		return nil, err
 	}
@@ -370,6 +396,9 @@ func decodeCheckoutSessionIdempotencyResult(payload json.RawMessage, fingerprint
 }
 
 func (s *CheckoutSessionService) createSessionWithValidation(ctx context.Context, req *CheckoutSessionCreateRequest, user *UserIdentity) (*CheckoutSessionResponse, error) {
+	if err := rejectCheckoutSessionPAN(req); err != nil {
+		return nil, err
+	}
 	// Solana subscription-lifecycle modes (cancel / tier-change) are owner-gated
 	// actions on an EXISTING subscription, not a price purchase — route them to
 	// their dedicated builder before the price-first validation below.
@@ -402,6 +431,9 @@ func (s *CheckoutSessionService) createSessionWithValidation(ctx context.Context
 	}
 
 	rail := strings.ToLower(strings.TrimSpace(req.Payment.Rail))
+	if rail == "stripe" && strings.TrimSpace(req.IdempotencyKey) == "" {
+		return nil, fmt.Errorf("%w: idempotency key is required for stripe checkout", ErrCheckoutSessionValidation)
+	}
 	mode, err := s.resolveMode(req.Mode, rail, price)
 	if err != nil {
 		return nil, err
@@ -428,8 +460,19 @@ func (s *CheckoutSessionService) createSessionWithValidation(ctx context.Context
 	if rail == "ccbill" || rail == "stripe" {
 		ttl = redirectCheckoutSessionTTL
 	}
+	sessionID := uuidutil.NewV7()
+	idempotencyKey := strings.TrimSpace(req.IdempotencyKey)
+	requestFingerprint := ""
+	if idempotencyKey != "" {
+		sessionID = idempotentCheckoutSessionID(price.MerchantID, idempotencyKey)
+		requestFingerprint = checkoutSessionRequestFingerprint(req)
+	}
+	railState := map[string]any{}
+	if requestFingerprint != "" {
+		railState[checkoutSessionFingerprintKey] = requestFingerprint
+	}
 	session := &models.CheckoutSession{
-		ID:         uuidutil.NewV7(),
+		ID:         sessionID,
 		CustomerID: identity.CustomerIDFromString(user.ID).UUID(),
 		PriceID:    price.ID,
 		Mode:       mode,
@@ -440,7 +483,7 @@ func (s *CheckoutSessionService) createSessionWithValidation(ctx context.Context
 		ExpiresAt:  timePtr(now.Add(ttl)),
 		Metadata:   normalizeMetadata(req.Metadata),
 		RailFields: s.buildRailFields(rail, &req.Payment),
-		RailState:  map[string]any{},
+		RailState:  railState,
 		CreatedAt:  now,
 		UpdatedAt:  now,
 		PspID:      pspID,
@@ -449,11 +492,24 @@ func (s *CheckoutSessionService) createSessionWithValidation(ctx context.Context
 		ExpiryDate: &req.Payment.ExpiryDate,
 	}
 
-	if strings.TrimSpace(req.IdempotencyKey) != "" {
+	if idempotencyKey != "" {
 		session.IdempotencyKey = normalize.OptionalString(req.IdempotencyKey)
+		existing, err := s.repo.GetByID(ctx, session.ID)
+		if err == nil {
+			return s.resumeIdempotentSession(ctx, existing, session, &req.Payment, req.SuccessURL, req.CancelURL, user)
+		}
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("failed to resolve idempotent checkout session: %w", err)
+		}
 	}
 
 	if err := s.repo.Create(ctx, session); err != nil {
+		if idempotencyKey != "" {
+			existing, getErr := s.repo.GetByID(ctx, session.ID)
+			if getErr == nil {
+				return s.resumeIdempotentSession(ctx, existing, session, &req.Payment, req.SuccessURL, req.CancelURL, user)
+			}
+		}
 		return nil, fmt.Errorf("failed to create checkout session: %w", err)
 	}
 
@@ -468,6 +524,60 @@ func (s *CheckoutSessionService) createSessionWithValidation(ctx context.Context
 	}
 
 	return s.sessionToResponse(session), nil
+}
+
+func idempotentCheckoutSessionID(merchantID uuid.UUID, key string) uuid.UUID {
+	name := "openrails:checkout-session:" + merchantID.String() + ":" + strings.TrimSpace(key)
+	return uuid.NewSHA1(uuid.NameSpaceURL, []byte(name))
+}
+
+func (s *CheckoutSessionService) resumeIdempotentSession(
+	ctx context.Context,
+	existing, requested *models.CheckoutSession,
+	payment *CheckoutSessionPaymentRequest,
+	successURL, cancelURL string,
+	user *UserIdentity,
+) (*CheckoutSessionResponse, error) {
+	if existing == nil || requested == nil {
+		return nil, fmt.Errorf("%w: idempotent checkout session unavailable", ErrCheckoutSessionConflict)
+	}
+	storedFingerprint, _ := existing.RailState[checkoutSessionFingerprintKey].(string)
+	requestedFingerprint, _ := requested.RailState[checkoutSessionFingerprintKey].(string)
+	parametersMatch := existing.CustomerID == requested.CustomerID &&
+		existing.PriceID == requested.PriceID &&
+		existing.Mode == requested.Mode &&
+		existing.Rail == requested.Rail &&
+		equalOptionalUUID(existing.PspID, requested.PspID) &&
+		storedFingerprint != "" &&
+		storedFingerprint == requestedFingerprint
+	if !parametersMatch {
+		return nil, fmt.Errorf("%w: idempotency key reused with different checkout session parameters", ErrCheckoutSessionConflict)
+	}
+
+	switch existing.Status {
+	case models.CheckoutSessionStatusRequiresAction, models.CheckoutSessionStatusSucceeded:
+		return s.sessionToResponse(existing), nil
+	case models.CheckoutSessionStatusCreated, models.CheckoutSessionStatusFailed:
+		existing.IdempotencyKey = requested.IdempotencyKey
+		if err := s.initializeSession(ctx, existing, payment, successURL, cancelURL, user); err != nil {
+			_ = s.MarkFailed(ctx, existing.ID, err.Error(), "")
+			return nil, err
+		}
+		existing.UpdatedAt = s.now()
+		if err := s.repo.Update(ctx, existing); err != nil {
+			return nil, fmt.Errorf("failed to update idempotent checkout session: %w", err)
+		}
+		return s.sessionToResponse(existing), nil
+	default:
+		return nil, fmt.Errorf("%w: previous checkout session is %s", ErrCheckoutSessionConflict, existing.Status)
+	}
+}
+
+func equalOptionalUUID(left, right *uuid.UUID) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
 }
 
 func (s *CheckoutSessionService) GetSession(ctx context.Context, sessionID uuid.UUID, user *UserIdentity) (*CheckoutSessionResponse, error) {
@@ -606,6 +716,48 @@ func (s *CheckoutSessionService) validatePayment(ctx context.Context, rail strin
 	default:
 		return fmt.Errorf("%w: unsupported rail", ErrCheckoutSessionValidation)
 	}
+}
+
+func rejectCheckoutSessionPAN(req *CheckoutSessionCreateRequest) error {
+	if req == nil {
+		return nil
+	}
+	payment := req.Payment
+	if err := RejectPANShapedFields(&CheckoutRequest{
+		PaymentMethodID: payment.PaymentMethodID,
+		PaymentToken:    payment.PaymentToken,
+		Email:           payment.Email,
+		FirstName:       payment.FirstName,
+		LastName:        payment.LastName,
+		Address1:        payment.Address1,
+		City:            payment.City,
+		State:           payment.State,
+		Zip:             payment.Zip,
+		Country:         payment.Country,
+		LastFour:        payment.LastFour,
+		CardType:        payment.CardType,
+		ExpiryDate:      payment.ExpiryDate,
+		Metadata:        req.Metadata,
+	}); err != nil {
+		return fmt.Errorf("%w: invalid checkout input: %v", ErrCheckoutSessionValidation, err)
+	}
+	extraFields := map[string]string{
+		"payment.rail":         payment.Rail,
+		"payment.token_symbol": payment.TokenSymbol,
+		"payment.flow":         payment.Flow,
+		"payment.wallet":       payment.Wallet,
+		"success_url":          req.SuccessURL,
+		"cancel_url":           req.CancelURL,
+		"subscription_id":      req.SubscriptionID,
+		"new_price_id":         req.NewPriceID,
+		"price_id":             req.PriceID,
+		"mode":                 req.Mode,
+		"idempotency_key":      req.IdempotencyKey,
+	}
+	if err := RejectPANShapedFields(&CheckoutRequest{Metadata: extraFields}); err != nil {
+		return fmt.Errorf("%w: invalid checkout input: %v", ErrCheckoutSessionValidation, err)
+	}
+	return nil
 }
 
 // validateNMIInput requires exactly one of payment_token or payment_method_id;
@@ -1363,24 +1515,25 @@ func (s *CheckoutSessionService) initializeCheckoutSession(ctx context.Context, 
 	}
 
 	req := &CheckoutRequest{
-		PriceID:         api.FormatPriceID(session.PriceID),
-		PaymentMethodID: payment.PaymentMethodID,
-		PaymentToken:    payment.PaymentToken,
-		Rail:            string(session.Rail),
-		SuccessURL:      successURL,
-		CancelURL:       cancelURL,
-		Metadata:        session.Metadata,
-		Email:           payment.Email,
-		FirstName:       payment.FirstName,
-		LastName:        payment.LastName,
-		Address1:        payment.Address1,
-		City:            payment.City,
-		State:           payment.State,
-		Zip:             payment.Zip,
-		Country:         payment.Country,
-		LastFour:        payment.LastFour,
-		CardType:        payment.CardType,
-		ExpiryDate:      payment.ExpiryDate,
+		PriceID:           api.FormatPriceID(session.PriceID),
+		PaymentMethodID:   payment.PaymentMethodID,
+		PaymentToken:      payment.PaymentToken,
+		Rail:              string(session.Rail),
+		SuccessURL:        successURL,
+		CancelURL:         cancelURL,
+		Metadata:          session.Metadata,
+		CheckoutStartedAt: session.CreatedAt,
+		Email:             payment.Email,
+		FirstName:         payment.FirstName,
+		LastName:          payment.LastName,
+		Address1:          payment.Address1,
+		City:              payment.City,
+		State:             payment.State,
+		Zip:               payment.Zip,
+		Country:           payment.Country,
+		LastFour:          payment.LastFour,
+		CardType:          payment.CardType,
+		ExpiryDate:        payment.ExpiryDate,
 	}
 
 	if session.IdempotencyKey != nil {
@@ -1597,7 +1750,8 @@ func scopeIdempotencyKey(userID, key string) string {
 	if strings.TrimSpace(userID) == "" || trimmedKey == "" {
 		return trimmedKey
 	}
-	return fmt.Sprintf("%s:%s", strings.TrimSpace(userID), trimmedKey)
+	sum := sha256.Sum256([]byte(trimmedKey))
+	return fmt.Sprintf("%s:%s", strings.TrimSpace(userID), hex.EncodeToString(sum[:]))
 }
 
 func (s *CheckoutSessionService) isTerminal(status models.CheckoutSessionStatus) bool {

--- a/internal/modules/checkout/stripe_checkout_idempotency_test.go
+++ b/internal/modules/checkout/stripe_checkout_idempotency_test.go
@@ -90,3 +90,15 @@ func TestEqualOptionalUUID(t *testing.T) {
 		t.Fatal("different optional UUIDs matched")
 	}
 }
+
+func TestRejectCheckoutSessionPANIgnoresDerivedIdempotencyHash(t *testing.T) {
+	t.Parallel()
+
+	request := &CheckoutSessionCreateRequest{
+		Payment:        CheckoutSessionPaymentRequest{Rail: "nmi", PaymentToken: "safe-token"},
+		IdempotencyKey: scopeIdempotencyKey(uuid.NewString(), "checkout-92"),
+	}
+	if err := rejectCheckoutSessionPAN(request); err != nil {
+		t.Fatalf("derived idempotency hash rejected as pan: %v", err)
+	}
+}

--- a/internal/modules/checkout/stripe_checkout_idempotency_test.go
+++ b/internal/modules/checkout/stripe_checkout_idempotency_test.go
@@ -1,0 +1,92 @@
+package checkout
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/open-rails/openrails/internal/db/models"
+)
+
+func TestStripeCheckoutIdempotencyKey(t *testing.T) {
+	t.Parallel()
+
+	first := stripeCheckoutIdempotencyKey(" customer:key ")
+	if first == "" {
+		t.Fatal("idempotency key is empty")
+	}
+	if first != stripeCheckoutIdempotencyKey("customer:key") {
+		t.Fatal("surrounding whitespace changed idempotency key")
+	}
+	if first == stripeCheckoutIdempotencyKey("customer:other-key") {
+		t.Fatal("different checkout keys produced the same provider key")
+	}
+	if len(first) > 255 {
+		t.Fatalf("provider key length = %d, exceeds Stripe limit", len(first))
+	}
+	if got := stripeCheckoutIdempotencyKey(strings.Repeat("x", 1<<10)); len(got) != len(first) {
+		t.Fatalf("long input key length = %d, want %d", len(got), len(first))
+	}
+	if got := stripeCheckoutIdempotencyKey("   "); got != "" {
+		t.Fatalf("blank key = %q, want empty", got)
+	}
+}
+
+func TestIdempotentCheckoutSessionID(t *testing.T) {
+	t.Parallel()
+
+	merchantID := uuid.New()
+	first := idempotentCheckoutSessionID(merchantID, " customer:key ")
+	if first != idempotentCheckoutSessionID(merchantID, "customer:key") {
+		t.Fatal("surrounding whitespace changed checkout session id")
+	}
+	if first == idempotentCheckoutSessionID(merchantID, "customer:other-key") {
+		t.Fatal("different idempotency keys produced the same checkout session id")
+	}
+	if first == idempotentCheckoutSessionID(uuid.New(), "customer:key") {
+		t.Fatal("checkout session id is not merchant scoped")
+	}
+}
+
+func TestRejectCheckoutSessionPAN(t *testing.T) {
+	t.Parallel()
+
+	err := rejectCheckoutSessionPAN(&CheckoutSessionCreateRequest{
+		Payment:  CheckoutSessionPaymentRequest{Rail: "stripe"},
+		Metadata: map[string]string{"note": "4111 1111 1111 1111"},
+	})
+	if !errors.Is(err, ErrCheckoutSessionValidation) {
+		t.Fatalf("reject checkout pan error = %v, want checkout validation error", err)
+	}
+
+	err = rejectCheckoutSessionPAN(&CheckoutSessionCreateRequest{
+		Mode:    string(models.CheckoutSessionModeSolanaCancel),
+		Payment: CheckoutSessionPaymentRequest{Rail: "solana", Wallet: "4111-1111-1111-1111"},
+	})
+	if !errors.Is(err, ErrCheckoutSessionValidation) {
+		t.Fatalf("reject lifecycle pan error = %v, want checkout validation error", err)
+	}
+
+	err = rejectCheckoutSessionPAN(&CheckoutSessionCreateRequest{
+		Payment:  CheckoutSessionPaymentRequest{Rail: "nmi", PaymentToken: "safe-token"},
+		Metadata: map[string]string{"4111111111111111": "note"},
+	})
+	if !errors.Is(err, ErrCheckoutSessionValidation) {
+		t.Fatalf("reject metadata key pan error = %v, want checkout validation error", err)
+	}
+}
+
+func TestEqualOptionalUUID(t *testing.T) {
+	t.Parallel()
+
+	first := uuid.New()
+	same := first
+	different := uuid.New()
+	if !equalOptionalUUID(nil, nil) || !equalOptionalUUID(&first, &same) {
+		t.Fatal("equal optional UUIDs did not match")
+	}
+	if equalOptionalUUID(&first, nil) || equalOptionalUUID(nil, &first) || equalOptionalUUID(&first, &different) {
+		t.Fatal("different optional UUIDs matched")
+	}
+}

--- a/tests/stripe_checkout_e2e_test.go
+++ b/tests/stripe_checkout_e2e_test.go
@@ -18,6 +18,8 @@ package tests
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -43,6 +45,7 @@ type fakeStripeAPI struct {
 	mu               sync.Mutex
 	checkoutForms    []url.Values
 	checkoutVersions []string
+	checkoutKeys     []string
 	customerCreates  int
 
 	webhookEndpointLists   int
@@ -70,6 +73,7 @@ func newFakeStripeAPI(t *testing.T) *fakeStripeAPI {
 		f.mu.Lock()
 		f.checkoutForms = append(f.checkoutForms, r.PostForm)
 		f.checkoutVersions = append(f.checkoutVersions, r.Header.Get(stripeapi.VersionHeader))
+		f.checkoutKeys = append(f.checkoutKeys, r.Header.Get(stripeapi.IdempotencyKeyHeader))
 		f.mu.Unlock()
 		writeJSON(w, map[string]any{
 			"id":     "cs_test_e2e_1",
@@ -119,6 +123,19 @@ func writeJSON(w http.ResponseWriter, v any) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
+func clearCheckoutIdempotency(t *testing.T, suite *TestContainerSuite, clientKey string) {
+	t.Helper()
+	sum := sha256.Sum256([]byte(clientKey))
+	keys, err := suite.RedisClient.Keys(
+		context.Background(),
+		"idemp:*:"+hex.EncodeToString(sum[:]),
+	).Result()
+	require.NoError(t, err)
+	if len(keys) > 0 {
+		require.NoError(t, suite.RedisClient.Del(context.Background(), keys...).Err())
+	}
+}
+
 // hostRewriteTransport sends every request to target regardless of the
 // original host (api.stripe.com), preserving method/path/query/body/headers.
 type hostRewriteTransport struct{ target string }
@@ -150,6 +167,8 @@ func seedStripeSubscriptionPrice(t *testing.T, suite *TestContainerSuite, stripe
 		},
 	}
 	suite.InsertProduct(ctx, product)
+	trialAmount := int64(0)
+	trialHours := 24
 	price := &models.Price{
 		ID:                  uuid.New(),
 		ProductID:           product.ID,
@@ -157,6 +176,8 @@ func seedStripeSubscriptionPrice(t *testing.T, suite *TestContainerSuite, stripe
 		Currency:            "usd",
 		AutoRenew:           true,
 		AccessDurationHours: intPtr(720),
+		TrialUnitAmount:     &trialAmount,
+		TrialDurationHours:  &trialHours,
 		PSPLinks: map[string]map[string]string{
 			string(models.RailStripe): {
 				models.RailKeyRail:          string(models.RailStripe),
@@ -195,6 +216,7 @@ func TestCheckoutSessionStripeRedirect(t *testing.T) {
 	req, _ := http.NewRequest("POST", "/v1/checkout", bytes.NewReader(jsonBody))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Idempotency-Key", "stripe-checkout-e2e")
 
 	suite.Server.Handler().ServeHTTP(w, req)
 
@@ -226,9 +248,13 @@ func TestCheckoutSessionStripeRedirect(t *testing.T) {
 	// Wire pinning: exactly one checkout-session create, with the fields the
 	// activation leg depends on (metadata linkage back to OUR session/user).
 	fake.mu.Lock()
-	defer fake.mu.Unlock()
-	require.Len(t, fake.checkoutForms, 1, "exactly one Stripe checkout session create")
-	form := fake.checkoutForms[0]
+	checkoutForms := append([]url.Values(nil), fake.checkoutForms...)
+	checkoutVersions := append([]string(nil), fake.checkoutVersions...)
+	checkoutKeys := append([]string(nil), fake.checkoutKeys...)
+	customerCreates := fake.customerCreates
+	fake.mu.Unlock()
+	require.Len(t, checkoutForms, 1, "exactly one Stripe checkout session create")
+	form := checkoutForms[0]
 	assert.Equal(t, "subscription", form.Get("mode"))
 	assert.Equal(t, "price_e2e_stripe", form.Get("line_items[0][price]"))
 	assert.Equal(t, "1", form.Get("line_items[0][quantity]"))
@@ -241,11 +267,61 @@ func TestCheckoutSessionStripeRedirect(t *testing.T) {
 	assert.Equal(t, userID, form.Get("subscription_data[metadata][user_id]"))
 	// One durable Stripe customer per user (#212): resolved BEFORE the session,
 	// and the session is created against it (not customer_email).
-	assert.Equal(t, 1, fake.customerCreates, "customer created once via search-miss → create")
+	assert.Equal(t, 1, customerCreates, "customer created once via search-miss → create")
 	assert.Equal(t, "cus_e2e_test", form.Get("customer"))
 	assert.Empty(t, form.Get("customer_email"), "customer and customer_email are mutually exclusive")
 	// Choke-point proof: the API version pin rode through the fake transport.
-	assert.Equal(t, stripeapi.APIVersion, fake.checkoutVersions[0])
+	assert.Equal(t, stripeapi.APIVersion, checkoutVersions[0])
+	assert.NotEmpty(t, checkoutKeys[0], "checkout create must carry a Stripe idempotency key")
+
+	// Drop both Redis replay layers to simulate retry after their cache windows.
+	// The durable session id/fingerprint must recover the original local row and
+	// redirect without issuing a second provider request.
+	clearCheckoutIdempotency(t, suite, "stripe-checkout-e2e")
+	second := httptest.NewRecorder()
+	secondReq, _ := http.NewRequest("POST", "/v1/checkout", bytes.NewReader(jsonBody))
+	secondReq.Header.Set("Content-Type", "application/json")
+	secondReq.Header.Set("Authorization", "Bearer "+token)
+	secondReq.Header.Set("Idempotency-Key", "stripe-checkout-e2e")
+	suite.Server.Handler().ServeHTTP(second, secondReq)
+	require.Equal(t, http.StatusOK, second.Code, "durable replay body: %s", second.Body.String())
+	var secondResp map[string]any
+	require.NoError(t, json.Unmarshal(second.Body.Bytes(), &secondResp))
+	assert.Equal(t, resp["id"], secondResp["id"], "durable replay must reuse the checkout session")
+	fake.mu.Lock()
+	checkoutCreateCount := len(fake.checkoutForms)
+	fake.mu.Unlock()
+	require.Equal(t, 1, checkoutCreateCount, "durable replay must not create another Stripe checkout session")
+
+	// Simulate a process dying after Stripe accepted the request but before the
+	// local row persisted the redirect. The next cache-miss retry must reuse both
+	// the local session id and Stripe key, so every provider parameter is stable.
+	_, err = suite.Pool.Exec(context.Background(), `
+		UPDATE openrails.checkout_sessions
+		   SET status = 'created', rail_state = rail_state - 'redirect_url'
+		 WHERE id = $1
+	`, sessionID)
+	require.NoError(t, err)
+	clearCheckoutIdempotency(t, suite, "stripe-checkout-e2e")
+	third := httptest.NewRecorder()
+	thirdReq, _ := http.NewRequest("POST", "/v1/checkout", bytes.NewReader(jsonBody))
+	thirdReq.Header.Set("Content-Type", "application/json")
+	thirdReq.Header.Set("Authorization", "Bearer "+token)
+	thirdReq.Header.Set("Idempotency-Key", "stripe-checkout-e2e")
+	suite.Server.Handler().ServeHTTP(third, thirdReq)
+	require.Equal(t, http.StatusOK, third.Code, "crash replay body: %s", third.Body.String())
+	var thirdResp map[string]any
+	require.NoError(t, json.Unmarshal(third.Body.Bytes(), &thirdResp))
+	assert.Equal(t, resp["id"], thirdResp["id"], "crash replay must reuse the checkout session")
+	fake.mu.Lock()
+	checkoutForms = append([]url.Values(nil), fake.checkoutForms...)
+	checkoutKeys = append([]string(nil), fake.checkoutKeys...)
+	fake.mu.Unlock()
+	require.Len(t, checkoutForms, 2, "crash replay must retry the same Stripe operation once")
+	assert.Equal(t, checkoutKeys[0], checkoutKeys[1], "crash replay must reuse the Stripe idempotency key")
+	assert.Equal(t, checkoutForms[0].Get("metadata[checkout_session_id]"), checkoutForms[1].Get("metadata[checkout_session_id]"))
+	assert.NotEmpty(t, checkoutForms[0].Get("subscription_data[trial_end]"))
+	assert.Equal(t, checkoutForms[0].Get("subscription_data[trial_end]"), checkoutForms[1].Get("subscription_data[trial_end]"))
 
 	// The user's rail-customer mapping was recorded at checkout time (#212).
 	var mapped string


### PR DESCRIPTION
## Summary
- make idempotent checkout sessions durable across Redis expiry and process crashes
- propagate stable Stripe idempotency parameters, trial anchors, and provider-account identity
- harden PAN filtering and hash client idempotency keys before Redis storage
- add stale-request takeover and Stripe crash-recovery coverage

Supports open-rails/openrails-saas#26.

## Verification
- go test ./...
- go vet ./...
- go test -race ./internal/modules/checkout ./internal/http/middleware
- integration-tag compilation
- focused review and adversarial audit: clean