### PR TITLE
or#816: plan-migration re-driver — deferred and crash-window rows heal automatically via River

### DIFF
--- a/internal/app/river_register.go
+++ b/internal/app/river_register.go
@@ -144,6 +144,16 @@ func (r *Runtime) addBillingWorkersToRegistry(ctx context.Context, workers *rive
 	}); err != nil {
 		return fmt.Errorf("add resume subscription worker: %w", err)
 	}
+	// Plan-migration re-driver (#816): re-drives blocked #813 plan-change rows
+	// (deferred far-future pushes entering their final pre-effective period;
+	// crash-window rows whose rail already carries the target) through the same
+	// idempotent execute paths a manual re-run uses. Nil service (worker-only
+	// runtimes) log-and-skips inside the worker.
+	if err := addTrackedWorker(r, workers, &riverjobs.PlanMigrationRedriveWorker{
+		Migrations: r.PlanMigrationService,
+	}); err != nil {
+		return fmt.Errorf("add plan migration redrive worker: %w", err)
+	}
 	// Provider intent ledger (#358): the executor drains due outbound provider
 	// mutations (deferred NMI deletes, refunds, manual rebills), the verifier
 	// resolves ambiguous outcomes via provider reads. These replaced the
@@ -476,6 +486,21 @@ func (r *Runtime) buildRiverPeriodicJobs(ctx context.Context) ([]*river.Periodic
 			return riverjobs.ProviderIntentExecuteArgs{}, &river.InsertOpts{
 				Queue:      riverjobs.QueueBilling,
 				UniqueOpts: river.UniqueOpts{ByQueue: true, ByPeriod: time.Minute},
+			}
+		},
+		&river.PeriodicJobOpts{RunOnStart: true},
+	))
+
+	// Hourly: plan-migration re-drive (#816). Period granularity is days, so
+	// hourly can never miss a subscription's final pre-effective period.
+	// RunOnStart=true: a reboot after downtime is exactly when deferred rows
+	// have accumulated, and an empty pass is a cheap indexed no-op.
+	jobs = append(jobs, r.healthPeriodic(
+		time.Hour,
+		func() (river.JobArgs, *river.InsertOpts) {
+			return riverjobs.PlanMigrationRedriveArgs{}, &river.InsertOpts{
+				Queue:      riverjobs.QueueBilling,
+				UniqueOpts: river.UniqueOpts{ByQueue: true, ByPeriod: time.Hour},
 			}
 		},
 		&river.PeriodicJobOpts{RunOnStart: true},

--- a/internal/db/gen/subscription_reprices.sql.go
+++ b/internal/db/gen/subscription_reprices.sql.go
@@ -89,6 +89,30 @@ func (q *Queries) CancelSubscriptionReprice(ctx context.Context, id uuid.UUID) (
 	return result.RowsAffected(), nil
 }
 
+const countPlanMigrationBatchRows = `-- name: CountPlanMigrationBatchRows :one
+SELECT
+    count(*) FILTER (WHERE status = 'blocked')  AS blocked,
+    count(*) FILTER (WHERE status <> 'blocked') AS scheduled
+FROM openrails.subscription_reprices
+WHERE reprice_batch_id = $1::uuid
+`
+
+type CountPlanMigrationBatchRowsRow struct {
+	Blocked   int64
+	Scheduled int64
+}
+
+// #816: batch-header re-sync source of truth. Rows exist only for
+// scheduled/blocked cohort members (skips are header-only), and the header's
+// "scheduled" has always counted every auto-migratable row regardless of how
+// far it progressed — so non-blocked = scheduled|applied|canceled.
+func (q *Queries) CountPlanMigrationBatchRows(ctx context.Context, batchID uuid.UUID) (CountPlanMigrationBatchRowsRow, error) {
+	row := q.db.QueryRow(ctx, countPlanMigrationBatchRows, batchID)
+	var i CountPlanMigrationBatchRowsRow
+	err := row.Scan(&i.Blocked, &i.Scheduled)
+	return i, err
+}
+
 const createBlockedSubscriptionReprice = `-- name: CreateBlockedSubscriptionReprice :one
 INSERT INTO openrails.subscription_reprices (
     merchant_id, subscription_id, from_price_id, to_price_id, effective_at, reprice_batch_id, kind, status, blocked_reason
@@ -259,6 +283,55 @@ func (q *Queries) GetSubscriptionRepriceByID(ctx context.Context, id uuid.UUID) 
 	return i, err
 }
 
+const listRedrivableBlockedPlanChangeReprices = `-- name: ListRedrivableBlockedPlanChangeReprices :many
+SELECT id, merchant_id, subscription_id, from_price_id, to_price_id, effective_at, status, reprice_batch_id, created_at, applied_at, canceled_at, acknowledged_short_notice, kind, blocked_reason FROM openrails.subscription_reprices
+WHERE kind = 'plan_change'
+  AND status = 'blocked'
+  AND blocked_reason LIKE 'rail_push_failed:%'
+ORDER BY created_at
+LIMIT $1::int
+`
+
+// #816: the re-driver's cross-merchant enumeration. Only push-failure blocks
+// are re-drivable (the prefix covers the deferred-window refusals and the NMI
+// push-verified-then-crash window); classification blocks
+// (rail_requires_user_action, interval/cent mismatches, missing rail config
+// at classify time) never carried a push attempt and stay terminal.
+func (q *Queries) ListRedrivableBlockedPlanChangeReprices(ctx context.Context, batchSize int32) ([]OpenrailsSubscriptionReprice, error) {
+	rows, err := q.db.Query(ctx, listRedrivableBlockedPlanChangeReprices, batchSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []OpenrailsSubscriptionReprice
+	for rows.Next() {
+		var i OpenrailsSubscriptionReprice
+		if err := rows.Scan(
+			&i.ID,
+			&i.MerchantID,
+			&i.SubscriptionID,
+			&i.FromPriceID,
+			&i.ToPriceID,
+			&i.EffectiveAt,
+			&i.Status,
+			&i.RepriceBatchID,
+			&i.CreatedAt,
+			&i.AppliedAt,
+			&i.CanceledAt,
+			&i.AcknowledgedShortNotice,
+			&i.Kind,
+			&i.BlockedReason,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listSubscriptionReprices = `-- name: ListSubscriptionReprices :many
 SELECT id, merchant_id, subscription_id, from_price_id, to_price_id, effective_at, status, reprice_batch_id, created_at, applied_at, canceled_at, acknowledged_short_notice, kind, blocked_reason FROM openrails.subscription_reprices
 WHERE ($1::uuid IS NULL OR subscription_id = $1::uuid)
@@ -315,4 +388,24 @@ func (q *Queries) ListSubscriptionReprices(ctx context.Context, arg ListSubscrip
 		return nil, err
 	}
 	return items, nil
+}
+
+const unblockSubscriptionReprice = `-- name: UnblockSubscriptionReprice :execrows
+UPDATE openrails.subscription_reprices SET
+    status = 'scheduled',
+    blocked_reason = ''
+WHERE id = $1 AND status = 'blocked'
+`
+
+// #816: the re-driver's un-block — the exact inverse of
+// BlockSubscriptionReprice, status-predicated so a concurrent transition wins
+// cleanly. uq_subscription_reprices_one_scheduled makes this fail (unique
+// violation) if the subscription acquired another scheduled row meanwhile —
+// callers treat that as a skip.
+func (q *Queries) UnblockSubscriptionReprice(ctx context.Context, id uuid.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, unblockSubscriptionReprice, id)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }

