### PR TITLE
Never close injected redis clients (ownership follows creation)

### DIFF
--- a/internal/app/build_runtime.go
+++ b/internal/app/build_runtime.go
@@ -177,6 +177,7 @@ func buildRuntimeWithOverrides(cfg *config.Config, overrides *runtimeOverrides) 
 		return nil, err
 	}
 
+	redisOwned := false
 	if overrides != nil && overrides.Redis != nil {
 		redisClient = overrides.Redis
 	} else {
@@ -184,6 +185,7 @@ func buildRuntimeWithOverrides(cfg *config.Config, overrides *runtimeOverrides) 
 		if err != nil {
 			return nil, fmt.Errorf("failed to create redis client: %w", err)
 		}
+		redisOwned = redisClient != nil
 	}
 
 	// Webhook-dedup posture (#678). Embedded hosts are identified by the injected
@@ -280,6 +282,7 @@ func buildRuntimeWithOverrides(cfg *config.Config, overrides *runtimeOverrides) 
 	runtime := &Runtime{
 		DB:          database,
 		RedisClient: redisClient,
+		redisOwned:  redisOwned,
 		Config:      cfg,
 		Clock:       clock,
 		// #746: one proxy-aware client-IP resolver, built once from config;

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -51,7 +51,10 @@ import (
 type Runtime struct {
 	DB          *db.DB
 	RedisClient *redis.Client
-	Config      *config.Config
+	// redisOwned marks a self-dialed client; injected clients are borrowed and
+	// must never be closed here (the host owns their lifecycle).
+	redisOwned bool
+	Config     *config.Config
 
 	// configuredMerchant scopes this engine instance to one merchant — set by
 	// embedded hosts that run one engine per merchant (zero in standalone,
@@ -310,7 +313,7 @@ func (r *Runtime) Close(ctx context.Context) error {
 	if r.HTTPIdempotency != nil {
 		r.HTTPIdempotency.Close()
 	}
-	if r.RedisClient != nil {
+	if r.RedisClient != nil && r.redisOwned {
 		if err := r.RedisClient.Close(); err != nil {
 			// Make shutdown idempotent: Close can be called multiple times across layers.
 			if !errors.Is(err, redis.ErrClosed) {

--- a/pkg/cache/redis_cache.go
+++ b/pkg/cache/redis_cache.go
@@ -47,6 +47,9 @@ func (c *RedisCache) Clear(ctx context.Context) error {
 	return c.client.FlushAll(ctx).Err()
 }
 
+// Close is a no-op: the redis client is injected (NewRedisCache borrows it),
+// so its owner — Runtime for self-dialed clients, the host for injected ones —
+// closes it. Closing here poisoned host-shared clients (cozy-art ca#198).
 func (c *RedisCache) Close() error {
-	return c.client.Close()
+	return nil
 }

--- a/pkg/embedded/redis_ownership_integration_test.go
+++ b/pkg/embedded/redis_ownership_integration_test.go
@@ -1,0 +1,39 @@
+//go:build integration
+
+package embedded
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/dbtest"
+)
+
+// An injected Redis client is borrowed from the host: Close must leave it
+// usable (cozy-art ca#198 — closing the host's shared client silently broke
+// its auth ephemeral store).
+func TestClose_DoesNotCloseInjectedRedisClient(t *testing.T) {
+	superDSN, _ := dbtest.SharedRLSPostgres(t)
+	pool, err := pgxpool.New(context.Background(), superDSN)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	rdb, ctx := dbtest.SharedRedisClient(t)
+	require.NoError(t, rdb.Ping(ctx).Err())
+
+	cfg := &config.Config{
+		Env:      "development",
+		TestMode: config.CredentialPostureSandbox,
+		DB:       &config.DBConfig{URL: superDSN},
+	}
+	e, err := New(Options{Config: cfg, PGXPool: pool, Redis: rdb})
+	require.NoError(t, err)
+	require.NoError(t, e.Close(context.Background()))
+
+	require.NoError(t, rdb.Ping(ctx).Err(),
+		"embed Close must not close a Redis client it did not create")
+}


### PR DESCRIPTION
An embedding host injects its redis client via `embedded.Options.Redis`. Two paths closed it on embed shutdown:

1. `Runtime.Close` closed `RedisClient` unconditionally.
2. `App.Close → Cache.Close → RedisCache.Close` closed the wrapped client.

In cozy-art (ca#198) a failed billing merchant init tore down the embed and killed the host's shared client — authkit's ephemeral store then failed every registration with `redis: client is closed`.

Fix: `Runtime` tracks `redisOwned` (true only for self-dialed clients) and closes only what it created; `RedisCache.Close` is a no-op since the cache always borrows. New integration test (`TestClose_DoesNotCloseInjectedRedisClient`) proves an injected client survives `Close` — it failed against the old code on both paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)