### PR TITLE
feat(money): add durable invoice collection retries

### DIFF
--- a/internal/db/gen/invoices.sql.go
+++ b/internal/db/gen/invoices.sql.go
@@ -421,6 +421,104 @@ func (q *Queries) GetInvoiceForPayerForUpdate(ctx context.Context, arg GetInvoic
 	return i, err
 }
 
+const getInvoicePaymentAttemptByClientKey = `-- name: GetInvoicePaymentAttemptByClientKey :one
+SELECT id, merchant_id, customer_id, invoice_id, ledger_transfer_id, currency, amount, status, rail, rail_payment_id, failure_code, failure_message, attempted_at, settled_at, created_at, updated_at, psp_id, failure_reason, payment_method_id, idempotency_key FROM openrails.invoice_payments
+WHERE merchant_id = $1
+  AND customer_id = $2
+  AND invoice_id = $3
+  AND idempotency_key LIKE $4 || ':%'
+LIMIT 1
+`
+
+type GetInvoicePaymentAttemptByClientKeyParams struct {
+	MerchantID uuid.UUID
+	CustomerID uuid.UUID
+	InvoiceID  uuid.UUID
+	ClientKey  *string
+}
+
+func (q *Queries) GetInvoicePaymentAttemptByClientKey(ctx context.Context, arg GetInvoicePaymentAttemptByClientKeyParams) (OpenrailsInvoicePayment, error) {
+	row := q.db.QueryRow(ctx, getInvoicePaymentAttemptByClientKey,
+		arg.MerchantID,
+		arg.CustomerID,
+		arg.InvoiceID,
+		arg.ClientKey,
+	)
+	var i OpenrailsInvoicePayment
+	err := row.Scan(
+		&i.ID,
+		&i.MerchantID,
+		&i.CustomerID,
+		&i.InvoiceID,
+		&i.LedgerTransferID,
+		&i.Currency,
+		&i.Amount,
+		&i.Status,
+		&i.Rail,
+		&i.RailPaymentID,
+		&i.FailureCode,
+		&i.FailureMessage,
+		&i.AttemptedAt,
+		&i.SettledAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.PspID,
+		&i.FailureReason,
+		&i.PaymentMethodID,
+		&i.IdempotencyKey,
+	)
+	return i, err
+}
+
+const getInvoicePaymentAttemptByKey = `-- name: GetInvoicePaymentAttemptByKey :one
+SELECT id, merchant_id, customer_id, invoice_id, ledger_transfer_id, currency, amount, status, rail, rail_payment_id, failure_code, failure_message, attempted_at, settled_at, created_at, updated_at, psp_id, failure_reason, payment_method_id, idempotency_key FROM openrails.invoice_payments
+WHERE merchant_id = $1
+  AND customer_id = $2
+  AND invoice_id = $3
+  AND idempotency_key = $4
+LIMIT 1
+`
+
+type GetInvoicePaymentAttemptByKeyParams struct {
+	MerchantID     uuid.UUID
+	CustomerID     uuid.UUID
+	InvoiceID      uuid.UUID
+	IdempotencyKey *string
+}
+
+func (q *Queries) GetInvoicePaymentAttemptByKey(ctx context.Context, arg GetInvoicePaymentAttemptByKeyParams) (OpenrailsInvoicePayment, error) {
+	row := q.db.QueryRow(ctx, getInvoicePaymentAttemptByKey,
+		arg.MerchantID,
+		arg.CustomerID,
+		arg.InvoiceID,
+		arg.IdempotencyKey,
+	)
+	var i OpenrailsInvoicePayment
+	err := row.Scan(
+		&i.ID,
+		&i.MerchantID,
+		&i.CustomerID,
+		&i.InvoiceID,
+		&i.LedgerTransferID,
+		&i.Currency,
+		&i.Amount,
+		&i.Status,
+		&i.Rail,
+		&i.RailPaymentID,
+		&i.FailureCode,
+		&i.FailureMessage,
+		&i.AttemptedAt,
+		&i.SettledAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.PspID,
+		&i.FailureReason,
+		&i.PaymentMethodID,
+		&i.IdempotencyKey,
+	)
+	return i, err
+}
+
 const insertInvoice = `-- name: InsertInvoice :exec
 INSERT INTO openrails.invoices (
     id, merchant_id, customer_id, currency,

--- a/internal/db/queries/invoices.sql
+++ b/internal/db/queries/invoices.sql
@@ -231,6 +231,22 @@ INSERT INTO openrails.invoice_payments (
     sqlc.narg(payment_method_id), sqlc.narg(idempotency_key)
 );
 
+-- name: GetInvoicePaymentAttemptByKey :one
+SELECT * FROM openrails.invoice_payments
+WHERE merchant_id = $1
+  AND customer_id = $2
+  AND invoice_id = $3
+  AND idempotency_key = sqlc.arg(idempotency_key)
+LIMIT 1;
+
+-- name: GetInvoicePaymentAttemptByClientKey :one
+SELECT * FROM openrails.invoice_payments
+WHERE merchant_id = $1
+  AND customer_id = $2
+  AND invoice_id = $3
+  AND idempotency_key LIKE sqlc.arg(client_key) || ':%'
+LIMIT 1;
+
 -- name: DeleteClaimedInvoicePaymentAttempt :execrows
 DELETE FROM openrails.invoice_payments
 WHERE merchant_id = $1

--- a/internal/modules/money/arrears.go
+++ b/internal/modules/money/arrears.go
@@ -304,9 +304,9 @@ func (s *MoneyService) chargeClaimedInvoice(ctx context.Context, charger Charger
 		defer cancel()
 		if isCollectionOutcomeAmbiguous(err) {
 			if recordErr := s.markInvoiceCollectionOutcomeUnknown(cleanupCtx, claim, s.now()); recordErr != nil {
-				return false, errors.Join(err, recordErr)
+				return false, errors.Join(ErrInvoiceRetryOutcomeUnknown, err, recordErr)
 			}
-			return false, err
+			return false, errors.Join(ErrInvoiceRetryOutcomeUnknown, err)
 		}
 		if releaseErr := s.releaseInvoiceCollectionClaim(cleanupCtx, claim, s.now()); releaseErr != nil {
 			return false, errors.Join(err, releaseErr)
@@ -322,9 +322,9 @@ func (s *MoneyService) chargeClaimedInvoice(ctx context.Context, charger Charger
 			markCtx, markCancel := collectionCleanupContext(ctx)
 			defer markCancel()
 			if markErr := s.markInvoiceCollectionOutcomeUnknown(markCtx, claim, s.now()); markErr != nil {
-				return false, errors.Join(err, markErr)
+				return false, errors.Join(ErrInvoiceRetryOutcomeUnknown, err, markErr)
 			}
-			return false, err
+			return false, errors.Join(ErrInvoiceRetryOutcomeUnknown, err)
 		}
 		return false, nil
 	}
@@ -416,9 +416,9 @@ func (s *MoneyService) chargeClaimedInvoice(ctx context.Context, charger Charger
 		markCtx, markCancel := collectionCleanupContext(ctx)
 		defer markCancel()
 		if markErr := s.markInvoiceCollectionOutcomeUnknown(markCtx, claim, s.now()); markErr != nil {
-			return false, errors.Join(err, markErr)
+			return false, errors.Join(ErrInvoiceRetryOutcomeUnknown, err, markErr)
 		}
-		return false, err
+		return false, errors.Join(ErrInvoiceRetryOutcomeUnknown, err)
 	}
 	return charged, nil
 }

--- a/internal/modules/money/invoice_recovery.go
+++ b/internal/modules/money/invoice_recovery.go
@@ -2,6 +2,8 @@ package money
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
@@ -24,7 +26,22 @@ var (
 	ErrInvoiceNotRetryable             = errors.New("invoice is not retryable")
 	ErrCollectionPaymentMethodRequired = errors.New("collection payment method required")
 	ErrCollectionPaymentMethodInvalid  = errors.New("collection payment method invalid")
+	ErrInvoiceRetryInProgress          = errors.New("invoice retry is in progress")
+	ErrInvoiceRetryOutcomeUnknown      = errors.New("invoice retry outcome is unknown")
+	ErrInvoiceRetryIdempotencyConflict = errors.New("invoice retry idempotency conflict")
 )
+
+type InvoiceCollectionRetryRequest struct {
+	InvoiceID       uuid.UUID
+	IdempotencyKey  string
+	PaymentMethodID uuid.UUID
+}
+
+type InvoiceCollectionRetryResult struct {
+	Invoice  *models.Invoice
+	Attempt  models.InvoicePaymentAttempt
+	Replayed bool
+}
 
 const (
 	collectionAttemptInProgress = "collection_attempt_in_progress"
@@ -183,6 +200,79 @@ func (s *MoneyService) RetryInvoiceCollection(ctx context.Context, charger Charg
 	return s.GetInvoiceByID(ctx, payer, invoiceID)
 }
 
+// RetryInvoiceCollectionIdempotent binds a client retry key to one saved
+// payment method. Reusing the key returns the durable terminal attempt without
+// dispatching another provider charge.
+func (s *MoneyService) RetryInvoiceCollectionIdempotent(ctx context.Context, charger Charger, payer identity.CustomerID, request InvoiceCollectionRetryRequest) (*InvoiceCollectionRetryResult, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("money service not initialized")
+	}
+	if charger == nil {
+		return nil, fmt.Errorf("charger required")
+	}
+	if payer.IsZero() {
+		return nil, fmt.Errorf("payer required")
+	}
+	if request.InvoiceID == uuid.Nil || request.PaymentMethodID == uuid.Nil {
+		return nil, fmt.Errorf("invoice_id and payment_method_id required")
+	}
+	request.IdempotencyKey = strings.TrimSpace(request.IdempotencyKey)
+	if request.IdempotencyKey == "" || len(request.IdempotencyKey) > 255 {
+		return nil, fmt.Errorf("idempotency_key must be between 1 and 255 bytes")
+	}
+	tid, err := merchant.Require(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.expireStaleInvoiceCollectionRetryClaims(ctx, tid.UUID(), s.now()); err != nil {
+		return nil, err
+	}
+	providerKey := invoiceRetryIdempotencyKey(request.InvoiceID, request.IdempotencyKey)
+	attemptKey := invoiceRetryAttemptKey(providerKey, request.PaymentMethodID)
+	claim, replay, claimed, err := s.claimInvoiceCollectionWithOptions(ctx, payer, request.InvoiceID, invoiceCollectionClaimOptions{
+		manual: true, now: s.now(), idempotencyKey: attemptKey,
+		providerIdempotencyKey: providerKey, paymentMethodID: &request.PaymentMethodID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if replay != nil {
+		invoice, err := s.GetInvoiceByID(ctx, payer, request.InvoiceID)
+		if err != nil {
+			return nil, err
+		}
+		return &InvoiceCollectionRetryResult{Invoice: invoice, Attempt: *replay, Replayed: true}, nil
+	}
+	if !claimed {
+		return nil, ErrInvoiceNotRetryable
+	}
+	if _, err := s.chargeClaimedInvoice(ctx, charger, claim); err != nil {
+		return nil, fmt.Errorf("retry invoice collection: %w", err)
+	}
+	loadCtx, cancel := collectionCleanupContext(ctx)
+	defer cancel()
+	invoice, err := s.GetInvoiceByID(loadCtx, payer, request.InvoiceID)
+	if err != nil {
+		return nil, err
+	}
+	attemptRow, err := s.db.Gen(loadCtx).GetInvoicePaymentAttemptByKey(loadCtx, gen.GetInvoicePaymentAttemptByKeyParams{
+		MerchantID: tid.UUID(), CustomerID: payer.UUID(), InvoiceID: request.InvoiceID, IdempotencyKey: &attemptKey,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("load invoice retry outcome: %w", err)
+	}
+	return &InvoiceCollectionRetryResult{Invoice: invoice, Attempt: invoicePaymentAttemptFromGen(attemptRow)}, nil
+}
+
+func invoiceRetryIdempotencyKey(invoiceID uuid.UUID, clientKey string) string {
+	digest := sha256.Sum256([]byte(invoiceID.String() + "\x00" + clientKey))
+	return "ir_" + base64.RawURLEncoding.EncodeToString(digest[:])
+}
+
+func invoiceRetryAttemptKey(providerKey string, paymentMethodID uuid.UUID) string {
+	return providerKey + ":" + paymentMethodID.String()
+}
+
 func invoiceCollectionRetryable(invoice *models.Invoice) bool {
 	return invoice != nil &&
 		invoice.CollectionMethod == CollectionChargeAutomatically &&
@@ -207,19 +297,36 @@ func scheduledInvoiceCollectionEligible(invoice *models.Invoice, minThreshold in
 		invoice.NextCollectionAttemptAt != nil && !invoice.NextCollectionAttemptAt.After(now)
 }
 
+type invoiceCollectionClaimOptions struct {
+	minThreshold           int64
+	manual                 bool
+	now                    time.Time
+	idempotencyKey         string
+	providerIdempotencyKey string
+	paymentMethodID        *uuid.UUID
+}
+
 func (s *MoneyService) claimInvoiceCollection(ctx context.Context, payer identity.CustomerID, invoiceID uuid.UUID, minThreshold int64, manual bool, now time.Time) (*invoiceCollectionClaim, bool, error) {
+	claim, _, claimed, err := s.claimInvoiceCollectionWithOptions(ctx, payer, invoiceID, invoiceCollectionClaimOptions{
+		minThreshold: minThreshold, manual: manual, now: now,
+	})
+	return claim, claimed, err
+}
+
+func (s *MoneyService) claimInvoiceCollectionWithOptions(ctx context.Context, payer identity.CustomerID, invoiceID uuid.UUID, options invoiceCollectionClaimOptions) (*invoiceCollectionClaim, *models.InvoicePaymentAttempt, bool, error) {
 	tid, err := merchant.Require(ctx)
 	if err != nil {
-		return nil, false, err
+		return nil, nil, false, err
 	}
 	var claim *invoiceCollectionClaim
+	var replay *models.InvoicePaymentAttempt
 	claimed := false
 	err = s.db.MerchantTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
 		q := gen.New(tx)
 		row, err := q.GetInvoiceForPayerForUpdate(ctx, gen.GetInvoiceForPayerForUpdateParams{
 			MerchantID: tid.UUID(), CustomerID: payer.UUID(), ID: invoiceID,
 		})
-		if errors.Is(err, pgx.ErrNoRows) && !manual {
+		if errors.Is(err, pgx.ErrNoRows) && !options.manual {
 			return nil
 		}
 		if err != nil {
@@ -229,35 +336,84 @@ func (s *MoneyService) claimInvoiceCollection(ctx context.Context, payer identit
 		if err != nil {
 			return fmt.Errorf("map invoice collection: %w", err)
 		}
-		eligible := scheduledInvoiceCollectionEligible(invoice, minThreshold, now)
-		if manual {
+		if options.idempotencyKey != "" {
+			row, err := q.GetInvoicePaymentAttemptByClientKey(ctx, gen.GetInvoicePaymentAttemptByClientKeyParams{
+				MerchantID: tid.UUID(), CustomerID: payer.UUID(), InvoiceID: invoiceID,
+				ClientKey: &options.providerIdempotencyKey,
+			})
+			if err == nil {
+				if row.IdempotencyKey == nil || *row.IdempotencyKey != options.idempotencyKey {
+					return ErrInvoiceRetryIdempotencyConflict
+				}
+				attempt := invoicePaymentAttemptFromGen(row)
+				switch attempt.Status {
+				case "failed", "settled":
+					replay = &attempt
+					return nil
+				default:
+					if derefStr(invoice.LastCollectionFailureCode) == collectionOutcomeUnknown {
+						return ErrInvoiceRetryOutcomeUnknown
+					}
+					return ErrInvoiceRetryInProgress
+				}
+			}
+			if !errors.Is(err, pgx.ErrNoRows) {
+				return fmt.Errorf("load invoice retry attempt: %w", err)
+			}
+			switch derefStr(invoice.LastCollectionFailureCode) {
+			case collectionAttemptInProgress:
+				return ErrInvoiceRetryInProgress
+			case collectionOutcomeUnknown:
+				return ErrInvoiceRetryOutcomeUnknown
+			}
+		}
+		eligible := scheduledInvoiceCollectionEligible(invoice, options.minThreshold, options.now)
+		if options.manual {
 			eligible = invoiceCollectionRetryable(invoice)
 		}
 		if !eligible {
 			return nil
 		}
-		settingsRow, err := q.GetMoneyAccountSettings(ctx, gen.GetMoneyAccountSettingsParams{
-			MerchantID: tid.UUID(), CustomerID: payer.UUID(), Currency: invoice.Currency,
-		})
-		if errors.Is(err, pgx.ErrNoRows) {
-			if manual {
-				return ErrCollectionPaymentMethodRequired
+		paymentMethodID := options.paymentMethodID
+		if paymentMethodID != nil {
+			method, err := q.GetPaymentMethodByID(ctx, *paymentMethodID)
+			if err != nil {
+				if errors.Is(err, pgx.ErrNoRows) {
+					return ErrCollectionPaymentMethodInvalid
+				}
+				return fmt.Errorf("load collection payment method: %w", err)
 			}
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("load invoice collection settings: %w", err)
-		}
-		settings := settingsFromGen(settingsRow)
-		paymentMethodID := settings.CollectionPaymentMethod
-		if paymentMethodID == nil {
-			paymentMethodID = settings.AutoTopupPaymentMethod
-		}
-		if paymentMethodID == nil {
-			if manual {
-				return ErrCollectionPaymentMethodRequired
+			if method.MerchantID != tid.UUID() || method.CustomerID != payer.UUID() || strings.TrimSpace(method.ParkReason) != "" {
+				return ErrCollectionPaymentMethodInvalid
 			}
-			return nil
+			descriptor, ok := rails.Lookup(models.Rail(method.Rail))
+			if !ok || !descriptor.SupportsChargeSavedMethod {
+				return ErrCollectionPaymentMethodInvalid
+			}
+		} else {
+			settingsRow, err := q.GetMoneyAccountSettings(ctx, gen.GetMoneyAccountSettingsParams{
+				MerchantID: tid.UUID(), CustomerID: payer.UUID(), Currency: invoice.Currency,
+			})
+			if errors.Is(err, pgx.ErrNoRows) {
+				if options.manual {
+					return ErrCollectionPaymentMethodRequired
+				}
+				return nil
+			}
+			if err != nil {
+				return fmt.Errorf("load invoice collection settings: %w", err)
+			}
+			settings := settingsFromGen(settingsRow)
+			paymentMethodID = settings.CollectionPaymentMethod
+			if paymentMethodID == nil {
+				paymentMethodID = settings.AutoTopupPaymentMethod
+			}
+			if paymentMethodID == nil {
+				if options.manual {
+					return ErrCollectionPaymentMethodRequired
+				}
+				return nil
+			}
 		}
 		attempts, err := q.CountInvoicePaymentAttemptsByPayer(ctx, gen.CountInvoicePaymentAttemptsByPayerParams{
 			MerchantID: tid.UUID(), CustomerID: payer.UUID(), InvoiceID: invoiceID,
@@ -266,9 +422,12 @@ func (s *MoneyService) claimInvoiceCollection(ctx context.Context, payer identit
 			return fmt.Errorf("count invoice collection attempts: %w", err)
 		}
 		attemptID := uuidutil.NewV7()
-		key := fmt.Sprintf("invoice:%s:attempt:%d", invoiceID, attempts)
+		key := options.idempotencyKey
+		if key == "" {
+			key = fmt.Sprintf("invoice:%s:attempt:%d", invoiceID, attempts)
+		}
 		updated, err := q.SetInvoiceCollectionClaim(ctx, gen.SetInvoiceCollectionClaimParams{
-			MerchantID: tid.UUID(), CustomerID: payer.UUID(), Now: now, InvoiceID: invoiceID,
+			MerchantID: tid.UUID(), CustomerID: payer.UUID(), Now: options.now, InvoiceID: invoiceID,
 		})
 		if err != nil {
 			return fmt.Errorf("set invoice collection claim: %w", err)
@@ -279,7 +438,7 @@ func (s *MoneyService) claimInvoiceCollection(ctx context.Context, payer identit
 		if err := q.InsertInvoicePayment(ctx, gen.InsertInvoicePaymentParams{
 			ID: attemptID, MerchantID: tid.UUID(), CustomerID: payer.UUID(), InvoiceID: invoiceID,
 			Currency: invoice.Currency, Amount: invoice.AmountDue, Status: "attempted",
-			AttemptedAt: now, CreatedAt: now, UpdatedAt: now,
+			AttemptedAt: options.now, CreatedAt: options.now, UpdatedAt: options.now,
 			PaymentMethodID: paymentMethodID, IdempotencyKey: &key,
 		}); err != nil {
 			return fmt.Errorf("record invoice collection claim: %w", err)
@@ -293,13 +452,16 @@ func (s *MoneyService) claimInvoiceCollection(ctx context.Context, payer identit
 			},
 			previous: invoice, attemptID: attemptID, idempotencyKey: key,
 		}
+		if options.providerIdempotencyKey != "" {
+			claim.idempotencyKey = options.providerIdempotencyKey
+		}
 		claimed = true
 		return nil
 	})
 	if err != nil {
-		return nil, false, err
+		return nil, nil, false, err
 	}
-	return claim, claimed, nil
+	return claim, replay, claimed, nil
 }
 
 func (s *MoneyService) markInvoiceCollectionOutcomeUnknown(ctx context.Context, claim *invoiceCollectionClaim, now time.Time) error {

--- a/internal/modules/money/invoice_recovery_integration_test.go
+++ b/internal/modules/money/invoice_recovery_integration_test.go
@@ -74,6 +74,56 @@ func TestInvoiceRecovery_SelectsSeparateMethodAndSettles(t *testing.T) {
 	require.Equal(t, "failed", attempts[1].Status)
 }
 
+func TestInvoiceRecovery_IdempotentRetryBindsMethodAndReplays(t *testing.T) {
+	svc, pool, payer, currency, ctx := moneyInEnv(t)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, "DELETE FROM openrails.invoice_payments WHERE customer_id = $1", payer.UUID())
+		_, _ = pool.Exec(ctx, "DELETE FROM openrails.invoice_items WHERE customer_id = $1", payer.UUID())
+		_, _ = pool.Exec(ctx, "DELETE FROM openrails.invoices WHERE customer_id = $1", payer.UUID())
+	})
+	defaultMethod := seedPaymentMethod(t, pool, ctx, payer, string(models.RailStripe))
+	boundMethod := seedPaymentMethod(t, pool, ctx, payer, string(models.RailStripe))
+	_, err := svc.UpsertAccountSettings(ctx, payer, currency, money.AccountSettingsInput{
+		BillingMode: strptr(money.BillingModeArrears), AutoTopupPaymentMethod: &defaultMethod,
+	})
+	require.NoError(t, err)
+	_, err = svc.AccrueOwed(ctx, payer, currency, "usage", "recovery-idempotent", 5_000_000)
+	require.NoError(t, err)
+	invoice, err := svc.FinalizeInvoice(ctx, payer, currency, time.Now().Add(-time.Hour), time.Now())
+	require.NoError(t, err)
+	_, err = svc.ChargeOutstanding(ctx, &fakeCharger{declineAll: true}, 0)
+	require.NoError(t, err)
+
+	request := money.InvoiceCollectionRetryRequest{
+		InvoiceID: invoice.ID, IdempotencyKey: "client-retry-key", PaymentMethodID: boundMethod,
+	}
+	charger := &fakeCharger{}
+	result, err := svc.RetryInvoiceCollectionIdempotent(ctx, charger, payer, request)
+	require.NoError(t, err)
+	require.False(t, result.Replayed)
+	require.Equal(t, "paid", result.Invoice.Status)
+	require.Equal(t, "settled", result.Attempt.Status)
+	require.Equal(t, boundMethod, *result.Attempt.PaymentMethodID)
+	require.Len(t, charger.charges, 1)
+	require.Equal(t, boundMethod, charger.charges[0].PaymentMethodID)
+
+	replayCharger := &fakeCharger{}
+	replayed, err := svc.RetryInvoiceCollectionIdempotent(ctx, replayCharger, payer, request)
+	require.NoError(t, err)
+	require.True(t, replayed.Replayed)
+	require.Equal(t, result.Attempt.ID, replayed.Attempt.ID)
+	require.Empty(t, replayCharger.charges)
+
+	request.PaymentMethodID = defaultMethod
+	_, err = svc.RetryInvoiceCollectionIdempotent(ctx, replayCharger, payer, request)
+	require.ErrorIs(t, err, money.ErrInvoiceRetryIdempotencyConflict)
+
+	_, err = pool.Exec(ctx, "DELETE FROM openrails.payment_methods WHERE id = $1", boundMethod)
+	require.NoError(t, err)
+	_, err = svc.RetryInvoiceCollectionIdempotent(ctx, replayCharger, payer, request)
+	require.ErrorIs(t, err, money.ErrInvoiceRetryIdempotencyConflict)
+}
+
 func TestInvoiceRecovery_AmbiguousOutcomeBlocksFurtherRetries(t *testing.T) {
 	svc, pool, payer, currency, ctx := moneyInEnv(t)
 	t.Cleanup(func() {
@@ -93,9 +143,12 @@ func TestInvoiceRecovery_AmbiguousOutcomeBlocksFurtherRetries(t *testing.T) {
 	_, err = svc.ChargeOutstanding(ctx, &fakeCharger{declineAll: true}, 0)
 	require.NoError(t, err)
 
+	request := money.InvoiceCollectionRetryRequest{
+		InvoiceID: invoice.ID, IdempotencyKey: "ambiguous-retry-key", PaymentMethodID: method,
+	}
 	ambiguous := &fakeCharger{ambiguous: true}
-	_, err = svc.RetryInvoiceCollection(ctx, ambiguous, payer, invoice.ID)
-	require.Error(t, err)
+	_, err = svc.RetryInvoiceCollectionIdempotent(ctx, ambiguous, payer, request)
+	require.ErrorIs(t, err, money.ErrInvoiceRetryOutcomeUnknown)
 	require.Len(t, ambiguous.charges, 1)
 
 	blocked, err := svc.GetInvoiceByID(ctx, payer, invoice.ID)
@@ -113,8 +166,11 @@ func TestInvoiceRecovery_AmbiguousOutcomeBlocksFurtherRetries(t *testing.T) {
 	require.Nil(t, attempts[0].FailureReason)
 
 	second := &fakeCharger{}
-	_, err = svc.RetryInvoiceCollection(ctx, second, payer, invoice.ID)
-	require.ErrorIs(t, err, money.ErrInvoiceNotRetryable)
+	_, err = svc.RetryInvoiceCollectionIdempotent(ctx, second, payer, request)
+	require.ErrorIs(t, err, money.ErrInvoiceRetryOutcomeUnknown)
+	request.IdempotencyKey = "different-key"
+	_, err = svc.RetryInvoiceCollectionIdempotent(ctx, second, payer, request)
+	require.ErrorIs(t, err, money.ErrInvoiceRetryOutcomeUnknown)
 	require.Empty(t, second.charges)
 }
 

--- a/internal/modules/money/invoice_recovery_test.go
+++ b/internal/modules/money/invoice_recovery_test.go
@@ -5,9 +5,29 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/integrations/nmi"
 )
+
+func TestInvoiceRetryIdempotencyKey(t *testing.T) {
+	t.Parallel()
+	invoiceID := uuid.New()
+	key := invoiceRetryIdempotencyKey(invoiceID, "client-key")
+	if len(key) > 50 {
+		t.Fatalf("provider key length = %d, want at most 50", len(key))
+	}
+	if key != invoiceRetryIdempotencyKey(invoiceID, "client-key") {
+		t.Fatal("provider key is not deterministic")
+	}
+	if key == invoiceRetryIdempotencyKey(uuid.New(), "client-key") {
+		t.Fatal("provider key does not include invoice scope")
+	}
+	methodID := uuid.New()
+	if attemptKey := invoiceRetryAttemptKey(key, methodID); attemptKey != key+":"+methodID.String() {
+		t.Fatalf("attempt key = %q, want immutable method binding", attemptKey)
+	}
+}
 
 func TestInvoiceCollectionRetryable(t *testing.T) {
 	t.Parallel()

--- a/pkg/service/spend.go
+++ b/pkg/service/spend.go
@@ -16,6 +16,9 @@ var (
 	ErrInvoiceNotRetryable             = money.ErrInvoiceNotRetryable
 	ErrCollectionPaymentMethodRequired = money.ErrCollectionPaymentMethodRequired
 	ErrCollectionPaymentMethodInvalid  = money.ErrCollectionPaymentMethodInvalid
+	ErrInvoiceRetryInProgress          = money.ErrInvoiceRetryInProgress
+	ErrInvoiceRetryOutcomeUnknown      = money.ErrInvoiceRetryOutcomeUnknown
+	ErrInvoiceRetryIdempotencyConflict = money.ErrInvoiceRetryIdempotencyConflict
 )
 
 // CreditAccountSnapshot is the balance + policy view of an payer's credit
@@ -191,6 +194,18 @@ type InvoicePaymentAttemptDTO struct {
 	FailureReason   *string    `json:"failure_reason,omitempty"`
 	AttemptedAt     time.Time  `json:"attempted_at"`
 	SettledAt       *time.Time `json:"settled_at,omitempty"`
+}
+
+type InvoiceCollectionRetryRequest struct {
+	InvoiceID       uuid.UUID `json:"invoice_id"`
+	IdempotencyKey  string    `json:"-"`
+	PaymentMethodID uuid.UUID `json:"payment_method_id"`
+}
+
+type InvoiceCollectionRetryResult struct {
+	Invoice  InvoiceDTO               `json:"invoice"`
+	Attempt  InvoicePaymentAttemptDTO `json:"attempt"`
+	Replayed bool                     `json:"replayed"`
 }
 
 // InvoiceContactDTO is one billing contact on an invoice document (#798).
@@ -392,6 +407,38 @@ func (s *Service) RetryInvoiceCollection(ctx context.Context, payer identity.Cus
 		}
 		dto := invoiceToDTO(invoice)
 		out = &dto
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// RetryInvoiceCollectionIdempotent retries collection with a durable client
+// key and an explicitly bound payer-owned saved method.
+func (s *Service) RetryInvoiceCollectionIdempotent(ctx context.Context, payer identity.CustomerID, request InvoiceCollectionRetryRequest) (*InvoiceCollectionRetryResult, error) {
+	if s == nil || s.rt == nil {
+		return nil, fmt.Errorf("service not initialized")
+	}
+	rt, err := s.runtime()
+	if err != nil {
+		return nil, err
+	}
+	if rt.MoneyCharger == nil {
+		return nil, fmt.Errorf("invoice collection charger not configured")
+	}
+	var out *InvoiceCollectionRetryResult
+	err = s.rt.DB.RunInMerchantConn(ctx, func(ctx context.Context) error {
+		result, err := s.moneyService().RetryInvoiceCollectionIdempotent(ctx, rt.MoneyCharger, payer, money.InvoiceCollectionRetryRequest{
+			InvoiceID: request.InvoiceID, IdempotencyKey: request.IdempotencyKey, PaymentMethodID: request.PaymentMethodID,
+		})
+		if err != nil {
+			return err
+		}
+		out = &InvoiceCollectionRetryResult{
+			Invoice: invoiceToDTO(result.Invoice), Attempt: invoicePaymentAttemptToDTO(result.Attempt), Replayed: result.Replayed,
+		}
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- add a durable client-key retry facade with explicit saved-method binding
- replay terminal attempts and return typed conflict, in-progress, and unknown-outcome errors
- keep provider keys compact while preserving method binding after method deletion

## Verification
- `task sqlc`
- `go test ./...`
- `go vet ./...`
- `DOCKER_HOST=unix:///Users/abdulrahmanyusuf/.colima/default/docker.sock TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock go test -tags=integration ./internal/modules/money -run 'TestInvoiceRecovery_(IdempotentRetryBindsMethodAndReplays|AmbiguousOutcomeBlocksFurtherRetries)' -count=1`\n- focused review and adversarial audit: clean