### PR TITLE
or#815: gateway-native NMI auto-migration for plan migrations

### DIFF
--- a/internal/app/build_runtime.go
+++ b/internal/app/build_runtime.go
@@ -771,8 +771,10 @@ func createServices(database *db.DB, cfg *config.Config, railConfigs railresolve
 	adminSubscriptionService.StripeService = &subscriptions.StripeService{Config: cfg, Rails: railConfigs}
 
 	// #813: plan migrations — cross-product bulk retirement over the #773
-	// reprice engine; Stripe is the one observed rail with a server-side push.
-	planMigrationService := subscriptions.NewPlanMigrationService(repriceService, &subscriptions.StripeService{Config: cfg, Rails: railConfigs}, paymentMethodService)
+	// reprice engine. Observed rails with a server-side push: Stripe, and
+	// (#815) gateway-native NMI recurring via the per-merchant client
+	// resolver.
+	planMigrationService := subscriptions.NewPlanMigrationService(repriceService, &subscriptions.StripeService{Config: cfg, Rails: railConfigs}, subscriptions.NewNMIPlanPusher(collectionResolver), paymentMethodService)
 
 	// #678: Postgres (webhook_events) is the dedup truth; Redis is cache + lease coordination.
 	deduplicationService := webhooks.NewDeduplicationService(webhookIdempotencyService, database)

--- a/internal/modules/subscriptions/plan_migration.go
+++ b/internal/modules/subscriptions/plan_migration.go
@@ -21,14 +21,23 @@ package subscriptions
 //                        item update with proration_behavior=none); converge
 //                        applies the internal cutover from provider truth.
 //   - engine-driven      AUTO — no rail push needed; the #773 renewal-boundary
-//     (no rail sub id):  pickup (ResolveEffectivePrice / RenewMembership)
+//     (#297 anchored):   pickup (ResolveEffectivePrice / RenewMembership)
 //                        applies it when OpenRails initiates the charge.
-//   - ccbill, solana,    REQUIRES USER ACTION — the rail cannot be mutated
-//     native gateway     server-side (redirect flows / on-chain co-sign /
-//     recurring:         gateway-owned plans). Rows land status=blocked with
-//                        the reason; the operator's fallback_policy records
-//                        intent (keep_grandfathered | cancel_at_period_end —
-//                        the latter is NOT automated in v1, it is surfaced).
+//   - gateway-native     AUTO (#815) — classic Direct Post update_subscription
+//     NMI recurring:     re-points the remote plan_amount (schedule untouched,
+//                        plan_payments preserved, read-back verified). NMI has
+//                        no future-dated schedules, so the push IS the
+//                        next-rebill flip: it happens only inside the change-
+//                        boundary period, and the internal cutover accompanies
+//                        it (provider truth flips at push). Requires matching
+//                        billing intervals — an interval change cannot be
+//                        expressed as an amount update and blocks honestly.
+//   - ccbill, solana:    REQUIRES USER ACTION — the rail cannot be mutated
+//                        server-side (redirect flows / on-chain co-sign).
+//                        Rows land status=blocked with the reason; the
+//                        operator's fallback_policy records intent
+//                        (keep_grandfathered | cancel_at_period_end — the
+//                        latter is NOT automated in v1, it is surfaced).
 
 import (
 	"context"
@@ -42,6 +51,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/shared/moneyutil"
 	"github.com/open-rails/openrails/internal/shared/uuidutil"
 )
 
@@ -51,6 +61,12 @@ const (
 	migrationBlockedRailUserAction   = "rail_requires_user_action"
 	migrationBlockedMissingRailPrice = "target_price_missing_rail_config"
 	migrationBlockedRailPushFailed   = "rail_push_failed"
+	// #815: an NMI amount update cannot change the billing interval; a target
+	// on a different cycle cannot be expressed rail-side.
+	migrationBlockedNMIIntervalMismatch = "nmi_interval_mismatch"
+	// #815: NMI bills whole cents; a micro-dollar amount that is not
+	// cent-representable cannot be pushed.
+	migrationBlockedNMISubCentAmount = "nmi_amount_not_cent_representable"
 )
 
 var (
@@ -141,11 +157,12 @@ type StripePusher interface {
 type PlanMigrationService struct {
 	reprice        *RepriceService
 	stripe         StripePusher
+	nmi            NMIPusher
 	paymentMethods PaymentMethodLookup
 }
 
-func NewPlanMigrationService(reprice *RepriceService, stripe StripePusher, paymentMethods PaymentMethodLookup) *PlanMigrationService {
-	return &PlanMigrationService{reprice: reprice, stripe: stripe, paymentMethods: paymentMethods}
+func NewPlanMigrationService(reprice *RepriceService, stripe StripePusher, nmi NMIPusher, paymentMethods PaymentMethodLookup) *PlanMigrationService {
+	return &PlanMigrationService{reprice: reprice, stripe: stripe, nmi: nmi, paymentMethods: paymentMethods}
 }
 
 // migrationCapability classifies one subscription's rail for forced
@@ -155,6 +172,7 @@ type migrationCapability int
 const (
 	capabilityAutoInternal migrationCapability = iota // engine-driven: reprice row alone suffices
 	capabilityAutoStripe                              // push to Stripe, converge applies
+	capabilityAutoNMI                                 // #815: push plan_amount to NMI, cutover accompanies the push
 	capabilityUserAction                              // rail cannot be mutated server-side
 )
 
@@ -168,19 +186,32 @@ func (s *PlanMigrationService) classifyMigrationCapability(ctx context.Context, 
 		// Non-stripe card rails split by who INITIATES the recurring charge:
 		// a payment method carrying the #297 stored-credential recurring
 		// anchor means OpenRails' own engine charges (RenewalCharger) — the
-		// renewal-boundary pickup is then the whole mechanism. Anything else
-		// is a gateway-native recurring plan OpenRails only observes; the
-		// gateway would keep charging the old plan, so it cannot be
-		// auto-migrated server-side.
-		if s.paymentMethods == nil || sub.PaymentMethodID == nil {
-			return capabilityUserAction
+		// renewal-boundary pickup is then the whole mechanism.
+		if s.paymentMethods != nil && sub.PaymentMethodID != nil {
+			pm, err := s.paymentMethods.GetByID(ctx, *sub.PaymentMethodID)
+			if err == nil && pm != nil && strings.TrimSpace(pm.StoredCredentialRecurringRef) != "" {
+				return capabilityAutoInternal
+			}
 		}
-		pm, err := s.paymentMethods.GetByID(ctx, *sub.PaymentMethodID)
-		if err != nil || pm == nil || strings.TrimSpace(pm.StoredCredentialRecurringRef) == "" {
-			return capabilityUserAction
+		// #815: a gateway-native NMI recurring record CAN be mutated
+		// server-side (classic update_subscription). CanPush is the
+		// resolver-driven NMI-family detector, so custom-named NMI provider
+		// accounts classify without code changes. Everything else stays a
+		// record OpenRails only observes — the gateway would keep charging
+		// the old plan.
+		if s.nmi != nil && s.nmi.CanPush(ctx, sub) {
+			return capabilityAutoNMI
 		}
-		return capabilityAutoInternal
+		return capabilityUserAction
 	}
+}
+
+// nmiCyclesCompatible: an NMI amount update never touches the remote
+// schedule, so a plan change is expressible only when the target bills on
+// the SAME cycle the cohort already bills on.
+func nmiCyclesCompatible(source, target *models.Price) bool {
+	src, tgt := source.RecurringCycleDays(), target.RecurringCycleDays()
+	return src != nil && tgt != nil && *src == *tgt
 }
 
 func normalizeFallback(policy string) (string, error) {
@@ -236,6 +267,7 @@ func (s *PlanMigrationService) classify(ctx context.Context, req *PlanMigrationR
 	}
 	for _, sub := range cohort {
 		out := PlanMigrationOutcome{SubscriptionID: sub.ID, Rail: string(sub.Rail)}
+		capability := s.classifyMigrationCapability(ctx, sub)
 		switch {
 		case sub.PriceID == target.ID:
 			out.Disposition = "skipped"
@@ -252,9 +284,19 @@ func (s *PlanMigrationService) classify(ctx context.Context, req *PlanMigrationR
 			out.Disposition = "skipped"
 			out.Reason = "self-scheduled downgrade pending"
 			rail(sub).Skipped++
-		case s.classifyMigrationCapability(ctx, sub) == capabilityUserAction:
+		case capability == capabilityUserAction:
 			out.Disposition = "blocked"
 			out.Reason = migrationBlockedRailUserAction
+			rail(sub).RequiresAction++
+		case capability == capabilityAutoNMI && !nmiCyclesCompatible(source, target):
+			// #815: the rail-side flip is an amount-only update; a target on a
+			// different billing cycle cannot be expressed at NMI.
+			out.Disposition = "blocked"
+			out.Reason = migrationBlockedNMIIntervalMismatch
+			rail(sub).RequiresAction++
+		case capability == capabilityAutoNMI && !centRepresentable(target.Amount):
+			out.Disposition = "blocked"
+			out.Reason = migrationBlockedNMISubCentAmount
 			rail(sub).RequiresAction++
 		default:
 			if err := s.reprice.scheduledConflict(ctx, sub.ID); err != nil {
@@ -403,7 +445,14 @@ func (s *PlanMigrationService) Migrate(ctx context.Context, req PlanMigrationReq
 				}
 				continue
 			}
-			if req.Immediate && s.classifyMigrationCapability(ctx, sub) == capabilityAutoInternal {
+			switch s.classifyMigrationCapability(ctx, sub) {
+			case capabilityAutoInternal:
+				if req.Immediate {
+					o.Disposition = "applied_immediately"
+				}
+			case capabilityAutoNMI:
+				// #815: the NMI push carries the internal cutover with it
+				// (provider truth flips at push) — the row is already applied.
 				o.Disposition = "applied_immediately"
 			}
 			s.reprice.emitPlanChangeNotification(ctx, sub, source, target, targetProduct, req.EffectiveAt)
@@ -445,6 +494,8 @@ func (s *PlanMigrationService) executeScheduled(ctx context.Context, req *PlanMi
 	switch s.classifyMigrationCapability(ctx, sub) {
 	case capabilityAutoStripe:
 		return s.pushStripe(ctx, req, sub, source, target, row)
+	case capabilityAutoNMI:
+		return s.pushNMI(ctx, req, sub, target, targetProduct, row)
 	case capabilityAutoInternal:
 		if req.Immediate {
 			return s.applyImmediately(ctx, sub, target, targetProduct, row)
@@ -453,6 +504,45 @@ func (s *PlanMigrationService) executeScheduled(ctx context.Context, req *PlanMi
 	default:
 		return fmt.Errorf("unexpected capability for scheduled row")
 	}
+}
+
+// centRepresentable reports whether a micro-dollar amount lands on a whole
+// cent — NMI's amount granularity.
+func centRepresentable(amountMicros int64) bool {
+	_, err := moneyutil.MicrosToCentsExact(amountMicros)
+	return err == nil
+}
+
+// pushNMI (#815) migrates a gateway-native NMI recurring subscription:
+// re-point the remote record's plan_amount at the target (schedule and
+// plan_payments untouched, read-back verified inside the pusher), then apply
+// the internal cutover — provider truth has already flipped, so the row goes
+// applied in the same operation. Billing flips at the NEXT rebill (NMI
+// charges the record's amount on its unchanged schedule); nothing is charged
+// here and the rebill date never moves.
+func (s *PlanMigrationService) pushNMI(ctx context.Context, req *PlanMigrationRequest, sub *models.Subscription, target *models.Price, targetProduct *models.Product, row *models.SubscriptionReprice) error {
+	if s.nmi == nil {
+		return fmt.Errorf("nmi pusher not configured")
+	}
+	if strings.TrimSpace(sub.RailSubscriptionID) == "" {
+		return fmt.Errorf("subscription missing nmi reference")
+	}
+	if sub.CurrentPeriodEndsAt == nil || sub.CurrentPeriodEndsAt.IsZero() {
+		return fmt.Errorf("subscription missing current period end")
+	}
+	// Early-flip guard, STRICTER than stripe's: NMI has no future-dated
+	// schedule object — the push IS the next-rebill flip. An effective date
+	// beyond the current period would flip at least one whole rebill EARLY (a
+	// money defect). Refuse honestly; the row lands blocked and an idempotent
+	// re-run inside the final pre-effective period succeeds. (Automated
+	// deferred push is the filed follow-up on #813.)
+	if req.EffectiveAt.After(*sub.CurrentPeriodEndsAt) {
+		return fmt.Errorf("nmi_deferred_push_required: effective_at %s is beyond the current period end %s — re-run the migration once the subscription enters its final period before the effective date", req.EffectiveAt.UTC().Format(time.RFC3339), sub.CurrentPeriodEndsAt.UTC().Format(time.RFC3339))
+	}
+	if err := s.nmi.PushPlanAmount(ctx, sub, target.Amount); err != nil {
+		return err
+	}
+	return s.applyImmediately(ctx, sub, target, targetProduct, row)
 }
 
 // pushStripe pushes the plan change to Stripe. Boundary mode schedules the

--- a/internal/modules/subscriptions/plan_migration_integration_test.go
+++ b/internal/modules/subscriptions/plan_migration_integration_test.go
@@ -14,6 +14,7 @@ package subscriptions
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -79,9 +80,33 @@ func (f pmLookupFunc) GetByID(ctx context.Context, id uuid.UUID) (*models.Paymen
 	return f(ctx, id)
 }
 
+// fakeNMIPusher (#815) records gateway-native NMI pushes at the seam level
+// (the real Direct Post wire shape is covered by the fake-gateway suite in
+// plan_migration_nmi_integration_test.go).
+type fakeNMIPusher struct {
+	canPush bool
+	pushErr error
+	pushes  []map[string]any
+}
+
+func (f *fakeNMIPusher) CanPush(_ context.Context, sub *models.Subscription) bool {
+	return f != nil && f.canPush && strings.TrimSpace(sub.RailSubscriptionID) != ""
+}
+
+func (f *fakeNMIPusher) PushPlanAmount(_ context.Context, sub *models.Subscription, amountMicros int64) error {
+	if f.pushErr != nil {
+		return f.pushErr
+	}
+	f.pushes = append(f.pushes, map[string]any{
+		"subscription_id": sub.ID, "rail_subscription_id": sub.RailSubscriptionID, "amount_micros": amountMicros,
+	})
+	return nil
+}
+
 type planMigrationFixture struct {
 	*repriceFixture
 	stripe *fakeStripePusher
+	nmi    *fakeNMIPusher
 	pm     *PlanMigrationService
 
 	targetProductID uuid.UUID
@@ -128,16 +153,18 @@ func newPlanMigrationFixture(t *testing.T) *planMigrationFixture {
 		`{"stripe": {"rail": "stripe", "price_id": "price_tgt_`+suffix+`"}}`)
 
 	stripe := &fakeStripePusher{}
+	nmiPusher := &fakeNMIPusher{canPush: true}
 	// Payment-method lookup: any PM id resolves to an engine-anchored
 	// instrument (per-test overrides construct their own service).
 	pmLookup := pmLookupFunc(func(_ context.Context, id uuid.UUID) (*models.PaymentMethod, error) {
 		return &models.PaymentMethod{ID: id, StoredCredentialRecurringRef: "anchor-" + id.String()}, nil
 	})
-	svc := NewPlanMigrationService(base.repriceSvc, stripe, pmLookup)
+	svc := NewPlanMigrationService(base.repriceSvc, stripe, nmiPusher, pmLookup)
 
 	f := &planMigrationFixture{
 		repriceFixture:      base,
 		stripe:              stripe,
+		nmi:                 nmiPusher,
 		pm:                  svc,
 		targetProductID:     targetProductID,
 		targetPriceID:       targetPriceID,
@@ -374,22 +401,24 @@ func TestPlanMigration_StripePushFailureDegradesToBlocked(t *testing.T) {
 	require.EqualValues(t, 1, batch.SubscriptionsBlocked)
 }
 
-// TestPlanMigration_CapabilityClassification: ccbill/solana and gateway-
-// native recurring (no stored-credential anchor) land blocked
-// rail_requires_user_action; the preview reports per-rail counts.
+// TestPlanMigration_CapabilityClassification: ccbill/solana land blocked
+// rail_requires_user_action; gateway-native NMI recurring (no stored-
+// credential anchor) is AUTO since #815 (server-side update_subscription);
+// the preview reports per-rail counts.
 func TestPlanMigration_CapabilityClassification(t *testing.T) {
 	f := newPlanMigrationFixture(t)
 	ctx := dbtest.WithTestMerchant(context.Background())
 	f.createSubscriptionOnRail(t, ctx, f.lowPriceID, "ccbill", false)
 	f.createSubscriptionOnRail(t, ctx, f.lowPriceID, "solana", false)
-	// NMI WITHOUT a payment method (gateway-native recurring): blocked too.
+	// NMI WITHOUT a payment method (gateway-native recurring): AUTO via the
+	// #815 pusher.
 	f.createSubscriptionOnRail(t, ctx, f.lowPriceID, "nmi", false)
-	// Engine-anchored NMI: auto.
+	// Engine-anchored NMI: auto via the renewal-boundary pickup.
 	f.createSubscriptionOnRail(t, ctx, f.lowPriceID, "nmi", true)
 
 	// Real PM lookup for this test: resolve from the DB so the anchored/
 	// unanchored split is driven by actual rows.
-	svc := NewPlanMigrationService(f.repriceSvc, f.stripe, pmLookupFunc(func(ctx context.Context, id uuid.UUID) (*models.PaymentMethod, error) {
+	svc := NewPlanMigrationService(f.repriceSvc, f.stripe, f.nmi, pmLookupFunc(func(ctx context.Context, id uuid.UUID) (*models.PaymentMethod, error) {
 		var anchor string
 		if err := f.pool.QueryRow(ctx, `SELECT stored_credential_recurring_ref FROM openrails.payment_methods WHERE id = $1`, id).Scan(&anchor); err != nil {
 			return nil, err
@@ -400,13 +429,13 @@ func TestPlanMigration_CapabilityClassification(t *testing.T) {
 	preview, err := svc.Preview(ctx, PlanMigrationRequest{SourcePriceID: f.lowPriceID, TargetPriceID: f.targetPriceID})
 	require.NoError(t, err)
 	require.Equal(t, 4, preview.Matched)
-	require.Equal(t, 1, preview.Scheduled)
-	require.Equal(t, 3, preview.Blocked)
+	require.Equal(t, 2, preview.Scheduled)
+	require.Equal(t, 2, preview.Blocked)
 	require.Nil(t, preview.BatchID, "preview must not create a batch")
 	require.Equal(t, 1, preview.ByRail["ccbill"].RequiresAction)
 	require.Equal(t, 1, preview.ByRail["solana"].RequiresAction)
-	require.Equal(t, 1, preview.ByRail["nmi"].RequiresAction)
-	require.Equal(t, 1, preview.ByRail["nmi"].Auto)
+	require.Equal(t, 2, preview.ByRail["nmi"].Auto, "anchored AND gateway-native NMI are both auto since #815")
+	require.Empty(t, f.nmi.pushes, "preview must not push")
 
 	// Preview wrote nothing.
 	var batches, reprices int
@@ -415,10 +444,14 @@ func TestPlanMigration_CapabilityClassification(t *testing.T) {
 	require.Zero(t, batches)
 	require.Zero(t, reprices)
 
-	// Migrate records the blocked ledger rows.
+	// Migrate records the blocked ledger rows and pushes the gateway-native
+	// NMI sub (preview counts == execute classification).
 	res, err := svc.Migrate(ctx, PlanMigrationRequest{SourcePriceID: f.lowPriceID, TargetPriceID: f.targetPriceID})
 	require.NoError(t, err)
-	require.Equal(t, 3, res.Blocked)
+	require.Equal(t, 2, res.Blocked)
+	require.Equal(t, preview.Scheduled, res.Scheduled, "preview counts must match execute classification")
+	require.Len(t, f.nmi.pushes, 1, "exactly the gateway-native NMI sub is pushed")
+	require.EqualValues(t, 9000000, f.nmi.pushes[0]["amount_micros"])
 	rows, err := f.repriceRepo.List(ctx, SubscriptionRepriceFilter{RepriceBatchID: res.BatchID}, 10, 0)
 	require.NoError(t, err)
 	require.Len(t, rows, 4)
@@ -429,7 +462,7 @@ func TestPlanMigration_CapabilityClassification(t *testing.T) {
 			require.Equal(t, "rail_requires_user_action", row.BlockedReason)
 		}
 	}
-	require.Equal(t, 3, blocked)
+	require.Equal(t, 2, blocked)
 }
 
 // TestPlanMigration_NoticeWindowGate (#781 reuse): an INCREASE migration

--- a/internal/modules/subscriptions/plan_migration_nmi.go
+++ b/internal/modules/subscriptions/plan_migration_nmi.go
@@ -96,9 +96,17 @@ func (p *nmiPlanPusher) PushPlanAmount(ctx context.Context, sub *models.Subscrip
 	if !found {
 		return fmt.Errorf("nmi push: subscription %s not found at nmi", railID)
 	}
-	planPayments := 0 // NMI's "until cancelled"
+	// plan_payments is the TOTAL payment count (0 = until cancelled; see
+	// AddRecurringPlan) and update_subscription always sends it. Absent/empty
+	// reads as NMI's own 0 default; a NON-empty value we cannot parse must
+	// block rather than silently rewrite a finite schedule to bill-forever.
+	planPayments := 0
 	if remote.Plan != nil {
-		if n, perr := strconv.Atoi(strings.TrimSpace(remote.Plan.PlanPayments)); perr == nil {
+		if raw := strings.TrimSpace(remote.Plan.PlanPayments); raw != "" {
+			n, perr := strconv.Atoi(raw)
+			if perr != nil || n < 0 {
+				return fmt.Errorf("nmi push: %s carries unparseable plan_payments %q — refusing to guess the schedule", railID, raw)
+			}
 			planPayments = n
 		}
 	}

--- a/internal/modules/subscriptions/plan_migration_nmi.go
+++ b/internal/modules/subscriptions/plan_migration_nmi.go
@@ -1,0 +1,145 @@
+package subscriptions
+
+// #815: gateway-native NMI auto-migration for #813 plan migrations.
+//
+// A gateway-native NMI recurring subscription (NMI initiates the rebills; no
+// #297 stored-credential anchor) CAN be migrated server-side: classic Direct
+// Post recurring=update_subscription mutates the remote record's plan_amount
+// (merchant-initiated, vault-backed, no user interaction). NMI knows only
+// amount + schedule — no product concept — so the rail-side flip for a plan
+// change is plan_amount -> the target price's amount; the product/entitlement
+// cutover stays internal.
+//
+// Timing is STRICTER than Stripe: NMI has no future-dated schedule object, so
+// the push IS the next-rebill flip. Pushes happen only inside the change-
+// boundary period (after the last old-price rebill, before the first
+// new-price one) — see pushNMI's early-flip guard. Provider truth flips at
+// push time (the remote record immediately reads the target amount, verified
+// by read-back), so the internal cutover accompanies the push — mirroring the
+// converge-from-provider-truth doctrine. Billing still flips only at the next
+// rebill; the rebill date never moves; nothing is charged off-cycle;
+// entitlement windows re-derive at the next renewal grant (#813 amendment).
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/integrations/nmi"
+	"github.com/open-rails/openrails/internal/shared/moneyutil"
+)
+
+// NMIPusher is the #815 gateway-native NMI push seam (production impl:
+// NewNMIPlanPusher over the #788 per-merchant client resolver; faked in
+// tests). CanPush doubles as the NMI-family rail detector — it is resolver-
+// driven, so custom-named NMI provider accounts classify without code
+// changes.
+type NMIPusher interface {
+	// CanPush reports whether sub is an addressable gateway-native NMI
+	// recurring record: the merchant declares an armable NMI account for it
+	// and the subscription carries a rail reference.
+	CanPush(ctx context.Context, sub *models.Subscription) bool
+	// PushPlanAmount sets the remote record's plan_amount to amountMicros
+	// (converted to NMI's decimal form), PRESERVING the record's current
+	// plan_payments, and read-back-verifies the flip took. It never touches
+	// the schedule (day/month frequency), so the rebill date is unchanged.
+	PushPlanAmount(ctx context.Context, sub *models.Subscription, amountMicros int64) error
+}
+
+type nmiPlanPusher struct {
+	resolver NMIClientSource
+}
+
+// NewNMIPlanPusher builds the production NMIPusher over the store-scoped NMI
+// client resolver (#788; satisfied by money.MerchantCollectionAdapterBuilder).
+func NewNMIPlanPusher(resolver NMIClientSource) NMIPusher {
+	return &nmiPlanPusher{resolver: resolver}
+}
+
+func (p *nmiPlanPusher) CanPush(ctx context.Context, sub *models.Subscription) bool {
+	if p == nil || p.resolver == nil || sub == nil {
+		return false
+	}
+	if strings.TrimSpace(sub.RailSubscriptionID) == "" {
+		return false
+	}
+	_, _, ok, err := NMIClientForExistingSubscription(ctx, p.resolver, sub)
+	return err == nil && ok
+}
+
+func (p *nmiPlanPusher) PushPlanAmount(ctx context.Context, sub *models.Subscription, amountMicros int64) error {
+	client, _, ok, err := NMIClientForExistingSubscription(ctx, p.resolver, sub)
+	if err != nil {
+		return fmt.Errorf("nmi push: resolve client: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("nmi push: merchant declares no armable nmi account")
+	}
+	railID := strings.TrimSpace(sub.RailSubscriptionID)
+	if railID == "" {
+		return fmt.Errorf("nmi push: subscription missing nmi reference")
+	}
+	cents, err := moneyutil.MicrosToCentsExact(amountMicros)
+	if err != nil {
+		return fmt.Errorf("nmi push: %w", err)
+	}
+
+	// Read the current record FIRST: existence check + plan_payments
+	// preservation (update_subscription always sends plan_payments; resetting
+	// it would rewrite a finite-payments schedule).
+	remote, found, err := client.GetSubscription(railID)
+	if err != nil {
+		return fmt.Errorf("nmi push: read %s: %w", railID, err)
+	}
+	if !found {
+		return fmt.Errorf("nmi push: subscription %s not found at nmi", railID)
+	}
+	planPayments := 0 // NMI's "until cancelled"
+	if remote.Plan != nil {
+		if n, perr := strconv.Atoi(strings.TrimSpace(remote.Plan.PlanPayments)); perr == nil {
+			planPayments = n
+		}
+	}
+
+	if _, err := client.UpdateRecurringSubscription(railID, moneyutil.FormatCentsDecimal(cents), planPayments); err != nil {
+		return fmt.Errorf("nmi push: update %s: %w", railID, err)
+	}
+
+	// Converge-from-provider-truth: confirm the flip took before the caller
+	// applies the internal cutover. A mismatch (or ambiguous update) leaves
+	// the row blocked; a re-run re-pushes the same amount (a set-to-value op,
+	// idempotent at NMI) and re-verifies.
+	after, found, err := client.GetSubscription(railID)
+	if err != nil {
+		return fmt.Errorf("nmi push: verify %s: %w", railID, err)
+	}
+	if !found {
+		return fmt.Errorf("nmi push: subscription %s vanished during update", railID)
+	}
+	gotCents, err := nmiRemoteAmountCents(after)
+	if err != nil {
+		return fmt.Errorf("nmi push: verify %s: %w", railID, err)
+	}
+	if gotCents != cents {
+		return fmt.Errorf("nmi push: update did not converge: remote amount %s, want %s",
+			moneyutil.FormatCentsDecimal(gotCents), moneyutil.FormatCentsDecimal(cents))
+	}
+	return nil
+}
+
+// nmiRemoteAmountCents parses the fetched record's amount with the same
+// precedence as the bulk NMI fetcher: subscription amount first, then the
+// embedded plan's plan_amount.
+func nmiRemoteAmountCents(sub nmi.V5Subscription) (int64, error) {
+	if cents, err := moneyutil.ParseDecimalToCents(strings.TrimSpace(sub.Amount)); err == nil && cents > 0 {
+		return cents, nil
+	}
+	if sub.Plan != nil {
+		if cents, err := moneyutil.ParseDecimalToCents(strings.TrimSpace(sub.Plan.PlanAmount)); err == nil {
+			return cents, nil
+		}
+	}
+	return 0, fmt.Errorf("no parseable amount on the remote record")
+}

--- a/internal/modules/subscriptions/plan_migration_nmi_integration_test.go
+++ b/internal/modules/subscriptions/plan_migration_nmi_integration_test.go
@@ -1,0 +1,314 @@
+//go:build integration
+
+package subscriptions
+
+// #815 gateway-native NMI auto-migration suite — exercises the REAL
+// nmiPlanPusher (classic Direct Post update_subscription + v5 GET read-back)
+// against a scripted fake NMI gateway, mirroring the intents package's
+// fake-gateway pattern. Covers: the boundary push end-to-end (wire shape,
+// plan_payments preservation, internal cutover, money invariants), the
+// early-flip guard + final-period re-run, push-failure and verify-mismatch
+// degradation, idempotent re-runs, interval-mismatch blocking, and
+// preview/execute parity.
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/internal/integrations/nmi"
+)
+
+// fakeNMIPlanGateway scripts the two endpoints the #815 push touches: the v5
+// subscription GET (read + verify) and the classic Direct Post
+// recurring=update_subscription write.
+type fakeNMIPlanGateway struct {
+	railSubID    string
+	amount       atomic.Value // decimal string NMI currently bills ("10.00")
+	planPayments string       // remote plan_payments the push must preserve
+	updateMode   atomic.Value // "ok" | "rejected" | "stale" (accepted, amount unchanged)
+	getCalls     atomic.Int64
+	updateCalls  atomic.Int64
+	updateForms  []map[string]string
+}
+
+func newFakeNMIPlanGateway(t *testing.T, railSubID, initialAmount, planPayments string) (*fakeNMIPlanGateway, *nmi.NMIClient) {
+	t.Helper()
+	f := &fakeNMIPlanGateway{railSubID: railSubID, planPayments: planPayments}
+	f.amount.Store(initialAmount)
+	f.updateMode.Store("ok")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/subscriptions/"):
+			f.getCalls.Add(1)
+			fmt.Fprintf(w, `{"object":"subscription","id":"%s","amount":"%s","delayed_condition":"active","next_billing_date":"2027-01-01","plan":{"object":"plan","id":"plan-x","plan_amount":"%s","plan_payments":"%s","day_frequency":"30"}}`,
+				f.railSubID, f.amount.Load().(string), f.amount.Load().(string), f.planPayments)
+		case r.Method == http.MethodPost:
+			_ = r.ParseForm()
+			if r.PostFormValue("recurring") != "update_subscription" {
+				fmt.Fprint(w, "response=1")
+				return
+			}
+			f.updateCalls.Add(1)
+			f.updateForms = append(f.updateForms, map[string]string{
+				"subscription_id": r.PostFormValue("subscription_id"),
+				"plan_amount":     r.PostFormValue("plan_amount"),
+				"plan_payments":   r.PostFormValue("plan_payments"),
+			})
+			switch f.updateMode.Load().(string) {
+			case "rejected":
+				fmt.Fprint(w, "response=3&responsetext=Invalid Subscription")
+			case "stale":
+				// Accepted on the wire, but the record never flips — the
+				// read-back verify must catch this.
+				fmt.Fprint(w, "response=1&responsetext=SUCCESS")
+			default:
+				f.amount.Store(r.PostFormValue("plan_amount"))
+				fmt.Fprint(w, "response=1&responsetext=SUCCESS")
+			}
+		default:
+			fmt.Fprint(w, `{}`)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := nmi.NewClient("nmi", &config.NMIProviderSettings{
+		SecurityKey: "test_security_key", WebhookSecret: "test_secret",
+	}, true)
+	require.NoError(t, err)
+	client.V5BaseURL = srv.URL
+	client.QueryURL = srv.URL
+	client.DirectPostURL = srv.URL
+	return f, client
+}
+
+// fakeNMIClientSource arms the fake gateway's client for every subscription.
+type fakeNMIClientSource struct{ client *nmi.NMIClient }
+
+func (f fakeNMIClientSource) ResolveNMIClient(_ context.Context, _ uuid.UUID, _ *uuid.UUID) (*nmi.NMIClient, bool, error) {
+	return f.client, true, nil
+}
+
+// nmiNativeFixture: the plan-migration fixture re-armed with the REAL
+// nmiPlanPusher over a fake gateway, and a pm-lookup that reports NO anchor
+// (gateway-native detection must come from the pusher, not the instrument).
+func nmiNativeFixture(t *testing.T, initialAmount, planPayments string) (*planMigrationFixture, *fakeNMIPlanGateway, uuid.UUID, string) {
+	t.Helper()
+	f := newPlanMigrationFixture(t)
+	ctx := dbtest.WithTestMerchant(context.Background())
+	subID, railSubID := f.createSubscriptionOnRail(t, ctx, f.lowPriceID, "nmi", false)
+	gateway, client := newFakeNMIPlanGateway(t, railSubID, initialAmount, planPayments)
+	f.pm = NewPlanMigrationService(f.repriceSvc, f.stripe, NewNMIPlanPusher(fakeNMIClientSource{client: client}),
+		pmLookupFunc(func(_ context.Context, id uuid.UUID) (*models.PaymentMethod, error) {
+			return &models.PaymentMethod{ID: id}, nil // no stored-credential anchor
+		}))
+	return f, gateway, subID, railSubID
+}
+
+// TestPlanMigration_NMINativeBoundaryPush: the full #815 mechanic — the push
+// re-points the remote plan_amount (exact decimal, plan_payments preserved,
+// schedule untouched), the internal cutover accompanies it, nothing is
+// charged, and the rebill date never moves.
+func TestPlanMigration_NMINativeBoundaryPush(t *testing.T) {
+	f, gateway, subID, railSubID := nmiNativeFixture(t, "10.00", "7")
+	ctx := dbtest.WithTestMerchant(context.Background())
+	var periodEndBefore time.Time
+	require.NoError(t, f.pool.QueryRow(ctx, `SELECT current_period_ends_at FROM openrails.subscriptions WHERE id = $1`, subID).Scan(&periodEndBefore))
+
+	res, err := f.pm.Migrate(ctx, PlanMigrationRequest{SourcePriceID: f.lowPriceID, TargetPriceID: f.targetPriceID})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Matched)
+	require.Equal(t, 1, res.Scheduled)
+	require.Zero(t, res.Blocked)
+	require.Equal(t, "applied_immediately", res.Outcomes[0].Disposition)
+	require.Equal(t, 1, res.ByRail["nmi"].Auto)
+
+	// Wire shape: one update, exact decimal amount, preserved plan_payments.
+	require.EqualValues(t, 1, gateway.updateCalls.Load())
+	form := gateway.updateForms[0]
+	require.Equal(t, railSubID, form["subscription_id"])
+	require.Equal(t, "9.00", form["plan_amount"], "9000000 micros must push as 9.00")
+	require.Equal(t, "7", form["plan_payments"], "plan_payments must be preserved, not reset")
+	require.Equal(t, "9.00", gateway.amount.Load().(string), "NMI now bills the target at the next rebill")
+
+	// Internal cutover accompanied the push (provider truth flipped at push).
+	priceID, productID := f.subscriptionRow(t, ctx, subID)
+	require.Equal(t, f.targetPriceID, priceID)
+	require.Equal(t, f.targetProductID, productID)
+	var specs string
+	require.NoError(t, f.pool.QueryRow(ctx, `SELECT entitlements_spec_snapshot::text FROM openrails.subscriptions WHERE id = $1`, subID).Scan(&specs))
+	require.Contains(t, specs, "plan_b_access")
+
+	// Money invariants: no charge, rebill date unchanged.
+	var payments int
+	require.NoError(t, f.pool.QueryRow(ctx, `SELECT count(*) FROM openrails.payments WHERE subscription_id = $1`, subID).Scan(&payments))
+	require.Zero(t, payments, "an NMI migration must never charge off-cycle")
+	var periodEndAfter time.Time
+	require.NoError(t, f.pool.QueryRow(ctx, `SELECT current_period_ends_at FROM openrails.subscriptions WHERE id = $1`, subID).Scan(&periodEndAfter))
+	require.True(t, periodEndBefore.Equal(periodEndAfter), "the rebill date must never move")
+
+	// Ledger: the row is applied.
+	rows, err := f.repriceRepo.List(ctx, SubscriptionRepriceFilter{RepriceBatchID: res.BatchID}, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, models.RepriceStatusApplied, rows[0].Status)
+	require.Equal(t, models.RepriceKindPlanChange, rows[0].Kind)
+}
+
+// TestPlanMigration_NMINativeFarFutureBlocksHonestly: NMI has no future-dated
+// schedules — an effective date beyond the current period must NOT push (it
+// would flip a whole rebill early); the row blocks and a re-run inside the
+// final pre-effective period succeeds.
+func TestPlanMigration_NMINativeFarFutureBlocksHonestly(t *testing.T) {
+	f, gateway, subID, _ := nmiNativeFixture(t, "10.00", "0")
+	ctx := dbtest.WithTestMerchant(context.Background())
+
+	// Period ends +30d; effective +45d — beyond it.
+	res, err := f.pm.Migrate(ctx, PlanMigrationRequest{
+		SourcePriceID: f.lowPriceID, TargetPriceID: f.targetPriceID,
+		EffectiveAt: f.clock.Now().Add(45 * 24 * time.Hour),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Blocked)
+	require.Contains(t, res.Outcomes[0].Reason, "nmi_deferred_push_required")
+	require.Zero(t, gateway.updateCalls.Load(), "no early flip may be pushed")
+	require.Equal(t, "10.00", gateway.amount.Load().(string))
+	priceID, _ := f.subscriptionRow(t, ctx, subID)
+	require.Equal(t, f.lowPriceID, priceID, "blocked row leaves the sub untouched")
+
+	// The sub renews into its final pre-effective period: re-run succeeds.
+	_, err = f.pool.Exec(ctx, `UPDATE openrails.subscriptions SET current_period_ends_at = $1 WHERE id = $2`,
+		f.clock.Now().Add(60*24*time.Hour), subID)
+	require.NoError(t, err)
+	res2, err := f.pm.Migrate(ctx, PlanMigrationRequest{
+		SourcePriceID: f.lowPriceID, TargetPriceID: f.targetPriceID,
+		EffectiveAt: f.clock.Now().Add(45 * 24 * time.Hour),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, res2.Scheduled)
+	require.EqualValues(t, 1, gateway.updateCalls.Load())
+	require.Equal(t, "9.00", gateway.amount.Load().(string))
+}
+
+// TestPlanMigration_NMINativePushFailureDegradesToBlocked: a gateway refusal
+// leaves the sub on the old plan on BOTH sides, records the row blocked with
+// the push error, and a re-run after the gateway heals migrates it.
+func TestPlanMigration_NMINativePushFailureDegradesToBlocked(t *testing.T) {
+	f, gateway, subID, _ := nmiNativeFixture(t, "10.00", "0")
+	ctx := dbtest.WithTestMerchant(context.Background())
+	gateway.updateMode.Store("rejected")
+
+	res, err := f.pm.Migrate(ctx, PlanMigrationRequest{SourcePriceID: f.lowPriceID, TargetPriceID: f.targetPriceID})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Blocked)
+	require.Contains(t, res.Outcomes[0].Reason, "rail_push_failed")
+	require.Equal(t, "10.00", gateway.amount.Load().(string), "NMI still bills the old amount")
+	priceID, _ := f.subscriptionRow(t, ctx, subID)
+	require.Equal(t, f.lowPriceID, priceID, "failed push leaves the sub untouched")
+	rows, err := f.repriceRepo.List(ctx, SubscriptionRepriceFilter{RepriceBatchID: res.BatchID}, 10, 0)
+	require.NoError(t, err)
+	require.Equal(t, models.RepriceStatusBlocked, rows[0].Status)
+
+	gateway.updateMode.Store("ok")
+	res2, err := f.pm.Migrate(ctx, PlanMigrationRequest{SourcePriceID: f.lowPriceID, TargetPriceID: f.targetPriceID})
+	require.NoError(t, err)
+	require.Equal(t, 1, res2.Scheduled)
+	require.Equal(t, "9.00", gateway.amount.Load().(string))
+	priceID, _ = f.subscriptionRow(t, ctx, subID)
+	require.Equal(t, f.targetPriceID, priceID)
+}
+
+// TestPlanMigration_NMINativeVerifyMismatchBlocks: an update the gateway
+// accepts but never applies (ambiguous) must fail the read-back verify and
+// land blocked — never an internal cutover NMI does not bill.
+func TestPlanMigration_NMINativeVerifyMismatchBlocks(t *testing.T) {
+	f, gateway, subID, _ := nmiNativeFixture(t, "10.00", "0")
+	ctx := dbtest.WithTestMerchant(context.Background())
+	gateway.updateMode.Store("stale")
+
+	res, err := f.pm.Migrate(ctx, PlanMigrationRequest{SourcePriceID: f.lowPriceID, TargetPriceID: f.targetPriceID})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Blocked)
+	require.Contains(t, res.Outcomes[0].Reason, "did not converge")
+	priceID, _ := f.subscriptionRow(t, ctx, subID)
+	require.Equal(t, f.lowPriceID, priceID, "no internal cutover without verified provider truth")
+}
+
+// TestPlanMigration_NMINativeIdempotentRerun: an applied NMI sub has LEFT the
+// source-price cohort (price flipped at push), so a re-run is an empty-cohort
+// no-op — nothing matched, nothing re-pushed.
+func TestPlanMigration_NMINativeIdempotentRerun(t *testing.T) {
+	f, gateway, _, _ := nmiNativeFixture(t, "10.00", "0")
+	ctx := dbtest.WithTestMerchant(context.Background())
+
+	res1, err := f.pm.Migrate(ctx, PlanMigrationRequest{SourcePriceID: f.lowPriceID, TargetPriceID: f.targetPriceID})
+	require.NoError(t, err)
+	require.Equal(t, 1, res1.Scheduled)
+	require.EqualValues(t, 1, gateway.updateCalls.Load())
+
+	res2, err := f.pm.Migrate(ctx, PlanMigrationRequest{SourcePriceID: f.lowPriceID, TargetPriceID: f.targetPriceID})
+	require.NoError(t, err)
+	require.Zero(t, res2.Matched, "the migrated sub is no longer on the source price")
+	require.Zero(t, res2.Scheduled)
+	require.Zero(t, res2.Blocked)
+	require.EqualValues(t, 1, gateway.updateCalls.Load(), "re-run must not re-push")
+}
+
+// TestPlanMigration_NMINativeIntervalMismatchBlocks: an amount update cannot
+// change the billing interval — a target on a different cycle blocks in BOTH
+// preview and execute, with zero pushes.
+func TestPlanMigration_NMINativeIntervalMismatchBlocks(t *testing.T) {
+	f, gateway, _, _ := nmiNativeFixture(t, "10.00", "0")
+	ctx := dbtest.WithTestMerchant(context.Background())
+
+	// Annual target on the target product (8760h vs the source's 720h).
+	annualTargetID := uuid.New()
+	_, err := f.pool.Exec(ctx, `
+		INSERT INTO openrails.prices (id, product_id, merchant_id, amount, currency, access_duration_hours, auto_renew, archived, key, created_at, updated_at)
+		VALUES ($1,$2,$3,90000000,'usd',8760,true,false,$4,$5,$5)`,
+		annualTargetID, f.targetProductID, f.merchantID, "planmig-annual-"+uuid.NewString()[:8], f.clock.Now())
+	require.NoError(t, err)
+
+	preview, err := f.pm.Preview(ctx, PlanMigrationRequest{SourcePriceID: f.lowPriceID, TargetPriceID: annualTargetID})
+	require.NoError(t, err)
+	require.Equal(t, 1, preview.Blocked)
+	require.Equal(t, "nmi_interval_mismatch", preview.Outcomes[0].Reason)
+
+	res, err := f.pm.Migrate(ctx, PlanMigrationRequest{SourcePriceID: f.lowPriceID, TargetPriceID: annualTargetID})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Blocked)
+	require.Equal(t, "nmi_interval_mismatch", res.Outcomes[0].Reason)
+	require.Zero(t, gateway.updateCalls.Load(), "an inexpressible change must never be pushed")
+}
+
+// TestPlanMigration_NMINativeSubCentAmountBlocks: NMI bills whole cents — a
+// micro-dollar target that is not cent-representable blocks with a reason.
+func TestPlanMigration_NMINativeSubCentAmountBlocks(t *testing.T) {
+	f, gateway, _, _ := nmiNativeFixture(t, "10.00", "0")
+	ctx := dbtest.WithTestMerchant(context.Background())
+
+	subCentID := uuid.New()
+	_, err := f.pool.Exec(ctx, `
+		INSERT INTO openrails.prices (id, product_id, merchant_id, amount, currency, access_duration_hours, auto_renew, archived, key, created_at, updated_at)
+		VALUES ($1,$2,$3,9000001,'usd',720,true,false,$4,$5,$5)`,
+		subCentID, f.targetProductID, f.merchantID, "planmig-subcent-"+uuid.NewString()[:8], f.clock.Now())
+	require.NoError(t, err)
+
+	res, err := f.pm.Migrate(ctx, PlanMigrationRequest{SourcePriceID: f.lowPriceID, TargetPriceID: subCentID})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Blocked)
+	require.Equal(t, "nmi_amount_not_cent_representable", res.Outcomes[0].Reason)
+	require.Zero(t, gateway.updateCalls.Load())
+}

--- a/internal/modules/subscriptions/plan_migration_nmi_integration_test.go
+++ b/internal/modules/subscriptions/plan_migration_nmi_integration_test.go
@@ -230,6 +230,23 @@ func TestPlanMigration_NMINativePushFailureDegradesToBlocked(t *testing.T) {
 	require.Equal(t, f.targetPriceID, priceID)
 }
 
+// TestPlanMigration_NMINativeGarbagePlanPaymentsBlocks: a NON-empty remote
+// plan_payments we cannot parse must block the push — silently defaulting to
+// 0 would rewrite a finite-payments schedule to bill-forever.
+func TestPlanMigration_NMINativeGarbagePlanPaymentsBlocks(t *testing.T) {
+	f, gateway, subID, _ := nmiNativeFixture(t, "10.00", "not-a-number")
+	ctx := dbtest.WithTestMerchant(context.Background())
+
+	res, err := f.pm.Migrate(ctx, PlanMigrationRequest{SourcePriceID: f.lowPriceID, TargetPriceID: f.targetPriceID})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Blocked)
+	require.Contains(t, res.Outcomes[0].Reason, "unparseable plan_payments")
+	require.Equal(t, int64(0), gateway.updateCalls.Load(), "no update may be attempted on an unreadable schedule")
+	require.Equal(t, "10.00", gateway.amount.Load().(string))
+	priceID, _ := f.subscriptionRow(t, ctx, subID)
+	require.Equal(t, f.lowPriceID, priceID)
+}
+
 // TestPlanMigration_NMINativeVerifyMismatchBlocks: an update the gateway
 // accepts but never applies (ambiguous) must fail the read-back verify and
 // land blocked — never an internal cutover NMI does not bill.


### PR DESCRIPTION
or#813 v1 classified gateway-native NMI recurring subscriptions (NMI initiates the rebills; no #297 stored-credential anchor) as blocked `rail_requires_user_action`. Too conservative: NMI supports server-side subscription mutation and the client already wraps it (`UpdateRecurringSubscription`, classic Direct Post per #663 — the v5 route is dead on the live gateway).

## What changes

- **classify()**: gateway-native NMI flips from blocked to AUTO when the #788 resolver arms an NMI client for the subscription (resolver-driven detection — custom-named NMI provider accounts classify without code changes), the target bills on the same cycle (an amount update cannot change the interval; mismatch blocks `nmi_interval_mismatch`), and the amount is whole-cent (`nmi_amount_not_cent_representable` otherwise). Preview and execute share the code path (or#813 invariant).
- **Push**: read the remote record first (existence + `plan_payments` preservation — never reset a finite-payments schedule), classic `update_subscription` with the target amount, then read-back verify via the v5 GET. The schedule (day/month frequency) is never touched, so the rebill date cannot move.
- **Cutover**: provider truth flips at push (NMI has no future-dated schedules — the push IS the next-rebill flip), so the internal cutover accompanies a verified push and the row lands applied in the same operation. Billing flips at the next rebill; nothing is charged off-cycle; entitlement windows re-derive at the next renewal grant (#813 amendment).
- **Early-flip guard** mirrors Stripe's: an effective date beyond the current period blocks honestly (`nmi_deferred_push_required`) and an idempotent re-run inside the final pre-effective period succeeds.

## Tests

New fake-NMI-gateway suite (real `nmiPlanPusher`, real Direct Post + v5 wire shapes): boundary push end-to-end (exact decimal amount, preserved plan_payments, internal cutover, zero payments, rebill date unchanged), far-future block + final-period re-run, gateway-refusal and verify-mismatch (accepted-but-stale) degradation to blocked with the sub untouched on both sides, empty-cohort idempotent re-run, interval-mismatch and sub-cent blocking in both preview and execute. Capability-matrix test updated for the gateway-native flip (ccbill/solana stay blocked). or#813 regression suites (subscriptions incl. reprice + full plan-migration, checkout/TierChange, webhooks) green; `go test -race` green on touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)