### PR TITLE
fix: console customer list must scope by explicit merchant predicate, not RLS alone

### DIFF
--- a/internal/db/customer_search_integration_test.go
+++ b/internal/db/customer_search_integration_test.go
@@ -1,0 +1,88 @@
+//go:build integration
+
+package db_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/db/gen"
+	"github.com/open-rails/openrails/internal/dbtest"
+)
+
+// TestSearchCustomersScopedToMerchant is the regression test for the console
+// customer list leaking across merchants on a BYPASSRLS connection: the shared
+// dbtest pool is exactly such a privileged handle, so before SearchCustomers/
+// CountSearchCustomers carried an explicit merchant predicate this test's
+// cross-merchant assertions failed (every merchant's customers came back).
+func TestSearchCustomersScopedToMerchant(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.SharedPGXPool(t)
+	dbtest.EnsureTestMerchant(ctx, t, pool)
+
+	otherMerchantID := uuid.New()
+	otherSlug := fmt.Sprintf("othr%x", time.Now().UnixNano())
+	_, err := pool.Exec(ctx,
+		`INSERT INTO openrails.merchants (id, slug, status) VALUES ($1, $2, 'active')`,
+		otherMerchantID, otherSlug)
+	require.NoError(t, err)
+
+	mine := uuid.New()
+	theirs := uuid.New()
+	for _, row := range []struct {
+		id       uuid.UUID
+		merchant uuid.UUID
+	}{
+		{mine, dbtest.TestMerchantID.UUID()},
+		{theirs, otherMerchantID},
+	} {
+		_, err := pool.Exec(ctx,
+			`INSERT INTO openrails.customers (id, merchant_id, subject) VALUES ($1, $2, $3)`,
+			row.id, row.merchant, row.id.String())
+		require.NoError(t, err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM openrails.customers WHERE id IN ($1, $2)`, mine, theirs)
+		_, _ = pool.Exec(ctx, `DELETE FROM openrails.merchants WHERE id = $1`, otherMerchantID)
+	})
+
+	queries := gen.New(pool)
+
+	// Unfiltered list: only the scoped merchant's customer comes back.
+	rows, err := queries.SearchCustomers(ctx, gen.SearchCustomersParams{
+		MerchantID: dbtest.TestMerchantID.UUID(),
+		Q:          "",
+		PageLimit:  200,
+		PageOffset: 0,
+	})
+	require.NoError(t, err)
+	seen := map[uuid.UUID]bool{}
+	for _, row := range rows {
+		seen[row.ID] = true
+	}
+	require.True(t, seen[mine], "scoped merchant's customer missing from its own list")
+	require.False(t, seen[theirs], "another merchant's customer leaked into the list")
+
+	// Searching by the other merchant's exact customer id must not cross scopes.
+	rows, err = queries.SearchCustomers(ctx, gen.SearchCustomersParams{
+		MerchantID: dbtest.TestMerchantID.UUID(),
+		Q:          theirs.String(),
+		PageLimit:  200,
+		PageOffset: 0,
+	})
+	require.NoError(t, err)
+	require.Empty(t, rows, "searching a foreign customer id must return nothing")
+
+	// The count obeys the same scope.
+	count, err := queries.CountSearchCustomers(ctx, gen.CountSearchCustomersParams{
+		MerchantID: otherMerchantID,
+		Q:          "",
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, count, "other merchant's count must see exactly its own customer")
+}

--- a/internal/db/gen/customers.sql.go
+++ b/internal/db/gen/customers.sql.go
@@ -14,17 +14,24 @@ import (
 
 const countSearchCustomers = `-- name: CountSearchCustomers :one
 SELECT count(*) FROM openrails.customers c
-WHERE $1::text = ''
-   OR c.subject ILIKE $1 || '%'
-   OR c.id::text ILIKE $1 || '%'
+WHERE c.merchant_id = $1
+  AND ($2::text = ''
+   OR c.subject ILIKE $2 || '%'
+   OR c.id::text ILIKE $2 || '%'
    OR EXISTS (
         SELECT 1 FROM openrails.subscriptions se
         WHERE se.customer_id = c.id
-          AND se.user_email ILIKE '%' || $1 || '%')
+          AND se.merchant_id = c.merchant_id
+          AND se.user_email ILIKE '%' || $2 || '%'))
 `
 
-func (q *Queries) CountSearchCustomers(ctx context.Context, q_ string) (int64, error) {
-	row := q.db.QueryRow(ctx, countSearchCustomers, q_)
+type CountSearchCustomersParams struct {
+	MerchantID uuid.UUID
+	Q          string
+}
+
+func (q *Queries) CountSearchCustomers(ctx context.Context, arg CountSearchCustomersParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countSearchCustomers, arg.MerchantID, arg.Q)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -135,21 +142,25 @@ func (q *Queries) LookupCustomerIDsBySubjects(ctx context.Context, arg LookupCus
 const searchCustomers = `-- name: SearchCustomers :many
 SELECT c.id, c.subject, c.created_at, c.last_seen_at,
   (SELECT s.user_email FROM openrails.subscriptions s
-     WHERE s.customer_id = c.id AND s.user_email IS NOT NULL
+     WHERE s.customer_id = c.id AND s.merchant_id = c.merchant_id
+       AND s.user_email IS NOT NULL
      ORDER BY s.created_at DESC LIMIT 1) AS email
 FROM openrails.customers c
-WHERE $1::text = ''
-   OR c.subject ILIKE $1 || '%'
-   OR c.id::text ILIKE $1 || '%'
+WHERE c.merchant_id = $1
+  AND ($2::text = ''
+   OR c.subject ILIKE $2 || '%'
+   OR c.id::text ILIKE $2 || '%'
    OR EXISTS (
         SELECT 1 FROM openrails.subscriptions se
         WHERE se.customer_id = c.id
-          AND se.user_email ILIKE '%' || $1 || '%')
+          AND se.merchant_id = c.merchant_id
+          AND se.user_email ILIKE '%' || $2 || '%'))
 ORDER BY c.last_seen_at DESC
-LIMIT $3 OFFSET $2
+LIMIT $4 OFFSET $3
 `
 
 type SearchCustomersParams struct {
+	MerchantID uuid.UUID
 	Q          string
 	PageOffset int64
 	PageLimit  int64
@@ -163,12 +174,20 @@ type SearchCustomersRow struct {
 	Email      *string
 }
 
-// Merchant-scoped customer list/search (#740). RLS pins the merchant (run on
-// a merchant conn). q matches subject (external ref) prefix, id prefix, or a
-// subscription email substring; empty q lists newest-touched first. email is
-// the latest subscription email on file (customers carry none themselves).
+// Merchant-scoped customer list/search (#740). merchant_id is an EXPLICIT
+// predicate (defense-in-depth doctrine, #227): RLS still pins the merchant on
+// enforcing roles, but a BYPASSRLS role (development's owner connection) must
+// never see another merchant's customers. q matches subject (external ref)
+// prefix, id prefix, or a subscription email substring; empty q lists
+// newest-touched first. email is the latest subscription email on file
+// (customers carry none themselves).
 func (q *Queries) SearchCustomers(ctx context.Context, arg SearchCustomersParams) ([]SearchCustomersRow, error) {
-	rows, err := q.db.Query(ctx, searchCustomers, arg.Q, arg.PageOffset, arg.PageLimit)
+	rows, err := q.db.Query(ctx, searchCustomers,
+		arg.MerchantID,
+		arg.Q,
+		arg.PageOffset,
+		arg.PageLimit,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/queries/customers.sql
+++ b/internal/db/queries/customers.sql
@@ -31,34 +31,42 @@ WHERE merchant_id = $1
   AND subject = ANY(sqlc.arg(subjects)::text[]);
 
 -- name: SearchCustomers :many
--- Merchant-scoped customer list/search (#740). RLS pins the merchant (run on
--- a merchant conn). q matches subject (external ref) prefix, id prefix, or a
--- subscription email substring; empty q lists newest-touched first. email is
--- the latest subscription email on file (customers carry none themselves).
+-- Merchant-scoped customer list/search (#740). merchant_id is an EXPLICIT
+-- predicate (defense-in-depth doctrine, #227): RLS still pins the merchant on
+-- enforcing roles, but a BYPASSRLS role (development's owner connection) must
+-- never see another merchant's customers. q matches subject (external ref)
+-- prefix, id prefix, or a subscription email substring; empty q lists
+-- newest-touched first. email is the latest subscription email on file
+-- (customers carry none themselves).
 SELECT c.id, c.subject, c.created_at, c.last_seen_at,
   (SELECT s.user_email FROM openrails.subscriptions s
-     WHERE s.customer_id = c.id AND s.user_email IS NOT NULL
+     WHERE s.customer_id = c.id AND s.merchant_id = c.merchant_id
+       AND s.user_email IS NOT NULL
      ORDER BY s.created_at DESC LIMIT 1) AS email
 FROM openrails.customers c
-WHERE sqlc.arg(q)::text = ''
+WHERE c.merchant_id = sqlc.arg(merchant_id)
+  AND (sqlc.arg(q)::text = ''
    OR c.subject ILIKE sqlc.arg(q) || '%'
    OR c.id::text ILIKE sqlc.arg(q) || '%'
    OR EXISTS (
         SELECT 1 FROM openrails.subscriptions se
         WHERE se.customer_id = c.id
-          AND se.user_email ILIKE '%' || sqlc.arg(q) || '%')
+          AND se.merchant_id = c.merchant_id
+          AND se.user_email ILIKE '%' || sqlc.arg(q) || '%'))
 ORDER BY c.last_seen_at DESC
 LIMIT sqlc.arg(page_limit) OFFSET sqlc.arg(page_offset);
 
 -- name: CountSearchCustomers :one
 SELECT count(*) FROM openrails.customers c
-WHERE sqlc.arg(q)::text = ''
+WHERE c.merchant_id = sqlc.arg(merchant_id)
+  AND (sqlc.arg(q)::text = ''
    OR c.subject ILIKE sqlc.arg(q) || '%'
    OR c.id::text ILIKE sqlc.arg(q) || '%'
    OR EXISTS (
         SELECT 1 FROM openrails.subscriptions se
         WHERE se.customer_id = c.id
-          AND se.user_email ILIKE '%' || sqlc.arg(q) || '%');
+          AND se.merchant_id = c.merchant_id
+          AND se.user_email ILIKE '%' || sqlc.arg(q) || '%'));
 
 -- name: UpsertCustomerBySubject :one
 -- Customer identity is the merchant plus the host/AuthKit stable UUID subject.

--- a/internal/http/handlers/admin_customers.go
+++ b/internal/http/handlers/admin_customers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/open-rails/openrails/internal/db/gen"
 	httprequest "github.com/open-rails/openrails/internal/http/request"
+	"github.com/open-rails/openrails/pkg/merchant"
 )
 
 // adminCustomerSummary is one row of the merchant customer list/search (#740).
@@ -51,8 +52,17 @@ func ListAdminCustomers(r *httprequest.Request) {
 		offset = n
 	}
 
+	// Explicit merchant predicate (defense-in-depth, #227): RLS also pins the
+	// merchant on enforcing roles, but a BYPASSRLS connection (development's
+	// owner role) must never list another merchant's customers.
+	tid, err := merchant.Require(ctx)
+	if err != nil {
+		r.ErrorJSON(http.StatusInternalServerError, "merchant scope required")
+		return
+	}
 	queries := r.State.DB.Gen(ctx)
 	rows, err := queries.SearchCustomers(ctx, gen.SearchCustomersParams{
+		MerchantID: tid.UUID(),
 		Q:          q,
 		PageLimit:  int64(limit),
 		PageOffset: int64(offset),
@@ -61,7 +71,10 @@ func ListAdminCustomers(r *httprequest.Request) {
 		r.ErrorJSON(http.StatusInternalServerError, "failed to search customers")
 		return
 	}
-	total, err := queries.CountSearchCustomers(ctx, q)
+	total, err := queries.CountSearchCustomers(ctx, gen.CountSearchCustomersParams{
+		MerchantID: tid.UUID(),
+		Q:          q,
+	})
 	if err != nil {
 		r.ErrorJSON(http.StatusInternalServerError, "failed to count customers")
 		return


### PR DESCRIPTION
Found during manual testing of the hosted SaaS: a merchant owner's console Customers page showed ANOTHER merchant's customers (the platform's #26 self-billing book). Root cause: SearchCustomers/CountSearchCustomers (#740) carried no merchant predicate — the comment said "RLS pins the merchant" — but development connects as the BYPASSRLS owner role (the boot warning's "explicit query predicates only" posture), so the query returned every customer in the database.

- SearchCustomers/CountSearchCustomers now take an explicit merchant_id predicate (defense-in-depth per #227; RLS remains the second layer on enforcing roles); the email subqueries pin to the same merchant.
- ListAdminCustomers passes the request's merchant scope (merchant.Require).
- Regression test runs on the shared dbtest pool — itself a BYPASSRLS handle, i.e. the exact leak condition: two merchants' customers, list/search/count must never cross scopes. Failed before the fix, passes after.

Staging/production were never exposed (openrails_app + FORCE RLS), but this removes the one-role-misconfiguration-away risk and makes dev truthful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)