### PR TITLE
feat(money): ensure invoice profile defaults

### DIFF
--- a/internal/db/gen/customer_invoice_profiles.sql.go
+++ b/internal/db/gen/customer_invoice_profiles.sql.go
@@ -41,6 +41,49 @@ func (q *Queries) GetCustomerInvoiceProfile(ctx context.Context, arg GetCustomer
 	return i, err
 }
 
+const insertCustomerInvoiceProfileIfAbsent = `-- name: InsertCustomerInvoiceProfileIfAbsent :execrows
+INSERT INTO openrails.customer_invoice_profiles (
+    merchant_id, customer_id, net_terms_days, collection_method,
+    po_number, tax, billing_contacts, memo, created_at, updated_at
+) VALUES (
+    $1, $2, $3, $4,
+    $5, COALESCE($6, '{}'::jsonb),
+    COALESCE($7, '[]'::jsonb), $8,
+    $9::timestamptz, $9::timestamptz
+)
+ON CONFLICT (merchant_id, customer_id) DO NOTHING
+`
+
+type InsertCustomerInvoiceProfileIfAbsentParams struct {
+	MerchantID       uuid.UUID
+	CustomerID       uuid.UUID
+	NetTermsDays     int32
+	CollectionMethod string
+	PoNumber         *string
+	Tax              []byte
+	BillingContacts  []byte
+	Memo             *string
+	Now              time.Time
+}
+
+func (q *Queries) InsertCustomerInvoiceProfileIfAbsent(ctx context.Context, arg InsertCustomerInvoiceProfileIfAbsentParams) (int64, error) {
+	result, err := q.db.Exec(ctx, insertCustomerInvoiceProfileIfAbsent,
+		arg.MerchantID,
+		arg.CustomerID,
+		arg.NetTermsDays,
+		arg.CollectionMethod,
+		arg.PoNumber,
+		arg.Tax,
+		arg.BillingContacts,
+		arg.Memo,
+		arg.Now,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const upsertCustomerInvoiceProfile = `-- name: UpsertCustomerInvoiceProfile :exec
 
 INSERT INTO openrails.customer_invoice_profiles (

--- a/internal/db/gen/customers.sql.go
+++ b/internal/db/gen/customers.sql.go
@@ -76,6 +76,24 @@ func (q *Queries) EnsureCustomerRow(ctx context.Context, arg EnsureCustomerRowPa
 	return err
 }
 
+const lockCustomerForMerchant = `-- name: LockCustomerForMerchant :one
+SELECT id FROM openrails.customers
+WHERE id = $1 AND merchant_id = $2
+FOR UPDATE
+`
+
+type LockCustomerForMerchantParams struct {
+	ID         uuid.UUID
+	MerchantID uuid.UUID
+}
+
+func (q *Queries) LockCustomerForMerchant(ctx context.Context, arg LockCustomerForMerchantParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, lockCustomerForMerchant, arg.ID, arg.MerchantID)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
 const lookupCustomerIDsBySubjects = `-- name: LookupCustomerIDsBySubjects :many
 SELECT id, subject FROM openrails.customers
 WHERE merchant_id = $1

--- a/internal/db/queries/customer_invoice_profiles.sql
+++ b/internal/db/queries/customer_invoice_profiles.sql
@@ -21,6 +21,18 @@ ON CONFLICT (merchant_id, customer_id) DO UPDATE SET
     memo = EXCLUDED.memo,
     updated_at = EXCLUDED.updated_at;
 
+-- name: InsertCustomerInvoiceProfileIfAbsent :execrows
+INSERT INTO openrails.customer_invoice_profiles (
+    merchant_id, customer_id, net_terms_days, collection_method,
+    po_number, tax, billing_contacts, memo, created_at, updated_at
+) VALUES (
+    $1, $2, sqlc.arg(net_terms_days), sqlc.arg(collection_method),
+    sqlc.narg(po_number), COALESCE(sqlc.arg(tax), '{}'::jsonb),
+    COALESCE(sqlc.arg(billing_contacts), '[]'::jsonb), sqlc.narg(memo),
+    sqlc.arg(now)::timestamptz, sqlc.arg(now)::timestamptz
+)
+ON CONFLICT (merchant_id, customer_id) DO NOTHING;
+
 -- name: GetCustomerInvoiceProfile :one
 SELECT * FROM openrails.customer_invoice_profiles
 WHERE merchant_id = $1 AND customer_id = $2

--- a/internal/db/queries/customers.sql
+++ b/internal/db/queries/customers.sql
@@ -18,6 +18,11 @@ INSERT INTO openrails.customers (id, merchant_id, subject)
 VALUES (sqlc.arg(id), sqlc.arg(merchant_id), sqlc.arg(subject))
 ON CONFLICT DO NOTHING;
 
+-- name: LockCustomerForMerchant :one
+SELECT id FROM openrails.customers
+WHERE id = sqlc.arg(id) AND merchant_id = sqlc.arg(merchant_id)
+FOR UPDATE;
+
 -- name: LookupCustomerIDsBySubjects :many
 -- Resolve merchant-local stable host subjects to customer ids. Issuer is audit
 -- metadata only and never participates in identity.

--- a/internal/modules/money/enterprise_invoicing_integration_test.go
+++ b/internal/modules/money/enterprise_invoicing_integration_test.go
@@ -189,6 +189,122 @@ func TestEnterpriseInvoicing_NetTermsDocumentSnapshotAndDunning(t *testing.T) {
 	require.Zero(t, outstanding)
 }
 
+func TestEnterpriseInvoicing_EnsureCustomerInvoiceProfileDoesNotOverwrite(t *testing.T) {
+	svc, pool, payer, _, ctx := moneyInEnv(t)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, "DELETE FROM openrails.customer_invoice_profiles WHERE customer_id = $1", payer.UUID())
+	})
+
+	created, err := svc.EnsureCustomerInvoiceProfile(ctx, payer, money.CustomerInvoiceProfile{
+		CollectionMethod: money.CollectionChargeAutomatically,
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	require.NoError(t, svc.SetCustomerInvoiceProfile(ctx, payer, money.CustomerInvoiceProfile{
+		NetTermsDays:     30,
+		CollectionMethod: money.CollectionSendInvoice,
+		Memo:             "operator terms",
+	}))
+
+	created, err = svc.EnsureCustomerInvoiceProfile(ctx, payer, money.CustomerInvoiceProfile{
+		CollectionMethod: money.CollectionChargeAutomatically,
+	})
+	require.NoError(t, err)
+	require.False(t, created)
+
+	got, err := svc.GetCustomerInvoiceProfile(ctx, payer)
+	require.NoError(t, err)
+	require.Equal(t, 30, got.NetTermsDays)
+	require.Equal(t, money.CollectionSendInvoice, got.CollectionMethod)
+	require.Equal(t, "operator terms", got.Memo)
+
+	_, err = pool.Exec(ctx, "DELETE FROM openrails.customer_invoice_profiles WHERE customer_id = $1", payer.UUID())
+	require.NoError(t, err)
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	go func() {
+		<-start
+		_, err := svc.EnsureCustomerInvoiceProfile(ctx, payer, money.CustomerInvoiceProfile{
+			CollectionMethod: money.CollectionChargeAutomatically,
+		})
+		errs <- err
+	}()
+	go func() {
+		<-start
+		errs <- svc.SetCustomerInvoiceProfile(ctx, payer, money.CustomerInvoiceProfile{
+			NetTermsDays:     45,
+			CollectionMethod: money.CollectionSendInvoice,
+			Memo:             "concurrent operator terms",
+		})
+	}()
+	close(start)
+	require.NoError(t, <-errs)
+	require.NoError(t, <-errs)
+
+	got, err = svc.GetCustomerInvoiceProfile(ctx, payer)
+	require.NoError(t, err)
+	require.Equal(t, 45, got.NetTermsDays)
+	require.Equal(t, money.CollectionSendInvoice, got.CollectionMethod)
+	require.Equal(t, "concurrent operator terms", got.Memo)
+
+	_, err = pool.Exec(ctx, "DELETE FROM openrails.customer_invoice_profiles WHERE customer_id = $1", payer.UUID())
+	require.NoError(t, err)
+	type ensureResult struct {
+		created bool
+		err     error
+	}
+	results := make(chan ensureResult, 2)
+	start = make(chan struct{})
+	for range 2 {
+		go func() {
+			<-start
+			created, err := svc.EnsureCustomerInvoiceProfile(ctx, payer, money.CustomerInvoiceProfile{
+				CollectionMethod: money.CollectionChargeAutomatically,
+			})
+			results <- ensureResult{created: created, err: err}
+		}()
+	}
+	close(start)
+	createdCount := 0
+	for range 2 {
+		result := <-results
+		require.NoError(t, result.err)
+		if result.created {
+			createdCount++
+		}
+	}
+	require.Equal(t, 1, createdCount)
+}
+
+func TestEnterpriseInvoicing_CustomerInvoiceProfileRejectsCrossMerchantPayer(t *testing.T) {
+	svc, pool, _, _, ctx := moneyInEnv(t)
+	foreignMerchantID := uuid.New()
+	foreignPayer := identity.CustomerIDFromString(uuid.NewString())
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, "DELETE FROM openrails.customers WHERE id = $1", foreignPayer.UUID())
+		_, _ = pool.Exec(ctx, "DELETE FROM openrails.merchants WHERE id = $1", foreignMerchantID)
+	})
+
+	_, err := pool.Exec(ctx,
+		"INSERT INTO openrails.merchants (id, slug) VALUES ($1, $2)",
+		foreignMerchantID, "foreign-profile-"+uuid.NewString()[:8],
+	)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx,
+		"INSERT INTO openrails.customers (id, merchant_id, subject) VALUES ($1, $2, $3)",
+		foreignPayer.UUID(), foreignMerchantID, foreignPayer.UUID().String(),
+	)
+	require.NoError(t, err)
+
+	profile := money.CustomerInvoiceProfile{CollectionMethod: money.CollectionChargeAutomatically}
+	created, err := svc.EnsureCustomerInvoiceProfile(ctx, foreignPayer, profile)
+	require.ErrorContains(t, err, "payer belongs to another merchant")
+	require.False(t, created)
+	require.ErrorContains(t, svc.SetCustomerInvoiceProfile(ctx, foreignPayer, profile), "payer belongs to another merchant")
+}
+
 // TestEnterpriseInvoicing_PastWindowFinalizeAttachesAccruals pins the #798
 // fix: finalizing a window that ENDED in the past (the previous-month close)
 // must rate + ATTACH that window's usage — accruals are stamped with their

