### PR TITLE
fleet analytics: exclude reversal mirror rows from sale aggregates + per-rail chargeback counts

### DIFF
--- a/internal/controlplane/fleet_analytics.go
+++ b/internal/controlplane/fleet_analytics.go
@@ -82,10 +82,12 @@ func (c *ControlPlane) FleetAnalytics(ctx context.Context, exclude merchant.ID, 
 		            WHERE p.merchant_id = m.id AND p.replaced_at IS NULL)),
 		       count(*) FILTER (WHERE EXISTS (
 		           SELECT 1 FROM openrails.payments pay
-		            WHERE pay.merchant_id = m.id AND pay.status = 'completed')),
+		            WHERE pay.merchant_id = m.id AND pay.status = 'completed'
+		              AND pay.reversal_kind IS NULL)),
 		       count(*) FILTER (WHERE EXISTS (
 		           SELECT 1 FROM openrails.payments pay
 		            WHERE pay.merchant_id = m.id AND pay.status = 'completed'
+		              AND pay.reversal_kind IS NULL
 		              AND pay.purchased_at >= $2))
 		  FROM openrails.merchants m
 		 WHERE m.deleted_at IS NULL AND m.status = 'active'
@@ -97,10 +99,12 @@ func (c *ControlPlane) FleetAnalytics(ctx context.Context, exclude merchant.ID, 
 		return nil, fmt.Errorf("fleet analytics: merchant funnel: %w", err)
 	}
 
+	// Sale rows only: refund/chargeback mirror rows share status='completed'
+	// (with negative amounts + reversal_kind set) and must not count as sales.
 	revenueRows, err := c.pool.Query(ctx, `
 		SELECT currency, count(*), COALESCE(sum(amount), 0)
 		  FROM openrails.payments
-		 WHERE status = 'completed' AND purchased_at >= $2
+		 WHERE status = 'completed' AND reversal_kind IS NULL AND purchased_at >= $2
 		   AND ($1::uuid IS NULL OR merchant_id <> $1)
 		 GROUP BY currency ORDER BY currency
 	`, excludeArg, since)
@@ -121,8 +125,8 @@ func (c *ControlPlane) FleetAnalytics(ctx context.Context, exclude merchant.ID, 
 
 	railRows, err := c.pool.Query(ctx, `
 		SELECT rail,
-		       count(*) FILTER (WHERE status = 'completed'),
-		       count(*) FILTER (WHERE status = 'failed')
+		       count(*) FILTER (WHERE status = 'completed' AND reversal_kind IS NULL),
+		       count(*) FILTER (WHERE status = 'failed' AND reversal_kind IS NULL)
 		  FROM openrails.payments
 		 WHERE purchased_at >= $2 AND status IN ('completed', 'failed')
 		   AND ($1::uuid IS NULL OR merchant_id <> $1)

--- a/internal/controlplane/fleet_analytics.go
+++ b/internal/controlplane/fleet_analytics.go
@@ -34,10 +34,13 @@ type FleetCurrencyRevenue struct {
 }
 
 // FleetRailHealth is one rail's window outcome split across the fleet.
+// Chargebacks counts reversal_kind='chargeback' mirror rows recorded in the
+// window (#733) — the dispute signal VAMP-style monitoring watches.
 type FleetRailHealth struct {
-	Rail      string
-	Succeeded int64
-	Failed    int64
+	Rail        string
+	Succeeded   int64
+	Failed      int64
+	Chargebacks int64
 }
 
 // FleetMRR is the monthly-normalized recurring run-rate in one currency, in
@@ -126,7 +129,8 @@ func (c *ControlPlane) FleetAnalytics(ctx context.Context, exclude merchant.ID, 
 	railRows, err := c.pool.Query(ctx, `
 		SELECT rail,
 		       count(*) FILTER (WHERE status = 'completed' AND reversal_kind IS NULL),
-		       count(*) FILTER (WHERE status = 'failed' AND reversal_kind IS NULL)
+		       count(*) FILTER (WHERE status = 'failed' AND reversal_kind IS NULL),
+		       count(*) FILTER (WHERE reversal_kind = 'chargeback')
 		  FROM openrails.payments
 		 WHERE purchased_at >= $2 AND status IN ('completed', 'failed')
 		   AND ($1::uuid IS NULL OR merchant_id <> $1)
@@ -138,7 +142,7 @@ func (c *ControlPlane) FleetAnalytics(ctx context.Context, exclude merchant.ID, 
 	defer railRows.Close()
 	for railRows.Next() {
 		var r FleetRailHealth
-		if err := railRows.Scan(&r.Rail, &r.Succeeded, &r.Failed); err != nil {
+		if err := railRows.Scan(&r.Rail, &r.Succeeded, &r.Failed, &r.Chargebacks); err != nil {
 			return nil, fmt.Errorf("fleet analytics: scan rail health: %w", err)
 		}
 		out.Rails = append(out.Rails, r)

--- a/pkg/embedded/controlplane/fleet_analytics.go
+++ b/pkg/embedded/controlplane/fleet_analytics.go
@@ -24,11 +24,14 @@ type FleetCurrencyRevenue struct {
 	SettledAmount int64  `json:"settled_amount_micros"`
 }
 
-// FleetRailHealth is one rail's completed/failed split across the fleet window.
+// FleetRailHealth is one rail's completed/failed/chargeback split across the
+// fleet window. Chargebacks counts #733 reversal mirror rows recorded in the
+// window — the dispute signal VAMP-style monitoring watches.
 type FleetRailHealth struct {
-	Rail      string `json:"rail"`
-	Succeeded int64  `json:"succeeded"`
-	Failed    int64  `json:"failed"`
+	Rail        string `json:"rail"`
+	Succeeded   int64  `json:"succeeded"`
+	Failed      int64  `json:"failed"`
+	Chargebacks int64  `json:"chargebacks"`
 }
 
 // FleetMRR is one currency's monthly-normalized recurring run-rate, in MICROS.
@@ -81,7 +84,7 @@ func FleetAnalytics(ctx context.Context, a *app.App, exclude merchant.ID, window
 		out.Revenue = append(out.Revenue, FleetCurrencyRevenue{Currency: r.Currency, Payments: r.Payments, SettledAmount: r.SettledAmount})
 	}
 	for _, r := range snapshot.Rails {
-		out.Rails = append(out.Rails, FleetRailHealth{Rail: r.Rail, Succeeded: r.Succeeded, Failed: r.Failed})
+		out.Rails = append(out.Rails, FleetRailHealth{Rail: r.Rail, Succeeded: r.Succeeded, Failed: r.Failed, Chargebacks: r.Chargebacks})
 	}
 	for _, r := range snapshot.MRR {
 		out.MRR = append(out.MRR, FleetMRR{Currency: r.Currency, Subscriptions: r.Subscriptions, MonthlyAmount: r.MonthlyAmount})


### PR DESCRIPTION
Two corrections to the openrails-saas #28 fleet snapshot, found while grounding the "chargeback rate" residual:

- fix: #733 refund/chargeback mirror rows share status='completed' (negative amount, reversal_kind set), so they were counting as sales — inflating payment counts, approval rates, and the funnel's revenue stages. All sale-side aggregates now require reversal_kind IS NULL (gross sales volume + true sale counts).
- feat: per-rail `chargebacks` in FleetRailHealth — count of reversal_kind='chargeback' mirror rows in the window. The dispute signal already exists (#733 mirror rows fed by CCBill/Stripe webhooks + reconcile), so the VAMP-style early-warning residual ships now instead of waiting on a new engine signal.

`go build ./...` + vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)