### PR TITLE
feat(embed): read system merchant providers

### DIFF
--- a/pkg/embedded/controlplane/payment_provider.go
+++ b/pkg/embedded/controlplane/payment_provider.go
@@ -2,7 +2,9 @@ package controlplane
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/open-rails/openrails/internal/app"
 	"github.com/open-rails/openrails/internal/merchants"
@@ -12,21 +14,46 @@ import (
 type PaymentProviderConfig = merchants.PaymentProviderConfig
 type UpsertPaymentProviderConfigRequest = merchants.UpsertPaymentProviderConfigRequest
 
+// GetPaymentProviderConfig returns one system-owned merchant provider account
+// with credential values redacted.
+func GetPaymentProviderConfig(ctx context.Context, a *app.App, id merchant.ID, rail, environment string) (PaymentProviderConfig, error) {
+	if strings.TrimSpace(rail) == "" {
+		return PaymentProviderConfig{}, errors.New("control plane get payment provider: rail required")
+	}
+	providerService, err := paymentProviderService(a)
+	if err != nil {
+		return PaymentProviderConfig{}, fmt.Errorf("control plane get payment provider: %w", err)
+	}
+	provider, err := providerService.GetPaymentProviderConfig(ctx, id, rail, environment)
+	if err != nil {
+		return PaymentProviderConfig{}, fmt.Errorf("control plane get payment provider: %w", err)
+	}
+	return provider, nil
+}
+
 // UpsertPaymentProviderConfig configures one provider account for a
 // system-owned merchant through the existing merchant-secret backend.
 func UpsertPaymentProviderConfig(ctx context.Context, a *app.App, id merchant.ID, rail string, req UpsertPaymentProviderConfigRequest) (PaymentProviderConfig, error) {
-	if Get(a) == nil {
-		return PaymentProviderConfig{}, fmt.Errorf("control plane configure payment provider: no control plane attached (call Attach first)")
+	providerService, err := paymentProviderService(a)
+	if err != nil {
+		return PaymentProviderConfig{}, fmt.Errorf("control plane configure payment provider: %w", err)
 	}
-	if a.Runtime == nil {
-		return PaymentProviderConfig{}, fmt.Errorf("control plane configure payment provider: runtime unavailable")
-	}
-	if a.Runtime.Merchants == nil {
-		return PaymentProviderConfig{}, fmt.Errorf("control plane configure payment provider: merchant secrets unavailable")
-	}
-	provider, err := a.Runtime.Merchants.UpsertPaymentProviderConfig(ctx, id, rail, req)
+	provider, err := providerService.UpsertPaymentProviderConfig(ctx, id, rail, req)
 	if err != nil {
 		return PaymentProviderConfig{}, fmt.Errorf("control plane configure payment provider: %w", err)
 	}
 	return provider, nil
+}
+
+func paymentProviderService(a *app.App) (*merchants.Service, error) {
+	if Get(a) == nil {
+		return nil, errors.New("no control plane attached (call Attach first)")
+	}
+	if a.Runtime == nil {
+		return nil, errors.New("runtime unavailable")
+	}
+	if a.Runtime.Merchants == nil {
+		return nil, errors.New("merchant secrets unavailable")
+	}
+	return a.Runtime.Merchants, nil
 }

--- a/pkg/embedded/controlplane/payment_provider_integration_test.go
+++ b/pkg/embedded/controlplane/payment_provider_integration_test.go
@@ -42,6 +42,10 @@ func TestUpsertPaymentProviderConfig(t *testing.T) {
 	require.Equal(t, "test", provider.Environment)
 	require.Equal(t, "acct_"+suffix, provider.AccountID)
 	require.True(t, provider.Credentials["webhook_signing_secret"].Configured)
+	loaded, err := embcp.GetPaymentProviderConfig(ctx, e.App(), provisioned.MerchantID, "stripe", "test")
+	require.NoError(t, err)
+	require.Equal(t, provider.ID, loaded.ID)
+	require.Equal(t, provider.AccountID, loaded.AccountID)
 
 	encoded, err := json.Marshal(provider)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- expose a redacted read-only provider-account lookup for system-owned merchants
- preserve the existing configure wrapper error contract
- reject blank rail lookups

## Verification
- `go test ./...`
- `go vet ./...`
- focused provider integration test
- focused review and adversarial audit: clean