### PR TITLE
feat(embed): configure system merchant providers

### DIFF
--- a/pkg/embedded/controlplane/payment_provider.go
+++ b/pkg/embedded/controlplane/payment_provider.go
@@ -1,0 +1,32 @@
+package controlplane
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-rails/openrails/internal/app"
+	"github.com/open-rails/openrails/internal/merchants"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+type PaymentProviderConfig = merchants.PaymentProviderConfig
+type UpsertPaymentProviderConfigRequest = merchants.UpsertPaymentProviderConfigRequest
+
+// UpsertPaymentProviderConfig configures one provider account for a
+// system-owned merchant through the existing merchant-secret backend.
+func UpsertPaymentProviderConfig(ctx context.Context, a *app.App, id merchant.ID, rail string, req UpsertPaymentProviderConfigRequest) (PaymentProviderConfig, error) {
+	if Get(a) == nil {
+		return PaymentProviderConfig{}, fmt.Errorf("control plane configure payment provider: no control plane attached (call Attach first)")
+	}
+	if a.Runtime == nil {
+		return PaymentProviderConfig{}, fmt.Errorf("control plane configure payment provider: runtime unavailable")
+	}
+	if a.Runtime.Merchants == nil {
+		return PaymentProviderConfig{}, fmt.Errorf("control plane configure payment provider: merchant secrets unavailable")
+	}
+	provider, err := a.Runtime.Merchants.UpsertPaymentProviderConfig(ctx, id, rail, req)
+	if err != nil {
+		return PaymentProviderConfig{}, fmt.Errorf("control plane configure payment provider: %w", err)
+	}
+	return provider, nil
+}

--- a/pkg/embedded/controlplane/payment_provider_integration_test.go
+++ b/pkg/embedded/controlplane/payment_provider_integration_test.go
@@ -1,0 +1,49 @@
+//go:build integration
+
+package controlplane_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/dbtest"
+	embcp "github.com/open-rails/openrails/pkg/embedded/controlplane"
+)
+
+func TestUpsertPaymentProviderConfig(t *testing.T) {
+	ctx := context.Background()
+	cfg := hostedTestConfig(dbtest.SharedPostgresDSN(t), "https://providers.openrails.test")
+	e := newHostApp(t, cfg)
+	require.NoError(t, embcp.Attach(ctx, e.App(), cfg, nil))
+	require.NoError(t, e.App().Runtime.EnsureMerchantsService(ctx))
+
+	suffix := strings.ToLower(uuid.NewString()[:8])
+	provisioned, err := embcp.ProvisionMerchant(ctx, e.App(), embcp.ProvisionMerchantRequest{Slug: "provider-" + suffix})
+	require.NoError(t, err)
+
+	const signingSecret = "whsec_integration_test"
+	provider, err := embcp.UpsertPaymentProviderConfig(ctx, e.App(), provisioned.MerchantID, "stripe", embcp.UpsertPaymentProviderConfigRequest{
+		Environment: "test",
+		AccountID:   "acct_" + suffix,
+		PublicConfig: map[string]string{
+			"publishable_key": "pk_test_" + suffix,
+		},
+		Credentials: map[string]string{
+			"webhook_signing_secret": signingSecret,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "stripe", provider.Rail)
+	require.Equal(t, "test", provider.Environment)
+	require.Equal(t, "acct_"+suffix, provider.AccountID)
+	require.True(t, provider.Credentials["webhook_signing_secret"].Configured)
+
+	encoded, err := json.Marshal(provider)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), signingSecret)
+}


### PR DESCRIPTION
## Summary
- expose one embedded control-plane wrapper for configuring a system-owned merchant provider account
- delegate validation and scoped secret storage to the existing merchant provider service
- return only the existing redacted provider status

## Verification
- `go test ./...`
- `go vet ./...`
- `DOCKER_HOST=unix:///Users/abdulrahmanyusuf/.colima/default/docker.sock TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock go test -tags=integration ./pkg/embedded/controlplane -run TestUpsertPaymentProviderConfig -count=1`
- focused review and adversarial audit: clean