### PR TITLE
feat(api): add subscription payment method contract

### DIFF
--- a/internal/db/gen/payment_methods.sql.go
+++ b/internal/db/gen/payment_methods.sql.go
@@ -96,6 +96,28 @@ func (q *Queries) CaptureStoredCredentialRefByRailInstrument(ctx context.Context
 	return result.RowsAffected(), nil
 }
 
+const countCompatiblePaymentMethodsByCustomer = `-- name: CountCompatiblePaymentMethodsByCustomer :one
+SELECT count(*) FROM openrails.payment_methods pm
+WHERE pm.customer_id = $1
+  AND lower(btrim(pm.rail)) = $2
+  AND ($3::uuid IS NULL
+       OR pm.psp_id IS NULL
+       OR pm.psp_id = $3::uuid)
+`
+
+type CountCompatiblePaymentMethodsByCustomerParams struct {
+	CustomerID uuid.UUID
+	Rail       string
+	PspID      *uuid.UUID
+}
+
+func (q *Queries) CountCompatiblePaymentMethodsByCustomer(ctx context.Context, arg CountCompatiblePaymentMethodsByCustomerParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countCompatiblePaymentMethodsByCustomer, arg.CustomerID, arg.Rail, arg.PspID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countPaymentMethodForUser = `-- name: CountPaymentMethodForUser :one
 SELECT count(*) FROM openrails.payment_methods pm
 WHERE pm.id = $1 AND pm.customer_id = $2
@@ -430,6 +452,77 @@ func (q *Queries) GetPaymentMethodByVaultFingerprint(ctx context.Context, arg Ge
 		&i.ParkedAt,
 	)
 	return i, err
+}
+
+const listCompatiblePaymentMethodsByCustomerPaged = `-- name: ListCompatiblePaymentMethodsByCustomerPaged :many
+SELECT id, rail, initial_transaction_id, last_four, card_type, expiry_date, metadata, created_at, updated_at, merchant_id, customer_id, psp_id, rail_customer_ref, rail_method_ref, rebill_driver, stored_credential_recurring_ref, stored_credential_unscheduled_ref, vault_provider, vault_fingerprint, network_token_id, network_token_status, network_token_par, charge_via, park_reason, parked_at FROM openrails.payment_methods pm
+WHERE pm.customer_id = $1
+  AND lower(btrim(pm.rail)) = $2
+  AND ($3::uuid IS NULL
+       OR pm.psp_id IS NULL
+       OR pm.psp_id = $3::uuid)
+ORDER BY pm.created_at DESC
+LIMIT NULLIF($5::int, 0) OFFSET $4::int
+`
+
+type ListCompatiblePaymentMethodsByCustomerPagedParams struct {
+	CustomerID uuid.UUID
+	Rail       string
+	PspID      *uuid.UUID
+	PageOffset int32
+	PageLimit  int32
+}
+
+func (q *Queries) ListCompatiblePaymentMethodsByCustomerPaged(ctx context.Context, arg ListCompatiblePaymentMethodsByCustomerPagedParams) ([]OpenrailsPaymentMethod, error) {
+	rows, err := q.db.Query(ctx, listCompatiblePaymentMethodsByCustomerPaged,
+		arg.CustomerID,
+		arg.Rail,
+		arg.PspID,
+		arg.PageOffset,
+		arg.PageLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []OpenrailsPaymentMethod
+	for rows.Next() {
+		var i OpenrailsPaymentMethod
+		if err := rows.Scan(
+			&i.ID,
+			&i.Rail,
+			&i.InitialTransactionID,
+			&i.LastFour,
+			&i.CardType,
+			&i.ExpiryDate,
+			&i.Metadata,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.MerchantID,
+			&i.CustomerID,
+			&i.PspID,
+			&i.RailCustomerRef,
+			&i.RailMethodRef,
+			&i.RebillDriver,
+			&i.StoredCredentialRecurringRef,
+			&i.StoredCredentialUnscheduledRef,
+			&i.VaultProvider,
+			&i.VaultFingerprint,
+			&i.NetworkTokenID,
+			&i.NetworkTokenStatus,
+			&i.NetworkTokenPar,
+			&i.ChargeVia,
+			&i.ParkReason,
+			&i.ParkedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listLatestChargeByPaymentMethodIDs = `-- name: ListLatestChargeByPaymentMethodIDs :many

--- a/internal/db/queries/payment_methods.sql
+++ b/internal/db/queries/payment_methods.sql
@@ -44,6 +44,24 @@ WHERE pm.customer_id = $1
 ORDER BY pm.created_at DESC
 LIMIT NULLIF(sqlc.arg(page_limit)::int, 0) OFFSET sqlc.arg(page_offset)::int;
 
+-- name: CountCompatiblePaymentMethodsByCustomer :one
+SELECT count(*) FROM openrails.payment_methods pm
+WHERE pm.customer_id = sqlc.arg(customer_id)
+  AND lower(btrim(pm.rail)) = sqlc.arg(rail)
+  AND (sqlc.narg(psp_id)::uuid IS NULL
+       OR pm.psp_id IS NULL
+       OR pm.psp_id = sqlc.narg(psp_id)::uuid);
+
+-- name: ListCompatiblePaymentMethodsByCustomerPaged :many
+SELECT * FROM openrails.payment_methods pm
+WHERE pm.customer_id = sqlc.arg(customer_id)
+  AND lower(btrim(pm.rail)) = sqlc.arg(rail)
+  AND (sqlc.narg(psp_id)::uuid IS NULL
+       OR pm.psp_id IS NULL
+       OR pm.psp_id = sqlc.narg(psp_id)::uuid)
+ORDER BY pm.created_at DESC
+LIMIT NULLIF(sqlc.arg(page_limit)::int, 0) OFFSET sqlc.arg(page_offset)::int;
+
 -- name: GetPaymentMethodByRailMethodRef :one
 SELECT * FROM openrails.payment_methods pm
 WHERE pm.rail = $1 AND pm.rail_method_ref = $2

--- a/internal/http/handlers/payment_methods.go
+++ b/internal/http/handlers/payment_methods.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/open-rails/openrails/internal/db"
 	"github.com/open-rails/openrails/internal/db/models"
 	httprequest "github.com/open-rails/openrails/internal/http/request"
 	"github.com/open-rails/openrails/internal/intents"
@@ -23,9 +24,10 @@ import (
 )
 
 type listPaymentMethodsQuery struct {
-	Limit           int  `form:"limit"`
-	Offset          int  `form:"offset"`
-	IncludeInactive bool `form:"include_inactive"`
+	Limit           int    `form:"limit"`
+	Offset          int    `form:"offset"`
+	IncludeInactive bool   `form:"include_inactive"`
+	SubscriptionID  string `form:"subscription_id"`
 }
 
 type paymentMethodURI struct {
@@ -447,7 +449,47 @@ func ListPaymentMethods(r *httprequest.Request) {
 		return
 	}
 
-	methods, totalItems, err := r.State.PaymentMethodService.ListByUserID(r.Request.Context(), user.ID, req.Limit, req.Offset)
+	var methods []*models.PaymentMethod
+	var totalItems int64
+	var err error
+	if subscriptionID := strings.TrimSpace(req.SubscriptionID); subscriptionID != "" {
+		parsedSubscriptionID, parseErr := api.ParseSubscriptionID(subscriptionID)
+		if parseErr != nil {
+			r.ErrorJSON(http.StatusBadRequest, "Invalid subscription_id format")
+			return
+		}
+		subscription, getErr := r.State.SubscriptionService.GetByID(
+			r.Request.Context(),
+			parsedSubscriptionID,
+		)
+		if getErr != nil {
+			if db.IsNotFound(getErr) {
+				r.ErrorJSON(http.StatusNotFound, "Subscription not found")
+				return
+			}
+			log.WithError(getErr).WithFields(log.Fields{
+				"subscription_id": parsedSubscriptionID,
+				"user_id":         user.ID,
+			}).Error("Failed to retrieve subscription for payment method filtering")
+			r.ErrorJSON(http.StatusInternalServerError, "Failed to retrieve subscription")
+			return
+		}
+		if subscription.CustomerID.String() != user.ID {
+			r.ErrorJSON(http.StatusNotFound, "Subscription not found")
+			return
+		}
+
+		methods, totalItems, err = r.State.PaymentMethodService.ListCompatibleByUserID(
+			r.Request.Context(),
+			user.ID,
+			subscription.Rail,
+			subscription.PspID,
+			req.Limit,
+			req.Offset,
+		)
+	} else {
+		methods, totalItems, err = r.State.PaymentMethodService.ListByUserID(r.Request.Context(), user.ID, req.Limit, req.Offset)
+	}
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{"user_id": user.ID, "limit": req.Limit, "offset": req.Offset}).Error("Failed to retrieve payment methods")
 		r.ErrorJSON(http.StatusInternalServerError, "Failed to retrieve payment methods")

--- a/internal/http/handlers/payment_methods_test.go
+++ b/internal/http/handlers/payment_methods_test.go
@@ -2,9 +2,11 @@ package handlers
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/modules/paymentmethods"
 	"github.com/stretchr/testify/require"
@@ -175,6 +177,57 @@ func TestPaymentMethodToAPIIncludesStoredBillingMetadata(t *testing.T) {
 	require.Equal(t, "100-0001", *got.BillingDetails.Address.PostalCode)
 	require.Equal(t, "1 Chiyoda", *got.BillingDetails.Address.Line1)
 	require.Equal(t, "Ada Lovelace", got.Metadata["name_on_card"])
+}
+
+func TestPaymentMethodToAPIPrivacyContract(t *testing.T) {
+	t.Parallel()
+
+	pspID := uuid.New()
+	response := paymentMethodToAPI(&models.PaymentMethod{
+		ID:                             uuid.New(),
+		Rail:                           models.RailNMI,
+		PspID:                          &pspID,
+		RailCustomerRef:                "private-customer-ref",
+		RailMethodRef:                  "private-method-ref",
+		InitialTransactionID:           "private-transaction-ref",
+		StoredCredentialRecurringRef:   "private-recurring-ref",
+		StoredCredentialUnscheduledRef: "private-unscheduled-ref",
+		VaultProvider:                  "private-vault-provider",
+		VaultFingerprint:               "private-vault-fingerprint",
+		NetworkTokenID:                 "private-network-token",
+		NetworkTokenPAR:                "private-network-par",
+		CreatedAt:                      time.Now().UTC(),
+	}, nil)
+
+	payload, err := json.Marshal(response)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(payload, &got))
+	for _, privateField := range []string{
+		"psp_id",
+		"provider_account_id",
+		"account_id",
+		"rail_customer_ref",
+		"rail_method_ref",
+		"secret",
+	} {
+		require.NotContains(t, got, privateField)
+	}
+	for _, privateValue := range []string{
+		pspID.String(),
+		"private-customer-ref",
+		"private-method-ref",
+		"private-transaction-ref",
+		"private-recurring-ref",
+		"private-unscheduled-ref",
+		"private-vault-provider",
+		"private-vault-fingerprint",
+		"private-network-token",
+		"private-network-par",
+	} {
+		require.False(t, strings.Contains(string(payload), privateValue))
+	}
 }
 
 func TestCreateVaultRequestDoesNotStoreRawProviderPayload(t *testing.T) {

--- a/internal/modules/paymentmethods/payment_method.go
+++ b/internal/modules/paymentmethods/payment_method.go
@@ -73,6 +73,28 @@ func (s *PaymentMethodService) ListByUserID(ctx context.Context, userID string, 
 	return items, total, nil
 }
 
+func (s *PaymentMethodService) ListCompatibleByUserID(ctx context.Context, userID string, rail models.Rail, pspID *uuid.UUID, limit, offset int) ([]*models.PaymentMethod, int64, error) {
+	if userID == "" {
+		return nil, 0, errors.New("user ID is required")
+	}
+	rail = models.Rail(strings.ToLower(strings.TrimSpace(string(rail))))
+	if rail == "" {
+		return nil, 0, errors.New("rail is required")
+	}
+	if limit < 1 {
+		limit = 20
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	items, total, err := s.repo.ListCompatibleByUserID(ctx, userID, rail, pspID, limit, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	return items, total, nil
+}
+
 // GetByRailMethodRef finds a payment method by its instrument-scope rail handle
 // (e.g. a Stripe pm_ token) for the given rail.
 func (s *PaymentMethodService) GetByRailMethodRef(ctx context.Context, provider, methodRef string) (*models.PaymentMethod, error) {

--- a/internal/modules/paymentmethods/payment_method_compatibility_integration_test.go
+++ b/internal/modules/paymentmethods/payment_method_compatibility_integration_test.go
@@ -1,0 +1,133 @@
+//go:build integration
+
+package paymentmethods
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/db"
+	"github.com/open-rails/openrails/internal/db/gen"
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/dbtest"
+)
+
+func TestListCompatibleByUserIDFiltersBeforePagination(t *testing.T) {
+	ctx := dbtest.WithTestMerchant(context.Background())
+	pool := dbtest.SharedPGXPool(t)
+	merchantID := dbtest.TestMerchantID.UUID()
+	database, err := db.NewWithPGXPool(pool, "")
+	require.NoError(t, err)
+
+	userID := uuid.NewString()
+	customerID := dbtest.EnsureCustomerIDPgx(ctx, t, pool, userID)
+	q := gen.New(pool)
+	environment := "test"
+	matchingPSP, err := q.UpsertPSP(ctx, gen.UpsertPSPParams{
+		MerchantID:  merchantID,
+		Rail:        string(models.RailNMI),
+		Environment: &environment,
+		AccountID:   "compatible-" + uuid.NewString(),
+	})
+	require.NoError(t, err)
+	otherPSP, err := q.UpsertPSP(ctx, gen.UpsertPSPParams{
+		MerchantID:  merchantID,
+		Rail:        string(models.RailNMI),
+		Environment: &environment,
+		AccountID:   "incompatible-" + uuid.NewString(),
+	})
+	require.NoError(t, err)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	repo := NewPaymentMethodRepo(database)
+	newMethod := func(rail models.Rail, pspID *uuid.UUID, createdAt time.Time) *models.PaymentMethod {
+		method := &models.PaymentMethod{
+			ID:              uuid.New(),
+			CustomerID:      customerID,
+			Rail:            rail,
+			PspID:           pspID,
+			RailCustomerRef: "customer-" + uuid.NewString(),
+			RailMethodRef:   "method-" + uuid.NewString(),
+			CreatedAt:       createdAt,
+			UpdatedAt:       createdAt,
+		}
+		require.NoError(t, repo.Create(ctx, method))
+		return method
+	}
+
+	matchingNewest := newMethod(models.RailNMI, &matchingPSP.ID, now.Add(5*time.Second))
+	wrongRail := newMethod(models.RailCCBill, &matchingPSP.ID, now.Add(4*time.Second))
+	wrongPSP := newMethod(models.RailNMI, &otherPSP.ID, now.Add(3*time.Second))
+	legacy := newMethod(models.RailNMI, nil, now.Add(2*time.Second))
+	matchingOldest := newMethod(models.RailNMI, &matchingPSP.ID, now.Add(time.Second))
+
+	productID := uuid.New()
+	priceID := uuid.New()
+	subscriptionID := uuid.New()
+	productKey := "compatible-product-" + uuid.NewString()
+	_, err = pool.Exec(ctx,
+		`INSERT INTO openrails.products (id, merchant_id, key, display_name) VALUES ($1, $2, $3, $4)`,
+		productID, merchantID, productKey, "Compatible Product")
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx,
+		`INSERT INTO openrails.prices (id, product_id, merchant_id, amount, currency) VALUES ($1, $2, $3, $4, $5)`,
+		priceID, productID, merchantID, 1000, "USD")
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx,
+		`INSERT INTO openrails.subscriptions
+		   (id, product_id, price_id, payment_method_id, rail, psp_id, merchant_id, customer_id)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		subscriptionID, productID, priceID, legacy.ID, string(models.RailNMI), matchingPSP.ID, merchantID, customerID)
+	require.NoError(t, err)
+
+	methodIDs := []uuid.UUID{matchingNewest.ID, wrongRail.ID, wrongPSP.ID, legacy.ID, matchingOldest.ID}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM openrails.subscriptions WHERE id = $1`, subscriptionID)
+		_, _ = pool.Exec(ctx, `DELETE FROM openrails.payment_methods WHERE id = ANY($1)`, methodIDs)
+		_, _ = pool.Exec(ctx, `DELETE FROM openrails.prices WHERE id = $1`, priceID)
+		_, _ = pool.Exec(ctx, `DELETE FROM openrails.products WHERE id = $1`, productID)
+		_, _ = pool.Exec(ctx, `DELETE FROM openrails.psps WHERE id = ANY($1)`, []uuid.UUID{matchingPSP.ID, otherPSP.ID})
+	})
+
+	service := NewPaymentMethodService(database)
+	methods, total, err := service.ListCompatibleByUserID(
+		ctx,
+		userID,
+		models.Rail(" NMI "),
+		&matchingPSP.ID,
+		1,
+		1,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), total)
+	require.Len(t, methods, 1)
+	require.Equal(t, legacy.ID, methods[0].ID)
+	require.Len(t, methods[0].Subscriptions, 1)
+	require.Equal(t, subscriptionID, methods[0].Subscriptions[0].ID)
+	require.NotNil(t, methods[0].Subscriptions[0].Product)
+	require.Equal(t, "Compatible Product", methods[0].Subscriptions[0].Product.DisplayName)
+
+	methods, total, err = service.ListCompatibleByUserID(
+		ctx,
+		userID,
+		models.RailNMI,
+		nil,
+		10,
+		0,
+	)
+	require.NoError(t, err)
+	require.Equal(t, int64(4), total)
+	require.Equal(t, []uuid.UUID{matchingNewest.ID, wrongPSP.ID, legacy.ID, matchingOldest.ID}, paymentMethodIDs(methods))
+}
+
+func paymentMethodIDs(methods []*models.PaymentMethod) []uuid.UUID {
+	ids := make([]uuid.UUID, 0, len(methods))
+	for _, method := range methods {
+		ids = append(ids, method.ID)
+	}
+	return ids
+}