--- a/internal/modules/money/invoice_profile.go
+++ b/internal/modules/money/invoice_profile.go
@@ -53,39 +53,78 @@ func normalizeCollectionMethod(s string) (string, error) {
 // SetCustomerInvoiceProfile upserts a payer's invoice profile. Operator
 // surface — a payer must not grant itself credit terms.
 func (s *MoneyService) SetCustomerInvoiceProfile(ctx context.Context, payer identity.CustomerID, p CustomerInvoiceProfile) error {
+	_, err := s.writeCustomerInvoiceProfile(ctx, payer, p, false)
+	return err
+}
+
+// EnsureCustomerInvoiceProfile inserts a payer's invoice profile when none is
+// stored. It never overwrites an operator-configured profile.
+func (s *MoneyService) EnsureCustomerInvoiceProfile(ctx context.Context, payer identity.CustomerID, p CustomerInvoiceProfile) (bool, error) {
+	return s.writeCustomerInvoiceProfile(ctx, payer, p, true)
+}
+
+func (s *MoneyService) writeCustomerInvoiceProfile(ctx context.Context, payer identity.CustomerID, p CustomerInvoiceProfile, insertOnly bool) (bool, error) {
 	if s == nil || s.db == nil {
-		return fmt.Errorf("money service not initialized")
+		return false, fmt.Errorf("money service not initialized")
 	}
 	if payer.IsZero() {
-		return fmt.Errorf("payer required")
+		return false, fmt.Errorf("payer required")
 	}
 	netTerms, castErr := safecast.Convert[int32](p.NetTermsDays)
 	if castErr != nil || netTerms < 0 {
-		return fmt.Errorf("net_terms_days must be a non-negative int32")
+		return false, fmt.Errorf("net_terms_days must be a non-negative int32")
 	}
 	method, err := normalizeCollectionMethod(p.CollectionMethod)
 	if err != nil {
-		return err
+		return false, err
 	}
 	tid, err := merchant.Require(ctx)
 	if err != nil {
-		return err
+		return false, err
 	}
 	taxJSON, err := toJSONBC(p.Tax)
 	if err != nil {
-		return fmt.Errorf("encode invoice profile tax: %w", err)
+		return false, fmt.Errorf("encode invoice profile tax: %w", err)
 	}
 	contactsJSON, err := json.Marshal(p.BillingContacts)
 	if err != nil {
-		return fmt.Errorf("encode invoice profile billing_contacts: %w", err)
+		return false, fmt.Errorf("encode invoice profile billing_contacts: %w", err)
 	}
 	if p.BillingContacts == nil {
 		contactsJSON = []byte("[]")
 	}
-	return s.db.MerchantTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+	created := false
+	err = s.db.MerchantTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
 		q := gen.New(tx)
 		if err := ensureCustomer(ctx, q, tid.UUID(), payer.UUID()); err != nil {
 			return err
+		}
+		_, err := q.LockCustomerForMerchant(ctx, gen.LockCustomerForMerchantParams{
+			ID: payer.UUID(), MerchantID: tid.UUID(),
+		})
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return fmt.Errorf("invoice profile payer belongs to another merchant")
+			}
+			return fmt.Errorf("lock invoice profile payer: %w", err)
+		}
+		if insertOnly {
+			rows, err := q.InsertCustomerInvoiceProfileIfAbsent(ctx, gen.InsertCustomerInvoiceProfileIfAbsentParams{
+				MerchantID:       tid.UUID(),
+				CustomerID:       payer.UUID(),
+				NetTermsDays:     netTerms,
+				CollectionMethod: method,
+				PoNumber:         nilIfEmpty(p.PONumber),
+				Tax:              taxJSON,
+				BillingContacts:  contactsJSON,
+				Memo:             nilIfEmpty(p.Memo),
+				Now:              s.now(),
+			})
+			if err != nil {
+				return err
+			}
+			created = rows == 1
+			return nil
 		}
 		return q.UpsertCustomerInvoiceProfile(ctx, gen.UpsertCustomerInvoiceProfileParams{
 			MerchantID:       tid.UUID(),
@@ -99,6 +138,10 @@ func (s *MoneyService) SetCustomerInvoiceProfile(ctx context.Context, payer iden
 			Now:              s.now(),
 		})
 	})
