### PR TITLE
controlplane: fleet analytics — cross-merchant operator aggregates (openrails-saas #28)

### DIFF
--- a/internal/controlplane/fleet_analytics.go
+++ b/internal/controlplane/fleet_analytics.go
@@ -1,0 +1,170 @@
+package controlplane
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// Fleet analytics (openrails-saas #28): cross-merchant operator aggregates over
+// the engine's truth tables. Like SearchMerchants (#226) this is a sensitive
+// cross-merchant read on the privileged control-plane pool — no per-merchant
+// RLS scope could compute a fleet view — and the CALLER is responsible for
+// gating (platform superadmin) and auditing each request.
+
+// FleetMerchantFunnel counts merchants by lifecycle stage: provisioned (total),
+// armed (a live PSP declared), first-revenue (any completed payment ever), and
+// active (a completed payment inside the window).
+type FleetMerchantFunnel struct {
+	Total         int64
+	Armed         int64
+	FirstRevenue  int64
+	ActiveRevenue int64
+}
+
+// FleetCurrencyRevenue is the window's settled volume in one currency, in
+// MICROS (millionths of a major unit — the ledger convention).
+type FleetCurrencyRevenue struct {
+	Currency      string
+	Payments      int64
+	SettledAmount int64
+}
+
+// FleetRailHealth is one rail's window outcome split across the fleet.
+type FleetRailHealth struct {
+	Rail      string
+	Succeeded int64
+	Failed    int64
+}
+
+// FleetMRR is the monthly-normalized recurring run-rate in one currency, in
+// MICROS: each active auto-renew subscription's price scaled by 720h/period.
+type FleetMRR struct {
+	Currency      string
+	Subscriptions int64
+	MonthlyAmount int64
+}
+
+// FleetAnalytics is one consistent operator snapshot of the hosted fleet.
+type FleetAnalytics struct {
+	WindowDays int
+	Merchants  FleetMerchantFunnel
+	Revenue    []FleetCurrencyRevenue
+	Rails      []FleetRailHealth
+	MRR        []FleetMRR
+}
+
+// FleetAnalytics aggregates the fleet snapshot. exclude removes one merchant
+// from every aggregate (the platform merchant itself, so its self-billing book
+// never counts as fleet processing volume); zero means exclude nothing.
+// windowDays outside 1..365 falls back to 30.
+func (c *ControlPlane) FleetAnalytics(ctx context.Context, exclude merchant.ID, windowDays int) (*FleetAnalytics, error) {
+	if c == nil || c.pool == nil {
+		return nil, errors.New("controlplane: pgx pool unavailable for fleet analytics")
+	}
+	if windowDays < 1 || windowDays > 365 {
+		windowDays = 30
+	}
+	since := time.Now().UTC().AddDate(0, 0, -windowDays)
+	var excludeArg any
+	if !exclude.IsZero() {
+		excludeArg = exclude.UUID()
+	}
+
+	out := &FleetAnalytics{WindowDays: windowDays}
+	if err := c.pool.QueryRow(ctx, `
+		SELECT count(*),
+		       count(*) FILTER (WHERE EXISTS (
+		           SELECT 1 FROM openrails.psps p
+		            WHERE p.merchant_id = m.id AND p.replaced_at IS NULL)),
+		       count(*) FILTER (WHERE EXISTS (
+		           SELECT 1 FROM openrails.payments pay
+		            WHERE pay.merchant_id = m.id AND pay.status = 'completed')),
+		       count(*) FILTER (WHERE EXISTS (
+		           SELECT 1 FROM openrails.payments pay
+		            WHERE pay.merchant_id = m.id AND pay.status = 'completed'
+		              AND pay.purchased_at >= $2))
+		  FROM openrails.merchants m
+		 WHERE m.deleted_at IS NULL AND m.status = 'active'
+		   AND ($1::uuid IS NULL OR m.id <> $1)
+	`, excludeArg, since).Scan(
+		&out.Merchants.Total, &out.Merchants.Armed,
+		&out.Merchants.FirstRevenue, &out.Merchants.ActiveRevenue,
+	); err != nil {
+		return nil, fmt.Errorf("fleet analytics: merchant funnel: %w", err)
+	}
+
+	revenueRows, err := c.pool.Query(ctx, `
+		SELECT currency, count(*), COALESCE(sum(amount), 0)
+		  FROM openrails.payments
+		 WHERE status = 'completed' AND purchased_at >= $2
+		   AND ($1::uuid IS NULL OR merchant_id <> $1)
+		 GROUP BY currency ORDER BY currency
+	`, excludeArg, since)
+	if err != nil {
+		return nil, fmt.Errorf("fleet analytics: revenue: %w", err)
+	}
+	defer revenueRows.Close()
+	for revenueRows.Next() {
+		var r FleetCurrencyRevenue
+		if err := revenueRows.Scan(&r.Currency, &r.Payments, &r.SettledAmount); err != nil {
+			return nil, fmt.Errorf("fleet analytics: scan revenue: %w", err)
+		}
+		out.Revenue = append(out.Revenue, r)
+	}
+	if err := revenueRows.Err(); err != nil {
+		return nil, fmt.Errorf("fleet analytics: revenue rows: %w", err)
+	}
+
+	railRows, err := c.pool.Query(ctx, `
+		SELECT rail,
+		       count(*) FILTER (WHERE status = 'completed'),
+		       count(*) FILTER (WHERE status = 'failed')
+		  FROM openrails.payments
+		 WHERE purchased_at >= $2 AND status IN ('completed', 'failed')
+		   AND ($1::uuid IS NULL OR merchant_id <> $1)
+		 GROUP BY rail ORDER BY rail
+	`, excludeArg, since)
+	if err != nil {
+		return nil, fmt.Errorf("fleet analytics: rail health: %w", err)
+	}
+	defer railRows.Close()
+	for railRows.Next() {
+		var r FleetRailHealth
+		if err := railRows.Scan(&r.Rail, &r.Succeeded, &r.Failed); err != nil {
+			return nil, fmt.Errorf("fleet analytics: scan rail health: %w", err)
+		}
+		out.Rails = append(out.Rails, r)
+	}
+	if err := railRows.Err(); err != nil {
+		return nil, fmt.Errorf("fleet analytics: rail rows: %w", err)
+	}
+
+	mrrRows, err := c.pool.Query(ctx, `
+		SELECT pr.currency, count(*),
+		       COALESCE(sum((pr.amount::numeric * 720 / pr.access_duration_hours)::bigint), 0)
+		  FROM openrails.subscriptions s
+		  JOIN openrails.prices pr ON pr.id = s.price_id
+		 WHERE s.status = 'active' AND pr.auto_renew AND pr.access_duration_hours > 0
+		   AND ($1::uuid IS NULL OR s.merchant_id <> $1)
+		 GROUP BY pr.currency ORDER BY pr.currency
+	`, excludeArg)
+	if err != nil {
+		return nil, fmt.Errorf("fleet analytics: mrr: %w", err)
+	}
+	defer mrrRows.Close()
+	for mrrRows.Next() {
+		var r FleetMRR
+		if err := mrrRows.Scan(&r.Currency, &r.Subscriptions, &r.MonthlyAmount); err != nil {
+			return nil, fmt.Errorf("fleet analytics: scan mrr: %w", err)
+		}
+		out.MRR = append(out.MRR, r)
+	}
+	if err := mrrRows.Err(); err != nil {
+		return nil, fmt.Errorf("fleet analytics: mrr rows: %w", err)
+	}
+	return out, nil
+}

--- a/pkg/embedded/controlplane/fleet_analytics.go
+++ b/pkg/embedded/controlplane/fleet_analytics.go
@@ -1,0 +1,90 @@
+package controlplane
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-rails/openrails/internal/app"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// FleetMerchantFunnel counts merchants by lifecycle stage (openrails-saas #28):
+// provisioned → armed (live PSP declared) → first-revenue → active-in-window.
+type FleetMerchantFunnel struct {
+	Total         int64 `json:"total"`
+	Armed         int64 `json:"armed"`
+	FirstRevenue  int64 `json:"first_revenue"`
+	ActiveRevenue int64 `json:"active_revenue"`
+}
+
+// FleetCurrencyRevenue is one currency's settled window volume, in MICROS.
+type FleetCurrencyRevenue struct {
+	Currency      string `json:"currency"`
+	Payments      int64  `json:"payments"`
+	SettledAmount int64  `json:"settled_amount_micros"`
+}
+
+// FleetRailHealth is one rail's completed/failed split across the fleet window.
+type FleetRailHealth struct {
+	Rail      string `json:"rail"`
+	Succeeded int64  `json:"succeeded"`
+	Failed    int64  `json:"failed"`
+}
+
+// FleetMRR is one currency's monthly-normalized recurring run-rate, in MICROS.
+type FleetMRR struct {
+	Currency      string `json:"currency"`
+	Subscriptions int64  `json:"subscriptions"`
+	MonthlyAmount int64  `json:"monthly_amount_micros"`
+}
+
+// FleetSnapshot is one operator snapshot of the hosted fleet.
+type FleetSnapshot struct {
+	WindowDays int                    `json:"window_days"`
+	Merchants  FleetMerchantFunnel    `json:"merchants"`
+	Revenue    []FleetCurrencyRevenue `json:"revenue"`
+	Rails      []FleetRailHealth      `json:"rails"`
+	MRR        []FleetMRR             `json:"mrr"`
+}
+
+// FleetAnalytics returns cross-merchant operator aggregates (openrails-saas
+// #28) from the control plane's privileged pool — the fleet view no
+// per-merchant RLS scope can compute. Like SearchMerchants (#226) this is a
+// sensitive cross-merchant read: the CALLER gates it behind platform-superadmin
+// authority and audits every request. exclude removes one merchant from every
+// aggregate (a hosted platform passes its own platform merchant); zero excludes
+// nothing. windowDays outside 1..365 falls back to 30. Calling without an
+// attached control plane is a wiring error (call Attach/AttachWithOptions
+// first).
+func FleetAnalytics(ctx context.Context, a *app.App, exclude merchant.ID, windowDays int) (*FleetSnapshot, error) {
+	cp := Get(a)
+	if cp == nil {
+		return nil, fmt.Errorf("control plane: no control plane attached (call Attach first)")
+	}
+	snapshot, err := cp.FleetAnalytics(ctx, exclude, windowDays)
+	if err != nil {
+		return nil, err
+	}
+	out := &FleetSnapshot{
+		WindowDays: snapshot.WindowDays,
+		Merchants: FleetMerchantFunnel{
+			Total:         snapshot.Merchants.Total,
+			Armed:         snapshot.Merchants.Armed,
+			FirstRevenue:  snapshot.Merchants.FirstRevenue,
+			ActiveRevenue: snapshot.Merchants.ActiveRevenue,
+		},
+		Revenue: make([]FleetCurrencyRevenue, 0, len(snapshot.Revenue)),
+		Rails:   make([]FleetRailHealth, 0, len(snapshot.Rails)),
+		MRR:     make([]FleetMRR, 0, len(snapshot.MRR)),
+	}
+	for _, r := range snapshot.Revenue {
+		out.Revenue = append(out.Revenue, FleetCurrencyRevenue{Currency: r.Currency, Payments: r.Payments, SettledAmount: r.SettledAmount})
+	}
+	for _, r := range snapshot.Rails {
+		out.Rails = append(out.Rails, FleetRailHealth{Rail: r.Rail, Succeeded: r.Succeeded, Failed: r.Failed})
+	}
+	for _, r := range snapshot.MRR {
+		out.MRR = append(out.MRR, FleetMRR{Currency: r.Currency, Subscriptions: r.Subscriptions, MonthlyAmount: r.MonthlyAmount})
+	}
+	return out, nil
+}


### PR DESCRIPTION
Adds the engine mechanism behind openrails-saas #28 (platform fleet analytics): `ControlPlane.FleetAnalytics` computes the merchant lifecycle funnel (provisioned → armed → first-revenue → active-in-window), per-currency settled window volume, per-rail completed/failed splits, and monthly-normalized MRR — one consistent snapshot on the privileged control-plane pool, the cross-merchant read no per-merchant RLS scope can perform. `embcp.FleetAnalytics` exposes it with wire-ready DTOs.

SearchMerchants (#226) doctrine: the caller gates (platform superadmin) and audits every request; an `exclude` parameter lets a hosted platform keep its own self-billing book out of fleet numbers.

Mechanism only — policy, HTTP surface, and UI stay in the wrapper (division of labor). `go build ./...` + vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)