--- a/internal/modules/paymentmethods/payment_method_repo.go
+++ b/internal/modules/paymentmethods/payment_method_repo.go
@@ -41,27 +41,27 @@ func (r *PaymentMethodRepo) Create(ctx context.Context, m *models.PaymentMethod)
 		pspID = db.ResolveRailMerchantAccountIDForStamp(ctx)
 	}
 	rows, err := r.db.Gen(ctx).CreatePaymentMethod(ctx, gen.CreatePaymentMethodParams{
-		ID:                    m.ID,
-		MerchantID:            tid.UUID(),
-		CustomerID:            m.CustomerID,
-		Rail:                  string(m.Rail),
-		PspID:                 pspID,
-		RailCustomerRef:       m.RailCustomerRef,
-		RailMethodRef:         m.RailMethodRef,
-		RebillDriver:          m.RebillDriver, // "" -> DB default 'provider'
-		InitialTransactionID:  m.InitialTransactionID,
-		LastFour:              m.LastFour,
-		CardType:              m.CardType,
-		ExpiryDate:            m.ExpiryDate,
-		Metadata:              meta,
-		CreatedAt:             m.CreatedAt,
-		UpdatedAt:             m.UpdatedAt,
-		VaultProvider:         m.VaultProvider,
-		VaultFingerprint:      m.VaultFingerprint,
-		NetworkTokenID:        m.NetworkTokenID,
-		NetworkTokenStatus:    m.NetworkTokenStatus,
-		NetworkTokenPar:       m.NetworkTokenPAR,
-		ChargeVia:             m.ChargeVia, // "" -> DB default 'pan_proxy'
+		ID:                   m.ID,
+		MerchantID:           tid.UUID(),
+		CustomerID:           m.CustomerID,
+		Rail:                 string(m.Rail),
+		PspID:                pspID,
+		RailCustomerRef:      m.RailCustomerRef,
+		RailMethodRef:        m.RailMethodRef,
+		RebillDriver:         m.RebillDriver, // "" -> DB default 'provider'
+		InitialTransactionID: m.InitialTransactionID,
+		LastFour:             m.LastFour,
+		CardType:             m.CardType,
+		ExpiryDate:           m.ExpiryDate,
+		Metadata:             meta,
+		CreatedAt:            m.CreatedAt,
+		UpdatedAt:            m.UpdatedAt,
+		VaultProvider:        m.VaultProvider,
+		VaultFingerprint:     m.VaultFingerprint,
+		NetworkTokenID:       m.NetworkTokenID,
+		NetworkTokenStatus:   m.NetworkTokenStatus,
+		NetworkTokenPar:      m.NetworkTokenPAR,
+		ChargeVia:            m.ChargeVia, // "" -> DB default 'pan_proxy'
 	})
 	if err != nil {
 		return err
@@ -184,6 +184,48 @@ func (r *PaymentMethodRepo) ListByUserID(ctx context.Context, userID string, lim
 	offset32, _ := safecast.Convert[int32](offset)
 	rows, err := q.ListPaymentMethodsByCustomerPaged(ctx, gen.ListPaymentMethodsByCustomerPagedParams{
 		CustomerID: tsid,
+		PageLimit:  limit32,
+		PageOffset: offset32,
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	methods, err := models.PaymentMethodsFromGen(rows)
+	if err != nil {
+		return nil, 0, err
+	}
+	if err := r.attachPaymentMethodSubscriptions(ctx, methods); err != nil {
+		return nil, 0, err
+	}
+	return methods, total, nil
+}
+
+func (r *PaymentMethodRepo) ListCompatibleByUserID(ctx context.Context, userID string, rail models.Rail, pspID *uuid.UUID, limit, offset int) ([]*models.PaymentMethod, int64, error) {
+	tsid, err := db.ResolveCustomerID(userID)
+	if err != nil {
+		return nil, 0, err
+	}
+	q := r.db.Gen(ctx)
+	total, err := q.CountCompatiblePaymentMethodsByCustomer(ctx, gen.CountCompatiblePaymentMethodsByCustomerParams{
+		CustomerID: tsid,
+		Rail:       string(rail),
+		PspID:      pspID,
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	limit32, err := safecast.Convert[int32](limit)
+	if err != nil {
+		return nil, 0, fmt.Errorf("convert payment method page limit: %w", err)
+	}
+	offset32, err := safecast.Convert[int32](offset)
+	if err != nil {
+		return nil, 0, fmt.Errorf("convert payment method page offset: %w", err)
+	}
+	rows, err := q.ListCompatiblePaymentMethodsByCustomerPaged(ctx, gen.ListCompatiblePaymentMethodsByCustomerPagedParams{
+		CustomerID: tsid,
+		Rail:       string(rail),
+		PspID:      pspID,
 		PageLimit:  limit32,
 		PageOffset: offset32,
 	})

--- a/internal/modules/subscriptions/user_service.go
+++ b/internal/modules/subscriptions/user_service.go
@@ -131,6 +131,7 @@ func (r *UserSubscriptionResponse) MarshalJSON() ([]byte, error) {
 		CurrentPeriodStartsAt *time.Time                `json:"current_period_starts_at,omitempty"`
 		CurrentPeriodEndsAt   *time.Time                `json:"current_period_ends_at,omitempty"`
 		Rail                  models.Rail               `json:"rail,omitempty"`
+		PaymentMethodID       string                    `json:"payment_method_id,omitempty"`
 		CancelFeedback        *string                   `json:"cancel_feedback,omitempty"`
 		CancelType            *models.CancelType        `json:"cancel_type,omitempty"`
 		CancelledAt           *time.Time                `json:"cancelled_at,omitempty"`
@@ -175,6 +176,9 @@ func (r *UserSubscriptionResponse) MarshalJSON() ([]byte, error) {
 			CreatedAt:             r.Subscription.CreatedAt,
 			UpdatedAt:             r.Subscription.UpdatedAt,
 			Access:                r.Access,
+		}
+		if r.Subscription.PaymentMethodID != nil {
+			out.PaymentMethodID = api.FormatPaymentMethodID(*r.Subscription.PaymentMethodID)
 		}
 		if r.Price != nil {
 			price := priceToAPIObject(r.Price)

--- a/internal/modules/subscriptions/user_service_contract_test.go
+++ b/internal/modules/subscriptions/user_service_contract_test.go
@@ -1,0 +1,79 @@
+package subscriptions
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/pkg/api"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserSubscriptionResponsePaymentMethodContract(t *testing.T) {
+	t.Parallel()
+
+	paymentMethodID := uuid.New()
+	pspID := uuid.New()
+	subscription := &models.Subscription{
+		ID:                 uuid.New(),
+		CustomerID:         uuid.New(),
+		ProductID:          uuid.New(),
+		PriceID:            uuid.New(),
+		Status:             models.StatusActive,
+		StartedAt:          time.Now().UTC(),
+		Rail:               models.RailNMI,
+		RailSubscriptionID: "private-subscription-ref",
+		PspID:              &pspID,
+		PaymentMethodID:    &paymentMethodID,
+		PaymentMethod: &models.PaymentMethod{
+			ID:              paymentMethodID,
+			RailCustomerRef: "private-customer-ref",
+			RailMethodRef:   "private-method-ref",
+		},
+		Metadata: json.RawMessage(`{"secret":"private-provider-secret"}`),
+	}
+
+	payload, err := json.Marshal(&UserSubscriptionResponse{Subscription: subscription})
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(payload, &got))
+	require.Equal(t, api.FormatPaymentMethodID(paymentMethodID), got["payment_method_id"])
+	require.NotContains(t, got, "psp_id")
+	require.NotContains(t, got, "rail_customer_ref")
+	require.NotContains(t, got, "rail_method_ref")
+	require.NotContains(t, got, "account_id")
+	require.NotContains(t, got, "rail_subscription_id")
+	require.NotContains(t, got, "gateway_response")
+	for _, privateValue := range []string{
+		pspID.String(),
+		"private-subscription-ref",
+		"private-customer-ref",
+		"private-method-ref",
+		"private-provider-secret",
+	} {
+		require.False(t, strings.Contains(string(payload), privateValue))
+	}
+}
+
+func TestUserSubscriptionResponseOmitsUnboundPaymentMethodContract(t *testing.T) {
+	t.Parallel()
+
+	payload, err := json.Marshal(&UserSubscriptionResponse{Subscription: &models.Subscription{
+		ID:         uuid.New(),
+		CustomerID: uuid.New(),
+		ProductID:  uuid.New(),
+		PriceID:    uuid.New(),
+		Status:     models.StatusActive,
+		StartedAt:  time.Now().UTC(),
+		Rail:       models.RailNMI,
+	}})
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(payload, &got))
+	require.NotContains(t, got, "payment_method_id")
+}

--- a/tests/payment_methods_test.go
+++ b/tests/payment_methods_test.go
@@ -175,6 +175,77 @@ func TestListPaymentMethods(t *testing.T) {
 	})
 }
 
+func TestListPaymentMethodsForSubscription(t *testing.T) {
+	suite, token, userID := setupTestSuiteWithAuth(t)
+	priceID := suite.SeedProducts()[0].Prices[0].ID
+	matching := suite.CreateTestPaymentMethodWithOptions(PaymentMethodOptions{
+		UserID:   userID,
+		Rail:     models.RailNMI,
+		LastFour: "4242",
+		CardType: "Visa",
+	})
+	suite.CreateTestPaymentMethodWithOptions(PaymentMethodOptions{
+		UserID:   userID,
+		Rail:     models.RailCCBill,
+		LastFour: "1111",
+		CardType: "Visa",
+	})
+	subscription := suite.CreateTestSubscriptionWithOptions(SubscriptionOptions{
+		UserID:          userID,
+		PriceID:         priceID,
+		Status:          models.StatusActive,
+		Rail:            models.RailNMI,
+		PaymentMethodID: &matching.ID,
+	})
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest(
+		http.MethodGet,
+		"/v1/me/payment-methods?subscription_id="+api.FormatSubscriptionID(subscription.ID),
+		nil,
+	)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	suite.Server.Handler().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var response struct {
+		Data  []map[string]any `json:"data"`
+		Total int64            `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.Equal(t, int64(1), response.Total)
+	require.Len(t, response.Data, 1)
+	require.Equal(t, api.FormatPaymentMethodID(matching.ID), response.Data[0]["id"])
+	subscriptions, ok := response.Data[0]["subscriptions"].([]any)
+	require.True(t, ok)
+	require.Len(t, subscriptions, 1)
+	require.Equal(t, subscription.ID.String(), subscriptions[0].(map[string]any)["id"])
+	for _, privateField := range []string{
+		"psp_id",
+		"provider_account_id",
+		"account_id",
+		"rail_customer_ref",
+		"rail_method_ref",
+		"secret",
+	} {
+		require.NotContains(t, response.Data[0], privateField)
+	}
+
+	otherUserID := uuid.NewString()
+	otherSubscription := suite.CreateTestSubscription(otherUserID, priceID, models.StatusActive)
+	w = httptest.NewRecorder()
+	req, err = http.NewRequest(
+		http.MethodGet,
+		"/v1/me/payment-methods?subscription_id="+api.FormatSubscriptionID(otherSubscription.ID),
+		nil,
+	)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	suite.Server.Handler().ServeHTTP(w, req)
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
 // TestCreatePaymentMethod tests creating payment methods
 func TestCreatePaymentMethod(t *testing.T) {
 	suite, mock := SetupSuiteWithMockNMI(t)


### PR DESCRIPTION
## Summary
- expose formatted payment_method_id on user subscription JSON without provider-native fields
- add owner-scoped subscription_id filtering to GET /me/payment-methods
- filter compatible rail/provider-account methods in SQL before pagination while preserving associations and totals

## Verification
- task sqlc
- go test ./internal/http/handlers ./internal/modules/paymentmethods ./internal/modules/subscriptions
- go vet ./internal/http/handlers ./internal/modules/paymentmethods ./internal/modules/subscriptions
- DOCKER_HOST=unix://$HOME/.colima/default/docker.sock TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock go test -tags=integration ./internal/modules/paymentmethods ./tests -run Test(ListCompatibleByUserIDFiltersBeforePagination|ListPaymentMethodsForSubscription)$ -count=1
- go test ./...
- go vet ./...
- git diff --check
- focused review and adversarial security audit: clean