--- a/internal/db/queries/subscription_reprices.sql
+++ b/internal/db/queries/subscription_reprices.sql
@@ -74,3 +74,38 @@ UPDATE openrails.subscription_reprices SET
     status = 'blocked',
     blocked_reason = sqlc.arg(blocked_reason)::text
 WHERE id = sqlc.arg(id) AND status = 'scheduled';
+
+-- #816: the re-driver's cross-merchant enumeration. Only push-failure blocks
+-- are re-drivable (the prefix covers the deferred-window refusals and the NMI
+-- push-verified-then-crash window); classification blocks
+-- (rail_requires_user_action, interval/cent mismatches, missing rail config
+-- at classify time) never carried a push attempt and stay terminal.
+-- name: ListRedrivableBlockedPlanChangeReprices :many
+SELECT * FROM openrails.subscription_reprices
+WHERE kind = 'plan_change'
+  AND status = 'blocked'
+  AND blocked_reason LIKE 'rail_push_failed:%'
+ORDER BY created_at
+LIMIT sqlc.arg(batch_size)::int;
+
+-- #816: the re-driver's un-block — the exact inverse of
+-- BlockSubscriptionReprice, status-predicated so a concurrent transition wins
+-- cleanly. uq_subscription_reprices_one_scheduled makes this fail (unique
+-- violation) if the subscription acquired another scheduled row meanwhile —
+-- callers treat that as a skip.
+-- name: UnblockSubscriptionReprice :execrows
+UPDATE openrails.subscription_reprices SET
+    status = 'scheduled',
+    blocked_reason = ''
+WHERE id = sqlc.arg(id) AND status = 'blocked';
+
+-- #816: batch-header re-sync source of truth. Rows exist only for
+-- scheduled/blocked cohort members (skips are header-only), and the header's
+-- "scheduled" has always counted every auto-migratable row regardless of how
+-- far it progressed — so non-blocked = scheduled|applied|canceled.
+-- name: CountPlanMigrationBatchRows :one
+SELECT
+    count(*) FILTER (WHERE status = 'blocked')  AS blocked,
+    count(*) FILTER (WHERE status <> 'blocked') AS scheduled
+FROM openrails.subscription_reprices
+WHERE reprice_batch_id = sqlc.arg(batch_id)::uuid;

--- a/internal/modules/subscriptions/plan_migration.go
+++ b/internal/modules/subscriptions/plan_migration.go
@@ -513,6 +513,15 @@ func centRepresentable(amountMicros int64) bool {
 	return err == nil
 }
 
+// deferredPushRequired is THE early-flip predicate (#813 stripe, #815 NMI,
+// #816 re-driver — one definition, never forked): an effective date beyond
+// the subscription's CURRENT period means a rail push now would flip at least
+// one whole rebill early (a money defect). The push must wait until the
+// subscription enters its final pre-effective period.
+func deferredPushRequired(effectiveAt time.Time, sub *models.Subscription) bool {
+	return sub.CurrentPeriodEndsAt != nil && !sub.CurrentPeriodEndsAt.IsZero() && effectiveAt.After(*sub.CurrentPeriodEndsAt)
+}
+
 // pushNMI (#815) migrates a gateway-native NMI recurring subscription:
 // re-point the remote record's plan_amount at the target (schedule and
 // plan_payments untouched, read-back verified inside the pusher), then apply
@@ -531,12 +540,10 @@ func (s *PlanMigrationService) pushNMI(ctx context.Context, req *PlanMigrationRe
 		return fmt.Errorf("subscription missing current period end")
 	}
 	// Early-flip guard, STRICTER than stripe's: NMI has no future-dated
