### PR TITLE
docs: post-merge accuracy fixes (#691 standing access, no rebind command)

### DIFF
--- a/docs/entitlements_timeline.md
+++ b/docs/entitlements_timeline.md
@@ -62,30 +62,19 @@ pass repairs any drift between the two.
 
 `source_type` + `source_id` on each window: `subscription` (paid access from a subscription),
 `one_off` (a one-time purchase), `admin` (admin-granted; source is the grant itself), and
-`grace` (below).
+`grace` (historical — see below).
 
-## Grace
+## Standing access — auto-renew subscriptions have no end date
 
-Grace is the primitive for **bounded, revocable generosity**: paid windows stay truthful
-(`end_at` = period end), and any access beyond what was paid is a separate `grace` window
-appended to the timeline (`source_id` = subscription id). Grace ends the moment truth
-arrives — resolution revokes active grace and soft-deletes scheduled grace — and with no
-resolution it lapses by its own `end_at`: fail-closed eventually. Half-open ranges mean a
-grace window starting exactly at the paid end never overlaps it. Producers:
-
-- **Renewal grace (NMI-backed + Stripe, #368).** Activation and every renewal pre-append a
-  trailing grace window `[period_end, period_end + slack)`; slack = half the billing cycle
-  capped at 48h (12h for daily; not configurable — see `GraceSlack`). Pre-appended so a lost
-  webhook or provider day-boundary billing never gates a paying user. Renewal success revokes
-  the old grace and appends the next paid + grace pair; terminal failure revokes it with the
-  cancellation; a **deliberate cancel deletes the scheduled grace at cancel time** (access
-  ends at the period end the user expects). Months-stale period ends get no resurrection
-  grace — the push is skipped once `period_end + slack` is already past.
-- **CCBill retry grace.** The paid window still ends at the paid term; if CCBill reports the
-  next retry after it (`nextRetryDate`), grace windows extend up to that retry. CCBill's own
-  retry cadence drives its grace — it does not get the pre-appended renewal grace.
-- **NMI/Solana dunning grace.** When the dunning retry schedule extends past the paid term
-  end, the failure path models that access as grace up to the next retry.
+An auto-renew subscription's entitlement window is **standing**: open-ended, closed only
+by a proven event (a confirmed cancellation, a terminal decline, exhausted dunning — never
+by the clock alone). A lost webhook, a provider billing on its own day boundary, or a dead
+webhook pipe therefore cannot gate a paying user: access simply continues while
+reconciliation converges the subscription against provider truth. This replaced the older
+appended-grace-window mechanism (#368, deleted by #691) — `grace` remains in the source
+vocabulary for historical rows and as a pacing marker in convergence, but no code appends
+grace windows today. Deliberate cancellation still ends access at the period end the user
+expects.
 
 Date-only CCBill values (`YYYY-MM-DD`) are read as end of that UTC day (`23:59:59Z`) to
 avoid access gaps from ambiguity.

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -60,7 +60,7 @@ OpenRails' workers converge state around that:
 |---|---|---|
 | Provider-intent executor | 1 min (+ on start) | drains due outbound provider mutations from the intent ledger |
 | Provider-intent verifier | 5 min | resolves `unknown_needs_verify` outcomes by *reading* the provider before any retry |
-| Convergence Engine sweep | 15 min (+ on start) | per-merchant internal-drift repair: stalled dunning, elapsed grace, unmaterialized grants ([operations.md](operations.md#the-convergence-engine)) |
+| Convergence Engine sweep | 15 min (+ on start) | per-merchant internal-drift repair: stalled dunning, lapsed periods, unmaterialized grants ([operations.md](operations.md#the-convergence-engine)) |
 | Provider Refresh | 4 h (+ on start) | watermarked missed-event backfill, unknown-cohort reconcile, CCBill DataLink refresh — reads only, never mutates a provider |
 | Dunning | 4 h | retries `past_due` per the derived no-knobs schedule; cancels past the staleness window instead of charging ([operations.md → Dunning](operations.md#dunning-359)) |
 | Credit expiry | 1 h | expires credit lots |
@@ -144,10 +144,9 @@ Cutover](operations.md#cutover-booting-against-production-credentials).
   every provider intent is stamped with the provider-account row it was
   enqueued against, and the executor parks intents whose account no longer
   resolves — a queue built against one account never executes against another.
-  Options: restore the old account's credentials so the queue drains, let
-  stale intents expire, or deliberately rebind them to the new account. Rules
-  and the rebind procedure: [operations.md → Provider account guard /
-  credential rotation](operations.md#durability-model).
+  Options: restore the old account's credentials so the queue drains, or let
+  stale intents expire/supersede. Rules:
+  [operations.md → Durability model](operations.md#durability-model).
 
 ### Observability
 


### PR DESCRIPTION
Two accuracy fixes found by the operations-manual verification pass after #181 merged:

- entitlements_timeline.md still documented renewal/dunning grace windows as live producers; #691 deleted all grace appends — auto-renew subscriptions project a standing entitlement window closed only on proven events. Rewritten accordingly.
- operator-guide.md referenced a "rebind procedure" for account-guard-parked intents; no such CLI command exists. Now states the real options (restore credentials, or let intents expire/supersede).

🤖 Generated with [Claude Code](https://claude.com/claude-code)