+	if err != nil {
+		return false, err
+	}
+	return created, nil
 }
 
 // GetCustomerInvoiceProfile returns the payer's invoice profile, or nil when
@@ -152,4 +195,3 @@ func invoiceProfileFromGen(row gen.OpenrailsCustomerInvoiceProfile) (*CustomerIn
 	}
 	return p, nil
 }
-

--- a/migrations/postgres/0008_invoice_profile_customer_ownership.down.sql
+++ b/migrations/postgres/0008_invoice_profile_customer_ownership.down.sql
@@ -1,0 +1,11 @@
+ALTER TABLE ONLY openrails.customer_invoice_profiles
+    DROP CONSTRAINT customer_invoice_profiles_customer_fk;
+
+ALTER TABLE ONLY openrails.customer_invoice_profiles
+    ADD CONSTRAINT customer_invoice_profiles_customer_fk
+    FOREIGN KEY (customer_id)
+    REFERENCES openrails.customers(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE ONLY openrails.customers
+    DROP CONSTRAINT customers_merchant_id_id_key;

--- a/migrations/postgres/0008_invoice_profile_customer_ownership.up.sql
+++ b/migrations/postgres/0008_invoice_profile_customer_ownership.up.sql
@@ -1,0 +1,22 @@
+-- Invoice profiles and their customers must belong to the same merchant.
+-- Remove legacy mismatches before enforcing the invariant at the DB boundary.
+-- Lock in application order so legacy writers cannot race the cleanup.
+LOCK TABLE openrails.customers IN SHARE ROW EXCLUSIVE MODE;
+LOCK TABLE openrails.customer_invoice_profiles IN SHARE ROW EXCLUSIVE MODE;
+
+DELETE FROM openrails.customer_invoice_profiles AS profile
+USING openrails.customers AS customer
+WHERE profile.customer_id = customer.id
+  AND profile.merchant_id <> customer.merchant_id;
+
+ALTER TABLE ONLY openrails.customers
+    ADD CONSTRAINT customers_merchant_id_id_key UNIQUE (merchant_id, id);
+
+ALTER TABLE ONLY openrails.customer_invoice_profiles
+    DROP CONSTRAINT customer_invoice_profiles_customer_fk;
+
+ALTER TABLE ONLY openrails.customer_invoice_profiles
+    ADD CONSTRAINT customer_invoice_profiles_customer_fk
+    FOREIGN KEY (merchant_id, customer_id)
+    REFERENCES openrails.customers(merchant_id, id)
+    ON DELETE CASCADE;

--- a/pkg/service/enterprise.go
+++ b/pkg/service/enterprise.go
@@ -59,6 +59,30 @@ func (s *Service) SetCustomerInvoiceProfile(ctx context.Context, payer identity.
 	})
 }
 