-	// schedule object — the push IS the next-rebill flip. An effective date
-	// beyond the current period would flip at least one whole rebill EARLY (a
-	// money defect). Refuse honestly; the row lands blocked and an idempotent
-	// re-run inside the final pre-effective period succeeds. (Automated
-	// deferred push is the filed follow-up on #813.)
-	if req.EffectiveAt.After(*sub.CurrentPeriodEndsAt) {
+	// schedule object — the push IS the next-rebill flip. Refuse honestly; the
+	// row lands blocked and the #816 re-driver (or a manual re-run) succeeds
+	// once the subscription enters its final pre-effective period.
+	if deferredPushRequired(req.EffectiveAt, sub) {
 		return fmt.Errorf("nmi_deferred_push_required: effective_at %s is beyond the current period end %s — re-run the migration once the subscription enters its final period before the effective date", req.EffectiveAt.UTC().Format(time.RFC3339), sub.CurrentPeriodEndsAt.UTC().Format(time.RFC3339))
 	}
 	if err := s.nmi.PushPlanAmount(ctx, sub, target.Amount); err != nil {
@@ -579,10 +586,10 @@ func (s *PlanMigrationService) pushStripe(ctx context.Context, req *PlanMigratio
 	}
 	// A Stripe subscription schedule flips at the CURRENT period end. If
 	// effective_at lies beyond it, pushing now would flip a whole period
-	// EARLY — a money defect. Refuse honestly; the row lands blocked and an
-	// idempotent re-run inside the final pre-effective period succeeds.
-	// (Automated deferred push is the filed follow-up on #813.)
-	if req.EffectiveAt.After(*sub.CurrentPeriodEndsAt) {
+	// EARLY — a money defect. Refuse honestly; the row lands blocked and the
+	// #816 re-driver (or a manual re-run) succeeds once the subscription
+	// enters its final pre-effective period.
+	if deferredPushRequired(req.EffectiveAt, sub) {
 		return fmt.Errorf("stripe_deferred_push_required: effective_at %s is beyond the current period end %s — re-run the migration once the subscription enters its final period before the effective date", req.EffectiveAt.UTC().Format(time.RFC3339), sub.CurrentPeriodEndsAt.UTC().Format(time.RFC3339))
 	}
 	periodStart := sub.StartedAt

--- a/internal/modules/subscriptions/plan_migration_redrive.go
+++ b/internal/modules/subscriptions/plan_migration_redrive.go
@@ -1,0 +1,221 @@
+package subscriptions
+
+// #816: the plan-migration re-driver — the background half that makes #813
+// migrations fully automatic. Two blocked-row classes heal here, on time,
+// with no operator involvement:
+//
+//  1. Deferred pushes: a far-future effective date blocked the rail push
+//     (stripe_deferred_push_required / nmi_deferred_push_required) because
+//     pushing early would flip a whole rebill period too soon. Each
+//     subscription enters its final pre-effective period on its OWN schedule;
+//     the re-driver fires the push inside that window.
+//  2. Crash-window rows: a rail push that succeeded (NMI verified / Stripe
+//     schedule created) followed by a DB failure left the rail on the target
+//     with the row blocked. The re-drive converges — set-to-value re-pushes
+//     are idempotent on both rails, and a subscription already carrying the
+//     target internally just has its ledger row marked applied.
+//
+// The re-driver does EXACTLY what a manual re-run would, through the same
+// executeScheduled paths and the same status-predicated transitions — no
+// forked logic, no new state vocabulary. Concurrency with a manual re-run (or
+// an overlapping tick) is safe by construction: the one-scheduled partial
+// unique index makes Unblock lose loudly when another scheduled row exists,
+// and every transition is status-predicated so exactly one actor wins.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// PlanMigrationRedriveResult summarizes one re-driver pass.
+type PlanMigrationRedriveResult struct {
+	Examined int `json:"examined"`
+	// Redriven: rows whose push (or convergence) succeeded this pass.
+	Redriven int `json:"redriven"`
+	// Converged: the Redriven subset healed WITHOUT a rail push — the
+	// subscription already carried the target (crash-window rows).
+	Converged int `json:"converged"`
+	// Deferred: still waiting for the subscription's final pre-effective
+	// period. Left blocked; a later pass picks them up.
+	Deferred int `json:"deferred"`
+	// Skipped: stale rows the re-driver must not touch (subscription gone,
+	// cancelled, moved to a different price, target archived, or another
+	// scheduled row owns the subscription).
+	Skipped int `json:"skipped"`
+	// Failed: the re-push failed again; the row is re-blocked with the fresh
+	// reason and a later pass retries.
+	Failed int `json:"failed"`
+}
+
+// RedriveBlocked enumerates re-drivable blocked plan-change rows across all
+// merchants and re-drives each under its own merchant context. batchSize
+// bounds one pass (default 200).
+func (s *PlanMigrationService) RedriveBlocked(ctx context.Context, batchSize int) (*PlanMigrationRedriveResult, error) {
+	if batchSize <= 0 {
+		batchSize = 200
+	}
+	rows, err := s.reprice.repo.ListRedrivableBlockedPlanChanges(ctx, batchSize)
+	if err != nil {
+		return nil, fmt.Errorf("redrive: list blocked plan changes: %w", err)
+	}
+	res := &PlanMigrationRedriveResult{}
+	touchedBatches := map[uuid.UUID]uuid.UUID{} // batch id -> merchant id
+	for _, row := range rows {
+		res.Examined++
+		mctx := merchant.WithID(ctx, merchant.ID(row.MerchantID))
+		outcome, rerr := s.redriveRow(mctx, row)
+		if rerr != nil {
+			// Row-level driver errors (DB unavailable mid-pass etc.) end the
+			// pass; everything already re-driven stays done and the next tick
+			// resumes — same partial-failure posture as Migrate itself.
+			return res, fmt.Errorf("redrive row %s: %w", row.ID, rerr)
+		}
+		switch outcome {
+		case redriveOutcomePushed:
+			res.Redriven++
+		case redriveOutcomeConverged:
+			res.Redriven++
+			res.Converged++
+		case redriveOutcomeDeferred:
+			res.Deferred++
+		case redriveOutcomeSkipped:
+			res.Skipped++
+		case redriveOutcomeFailed:
+			res.Failed++
+		}
+		if row.RepriceBatchID != nil && outcome != redriveOutcomeDeferred && outcome != redriveOutcomeSkipped {
+			touchedBatches[*row.RepriceBatchID] = row.MerchantID
+		}
+	}
+	// Re-sync every touched batch header from its actual rows — the header
+	// must always agree with the per-subscription ledger (#813 invariant).
+	for batchID, merchantID := range touchedBatches {
+		mctx := merchant.WithID(ctx, merchant.ID(merchantID))
+		scheduled, blocked, cerr := s.reprice.repo.CountBatchRows(mctx, batchID)
+		if cerr != nil {
+			return res, fmt.Errorf("redrive: count batch %s rows: %w", batchID, cerr)
+		}
+		if uerr := s.reprice.repo.UpdatePlanMigrationBatchCounts(mctx, batchID, scheduled, blocked); uerr != nil {
+			return res, fmt.Errorf("redrive: sync batch %s counts: %w", batchID, uerr)
+		}
+	}
+	return res, nil
+}
+
+type redriveOutcome int
+
+const (
+	redriveOutcomePushed redriveOutcome = iota
+	redriveOutcomeConverged
+	redriveOutcomeDeferred
+	redriveOutcomeSkipped
+	redriveOutcomeFailed
+)
+
+// redriveRow re-drives ONE blocked plan-change row under its merchant
+// context. Returns a non-nil error only for driver failures (the row itself
+// is left untouched then); rail failures re-block the row and return
+// redriveOutcomeFailed.
+func (s *PlanMigrationService) redriveRow(ctx context.Context, row *models.SubscriptionReprice) (redriveOutcome, error) {
+	logger := log.WithContext(ctx).WithFields(log.Fields{
+		"reprice_id":      row.ID,
+		"subscription_id": row.SubscriptionID,
+	})
+	sub, err := s.reprice.subscriptions.GetByID(ctx, row.SubscriptionID)
+	if err != nil || sub == nil {
+		logger.Debug("redrive: subscription not found; leaving row blocked")
+		return redriveOutcomeSkipped, nil
+	}
+	if sub.Status != models.StatusActive && sub.Status != models.StatusPastDue {
+		// Left the migratable cohort (cancelled etc.) — the row stays blocked
+		// as the honest ledger of what never happened.
+		return redriveOutcomeSkipped, nil
+	}
+
+	// Crash-window convergence: the subscription already carries the target
+	// internally (the NMI cutover's sub update landed but the row transition
+	// died, or another actor migrated it). No push — just converge the ledger
+	// row through the same scheduled->applied transition every other path
+	// uses.
+	if sub.PriceID == row.ToPriceID {
+		if err := s.reprice.repo.Unblock(ctx, row.ID); err != nil {
+			// Concurrent transition or another scheduled row owns the sub.
+			return redriveOutcomeSkipped, nil //nolint:nilerr // skip is the contract
+		}
+		if err := s.reprice.repo.Apply(ctx, row.ID); err != nil {
+			return redriveOutcomeSkipped, nil //nolint:nilerr // concurrent transition won
+		}
+		logger.Info("redrive: converged blocked row — subscription already on target")
+		return redriveOutcomeConverged, nil
+	}
+	if sub.PriceID != row.FromPriceID {
+		// The subscription moved somewhere else entirely; this row's migration
+		// never happened and never will. Leave the honest blocked ledger row.
+		return redriveOutcomeSkipped, nil
+	}
+	if err := s.reprice.scheduledConflict(ctx, sub.ID); err != nil {
+		// Another scheduled row owns the subscription (a manual re-run got
+		// here first). Its own path completes the migration.
+		return redriveOutcomeSkipped, nil //nolint:nilerr // skip is the contract
+	}
+	if deferredPushRequired(row.EffectiveAt, sub) {
+		return redriveOutcomeDeferred, nil
+	}
+
+	source, err := s.reprice.prices.GetByID(ctx, row.FromPriceID)
+	if err != nil {
+		return redriveOutcomeSkipped, nil //nolint:nilerr // price gone; leave blocked
+	}
+	target, err := s.reprice.prices.GetByID(ctx, row.ToPriceID)
+	if err != nil {
+		return redriveOutcomeSkipped, nil //nolint:nilerr // price gone; leave blocked
+	}
+	if target.Archived {
+		// The operator archived the target since the migration was committed —
+		// migrating onto a dead price would violate the same gate Migrate
+		// enforces. Leave blocked for the operator.
+		return redriveOutcomeSkipped, nil
+	}
+	targetProduct, err := s.reprice.products(ctx, target.ProductID)
+	if err != nil {
+		return redriveOutcomeSkipped, nil //nolint:nilerr // product gone; leave blocked
+	}
+
+	// Take ownership: blocked -> scheduled. The one-scheduled unique index
+	// and the status predicate make this the concurrency gate — exactly one
+	// actor (this tick, a parallel tick, a manual re-run) wins the row.
+	if err := s.reprice.repo.Unblock(ctx, row.ID); err != nil {
+		return redriveOutcomeSkipped, nil //nolint:nilerr // lost the race; skip
+	}
+
+	// Re-drive through the SAME per-rail execute path Migrate uses. Boundary
+	// mode always: by re-drive time the operator's original Immediate intent
+	// (not persisted, and stale by definition) must not manufacture an
+	// off-schedule entitlement cutover — the renewal-boundary flip is the
+	// forced-migration invariant-safe mode on every rail.
+	req := &PlanMigrationRequest{
+		SourcePriceID: source.ID,
+		TargetPriceID: target.ID,
+		EffectiveAt:   row.EffectiveAt,
+	}
+	if perr := s.executeScheduled(ctx, req, sub, source, target, targetProduct, row); perr != nil {
+		if berr := s.reprice.repo.BlockScheduledReprice(ctx, row.ID, migrationBlockedRailPushFailed+": "+perr.Error()); berr != nil {
+			return redriveOutcomeFailed, fmt.Errorf("re-block after failed push: %w", berr)
+		}
+		logger.WithError(perr).Warn("redrive: rail push failed again; row re-blocked")
+		return redriveOutcomeFailed, nil
+	}
+	// The original Migrate never emitted this row's schedule-time disclosure
+	// (rows block BEFORE the notification step) — emit it now that the
+	// migration is genuinely in motion.
+	s.reprice.emitPlanChangeNotification(ctx, sub, source, target, targetProduct, row.EffectiveAt)
+	logger.WithField("effective_at", row.EffectiveAt.UTC().Format(time.RFC3339)).Info("redrive: rail push succeeded")
+	return redriveOutcomePushed, nil
+}

--- a/internal/modules/subscriptions/plan_migration_redrive_integration_test.go
+++ b/internal/modules/subscriptions/plan_migration_redrive_integration_test.go
@@ -1,0 +1,347 @@
+//go:build integration
+
+package subscriptions
+
+// #816 re-driver suite: blocked #813 plan-change rows heal UNATTENDED — the
+// deferred far-future pushes as each subscription enters its final
+// pre-effective period, and the crash-window rows whose state already matches
+// the target — through the same execute paths a manual re-run uses, safely
+// alongside one.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/dbtest"
+)
+
+// rollPeriod simulates the subscription's renewal boundary having passed: the
+// next period begins. Only the period fields move — exactly what a real
+// renewal does to the window predicate's inputs.
+func (f *planMigrationFixture) rollPeriod(t *testing.T, ctx context.Context, subID uuid.UUID) {
+	t.Helper()
+	_, err := f.pool.Exec(ctx, `
+		UPDATE openrails.subscriptions
+		SET current_period_starts_at = current_period_ends_at,
+		    current_period_ends_at   = current_period_ends_at + interval '30 days'
+		WHERE id = $1`, subID)
+	require.NoError(t, err)
+}
+
+func (f *planMigrationFixture) repriceRow(t *testing.T, ctx context.Context, subID uuid.UUID) (id uuid.UUID, status, reason string) {
+	t.Helper()
+	require.NoError(t, f.pool.QueryRow(ctx, `
+		SELECT id, status, COALESCE(blocked_reason, '') FROM openrails.subscription_reprices
+		WHERE subscription_id = $1 ORDER BY created_at DESC LIMIT 1`, subID).Scan(&id, &status, &reason))
+	return id, status, reason
+}
+
+func (f *planMigrationFixture) periodEnd(t *testing.T, ctx context.Context, subID uuid.UUID) time.Time {
+	t.Helper()
+	var end time.Time
+	require.NoError(t, f.pool.QueryRow(ctx,
+		`SELECT current_period_ends_at FROM openrails.subscriptions WHERE id = $1`, subID).Scan(&end))
+	return end
+}
+
+func schedulesFor(f *fakeStripePusher, railSubID string) int {
+	n := 0
+	for _, s := range f.schedules {
+		if s["subscription_id"] == railSubID {
+			n++
+		}
+	}
+	return n
+}
+
+func pushesFor(f *fakeNMIPusher, railSubID string) int {
+	n := 0
+	for _, p := range f.pushes {
+		if p["rail_subscription_id"] == railSubID {
+			n++
+		}
+	}
+	return n
+}
+
+// TestPlanMigrationRedrive_StripeDeferredHealsAtRollover: the headline #816
+// mechanic — a far-future migration blocks at commit, then heals UNATTENDED
+// once the subscription enters its final pre-effective period, with the
+// rebill date untouched.
+func TestPlanMigrationRedrive_StripeDeferredHealsAtRollover(t *testing.T) {
+	f := newPlanMigrationFixture(t)
+	ctx := dbtest.WithTestMerchant(context.Background())
+	subID, railSubID := f.createSubscriptionOnRail(t, ctx, f.stripeSourcePriceID, "stripe", false)
+
+	// Effective beyond the current period (period end = now+30d) — the commit
+	// blocks the push honestly.
+	effective := f.clock.Now().Add(45 * 24 * time.Hour)
+	res, err := f.pm.Migrate(ctx, PlanMigrationRequest{
+		SourcePriceID: f.stripeSourcePriceID, TargetPriceID: f.stripeTargetPriceID, EffectiveAt: effective,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Blocked)
+	rowID, status, reason := f.repriceRow(t, ctx, subID)
+	require.Equal(t, "blocked", status)
+	require.Contains(t, reason, "stripe_deferred_push_required")
+	require.Zero(t, schedulesFor(f.stripe, railSubID))
+
+	// Not yet in window: the re-driver defers, touches nothing.
+	rd, err := f.pm.RedriveBlocked(ctx, 500)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, rd.Deferred, 1)
+	_, status, _ = f.repriceRow(t, ctx, subID)
+	require.Equal(t, "blocked", status)
+	require.Zero(t, schedulesFor(f.stripe, railSubID))
+
+	// The renewal boundary passes; the sub is now in its final pre-effective
+	// period (new period end = now+60d >= effective now+45d).
+	f.rollPeriod(t, ctx, subID)
+	endBefore := f.periodEnd(t, ctx, subID)
+
+	rd, err = f.pm.RedriveBlocked(ctx, 500)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, rd.Redriven, 1)
+
+	// Push fired exactly once; the row is scheduled again (stripe's converge
+	// applies it at the boundary); the rebill date never moved.
+	require.Equal(t, 1, schedulesFor(f.stripe, railSubID))
+	gotID, status, _ := f.repriceRow(t, ctx, subID)
+	require.Equal(t, rowID, gotID)
+	require.Equal(t, "scheduled", status)
+	require.Equal(t, endBefore, f.periodEnd(t, ctx, subID))
+
+	// Idempotent: a second tick finds nothing to do for this row.
+	_, err = f.pm.RedriveBlocked(ctx, 500)
+	require.NoError(t, err)
+	require.Equal(t, 1, schedulesFor(f.stripe, railSubID))
+	_, status, _ = f.repriceRow(t, ctx, subID)
+	require.Equal(t, "scheduled", status)
+}
+
+// TestPlanMigrationRedrive_NMIDeferredHealsAtRollover: same heal on the
+// gateway-native NMI rail — the push carries the internal cutover, so the row
+// lands applied and the subscription is on the target.
+func TestPlanMigrationRedrive_NMIDeferredHealsAtRollover(t *testing.T) {
+	f := newPlanMigrationFixture(t)
+	ctx := dbtest.WithTestMerchant(context.Background())
+	subID, railSubID := f.createSubscriptionOnRail(t, ctx, f.lowPriceID, "nmi", false)
+
+	effective := f.clock.Now().Add(45 * 24 * time.Hour)
+	res, err := f.pm.Migrate(ctx, PlanMigrationRequest{
+		SourcePriceID: f.lowPriceID, TargetPriceID: f.targetPriceID, EffectiveAt: effective,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Blocked)
+	_, status, reason := f.repriceRow(t, ctx, subID)
+	require.Equal(t, "blocked", status)
+	require.Contains(t, reason, "nmi_deferred_push_required")
+	require.Zero(t, pushesFor(f.nmi, railSubID))
+
+	f.rollPeriod(t, ctx, subID)
+	endBefore := f.periodEnd(t, ctx, subID)
+
+	rd, err := f.pm.RedriveBlocked(ctx, 500)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, rd.Redriven, 1)
+
+	require.Equal(t, 1, pushesFor(f.nmi, railSubID))
+	_, status, _ = f.repriceRow(t, ctx, subID)
+	require.Equal(t, "applied", status)
+	priceID, productID := f.subscriptionRow(t, ctx, subID)
+	require.Equal(t, f.targetPriceID, priceID)
+	require.Equal(t, f.targetProductID, productID)
+	require.Equal(t, endBefore, f.periodEnd(t, ctx, subID))
+}
+
+// TestPlanMigrationRedrive_CrashWindowConvergesWithoutPush: a row blocked
+// after its rail push succeeded (the sub already carries the target) heals to
+// applied with ZERO rail traffic.
+func TestPlanMigrationRedrive_CrashWindowConvergesWithoutPush(t *testing.T) {
+	f := newPlanMigrationFixture(t)
+	ctx := dbtest.WithTestMerchant(context.Background())
+	subID, railSubID := f.createSubscriptionOnRail(t, ctx, f.lowPriceID, "nmi", false)
+
+	// Manufacture the crash window: push verified + sub cut over, then the row
+	// transition died — sub on target, row blocked with the push-failure
+	// prefix.
+	_, err := f.pool.Exec(ctx, `
+		UPDATE openrails.subscriptions SET price_id = $2, product_id = $3 WHERE id = $1`,
+		subID, f.targetPriceID, f.targetProductID)
+	require.NoError(t, err)
+	row, err := f.repriceRepo.CreateBlockedReprice(ctx, subID, f.lowPriceID, f.targetPriceID,
+		f.clock.Now(), nil, models.RepriceKindPlanChange, "rail_push_failed: apply immediately: db went away")
+	require.NoError(t, err)
+
+	rd, err := f.pm.RedriveBlocked(ctx, 500)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, rd.Converged, 1)
+
+	got, err := f.repriceRepo.GetByID(ctx, row.ID)
+	require.NoError(t, err)
+	require.Equal(t, models.RepriceStatusApplied, got.Status)
+	require.Zero(t, pushesFor(f.nmi, railSubID))
+	require.Zero(t, schedulesFor(f.stripe, railSubID))
+}
+
+// TestPlanMigrationRedrive_ConcurrentManualRerunPushesOnce: a manual re-run
+// that got there first owns the subscription; the re-driver skips the stale
+// blocked row — exactly one rail push total.
+func TestPlanMigrationRedrive_ConcurrentManualRerunPushesOnce(t *testing.T) {
+	f := newPlanMigrationFixture(t)
+	ctx := dbtest.WithTestMerchant(context.Background())
+	subID, railSubID := f.createSubscriptionOnRail(t, ctx, f.stripeSourcePriceID, "stripe", false)
+
+	effective := f.clock.Now().Add(45 * 24 * time.Hour)
+	_, err := f.pm.Migrate(ctx, PlanMigrationRequest{
+		SourcePriceID: f.stripeSourcePriceID, TargetPriceID: f.stripeTargetPriceID, EffectiveAt: effective,
+	})
+	require.NoError(t, err)
+	blockedID, status, _ := f.repriceRow(t, ctx, subID)
+	require.Equal(t, "blocked", status)
+
+	f.rollPeriod(t, ctx, subID)
+
+	// The operator re-runs manually first: a fresh row schedules and pushes.
+	res, err := f.pm.Migrate(ctx, PlanMigrationRequest{
+		SourcePriceID: f.stripeSourcePriceID, TargetPriceID: f.stripeTargetPriceID, EffectiveAt: effective,
+		ArchiveSource: func() *bool { b := false; return &b }(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Scheduled)
+	require.Equal(t, 1, schedulesFor(f.stripe, railSubID))
+
+	// The re-driver then meets the old blocked row: the one-scheduled index +
+	// conflict check make it skip — no second push, old row stays blocked.
+	_, err = f.pm.RedriveBlocked(ctx, 500)
+	require.NoError(t, err)
+	require.Equal(t, 1, schedulesFor(f.stripe, railSubID))
+	var oldStatus string
+	require.NoError(t, f.pool.QueryRow(ctx,
+		`SELECT status FROM openrails.subscription_reprices WHERE id = $1`, blockedID).Scan(&oldStatus))
+	require.Equal(t, "blocked", oldStatus)
+}
+
+// TestPlanMigrationRedrive_TransientPushFailureRetriesAndReblocks: a
+// transient rail failure re-drives on the next tick; a persistent one
+// re-blocks with the fresh reason and keeps the ledger honest.
+func TestPlanMigrationRedrive_TransientPushFailureRetriesAndReblocks(t *testing.T) {
+	f := newPlanMigrationFixture(t)
+	ctx := dbtest.WithTestMerchant(context.Background())
+	subID, railSubID := f.createSubscriptionOnRail(t, ctx, f.stripeSourcePriceID, "stripe", false)
+
+	// First commit fails at the rail (transient 500): row degrades to blocked.
+	f.stripe.scheduleErr = fmt.Errorf("stripe 500")
+	_, err := f.pm.Migrate(ctx, PlanMigrationRequest{
+		SourcePriceID: f.stripeSourcePriceID, TargetPriceID: f.stripeTargetPriceID,
+	})
+	require.NoError(t, err)
+	rowID, status, reason := f.repriceRow(t, ctx, subID)
+	require.Equal(t, "blocked", status)
+	require.Contains(t, reason, "rail_push_failed")
+
+	// Still failing: the re-driver re-blocks (fresh reason), row keeps its id.
+	rd, err := f.pm.RedriveBlocked(ctx, 500)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, rd.Failed, 1)
+	gotID, status, reason := f.repriceRow(t, ctx, subID)
+	require.Equal(t, rowID, gotID)
+	require.Equal(t, "blocked", status)
+	require.Contains(t, reason, "stripe 500")
+
+	// Rail heals: the next tick migrates it.
+	f.stripe.scheduleErr = nil
+	rd, err = f.pm.RedriveBlocked(ctx, 500)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, rd.Redriven, 1)
+	require.Equal(t, 1, schedulesFor(f.stripe, railSubID))
+	_, status, _ = f.repriceRow(t, ctx, subID)
+	require.Equal(t, "scheduled", status)
+}
+
+// TestPlanMigrationRedrive_BatchHeaderStaysInSync: after the re-driver moves
+// rows between blocked and scheduled, the batch header agrees with its rows.
+func TestPlanMigrationRedrive_BatchHeaderStaysInSync(t *testing.T) {
+	f := newPlanMigrationFixture(t)
+	ctx := dbtest.WithTestMerchant(context.Background())
+	subID, _ := f.createSubscriptionOnRail(t, ctx, f.stripeSourcePriceID, "stripe", false)
+
+	effective := f.clock.Now().Add(45 * 24 * time.Hour)
+	res, err := f.pm.Migrate(ctx, PlanMigrationRequest{
+		SourcePriceID: f.stripeSourcePriceID, TargetPriceID: f.stripeTargetPriceID, EffectiveAt: effective,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res.BatchID)
+	batch, _, err := f.pm.GetBatch(ctx, *res.BatchID, 100, 0)
+	require.NoError(t, err)
+	require.Equal(t, 0, batch.SubscriptionsScheduled)
+	require.Equal(t, 1, batch.SubscriptionsBlocked)
+
+	f.rollPeriod(t, ctx, subID)
+	_, err = f.pm.RedriveBlocked(ctx, 500)
+	require.NoError(t, err)
+
+	batch, rows, err := f.pm.GetBatch(ctx, *res.BatchID, 100, 0)
+	require.NoError(t, err)
+	require.Equal(t, 1, batch.SubscriptionsScheduled)
+	require.Equal(t, 0, batch.SubscriptionsBlocked)
+	require.Len(t, rows, 1)
+	require.Equal(t, models.RepriceStatusScheduled, rows[0].Status)
+}
+
+// TestPlanMigrationRedrive_TerminalClassificationsUntouched: classification
+// blocks (rail_requires_user_action) are not push failures and never
+// re-drive.
+func TestPlanMigrationRedrive_TerminalClassificationsUntouched(t *testing.T) {
+	f := newPlanMigrationFixture(t)
+	ctx := dbtest.WithTestMerchant(context.Background())
+	subID, _ := f.createSubscriptionOnRail(t, ctx, f.lowPriceID, "ccbill", false)
+
+	_, err := f.pm.Migrate(ctx, PlanMigrationRequest{
+		SourcePriceID: f.lowPriceID, TargetPriceID: f.targetPriceID,
+	})
+	require.NoError(t, err)
+	rowID, status, reason := f.repriceRow(t, ctx, subID)
+	require.Equal(t, "blocked", status)
+	require.Equal(t, "rail_requires_user_action", reason)
+
+	_, err = f.pm.RedriveBlocked(ctx, 500)
+	require.NoError(t, err)
+	gotID, status, reason := f.repriceRow(t, ctx, subID)
+	require.Equal(t, rowID, gotID)
+	require.Equal(t, "blocked", status)
+	require.Equal(t, "rail_requires_user_action", reason)
+}
+
+// TestPlanMigrationRedrive_CancelledSubscriptionLeftBlocked: a subscription
+// that left the migratable cohort is never touched.
+func TestPlanMigrationRedrive_CancelledSubscriptionLeftBlocked(t *testing.T) {
+	f := newPlanMigrationFixture(t)
+	ctx := dbtest.WithTestMerchant(context.Background())
+	subID, railSubID := f.createSubscriptionOnRail(t, ctx, f.stripeSourcePriceID, "stripe", false)
+
+	effective := f.clock.Now().Add(45 * 24 * time.Hour)
+	_, err := f.pm.Migrate(ctx, PlanMigrationRequest{
+		SourcePriceID: f.stripeSourcePriceID, TargetPriceID: f.stripeTargetPriceID, EffectiveAt: effective,
+	})
+	require.NoError(t, err)
+
+	_, err = f.pool.Exec(ctx, `
+		UPDATE openrails.subscriptions
+		SET status = 'cancelled', cancelled_at = now(), cancel_type = 'user_cancelled'
+		WHERE id = $1`, subID)
+	require.NoError(t, err)
+	f.rollPeriod(t, ctx, subID)
+
+	_, err = f.pm.RedriveBlocked(ctx, 500)
+	require.NoError(t, err)
+	_, status, _ := f.repriceRow(t, ctx, subID)
+	require.Equal(t, "blocked", status)
+	require.Zero(t, schedulesFor(f.stripe, railSubID))
+}

--- a/internal/modules/subscriptions/reprice_repo.go
+++ b/internal/modules/subscriptions/reprice_repo.go
@@ -179,6 +179,49 @@ func (r *RepriceRepo) ListMigratableSubscriptionsByPriceID(ctx context.Context, 
 	return out, nil
 }
 
+// ListRedrivableBlockedPlanChanges (#816) is the re-driver's CROSS-MERCHANT
+// enumeration (base pool, same posture as the River workers' other sweeps):
+// plan_change rows blocked by a rail push failure — the deferred-window
+// refusals and the push-verified-then-crash window. Classification blocks
+// stay terminal and are excluded by the reason prefix.
+func (r *RepriceRepo) ListRedrivableBlockedPlanChanges(ctx context.Context, batchSize int) ([]*models.SubscriptionReprice, error) {
+	batch32, _ := safecast.Convert[int32](batchSize)
+	rows, err := r.db.GenGlobal().ListRedrivableBlockedPlanChangeReprices(ctx, batch32)
+	if err != nil {
+		return nil, err
+	}
+	return models.SubscriptionRepricesFromGen(rows), nil
+}
+
+// Unblock (#816) transitions a blocked row back to scheduled for a re-drive —
+// the exact inverse of BlockScheduledReprice, status-predicated. Returns
+// ErrRepriceNotScheduled when the row is no longer blocked (a concurrent
+// transition won); a unique violation on
+// uq_subscription_reprices_one_scheduled (the subscription acquired another
+// scheduled row meanwhile) surfaces as the driver error for the caller to
+// treat as a skip.
+func (r *RepriceRepo) Unblock(ctx context.Context, id uuid.UUID) error {
+	rows, err := r.db.Gen(ctx).UnblockSubscriptionReprice(ctx, id)
+	if err != nil {
+		return err
+	}
+	if rows < 1 {
+		return ErrRepriceNotScheduled
+	}
+	return nil
+}
+
+// CountBatchRows (#816) recomputes a plan-migration batch header's
+// scheduled/blocked counts from its actual rows — the re-sync source of
+// truth after re-drives move rows between the classes.
+func (r *RepriceRepo) CountBatchRows(ctx context.Context, batchID uuid.UUID) (scheduled, blocked int, err error) {
+	row, err := r.db.Gen(ctx).CountPlanMigrationBatchRows(ctx, batchID)
+	if err != nil {
+		return 0, 0, err
+	}
+	return int(row.Scheduled), int(row.Blocked), nil
+}
+
 func (r *RepriceRepo) GetByID(ctx context.Context, id uuid.UUID) (*models.SubscriptionReprice, error) {
 	row, err := r.db.Gen(ctx).GetSubscriptionRepriceByID(ctx, id)
 	if err != nil {

--- a/internal/river/jobs_plan_migration_redrive.go
+++ b/internal/river/jobs_plan_migration_redrive.go
@@ -1,0 +1,53 @@
+package riverjobs
+
+import (
+	"context"
+
+	"github.com/riverqueue/river"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/open-rails/openrails/internal/modules/subscriptions"
+)
+
+const KindPlanMigrationRedrive = "openrails.plan_migration_redrive"
+
+type PlanMigrationRedriveArgs struct{}
+
+func (PlanMigrationRedriveArgs) Kind() string { return KindPlanMigrationRedrive }
+
+// PlanMigrationRedriveWorker (#816) is the background half of #813 plan
+// migrations: it re-drives blocked plan-change rows through the SAME
+// classify/execute paths a manual re-run uses — deferred far-future pushes as
+// each subscription enters its final pre-effective period, and crash-window
+// rows whose rail already carries the target. Hourly is plenty: period
+// granularity is days, and every transition is status-predicated + rail-
+// idempotent, so an extra tick (or a concurrent manual re-run) can never
+// double-push.
+type PlanMigrationRedriveWorker struct {
+	river.WorkerDefaults[PlanMigrationRedriveArgs]
+	Migrations *subscriptions.PlanMigrationService
+	BatchSize  int
+}
+
+func (PlanMigrationRedriveWorker) Kind() string { return KindPlanMigrationRedrive }
+
+func (w PlanMigrationRedriveWorker) Work(ctx context.Context, _ *river.Job[PlanMigrationRedriveArgs]) error {
+	logger := log.WithContext(ctx).WithField("worker", KindPlanMigrationRedrive)
+	if w.Migrations == nil {
+		// Worker-only runtimes without the migration service wired: log-and-skip,
+		// same posture as the money-in workers awaiting their charger.
+		logger.Debug("plan migration service not wired; skipping")
+		return nil
+	}
+	res, err := w.Migrations.RedriveBlocked(ctx, w.BatchSize)
+	if err != nil {
+		return err
+	}
+	if res.Examined > 0 {
+		logger.WithFields(log.Fields{
+			"examined": res.Examined, "redriven": res.Redriven, "converged": res.Converged,
+			"deferred": res.Deferred, "skipped": res.Skipped, "failed": res.Failed,
+		}).Info("plan-migration re-drive pass complete")
+	}
+	return nil
+}


### PR DESCRIPTION
Closes the manual-re-run gap in #813/#815 plan migrations: the two blocked-row classes that previously healed only by an operator re-running the migration now converge on their own.

- **One hourly River worker** (`openrails.plan_migration_redrive`, RunOnStart, unique per queue+period) enumerates re-drivable rows cross-merchant — `kind=plan_change, status=blocked, blocked_reason LIKE 'rail_push_failed:%'` — and re-drives each under its own merchant context through the SAME `executeScheduled` paths a manual re-run uses. Classification blocks (`rail_requires_user_action`, interval/cent mismatches) never carried a push attempt and stay terminal.
- **Deferred pushes** (`stripe_deferred_push_required` / `nmi_deferred_push_required`): the early-flip predicate is extracted into one shared `deferredPushRequired` (both rails' guards + the re-driver window check — one definition, never forked). Each subscription heals in its own final pre-effective period.
- **Crash-window rows** (rail already on target): converge with zero rail traffic — the ledger row walks the same status-predicated `blocked→scheduled→applied` transitions.
- **Concurrency-safe by construction**: `uq_subscription_reprices_one_scheduled` + status-predicated transitions make exactly one actor (worker tick, overlapping tick, manual re-run) win each row; rail pushes stay set-to-value idempotent.
- **Batch headers re-sync from actual rows** after every pass (the #813 header/rows invariant), and the schedule-time plan-change notification — which blocked rows never emitted — fires when the migration genuinely goes into motion.
- Re-drive always runs boundary mode: the original request's `Immediate` flag is not persisted and is stale by re-drive time; the renewal-boundary flip is the forced-migration invariant-safe mode on every rail.

Tests (all green, plus full subscriptions/checkout/river/app integration suites and `-race`): stripe + NMI far-future migrations heal unattended at period rollover with rebill dates byte-unchanged; crash-window row converges pushlessly; worker + concurrent manual re-run = exactly one push; transient rail failure re-blocks with the fresh reason then heals; terminal classifications and cancelled subscriptions untouched; batch header equals its rows after redistribution.

Honest limits: a Stripe ambiguous-outcome push (500 reported, schedule actually created) re-drives into a rail-side "already has a schedule" error and re-blocks hourly with that reason — no money moves and the ledger stays loud, but resolving it needs the provider-truth release path (same class as CancelBatch's documented non-release). The `cancel_at_period_end` fallback remains surfaced-not-automated, per #813.

🤖 Generated with [Claude Code](https://claude.com/claude-code)