+// EnsureCustomerInvoiceProfile inserts a payer's invoicing profile when none
+// is stored. Existing operator configuration is left unchanged. The returned
+// boolean is true only when this call committed a new profile.
+func (s *Service) EnsureCustomerInvoiceProfile(ctx context.Context, payer identity.CustomerID, p InvoiceProfileDTO) (bool, error) {
+	if s == nil || s.rt == nil {
+		return false, fmt.Errorf("service not initialized")
+	}
+	if payer.IsZero() {
+		return false, fmt.Errorf("payer required")
+	}
+	contacts := make([]models.InvoiceContact, 0, len(p.BillingContacts))
+	for _, c := range p.BillingContacts {
+		contacts = append(contacts, models.InvoiceContact{Name: c.Name, Email: c.Email})
+	}
+	return s.moneyService().EnsureCustomerInvoiceProfile(ctx, payer, money.CustomerInvoiceProfile{
+		NetTermsDays:     p.NetTermsDays,
+		CollectionMethod: p.CollectionMethod,
+		PONumber:         p.PONumber,
+		Tax:              p.Tax,
+		BillingContacts:  contacts,
+		Memo:             p.Memo,
+	})
+}
+
 // GetCustomerInvoiceProfile returns a payer's invoicing profile (nil = none).
 func (s *Service) GetCustomerInvoiceProfile(ctx context.Context, payer identity.CustomerID) (*InvoiceProfileDTO, error) {
 	if s == nil || s.rt == nil {

--- a/scripts/sqlc-vet-db.sh
+++ b/scripts/sqlc-vet-db.sh
@@ -36,7 +36,7 @@ done
 # fails the whole build at 0007 with "schema profiles does not exist".
 psql "$VET_URL" -v ON_ERROR_STOP=1 -q -f internal/db/schema/profiles_shim.sql 1>&2
 for f in $(ls migrations/postgres/*.up.sql | sort -V); do
-    psql "$VET_URL" -v ON_ERROR_STOP=1 -q -f "$f" 1>&2
+    psql "$VET_URL" -v ON_ERROR_STOP=1 -q -1 -f "$f" 1>&2
 done
 
 printf '%s\n' "$VET_URL"


### PR DESCRIPTION
## Summary
- add an atomic create-if-absent invoice profile API without changing operator upsert behavior
- enforce customer/profile merchant ownership in code and with a composite foreign key
- cover non-overwrite, concurrent ensure, and cross-merchant behavior
- align the sqlc migration harness with production per-migration transactions

## Verification
- task sqlc
- go test ./...
- go vet ./...
- bash scripts/test_integration.sh ./internal/modules/money -run 'TestEnterpriseInvoicing_(EnsureCustomerInvoiceProfileDoesNotOverwrite|CustomerInvoiceProfileRejectsCrossMerchantPayer)'