### PR TITLE
RLS-bypass class fix (#826), settlements merchant scoping + RLS (#827), README marketing + batch-import guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,170 @@ Customer Side (your users):
 
 ---
 
+### Features
+
+- **Checkout sessions** — one unified session model across every rail: provider-hosted
+  redirect (Stripe, CCBill), tokenized-vault card entry (NMI Collect.js), and Solana Pay.
+- **Catalog as source of truth** — declare your products, prices, rate cards, and tiers
+  once; OpenRails pushes them to providers (find-or-create) and watches for drift.
+- **Entitlements & product ownership** — your webserver asks one question ("does user X
+  have Y right now?") against your own database, never a provider API.
+- **Tiered plans with proration** — users upgrade/downgrade between tiers; preview the
+  proration before committing.
+- **Dunning: capture lost revenue** — failed rebills are retried on a schedule derived
+  from the billing cycle, with a staleness window that guarantees a months-old failure is
+  cancelled, never surprise-charged.
+- **Payment-lifecycle emails, handled** — "your payment failed", "your card expires
+  soon", renewal and cancellation notices: templated, deduplicated (a resolved failure
+  supersedes the stale notice instead of double-sending), and branded per merchant. You
+  don't build the awkward-conversation system; we are the awkward-conversation system.
+- **Higher approval rates, measurably** — network tokens, automatic account-updater
+  refresh of expired/reissued cards before rebills, and correct stored-credential
+  (MIT/CIT) framing on every recurring charge. Then prove the uplift in your own
+  dashboard: approval rate is sliceable by token type, rail, and decline reason.
+- **Metered billing & spend control** — pre-authorize with holds (admit → capture/release),
+  per-user budgets, spend caps, trust levels, prepaid credits or arrears invoicing.
+- **Solana, for real** — one-off USDC payments *and* on-chain recurring subscriptions via
+  the official delegation program, devnet-tested like any other sandbox.
+- **Browser-direct self-service** — end-users hit `/v1/me/*` (balance, invoices,
+  subscriptions, payment methods, cancellation) straight from your frontend; no proxy
+  routes to write or maintain.
+- **Batch import of legacy data** — bring existing subscribers, payments, and vault
+  references in from a previous billing system and let reconciliation converge them.
+- **Metric alerts to your endpoints** — define alerts on any billing metric (approval
+  rate drops, chargeback spikes, revenue anomalies) and receive them on outbound
+  webhook sinks you configure.
+- **Team & scoped API keys** — invite your staff with role-scoped permissions;
+  machine access through API keys that carry explicit grants and can never cross
+  merchants.
+- **Merchant console** — an optional admin UI for your team: customers, subscriptions,
+  refunds, catalog, API keys, and a metrics dashboard you can customize with your own
+  key-metric widgets (plus an optional LLM analytics copilot).
+
+---
+
+### Who Uses OpenRails
+
+Archetypes — the site you're building, and what OpenRails does for it:
+
+- **Building an OnlyFans, Fansly, or Pornhub Premium** — recurring memberships on
+  processors that will actually board adult content (NMI ISOs like MobiusPay/PaymentCloud,
+  CCBill). You get duplicate-subscription prevention, dunning that chases failed rebills,
+  and entitlements that survive lost webhooks — the subscription-lifecycle plumbing every
+  paysite rebuilds badly.
+- **Building a Patreon or Substack** — creator/membership tiers with upgrades,
+  downgrades, and proration. Your app asks "is this person a patron at tier 2 right now?"
+  against its own database, not a provider API.
+- **Building a Gumroad, itch.io, or Teachable** — videos, courses, games, downloads sold
+  individually. Every purchase is a permanent ownership record (entitlement) your server
+  queries forever; one checkout model whether the buyer pays by card or USDC.
+- **Building a Linear, Notion, or Figma** — classic SaaS seat billing: define the tier
+  list once, customers self-serve upgrades with proration previews, Stripe rail today
+  with an exit ramp built in.
+- **Building an OpenAI-platform or Replicate** — the credits console: users pre-pay a
+  balance (or run arrears with monthly invoices), you draw it down per request. The
+  admission API pre-authorizes with holds so a runaway job stops *before* the balance
+  goes negative — a real ledger, not a usage counter bolted to Stripe.
+- **Building a Midjourney or Cursor** — subscription + metered hybrid: a base plan plus
+  GPU/LLM usage, per-user and even per-agent spend budgets with trust levels. Built for
+  AI products where the marginal cost of a request is real money.
+- **Building a Helius-style paid service for crypto users** — your customers live
+  on-chain; take USDC straight to a wallet you control, including recurring on-chain
+  subscriptions. No processor exists in the loop to drop you.
+- **Running an Aylo-style network of sites** — several brands, one self-hosted billing
+  deployment, each site an isolated merchant with its own rails on shared
+  infrastructure, isolation enforced by the database.
+- **Anyone who watched the 2021 OnlyFans near-ban** — if you're in a category processors
+  purge (content, crypto, CBD, gaming), the question isn't *if* you get a termination
+  email, it's *when*. Integrate rail-agnostic now and that email becomes a config change
+  — swap to a high-risk gateway over a weekend, keep your subscribers, keep your
+  entitlements, lose nothing.
+
+---
+
+### Failed Payments Are a Revenue Line
+
+Industry numbers: 5–14% of subscription payments fail, involuntary churn is 20–40% of all
+churn (ProfitWell), and good recovery tooling wins back 30–60% of failed payments. For a
+site doing $100K/mo, that's roughly $2–5K/mo of revenue that leaks or doesn't, depending
+entirely on plumbing. Merchants pay $79–500/mo for standalone dunning tools — or 10–25%
+of recovered revenue to success-fee vendors — to capture it.
+
+OpenRails ships the whole recovery stack built in:
+
+- **Fewer failures in the first place** — network tokens, account-updater card refresh
+  before rebills, and correct MIT/CIT stored-credential framing lift issuer approval
+  rates on the charges that matter most: the renewals.
+- **Smart retries on the failures that remain** — hard declines (stolen card,
+  do-not-honor) go terminal immediately instead of burning retries; soft declines get a
+  cycle-derived schedule, and a months-stale failure is cancelled, never surprise-charged.
+- **The customer conversation, handled** — templated, deduplicated payment-failure and
+  card-expiry emails that supersede themselves when the problem resolves.
+- **Proof it's working** — approval rate by rail, token type, and decline reason on your
+  dashboard, with alerts to your endpoints when it drops.
+
+---
+
+### Technical Guarantees
+
+The engineering underneath, and the invariants it enforces — this is what you'd otherwise
+build yourself, badly, under deadline:
+
+- **The Convergence Engine.** Billing systems rot by drifting from provider truth: a lost
+  webhook here, a manual refund there. OpenRails treats the provider as the source of
+  truth for money state and *continuously* re-converges against it — inline after every
+  mutation, on a background sweep, and via watermarked provider reads. Every divergence
+  becomes a classified finding on one of four planes (provider-observed truth, derived
+  effects, lifecycle clocks, internal consistency); safe repairs apply automatically,
+  judgment calls queue for a human and never auto-fire.
+- **Rebilling, both ways.** Leave recurring billing to the provider's native engine
+  (NMI/CCBill/Stripe plans — OpenRails observes and converges), or let OpenRails drive
+  the renewal itself: engine-initiated stored-credential charges where *we* decide the
+  amount and timing (scheduled reprices, vaulted-card rails), and the on-chain crank for
+  Solana. Same subscription model either way.
+- **Double-entry money, twice over.** Every money movement is a balanced double-entry
+  ledger transaction — value is never created or destroyed, only moved. A separate grant
+  ledger tracks credit lots (who was granted what, from which source), and the
+  Convergence Engine cross-checks the two continuously: duplicates, broken source
+  references, and unbalanced effects surface as findings instead of festering.
+- **Audited entitlements.** No entitlement exists without provenance: every access window
+  records its source event, grant, and lifecycle (granted → revoked, with reason), so
+  "why does this user have premium?" is a query, not an investigation. Excess grants
+  (e.g. access surviving a refund) are detected and flagged automatically.
+- **Effectively-once provider writes.** Every outbound mutation is a durable intent
+  before it's an HTTP call: idempotency-keyed, origin-tagged, account-fingerprinted, and
+  drained by an executor that resolves ambiguous outcomes by *reading* the provider
+  before any retry. A charge is never blind-retried; a credential swap can never fire a
+  stale queue against the wrong account.
+- **Sandbox that can't lie.** `test_mode=sandbox` doesn't trust configuration — it
+  proves it: live Stripe keys refuse to boot, and every NMI account is probed with a
+  card only a simulator would approve. No real money can move in a sandbox boot, in any
+  environment.
+- **Your users never pay for our malfunction.** Access is closed by *evidence* — a
+  confirmed cancellation, a terminal decline, exhausted dunning — never by the clock
+  alone. A lost webhook, a dead pipe, or stale data parks the subscription for
+  verification with access intact. Terminal cancellation is the last resort, not the
+  default.
+- **Database-enforced merchant isolation.** Multi-merchant isolation isn't application
+  code you have to trust — it's Postgres row-level security on an unprivileged role,
+  with every merchant-scoped table behind a policy. A query without merchant context
+  returns nothing, by construction.
+- **Time is injected, and the build enforces it.** Every billing decision runs on an
+  injectable clock, guarded by a lint that fails the build on naked `time.Now()` in
+  business logic. That's why a year of renewals, dunning, and expiry can be
+  fast-forwarded in an integration test — the billing engine is deterministic under
+  time travel.
+- **One client, structurally incapable of drift.** Embedded and standalone modes share
+  one client implementation over one handler surface — the in-process transport
+  dispatches into the same routes HTTP does. Parity between modes isn't tested into
+  existence; there's nothing to diverge.
+- **Work scales with activity, not accounts.** No routine job ever sweeps
+  everything-on-file: due work is indexed, provider reads are watermarked, and
+  per-merchant jobs fan out only for merchants with something to do. Ten thousand idle
+  merchants cost roughly nothing.
+
+---
+
 ### Manifesto
 
 OpenRails ultimate goal is to break the parasitic monopoly Visa + MasterCard currently hold upon American's financial lives. This pain is especially acute for 'high risk' businesses (crypto, porn, gambling, CBD, etc.) who are banned from most payment providers. OpenRails makes it much easier to integrate with 'high risk payment gateways', which have really shitty APIs usually, and lack all of the dev-ex nicities you get with Stripe.
@@ -191,7 +355,9 @@ The agent-facing guide itself lives at [docs/agent-integration.md](docs/agent-in
 - [Standalone integration (service)](docs/standalone-integration.md) — deploy OpenRails as its own service: production config, first-run provisioning, API keys, the Go SDK and plain-HTTP integration.
 - [Frontend integration](docs/frontend-integration.md) — the browser side: self-service routes, checkout flows (redirect, tokenized-vault, Solana), payment methods, tokens, and error handling.
 - [The auth model](docs/auth.md) — one credential per trust domain: why embedded uses your session credential and standalone uses delegated tokens.
+- [Batch import / legacy migration](docs/batch-import.md) — moving an existing subscriber base onto OpenRails: the import surface, the phased playbook, and the limited-mode cutover.
 - [HTTP API reference](docs/api/endpoints.md) — every route, grouped by caller class.
+- [Example: gated premium page](examples/gated-premium-page/) — a runnable standalone demo: public page, entitlement-gated `/premium`, delegated tokens, NMI tokenized-vault checkout.
 
 **Payment rails** — per-rail setup: credentials, the manifest entry, webhooks, sandbox testing:
 

--- a/config/merchants_config.example.yaml
+++ b/config/merchants_config.example.yaml
@@ -33,8 +33,8 @@ merchants:
       - { key: burst, window: 15m, limit: 5_000_000 }
       - { key: sustained, window: 5h, limit: 20_000_000 }
 
-    # Operator-declared rail merchant accounts (#698: the config key is `accounts`;
-    # the DB table and secret-name prefix deliberately remain `rail_merchant_accounts`).
+    # Operator-declared PSPs: the merchant's payment service providers, keyed by
+    # PSP key, one rail each (secret names use the psps/<rail>/... prefix).
     psps:
       mobius:
         nmi:

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -84,11 +84,13 @@ Follow [standalone-integration.md](standalone-integration.md). Milestones:
 |---|---|
 | Full embedded guide | [embedded-integration.md](embedded-integration.md) |
 | Full standalone guide | [standalone-integration.md](standalone-integration.md) |
+| Runnable standalone example (entitlement gate + NMI checkout) | [../examples/gated-premium-page/](../examples/gated-premium-page/) |
 | Browser/UI work | [frontend-integration.md](frontend-integration.md) |
 | Why the auth model is shaped this way | [auth.md](auth.md) |
 | Per-rail credentials/webhooks/sandbox | [rails/nmi.md](rails/nmi.md), [rails/stripe.md](rails/stripe.md), [rails/ccbill.md](rails/ccbill.md), [rails/solana.md](rails/solana.md) |
 | Catalog authoring (products/prices/entitlements) | [merchant-guide.md](merchant-guide.md) |
 | Every HTTP route | [api/endpoints.md](api/endpoints.md) |
+| Migrating an existing subscriber base in | [batch-import.md](batch-import.md) |
 | Admin console on/off + usage | [admin-console.md](admin-console.md) |
 | Day-2 ops, safety levers, cutover | [operator-guide.md](operator-guide.md), [operations.md](operations.md) |
 | Vocabulary | [glossary.md](glossary.md) |

--- a/docs/batch-import.md
+++ b/docs/batch-import.md
@@ -1,0 +1,167 @@
+# Batch import: migrating legacy billing data into OpenRails
+
+How to move an existing site's subscribers, payment history, and provider-side
+subscription/vault records from a legacy billing system onto OpenRails
+(embedded or standalone). The import surface here is the #737 DeclaredBilling
+seam; the cutover doctrine it feeds into lives in
+[operations.md](operations.md).
+
+### The mental model
+
+Import **seeds OpenRails' local truth** — customers, subscriptions, payment
+history, vault *references* — while the **provider stays the source of truth
+for live money state**. For provider-vaulted rails (NMI, CCBill, Stripe) the
+provider owns the card vault and the recurring billing schedule: it keeps
+charging on its own clock after your cutover. Importing brings OpenRails'
+mirror up to date as of a declared horizon; from then on webhooks, the
+scheduled [Provider Refresh](operations.md#provider-refresh-574-and-the-unknown-cohort-632664665),
+and manual `pull-provider` runs converge the mirror against provider truth.
+
+You hand over **facts, not classifications**: who, which price, which rail,
+the provider's subscription id, paid-through evidence, explicit cancel
+evidence, dunning state, and the raw charge history. OpenRails classifies
+every row through the same decider pipeline its webhook/pull planes use,
+evaluated at the declared `as_of` horizon — so the same book classifies
+identically whenever the import runs.
+
+What import does **not** do:
+
+- **No provider I/O.** The import never calls a provider. The one
+  provider-affecting output: a declared cancel whose legacy schedule was not
+  confirmed dead (`schedule_live`) enqueues a durable rail-delete intent,
+  executed later by the intent executor under the
+  [mode gate](operations.md#operating-modes-the-safety-levers).
+- **No card-data movement.** OpenRails never holds card data. Declared
+  payment methods are *references* into the provider's vault
+  (`rail_customer_ref` / `rail_method_ref`), meaningful only within the PSP
+  account that created them. You cannot import your way onto a different
+  provider account — see
+  [PSP binding and credential rotation](operations.md#psp-binding-and-credential-rotation);
+  between accounts, cards can only be re-captured when customers next pay.
+
+### The import surface
+
+**Embedded**: `pkg/embedded.ImportBilling(ctx, BillingImportOptions{Config,
+PGXPool, MerchantSlug (or MerchantID), Book})`. **HTTP**:
+`POST /v1/import/billing` with the identical JSON body — merchant from the
+authenticated credential, gated on the owner-level `merchant:billing:import`
+permission. The HTTP body cap (1 MiB) forces large books to batch.
+
+The book (`DeclaredBilling`) carries four record kinds:
+
+| Kind | Idempotency key | Notes |
+|---|---|---|
+| `customers` | customer UUID (upsert) | the host's stable subject id = `customers.id` |
+| `payment_methods` | (rail, rail_customer_ref, rail_method_ref) | vault refs + card metadata (last four, type, expiry) |
+| `subscriptions` | (rail, rail_subscription_id) | `source_id` (host's stable id) keys per-row results; `psp_id` binds to a declared PSP; optional `payment_method` ref, `cancel` / `dunning` evidence, raw `evidence` JSON stored verbatim on `gateway_response` |
+| `transactions` | (rail, transaction_id) | successes **and** declines — the true attempt history; `amount_cents` is provider-wire cents, converted to ledger micros inside OpenRails |
+
+`as_of` (RFC3339) is required: the instant the legacy data was true. All
+classification evaluates against it, never wall-clock.
+`subscriptions_exhaustive: true` is an absence proof valid only when one call
+covers the merchant's entire book — it MUST be false for batched imports.
+
+Each subscription fact takes one of two lanes:
+
+- **Explicit cancel evidence** (`user_cancelled` / `chargeback` /
+  `provider_terminated`) is settled history — written directly with faithful
+  `cancel_type` and dates (cancel-with-runway keeps the paid-through end).
+- **No cancel evidence** — seeded `unknown` and resolved by the decider at
+  `as_of`: paid-through in the future → `active`; mid-dunning within the
+  window → `past_due` with grace; roster-dead → cancelled; evidence-starved →
+  stays parked `unknown` (cancellation-last-resort by construction).
+
+**Re-run semantics**: re-posting the same book at the same `as_of` is a pure
+no-op (everything reports `skipped`; no duplicate payments, no lifecycle
+regression). A later import at a **newer** `as_of` converges existing rows
+forward through the decider — e.g. a row re-declared as stalled beyond the
+dunning window lands a terminal cancel dated at the new horizon. Settled
+history is never rewritten. Per-`source_id` results come back as
+`imported` / `skipped` / `blocked` (+ reason); a blocked row (unknown price,
+rail id owned by another customer, lifecycle-slot conflict) never fails the
+batch — it stays parked and is reported loudly.
+
+**Entitlements are derived, not imported.** The book has no entitlement
+record kind. Subscription access follows from subscription standing and from
+the derive pass: run `embedded.ConvergeMerchant` (the operator-triggerable
+merchant-wide convergence) after import to materialize grants + entitlement
+windows from the imported subscriptions/payments immediately. Operator/manual
+comps — access with no payment behind it — go through the separate
+`embedded.ImportAdminGrants` seam as grant-ledger facts; OpenRails derives
+the windows.
+
+### The migration playbook
+
+The ordered phases, from a production host that migrated many years of legacy
+billing data over this seam:
+
+1. **Apply migrations.** OpenRails' baseline schema (via migratekit from
+   `migrations/postgres`), River's tables, and your app schemas. Validate the
+   target shape before writing anything.
+2. **Declare the merchant, PSPs, and catalog.** Upsert the merchant + its
+   operator-declared PSP rows through `embed.Runtime.UpsertMerchantConfig`
+   (or manifest boot), then push the catalog — including *retired* historical
+   price points, so every legacy subscription resolves a price. Resolve the
+   `psps` row ids to stamp on imported rows.
+3. **Fix the horizon.** Derive `as_of` from the legacy dump itself (e.g. the
+   max source `updated_at`) or declare it explicitly; never default to
+   wall-clock.
+4. **Import in dependency order, batched**: customers → payment methods →
+   subscriptions + their transactions. Keep the host's stable ids as
+   `source_id` so re-runs are exact and results are auditable per row. Hand
+   admin/manual comps to `ImportAdminGrants`.
+5. **Converge.** Run `ConvergeMerchant` once so entitlements/grants derive
+   now rather than on the next scheduled sweep.
+6. **Boot with `PROVIDER_WRITE_MODE=limited` — set before first start.**
+   Imported stale `past_due` rows are immediately "due"; a full-behavior boot
+   would start charging them within hours.
+7. **Let the first dunning cycle materialize the backlog**, then review
+   `openrails intents` — the
+   [drain forecast](operations.md#inspecting-the-ledger) is the dry-run view
+   of your cutover ("N execute under limited, M require full").
+8. **Verify against the provider** with `openrails pull-provider` /
+   `pull-provider report`, then raise to `PROVIDER_WRITE_MODE=full` — it
+   drains exactly what the forecast showed.
+
+Steps 6–8 in depth:
+[Cutover: booting against production credentials](operations.md#cutover-booting-against-production-credentials)
+and [Materialized backlog under mode=limited](operations.md#materialized-backlog-under-modelimited-366).
+
+### Gotchas
+
+- **Stale `past_due` is cancelled, never charged.** Anything past the
+  [dunning staleness window](operations.md#dunning-359) (derived from the
+  billing cycle; 14 days for monthly) gets the local no-charge cancel +
+  downgrade. Missed billing periods are never back-billed.
+- **`unknown` is healthy.** Evidence-starved rows park as `unknown` and keep
+  projecting standing access; Provider Refresh and probes resolve them with
+  real provider evidence. Absent evidence never costs a customer access.
+- **Adoption alone never grants access.** An adopted-active row re-anchors
+  its period end only; entitlement windows come from real charges and the
+  derive pass — hence step 5.
+- **Period anchoring**: `current_period_ends_at` = the declared
+  `paid_through`; the period start is one billing cycle back, clamped to
+  `started_at`. Provider-billed rails then renew on the *provider's*
+  schedule — the renewal reaches you as a webhook/backfilled charge, not as
+  something OpenRails initiates.
+- **Dates stay faithful.** `cancelled_at`/`ended_at` come from the declared
+  evidence, not import wall-clock; grace = missed period end + the grace
+  window; a re-import never regresses them.
+- **Money is micros locally, cents on the wire.** `amount_cents: 2300` lands
+  as `23,000,000` micros. Don't pre-convert.
+
+### Verifying success
+
+- The final import pass reports zero `blocked` (or every blocked reason is
+  triaged), and an immediate re-post of the same book is all `skipped`.
+- Payment counts and amounts match the legacy ledger; declines are present
+  (they are attempt history, not noise).
+- Status distribution is sane at `as_of`: runway → `active`, mid-dunning →
+  `past_due`, explicit cancels carry their true `cancel_type`, the rest
+  `unknown`.
+- `openrails pull-provider report` shows a clean (or explained) diff against
+  each provider's roster.
+- `openrails intents` shows only the drains you expect before raising the
+  mode; nothing fires at `full` that the forecast didn't show.
+- The `unknown` cohort shrinks over subsequent Provider Refresh cycles as
+  provider evidence arrives.

--- a/docs/frontend-integration.md
+++ b/docs/frontend-integration.md
@@ -28,8 +28,11 @@ credentials.
 **Standalone**: your session token never leaves your trust domain
 ([docs/auth.md](auth.md)). Instead, your backend exposes a token-exchange endpoint that
 swaps a logged-in session for a delegated JWT (`aud: ["openrails"]`,
-`delegated_sub: <your user id>`, TTL of minutes). The browser caches it and sends it as
-`Authorization: Bearer <token>` to OpenRails:
+`delegated_sub: <your user id>`, TTL of minutes; the JOSE header MUST carry
+`typ: "delegated-access+jwt"` and a `kid` resolving in your registered JWKS — a token
+without that `typ` is rejected). The browser caches it and sends it as
+`Authorization: Bearer <token>` to OpenRails. A complete minting recipe is in
+[../examples/gated-premium-page/](../examples/gated-premium-page/):
 
 ```ts
 const OPENRAILS = "https://openrails.example";

--- a/internal/controlplane/payment_settlements.go
+++ b/internal/controlplane/payment_settlements.go
@@ -2,6 +2,7 @@ package controlplane
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -10,6 +11,10 @@ import (
 	"github.com/open-rails/openrails/internal/db/gen"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
+
+// ErrPaymentSettlementNotFound indicates the settlement id does not exist
+// under the given merchant scope.
+var ErrPaymentSettlementNotFound = errors.New("controlplane: payment settlement not found for merchant")
 
 // PaymentSettlement is a durable successful-payment event for an embedding
 // host. A host should acknowledge it only after its idempotent processing
@@ -23,12 +28,20 @@ type PaymentSettlement struct {
 	SettledAt  time.Time
 }
 
-// ListPendingPaymentSettlements returns the oldest unacknowledged settlements.
-func (c *ControlPlane) ListPendingPaymentSettlements(ctx context.Context, limit int) ([]PaymentSettlement, error) {
+// ListPendingPaymentSettlements returns the oldest unacknowledged settlements
+// for one merchant. This is a privileged host seam; callers must authorize the
+// merchant ID before use.
+func (c *ControlPlane) ListPendingPaymentSettlements(ctx context.Context, merchantID merchant.ID, limit int) ([]PaymentSettlement, error) {
+	if merchantID.IsZero() {
+		return nil, errors.New("control plane: list payment settlements: merchant id is required")
+	}
 	if limit <= 0 {
 		limit = 100
 	}
-	rows, err := gen.New(c.pool).ListPendingPaymentSettlements(ctx, int64(limit))
+	rows, err := gen.New(c.pool).ListPendingPaymentSettlements(ctx, gen.ListPendingPaymentSettlementsParams{
+		MerchantID: merchantID.UUID(),
+		RowLimit:   int64(limit),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("control plane: list payment settlements: %w", err)
 	}
@@ -48,9 +61,21 @@ func (c *ControlPlane) ListPendingPaymentSettlements(ctx context.Context, limit 
 }
 
 // AcknowledgePaymentSettlement removes a settlement from the pending feed.
-func (c *ControlPlane) AcknowledgePaymentSettlement(ctx context.Context, id uuid.UUID) error {
-	if err := gen.New(c.pool).AcknowledgePaymentSettlement(ctx, id); err != nil {
+// The id must belong to the given merchant; acking another merchant's event
+// returns ErrPaymentSettlementNotFound.
+func (c *ControlPlane) AcknowledgePaymentSettlement(ctx context.Context, merchantID merchant.ID, id uuid.UUID) error {
+	if merchantID.IsZero() {
+		return errors.New("control plane: acknowledge payment settlement: merchant id is required")
+	}
+	n, err := gen.New(c.pool).AcknowledgePaymentSettlement(ctx, gen.AcknowledgePaymentSettlementParams{
+		MerchantID: merchantID.UUID(),
+		ID:         id,
+	})
+	if err != nil {
 		return fmt.Errorf("control plane: acknowledge payment settlement: %w", err)
+	}
+	if n == 0 {
+		return ErrPaymentSettlementNotFound
 	}
 	return nil
 }

--- a/internal/controlplane/payment_settlements_integration_test.go
+++ b/internal/controlplane/payment_settlements_integration_test.go
@@ -1,0 +1,157 @@
+//go:build integration
+
+package controlplane
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/db/gen"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// #827: the payment-settlements host feed must be merchant-scoped end to end —
+// the controlplane functions by explicit predicate (the controlplane pool is
+// privileged) and payment_settlement_events by fail-closed RLS for the
+// openrails_app (NOBYPASSRLS) role.
+func TestPaymentSettlementsCrossMerchantIsolation(t *testing.T) {
+	ctx := context.Background()
+	_, appDSN := dbtest.SharedRLSPostgres(t)
+	super := dbtest.SharedPGXPool(t)
+
+	appPool, err := pgxpool.New(ctx, appDSN)
+	require.NoError(t, err)
+	t.Cleanup(appPool.Close)
+
+	cfg := &config.Config{
+		Env:  "test",
+		DB:   &config.DBConfig{},
+		Auth: &config.AuthConfig{Issuer: "https://openrails.test", MintDisabled: true},
+	}
+	cp, err := New(ctx, cfg, super)
+	require.NoError(t, err)
+
+	suffix := strings.ReplaceAll(uuid.NewString(), "-", "")[:10]
+	mA, mB := uuid.New(), uuid.New()
+	custA, custB := uuid.New(), uuid.New()
+	prodA, prodB := uuid.New(), uuid.New()
+	priceA, priceB := uuid.New(), uuid.New()
+	payA, payB := uuid.New(), uuid.New()
+
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		_, err := super.Exec(ctx, sql, args...)
+		require.NoError(t, err, sql)
+	}
+	exec(`INSERT INTO openrails.merchants (id, slug, status) VALUES ($1, $2, 'active'), ($3, $4, 'active')`,
+		mA, "psiso-a-"+suffix, mB, "psiso-b-"+suffix)
+	exec(`INSERT INTO openrails.customers (id, merchant_id) VALUES ($1, $2), ($3, $4)`, custA, mA, custB, mB)
+	exec(`INSERT INTO openrails.products (id, key, display_name, merchant_id) VALUES ($1, $2, 'PS A', $3), ($4, $5, 'PS B', $6)`,
+		prodA, "psiso-pa-"+suffix, mA, prodB, "psiso-pb-"+suffix, mB)
+	exec(`INSERT INTO openrails.prices (id, product_id, amount, currency, merchant_id, auto_renew) VALUES ($1, $2, 7000000, 'usd', $3, false), ($4, $5, 9000000, 'usd', $6, false)`,
+		priceA, prodA, mA, priceB, prodB, mB)
+
+	// Insert completed payments as openrails_app under each merchant's GUC: the
+	// enqueue trigger's INSERT must pass the new fail-closed WITH CHECK.
+	insertPayment := func(mid, payID, custID, priceID uuid.UUID, amount int64) {
+		t.Helper()
+		tx, err := appPool.Begin(ctx)
+		require.NoError(t, err)
+		defer tx.Rollback(ctx) //nolint:errcheck
+		_, err = tx.Exec(ctx, `SELECT set_config('app.merchant_id', $1, true)`, mid.String())
+		require.NoError(t, err)
+		_, err = tx.Exec(ctx, `INSERT INTO openrails.payments
+			(id, merchant_id, customer_id, price_id, rail, transaction_id, amount, list_amount, currency, status)
+			VALUES ($1, $2, $3, $4, 'nmi', $5, $6, $6, 'usd', 'completed')`,
+			payID, mid, custID, priceID, "psiso-"+suffix+"-"+payID.String()[:8], amount)
+		require.NoError(t, err)
+		require.NoError(t, tx.Commit(ctx))
+	}
+	insertPayment(mA, payA, custA, priceA, 7_000_000)
+	insertPayment(mB, payB, custB, priceB, 9_000_000)
+
+	idA, idB := merchant.ID(mA), merchant.ID(mB)
+
+	// Each merchant sees exactly its own event.
+	listA, err := cp.ListPendingPaymentSettlements(ctx, idA, 10)
+	require.NoError(t, err)
+	require.Len(t, listA, 1)
+	require.Equal(t, payA, listA[0].PaymentID)
+	require.Equal(t, idA, listA[0].MerchantID)
+	require.EqualValues(t, 7_000_000, listA[0].Amount)
+
+	listB, err := cp.ListPendingPaymentSettlements(ctx, idB, 10)
+	require.NoError(t, err)
+	require.Len(t, listB, 1)
+	require.Equal(t, payB, listB[0].PaymentID)
+
+	// A cannot ack B's event; B's feed is undisturbed.
+	err = cp.AcknowledgePaymentSettlement(ctx, idA, listB[0].ID)
+	require.ErrorIs(t, err, ErrPaymentSettlementNotFound)
+	listB, err = cp.ListPendingPaymentSettlements(ctx, idB, 10)
+	require.NoError(t, err)
+	require.Len(t, listB, 1, "cross-merchant ack must not deliver B's event")
+
+	// A zero merchant id is refused outright.
+	_, err = cp.ListPendingPaymentSettlements(ctx, merchant.ID{}, 10)
+	require.Error(t, err)
+	require.Error(t, cp.AcknowledgePaymentSettlement(ctx, merchant.ID{}, listB[0].ID))
+
+	// RLS proof on the NOBYPASSRLS app role: under A's GUC only A's rows are
+	// visible and B's row cannot be acked; with no GUC the table is fail-closed.
+	appTx := func(mid *uuid.UUID, fn func(tx gen.DBTX)) {
+		t.Helper()
+		tx, err := appPool.Begin(ctx)
+		require.NoError(t, err)
+		defer tx.Rollback(ctx) //nolint:errcheck
+		if mid != nil {
+			_, err = tx.Exec(ctx, `SELECT set_config('app.merchant_id', $1, true)`, mid.String())
+			require.NoError(t, err)
+		}
+		fn(tx)
+		require.NoError(t, tx.Commit(ctx))
+	}
+	appTx(&mA, func(tx gen.DBTX) {
+		var n int
+		require.NoError(t, tx.QueryRow(ctx, `SELECT count(*) FROM openrails.payment_settlement_events WHERE merchant_id = $1`, mB).Scan(&n))
+		require.Zero(t, n, "app role under A's GUC must not see B's events")
+		require.NoError(t, tx.QueryRow(ctx, `SELECT count(*) FROM openrails.payment_settlement_events`).Scan(&n))
+		require.Equal(t, 1, n, "app role under A's GUC sees exactly A's event")
+		tag, err := tx.Exec(ctx, `UPDATE openrails.payment_settlement_events SET delivered_at = now() WHERE id = $1`, listB[0].ID)
+		require.NoError(t, err)
+		require.Zero(t, tag.RowsAffected(), "app role under A's GUC must not ack B's event")
+	})
+	appTx(nil, func(tx gen.DBTX) {
+		var n int
+		require.NoError(t, tx.QueryRow(ctx, `SELECT count(*) FROM openrails.payment_settlement_events`).Scan(&n))
+		require.Zero(t, n, "no merchant GUC must fail closed")
+	})
+
+	// B acks its own event; ack is idempotent; feed drains.
+	require.NoError(t, cp.AcknowledgePaymentSettlement(ctx, idB, listB[0].ID))
+	require.NoError(t, cp.AcknowledgePaymentSettlement(ctx, idB, listB[0].ID))
+	listB, err = cp.ListPendingPaymentSettlements(ctx, idB, 10)
+	require.NoError(t, err)
+	require.Empty(t, listB)
+
+	// Pruning (#827): only acked rows older than the cutoff go; A's pending
+	// event survives, and RLS scopes the delete to B.
+	_, err = super.Exec(ctx, `UPDATE openrails.payment_settlement_events SET delivered_at = now() - interval '31 days' WHERE payment_id = $1`, payB)
+	require.NoError(t, err)
+	appTx(&mB, func(tx gen.DBTX) {
+		n, err := gen.New(tx).DeleteDeliveredPaymentSettlementsBefore(ctx, time.Now().Add(-30*24*time.Hour))
+		require.NoError(t, err)
+		require.EqualValues(t, 1, n)
+	})
+	listA, err = cp.ListPendingPaymentSettlements(ctx, idA, 10)
+	require.NoError(t, err)
+	require.Len(t, listA, 1, "pruning acked rows must not touch pending events")
+}

--- a/internal/db/gen/payment_settlements.sql.go
+++ b/internal/db/gen/payment_settlements.sql.go
@@ -12,24 +12,53 @@ import (
 	"github.com/google/uuid"
 )
 
-const acknowledgePaymentSettlement = `-- name: AcknowledgePaymentSettlement :exec
+const acknowledgePaymentSettlement = `-- name: AcknowledgePaymentSettlement :execrows
 UPDATE openrails.payment_settlement_events
    SET delivered_at = COALESCE(delivered_at, now())
- WHERE id = $1
+ WHERE merchant_id = $1
+   AND id = $2
 `
 
-func (q *Queries) AcknowledgePaymentSettlement(ctx context.Context, id uuid.UUID) error {
-	_, err := q.db.Exec(ctx, acknowledgePaymentSettlement, id)
-	return err
+type AcknowledgePaymentSettlementParams struct {
+	MerchantID uuid.UUID
+	ID         uuid.UUID
+}
+
+func (q *Queries) AcknowledgePaymentSettlement(ctx context.Context, arg AcknowledgePaymentSettlementParams) (int64, error) {
+	result, err := q.db.Exec(ctx, acknowledgePaymentSettlement, arg.MerchantID, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const deleteDeliveredPaymentSettlementsBefore = `-- name: DeleteDeliveredPaymentSettlementsBefore :execrows
+DELETE FROM openrails.payment_settlement_events
+ WHERE delivered_at IS NOT NULL
+   AND delivered_at < $1::timestamptz
+`
+
+func (q *Queries) DeleteDeliveredPaymentSettlementsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteDeliveredPaymentSettlementsBefore, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const listPendingPaymentSettlements = `-- name: ListPendingPaymentSettlements :many
 SELECT id, merchant_id, payment_id, amount, currency, settled_at
   FROM openrails.payment_settlement_events
- WHERE delivered_at IS NULL
+ WHERE merchant_id = $1
+   AND delivered_at IS NULL
  ORDER BY id
- LIMIT $1
+ LIMIT $2
 `
+
+type ListPendingPaymentSettlementsParams struct {
+	MerchantID uuid.UUID
+	RowLimit   int64
+}
 
 type ListPendingPaymentSettlementsRow struct {
 	ID         uuid.UUID
@@ -40,8 +69,8 @@ type ListPendingPaymentSettlementsRow struct {
 	SettledAt  time.Time
 }
 
-func (q *Queries) ListPendingPaymentSettlements(ctx context.Context, limit int64) ([]ListPendingPaymentSettlementsRow, error) {
-	rows, err := q.db.Query(ctx, listPendingPaymentSettlements, limit)
+func (q *Queries) ListPendingPaymentSettlements(ctx context.Context, arg ListPendingPaymentSettlementsParams) ([]ListPendingPaymentSettlementsRow, error) {
+	rows, err := q.db.Query(ctx, listPendingPaymentSettlements, arg.MerchantID, arg.RowLimit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/merchant_conn_guard_test.go
+++ b/internal/db/merchant_conn_guard_test.go
@@ -1,0 +1,96 @@
+package db
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNoPoolInsideRunInMerchantConn guards the #826 bug class: a
+// RunInMerchantConn callback querying the raw pool (Pool()/DataPool()) instead
+// of Qx(ctx). The raw pool has no merchant GUC — under the RLS-enforced
+// openrails_app role such queries see ZERO rows fail-closed — and skips the
+// #471 schema rewrite. Lexical AST check: any zero-arg .Pool()/.DataPool()
+// call inside a function literal passed to RunInMerchantConn fails.
+func TestNoPoolInsideRunInMerchantConn(t *testing.T) {
+	root := moduleRoot(t)
+	fset := token.NewFileSet()
+	var violations []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			switch info.Name() {
+			case "vendor", ".git", ".claude", "node_modules":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return nil // non-compiling scratch files are not this test's business
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "RunInMerchantConn" {
+				return true
+			}
+			for _, arg := range call.Args {
+				fl, ok := arg.(*ast.FuncLit)
+				if !ok {
+					continue
+				}
+				ast.Inspect(fl.Body, func(m ast.Node) bool {
+					c, ok := m.(*ast.CallExpr)
+					if !ok {
+						return true
+					}
+					s, ok := c.Fun.(*ast.SelectorExpr)
+					if ok && (s.Sel.Name == "Pool" || s.Sel.Name == "DataPool") && len(c.Args) == 0 {
+						violations = append(violations, fset.Position(c.Pos()).String())
+					}
+					return true
+				})
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if len(violations) > 0 {
+		t.Fatalf("raw pool used inside RunInMerchantConn bodies (use Qx(ctx) — the raw pool has no merchant GUC, RLS returns zero rows fail-closed, and it skips the schema rewrite):\n  %s",
+			strings.Join(violations, "\n  "))
+	}
+}
+
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found above test directory")
+		}
+		dir = parent
+	}
+}

--- a/internal/db/queries/payment_settlements.sql
+++ b/internal/db/queries/payment_settlements.sql
@@ -1,11 +1,18 @@
 -- name: ListPendingPaymentSettlements :many
 SELECT id, merchant_id, payment_id, amount, currency, settled_at
   FROM openrails.payment_settlement_events
- WHERE delivered_at IS NULL
+ WHERE merchant_id = sqlc.arg(merchant_id)
+   AND delivered_at IS NULL
  ORDER BY id
- LIMIT $1;
+ LIMIT sqlc.arg(row_limit);
 
--- name: AcknowledgePaymentSettlement :exec
+-- name: AcknowledgePaymentSettlement :execrows
 UPDATE openrails.payment_settlement_events
    SET delivered_at = COALESCE(delivered_at, now())
- WHERE id = $1;
+ WHERE merchant_id = sqlc.arg(merchant_id)
+   AND id = sqlc.arg(id);
+
+-- name: DeleteDeliveredPaymentSettlementsBefore :execrows
+DELETE FROM openrails.payment_settlement_events
+ WHERE delivered_at IS NOT NULL
+   AND delivered_at < sqlc.arg(cutoff)::timestamptz;

--- a/internal/modules/money/credit_purchase.go
+++ b/internal/modules/money/credit_purchase.go
@@ -155,7 +155,7 @@ func (s *MoneyService) loadCatalogCreditPurchase(ctx context.Context, productKey
 	provider = strings.ToLower(strings.TrimSpace(provider))
 	var row catalogCreditPurchaseRow
 	err = s.db.RunInMerchantConn(ctx, func(ctx context.Context) error {
-		rows, err := s.db.Pool().Query(ctx, `
+		rows, err := s.db.Qx(ctx).Query(ctx, `
 SELECT p.key, cpp.credit_key, cb.unit, cpp.currency, cb.expires_hours, cpp.input_min, cpp.input_max, cpp.price
 FROM openrails.catalog_credit_purchase_prices cpp
 JOIN openrails.products p
@@ -218,7 +218,8 @@ func (s *MoneyService) qualifyCatalogCreditUnit(ctx context.Context, unit string
 			return "", err
 		}
 		var slug string
-		if err := s.db.Pool().QueryRow(ctx, `SELECT slug FROM openrails.merchants WHERE id = $1`, tid.UUID()).Scan(&slug); err != nil {
+		// merchants is a global (no-RLS) table, but Qx applies the #471 schema rewrite.
+		if err := s.db.Qx(ctx).QueryRow(ctx, `SELECT slug FROM openrails.merchants WHERE id = $1`, tid.UUID()).Scan(&slug); err != nil {
 			return "", err
 		}
 		unit = slug + "/" + unit

--- a/internal/modules/money/enterprise.go
+++ b/internal/modules/money/enterprise.go
@@ -228,7 +228,7 @@ func (s *MoneyService) DeletePayerRateCard(ctx context.Context, payer identity.C
 		return err
 	}
 	return s.db.RunInMerchantConn(ctx, func(ctx context.Context) error {
-		_, e := s.db.Pool().Exec(ctx, `
+		_, e := s.db.Qx(ctx).Exec(ctx, `
 DELETE FROM openrails.catalog_rate_cards
 WHERE merchant_id = $1 AND customer_id = $2 AND meter_key = $3`,
 			tid.UUID(), payer.UUID(), meterKey)

--- a/internal/modules/money/metered_rating.go
+++ b/internal/modules/money/metered_rating.go
@@ -114,7 +114,7 @@ func (s *MoneyService) sweepCatalogRateCardUsage(ctx context.Context, payer iden
 func (s *MoneyService) loadCatalogRateCards(ctx context.Context, merchantID uuid.UUID, payer identity.CustomerID, currency string) ([]catalogRateCardRow, error) {
 	var out []catalogRateCardRow
 	err := s.db.RunInMerchantConn(ctx, func(ctx context.Context) error {
-		rows, qerr := s.db.Pool().Query(ctx, `
+		rows, qerr := s.db.Qx(ctx).Query(ctx, `
 SELECT rc.id,
        rc.meter_key,
        rc.customer_id IS NOT NULL AS payer_scoped,
@@ -209,7 +209,7 @@ func (s *MoneyService) aggregateRateCardUsage(ctx context.Context, merchantID uu
 	}
 	out := map[string]int64{}
 	err := s.db.RunInMerchantConn(ctx, func(ctx context.Context) error {
-		rows, qerr := s.db.Pool().Query(ctx, `
+		rows, qerr := s.db.Qx(ctx).Query(ctx, `
 SELECT COALESCE(NULLIF(ue.metadata ->> $8, ''), NULLIF(ue.dimensions ->> $8, ''), '') AS dim_value,
        COALESCE(SUM(
            CASE WHEN $9 = 'count' THEN 1
@@ -272,7 +272,7 @@ func (s *MoneyService) accruedAllowanceUnits(ctx context.Context, merchantID uui
 
 	total := int64(0)
 	err = s.db.RunInMerchantConn(ctx, func(ctx context.Context) error {
-		rows, qerr := s.db.Pool().Query(ctx, `
+		rows, qerr := s.db.Qx(ctx).Query(ctx, `
 SELECT COALESCE(NULLIF(ue.metadata ->> $8, ''), NULLIF(ue.dimensions ->> $8, ''), '') AS dim_value,
        COALESCE(NULLIF(ue.metadata ->> $9, ''), NULLIF(ue.dimensions ->> $9, ''), '') AS resource_id,
        COALESCE(SUM(

--- a/internal/modules/money/metered_rating_rls_integration_test.go
+++ b/internal/modules/money/metered_rating_rls_integration_test.go
@@ -1,0 +1,87 @@
+//go:build integration
+
+package money_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/internal/modules/money"
+	"github.com/open-rails/openrails/pkg/identity"
+	"github.com/stretchr/testify/require"
+)
+
+// #826 regression: metered rating under the merchant-scoped path (pinned
+// connection, unprivileged openrails_app role, RLS enforced) must see the rate
+// cards and usage events and rate a NON-ZERO amount. Before the fix the
+// RunInMerchantConn bodies queried the raw pool (no GUC → zero rows
+// fail-closed) and silently rated $0.
+func TestSweepUsage_AppRoleMerchantScoped_RatesNonZero(t *testing.T) {
+	superDSN, appDSN := dbtest.SharedRLSPostgres(t)
+	ctx := context.Background()
+
+	superPool, err := pgxpool.New(ctx, superDSN)
+	require.NoError(t, err)
+	t.Cleanup(superPool.Close)
+
+	dbtest.EnsureTestMerchant(ctx, t, superPool)
+	merchantID := dbtest.TestMerchantID.UUID()
+	payer := identity.CustomerIDFromString(uuid.NewString())
+	productID := uuid.New()
+	meterKey := "rls-seconds-" + uuid.NewString()
+	eventType := "rls.usage." + uuid.NewString()
+
+	t.Cleanup(func() {
+		_, _ = superPool.Exec(ctx, "DELETE FROM openrails.invoice_items WHERE customer_id = $1", payer.UUID())
+		_, _ = superPool.Exec(ctx, "DELETE FROM openrails.metered_rating_watermarks WHERE customer_id = $1", payer.UUID())
+		_, _ = superPool.Exec(ctx, "DELETE FROM openrails.ledger_transfers WHERE customer_id = $1", payer.UUID())
+		_, _ = superPool.Exec(ctx, "DELETE FROM openrails.usage_events WHERE customer_id = $1", payer.UUID())
+		_, _ = superPool.Exec(ctx, "DELETE FROM openrails.money_settings WHERE customer_id = $1", payer.UUID())
+		_, _ = superPool.Exec(ctx, "DELETE FROM openrails.catalog_rate_cards WHERE merchant_id = $1 AND product_id = $2", merchantID, productID)
+		_, _ = superPool.Exec(ctx, "DELETE FROM openrails.catalog_meters WHERE merchant_id = $1 AND key = $2", merchantID, meterKey)
+		_, _ = superPool.Exec(ctx, "DELETE FROM openrails.products WHERE id = $1", productID)
+		_, _ = superPool.Exec(ctx, "DELETE FROM openrails.customers WHERE id = $1", payer.UUID())
+	})
+
+	// Seed catalog + usage with the RLS-bypassing super role.
+	_, err = superPool.Exec(ctx, `INSERT INTO openrails.customers (id, merchant_id) VALUES ($1, $2)`, payer.UUID(), merchantID)
+	require.NoError(t, err)
+	_, err = superPool.Exec(ctx, `INSERT INTO openrails.products (id, key, display_name, merchant_id) VALUES ($1, $2, 'RLS Rating', $3)`,
+		productID, "rls-rating-"+uuid.NewString(), merchantID)
+	require.NoError(t, err)
+	_, err = superPool.Exec(ctx, `
+INSERT INTO openrails.catalog_meters (merchant_id, key, event_type, value_property, aggregation, unit)
+VALUES ($1, $2, $3, 'seconds', 'sum', 'second')`, merchantID, meterKey, eventType)
+	require.NoError(t, err)
+	_, err = superPool.Exec(ctx, `
+INSERT INTO openrails.catalog_rate_cards (merchant_id, product_id, ordinal, meter_key, payment_term, price)
+VALUES ($1, $2, 1, $3, 'in_arrears', '{"model":"per_unit","currency":"USD","per_unit":{"unit_amount":10000}}'::jsonb)`,
+		merchantID, productID, meterKey)
+	require.NoError(t, err)
+	occurred := time.Now().UTC()
+	_, err = superPool.Exec(ctx, `
+INSERT INTO openrails.usage_events (merchant_id, customer_id, invoker_id, currency, event_type, dimensions, amount, source, source_id, occurred_at)
+VALUES ($1, $2, $3, 'USD', $4, '{"seconds": 7200}'::jsonb, 0, 'rls-826', $5, $6)`,
+		merchantID, payer.UUID(), payer.UUID().String(), eventType, uuid.NewString(), occurred)
+	require.NoError(t, err)
+
+	// Run the sweep exactly like a worker: app role + RunInMerchantConn.
+	appDB := dbtest.OpenAppDB(t, appDSN)
+	svc := money.NewMoneyService(appDB)
+	mctx := dbtest.WithTestMerchant(ctx)
+	from, to := occurred.Add(-time.Hour), occurred.Add(time.Hour)
+	require.NoError(t, appDB.RunInMerchantConn(mctx, func(ctx context.Context) error {
+		return svc.SweepUsage(ctx, payer, money.DefaultCurrency, from, to)
+	}))
+
+	var total int64
+	require.NoError(t, superPool.QueryRow(ctx, `
+SELECT COALESCE(sum(amount), 0)::bigint
+FROM openrails.invoice_items
+WHERE customer_id = $1 AND status = 'pending' AND source_id LIKE 'metered:%'`, payer.UUID()).Scan(&total))
+	require.Equal(t, int64(72_000_000), total, "7200 units x 10000 micros must rate non-zero under the app role")
+}

--- a/internal/river/jobs_cleanup.go
+++ b/internal/river/jobs_cleanup.go
@@ -32,6 +32,11 @@ type CleanupConfig struct {
 	// (openrails.webhook_events, #678) are kept. Default: 90 days — the same
 	// window as the Redis completed-key cache TTL.
 	WebhookEventRetention time.Duration
+
+	// PaymentSettlementAckedRetention is how long acknowledged (delivered)
+	// payment settlement events (#827) are kept. Default: 30 days. Pending
+	// (unacked) events are never pruned.
+	PaymentSettlementAckedRetention time.Duration
 }
 
 // DefaultCleanupConfig is the ONE defaults path (#711): worker registration
@@ -42,11 +47,13 @@ func DefaultCleanupConfig() CleanupConfig {
 		NotificationSeenRetention:   90 * 24 * time.Hour,
 		NotificationUnseenRetention: 180 * 24 * time.Hour,
 		WebhookEventRetention:       webhooks.WebhookIdempotencyTTL,
+
+		PaymentSettlementAckedRetention: 30 * 24 * time.Hour,
 	}
 }
 
 func (c CleanupConfig) validate() error {
-	if c.NotificationSeenRetention <= 0 || c.NotificationUnseenRetention <= 0 || c.WebhookEventRetention <= 0 {
+	if c.NotificationSeenRetention <= 0 || c.NotificationUnseenRetention <= 0 || c.WebhookEventRetention <= 0 || c.PaymentSettlementAckedRetention <= 0 {
 		return fmt.Errorf("cleanup worker config requires positive retentions (wire DefaultCleanupConfig()): %+v", c)
 	}
 	return nil
@@ -71,6 +78,7 @@ type CleanupResult struct {
 	NotificationsSeen       int64
 	NotificationsAll        int64
 	WebhookEvents           int64
+	PaymentSettlements      int64
 }
 
 func (w CleanupExpiredDataWorker) Work(ctx context.Context, job *river.Job[CleanupExpiredDataArgs]) error {
@@ -119,11 +127,19 @@ func (w CleanupExpiredDataWorker) Work(ctx context.Context, job *river.Job[Clean
 		cleanupErr = errors.Join(cleanupErr, err)
 	}
 
+	// 4. Retention for acked payment settlement events (#827)
+	result.PaymentSettlements, err = w.cleanupPaymentSettlements(ctx, now, config.PaymentSettlementAckedRetention)
+	if err != nil {
+		logger.WithError(err).Error("Failed to cleanup acked payment settlements")
+		cleanupErr = errors.Join(cleanupErr, err)
+	}
+
 	logger.WithFields(log.Fields{
 		"checkout_sessions_expired": result.CheckoutSessionsExpired,
 		"notifications_seen":        result.NotificationsSeen,
 		"notifications_unseen":      result.NotificationsAll,
 		"webhook_events":            result.WebhookEvents,
+		"payment_settlements":       result.PaymentSettlements,
 	}).Info("Cleanup completed")
 
 	if cleanupErr != nil {
@@ -184,6 +200,31 @@ func (w CleanupExpiredDataWorker) cleanupWebhookEvents(ctx context.Context, now 
 			return err
 		}); err != nil {
 			sweepErr = errors.Join(sweepErr, fmt.Errorf("delete webhook events for merchant %s: %w", mid, err))
+		}
+	}
+	return total, sweepErr
+}
+
+// cleanupPaymentSettlements deletes acknowledged (delivered) settlement events
+// older than the retention window (#827). RLS-scoped, so per merchant under
+// MerchantTx like cleanupWebhookEvents. Pending events are never touched.
+func (w CleanupExpiredDataWorker) cleanupPaymentSettlements(ctx context.Context, now time.Time, retention time.Duration) (int64, error) {
+	cutoff := now.Add(-retention)
+
+	merchantIDs, err := w.DB.Gen(ctx).ListActiveMerchantIDs(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("cleanup payment settlements: list merchants: %w", err)
+	}
+	var total int64
+	var sweepErr error
+	for _, mid := range merchantIDs {
+		mctx := merchant.WithID(ctx, merchant.ID(mid))
+		if err := w.DB.MerchantTx(mctx, func(ctx context.Context, tx pgx.Tx) error {
+			n, err := gen.New(tx).DeleteDeliveredPaymentSettlementsBefore(ctx, cutoff)
+			total += n
+			return err
+		}); err != nil {
+			sweepErr = errors.Join(sweepErr, fmt.Errorf("delete payment settlements for merchant %s: %w", mid, err))
 		}
 	}
 	return total, sweepErr

--- a/migrations/postgres/0010_payment_settlement_events_rls.down.sql
+++ b/migrations/postgres/0010_payment_settlement_events_rls.down.sql
@@ -1,0 +1,3 @@
+DROP POLICY merchant_isolation ON openrails.payment_settlement_events;
+ALTER TABLE ONLY openrails.payment_settlement_events NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE openrails.payment_settlement_events DISABLE ROW LEVEL SECURITY;

--- a/migrations/postgres/0010_payment_settlement_events_rls.up.sql
+++ b/migrations/postgres/0010_payment_settlement_events_rls.up.sql
@@ -1,0 +1,13 @@
+-- #827: payment_settlement_events (0005, #165 host feed) shipped without RLS —
+-- in a shared DB any openrails_app connection could read/ack every merchant's
+-- settlement events. Fail-closed merchant_isolation, same pattern as 0001/0002.
+
+ALTER TABLE openrails.payment_settlement_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ONLY openrails.payment_settlement_events FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY merchant_isolation ON openrails.payment_settlement_events USING ((merchant_id = (NULLIF(current_setting('app.merchant_id'::text, true), ''::text))::uuid)) WITH CHECK ((merchant_id = (NULLIF(current_setting('app.merchant_id'::text, true), ''::text))::uuid));
+
+-- RLS-exemption markers (audited by TestRLSExemptionsAreClassifiedAndReviewed):
+-- deliberately-global tables must say so explicitly.
+COMMENT ON TABLE openrails.merchants IS 'Merchant / billing-namespace directory: a dumb billing bucket (whose books a row goes on). GLOBAL (control-plane) table, not tenant-scoped. Carries ONLY billing/money-rail state, NO auth. Merchants are registered explicitly; there is no default merchant. RLS-exempt by design: it IS the tenant directory — the scope, not a scoped row.';
+COMMENT ON TABLE openrails.worker_health IS '#689 per-River-worker-kind health: last success/error + failure streak, written by the worker middleware. Operator-global control-plane table. RLS-exempt by design: process health per worker kind, not tenant data.';

--- a/migrations/postgres/merchant_aware_schema_test.go
+++ b/migrations/postgres/merchant_aware_schema_test.go
@@ -2,81 +2,50 @@ package postgresmigrations
 
 import (
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
 )
 
-// Merchant-owned tables that the consolidated schema must scope by merchant_id
-// (issue #223). Kept in sync with the merchant_isolation policies in 001.
-// Updated after squashing 001..068 (rail_* renames per #683; catalog/metering
-// sidecars, webhook_events, customer_minimum_spend, metered_rating_watermarks
-// added along the chain).
-var merchantOwnedTables = []string{
-	"customers",
-	"merchant_deks",
-	"merchant_secrets",
-	"merchant_exports",
-	"products",
-	"prices",
-	"payment_methods",
-	"subscriptions",
-	"payments",
-	"checkout_sessions",
-	"solana_subscriptions",
-	"entitlements",
-	"invoices",
-	"invoice_items",
-	"invoice_payments",
-	"notification_queue",
-	"rail_customer_accounts",
-	"rail_mutation_logs",
-	"grants",
-	"ledger_accounts",
-	"ledger_transfers",
-	"rail_merchant_accounts",
-	"rail_intents",
-	"rail_refresh_watermarks",
-	"reconciliation_state",
-	// #472: money ledger replaced the credit_* tables. money_balances dropped (#491).
-	"invoker_spend_limits",
-	"payer_spend_limits",
-	"tier_schedules",
-	"merchant_configurations",
-	"usage_events",
-	"catalog_drift_events",
-	"reconciliation_runs",
-	"reconciliation_findings",
-	"money_settings",
-	"custom_credit_types",
-	// #594/#599/#638/#639/#640 catalog + metering sidecars
-	"catalog_usage_limits",
-	"product_usage_limit_bindings",
-	"catalog_meters",
-	"product_includes",
-	"product_usage_limits",
-	"catalog_rate_cards",
-	"catalog_credit_balances",
-	"catalog_credit_purchase_prices",
-	"customer_minimum_spend",
-	"metered_rating_watermarks",
-	// #678 webhook dedup truth
-	"webhook_events",
-	// added by 0002-0014, folded into the 0001 baseline (2026-07-07 squash)
-	"imported_dunning_history",
-	"subscription_status_transitions",
-	"admission_denials_hourly",
-	"dashboard_configs",
-	"alert_rules",
-	"merchant_webhooks",
-	"merchant_notifications",
-	"price_key_movements",
-	"reprice_batches",
-	"subscription_reprices",
-	"finding_digest_state",
-	"webhook_health",
-	"webhook_health_daily",
+// RLS guard (SEC-16). The rule: every openrails table is merchant-scoped with a
+// merchant_isolation policy, or it is an explicitly classified global table.
+//
+// The table list is DERIVED from every migration's SQL, not hand-maintained —
+// the previous hardcoded list only covered 0001, so a merchant-scoped table
+// added in a later migration escaped enforcement silently (0005's
+// payment_settlement_events shipped with merchant_id and no RLS; nothing
+// failed). Exemptions are declared IN the schema as a
+// `COMMENT ON TABLE ... 'RLS-exempt by design: ...'` marker, and the exempt set
+// is additionally asserted by name below so widening it requires review here.
+var rlsExemptTables = []string{
+	"merchants",      // the tenant directory itself — the scope, not a scoped row
+	"probe_verdicts", // instance-level credential state
+	"worker_health",  // per-worker-kind process health
 }
 
+// minMerchantScopedTables guards against a vacuous pass: if the SQL parsing
+// below ever breaks, the derived set collapses and every loop becomes a no-op.
+const minMerchantScopedTables = 60
+
+// rlsExemptMarker is the machine-checkable classification a table COMMENT must
+// carry to opt out of merchant isolation.
+const rlsExemptMarker = "RLS-exempt by design:"
+
+var (
+	reCreateTable   = regexp.MustCompile(`(?s)CREATE TABLE (?:IF NOT EXISTS )?openrails\.([a-z0-9_]+) \((.*?)\n\);`)
+	reMerchantIDCol = regexp.MustCompile(`(?m)^\s*merchant_id\s+uuid`)
+	reAddMerchantID = regexp.MustCompile(`(?s)ALTER TABLE (?:ONLY )?openrails\.([a-z0-9_]+)[^;]*?ADD COLUMN\s+merchant_id\s+uuid`)
+	reDropTable     = regexp.MustCompile(`DROP TABLE (?:IF EXISTS )?openrails\.([a-z0-9_]+)`)
+	reRenameTable   = regexp.MustCompile(`ALTER TABLE (?:ONLY )?openrails\.([a-z0-9_]+) RENAME TO ([a-z0-9_]+)`)
+	reEnableRLS     = regexp.MustCompile(`ALTER TABLE (?:ONLY )?openrails\.([a-z0-9_]+) ENABLE ROW LEVEL SECURITY`)
+	reForceRLS      = regexp.MustCompile(`ALTER TABLE (?:ONLY )?openrails\.([a-z0-9_]+) FORCE ROW LEVEL SECURITY`)
+	rePolicy        = regexp.MustCompile(`CREATE POLICY merchant_isolation ON openrails\.([a-z0-9_]+)`)
+	reDropPolicy    = regexp.MustCompile(`DROP POLICY (?:IF EXISTS )?merchant_isolation ON openrails\.([a-z0-9_]+)`)
+	reExemptComment = regexp.MustCompile(`(?s)COMMENT ON TABLE openrails\.([a-z0-9_]+) IS '((?:[^']|'')*)'`)
+)
+
+// loadSchema001 reads the consolidated baseline alone (invariants that are
+// specifically about the baseline's shape).
 func loadSchema001(t *testing.T) string {
 	t.Helper()
 	b, err := FS.ReadFile("0001_schema.up.sql")
@@ -84,6 +53,137 @@ func loadSchema001(t *testing.T) string {
 		t.Fatalf("read 0001_schema.up.sql: %v", err)
 	}
 	return string(b)
+}
+
+// loadAllSchema concatenates every up migration in apply order — the schema as
+// deployed, which is what the RLS guard must reason about.
+func loadAllSchema(t *testing.T) string {
+	t.Helper()
+	entries, err := FS.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read migrations dir: %v", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".up.sql") {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names) // zero-padded prefixes => lexical order == apply order
+	if len(names) == 0 {
+		t.Fatal("no *.up.sql migrations found")
+	}
+	var b strings.Builder
+	for _, n := range names {
+		c, err := FS.ReadFile(n)
+		if err != nil {
+			t.Fatalf("read %s: %v", n, err)
+		}
+		b.Write(c)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// schemaTables is the derived table inventory of the deployed schema, keyed by
+// each table's FINAL name (renames are folded in — RLS state travels with a
+// RENAME, so the sets must too).
+type schemaTables struct {
+	blocks          map[string]string // live openrails tables -> CREATE TABLE body
+	merchantScoped  map[string]bool   // carry a merchant_id column
+	enable          map[string]bool   // ENABLE ROW LEVEL SECURITY
+	force           map[string]bool   // FORCE ROW LEVEL SECURITY
+	policy          map[string]bool   // merchant_isolation policy
+	rlsExemptMarked map[string]bool   // classified RLS-exempt by a table COMMENT
+}
+
+func deriveSchemaTables(t *testing.T, schema string) schemaTables {
+	t.Helper()
+	s := schemaTables{
+		blocks:          map[string]string{},
+		merchantScoped:  map[string]bool{},
+		enable:          map[string]bool{},
+		force:           map[string]bool{},
+		policy:          map[string]bool{},
+		rlsExemptMarked: map[string]bool{},
+	}
+	for _, m := range reCreateTable.FindAllStringSubmatch(schema, -1) {
+		s.blocks[m[1]] = m[2]
+		if reMerchantIDCol.MatchString(m[2]) {
+			s.merchantScoped[m[1]] = true
+		}
+	}
+	for _, m := range reAddMerchantID.FindAllStringSubmatch(schema, -1) {
+		s.merchantScoped[m[1]] = true
+	}
+	for _, m := range reDropTable.FindAllStringSubmatch(schema, -1) {
+		delete(s.blocks, m[1])
+		delete(s.merchantScoped, m[1])
+	}
+	for _, m := range reEnableRLS.FindAllStringSubmatch(schema, -1) {
+		s.enable[m[1]] = true
+	}
+	for _, m := range reForceRLS.FindAllStringSubmatch(schema, -1) {
+		s.force[m[1]] = true
+	}
+	for _, m := range rePolicy.FindAllStringSubmatch(schema, -1) {
+		s.policy[m[1]] = true
+	}
+	for _, m := range reDropPolicy.FindAllStringSubmatch(schema, -1) {
+		delete(s.policy, m[1])
+	}
+	for _, m := range reExemptComment.FindAllStringSubmatch(schema, -1) {
+		if strings.Contains(m[2], rlsExemptMarker) {
+			s.rlsExemptMarked[m[1]] = true
+		}
+	}
+	for _, m := range reRenameTable.FindAllStringSubmatch(schema, -1) {
+		s.rename(m[1], m[2])
+	}
+	return s
+}
+
+// rename folds old into new across every set: Postgres carries RLS state,
+// policies and comments through an ALTER TABLE ... RENAME TO.
+func (s schemaTables) rename(old, next string) {
+	if body, ok := s.blocks[old]; ok {
+		s.blocks[next] = body
+		delete(s.blocks, old)
+	}
+	for _, m := range []map[string]bool{s.merchantScoped, s.enable, s.force, s.policy, s.rlsExemptMarked} {
+		if m[old] {
+			m[next] = true
+			delete(m, old)
+		}
+	}
+}
+
+// missingRLS lists the RLS pieces tbl lacks.
+func (s schemaTables) missingRLS(tbl string) []string {
+	var missing []string
+	if !s.enable[tbl] {
+		missing = append(missing, "ENABLE ROW LEVEL SECURITY")
+	}
+	if !s.force[tbl] {
+		missing = append(missing, "FORCE ROW LEVEL SECURITY")
+	}
+	if !s.policy[tbl] {
+		missing = append(missing, "CREATE POLICY merchant_isolation")
+	}
+	return missing
+}
+
+// merchantOwnedTables returns the merchant-scoped tables the deployed schema
+// declares (sorted). Other schema tests consume it instead of a static list.
+func merchantOwnedTables(t *testing.T) []string {
+	t.Helper()
+	s := deriveSchemaTables(t, loadAllSchema(t))
+	out := make([]string, 0, len(s.merchantScoped))
+	for tbl := range s.merchantScoped {
+		out = append(out, tbl)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // #336: there is no default merchant. The consolidated schema creates the
@@ -100,40 +200,91 @@ func TestConsolidatedSchemaHasNoDefaultMerchant(t *testing.T) {
 	}
 }
 
-func TestConsolidatedSchemaMerchantIDColumns(t *testing.T) {
-	c := loadSchema001(t)
+func TestSchemaMerchantIDColumns(t *testing.T) {
+	c := loadAllSchema(t)
 
 	if strings.Contains(c, "WHERE merchant_id IS NULL") {
-		t.Error("consolidated schema must not contain merchant_id backfill logic")
+		t.Error("schema must not contain merchant_id backfill logic")
 	}
 	if strings.Contains(c, "merchant_id uuid NOT NULL DEFAULT") {
-		t.Error("consolidated schema must not default merchant_id")
+		t.Error("schema must not default merchant_id")
 	}
 	if strings.Contains(c, "current_setting('app.merchant_id'::text, true), ''::text))::uuid,") {
-		t.Error("consolidated schema must not default merchant_id from app.merchant_id")
+		t.Error("schema must not default merchant_id from app.merchant_id")
 	}
-	for _, tbl := range merchantOwnedTables {
-		wantTable := "CREATE TABLE openrails." + tbl
-		if !strings.Contains(c, wantTable) {
-			t.Errorf("001 schema missing merchant-owned table %q", tbl)
+	for tbl, body := range deriveSchemaTables(t, c).blocks {
+		if reMerchantIDCol.MatchString(body) && !strings.Contains(body, "merchant_id uuid NOT NULL") {
+			t.Errorf("merchant-owned table %q must declare merchant_id uuid NOT NULL", tbl)
 		}
-		if !strings.Contains(tableBlock(t, c, tbl), "merchant_id uuid NOT NULL") {
-			t.Errorf("001 schema merchant-owned table %q must declare merchant_id uuid NOT NULL", tbl)
+	}
+}
+
+// TestEveryMerchantIDTableRequiresRLS is the guard: derived from ALL migrations,
+// so a merchant-scoped table added in any future migration must ship RLS.
+func TestEveryMerchantIDTableRequiresRLS(t *testing.T) {
+	c := loadAllSchema(t)
+	s := deriveSchemaTables(t, c)
+
+	if len(s.merchantScoped) < minMerchantScopedTables {
+		t.Fatalf("derived only %d merchant-scoped tables (< %d): schema parsing is broken, the guard would pass vacuously",
+			len(s.merchantScoped), minMerchantScopedTables)
+	}
+	// Sentinels from migrations beyond the baseline: proves later migrations are
+	// actually being read.
+	for _, tbl := range []string{"payments", "customer_invoice_profiles", "payment_settlement_events"} {
+		if !s.merchantScoped[tbl] {
+			t.Fatalf("expected %q in the derived merchant-scoped set", tbl)
 		}
-		if !strings.Contains(c, "ALTER TABLE ONLY openrails."+tbl+" FORCE ROW LEVEL SECURITY") {
-			t.Errorf("001 schema missing FORCE ROW LEVEL SECURITY for %q", tbl)
+	}
+
+	for tbl := range s.merchantScoped {
+		if s.rlsExemptMarked[tbl] {
+			continue
 		}
-		if !strings.Contains(c, "ALTER TABLE openrails."+tbl+" ENABLE ROW LEVEL SECURITY") {
-			t.Errorf("001 schema missing ENABLE ROW LEVEL SECURITY for %q", tbl)
+		if missing := s.missingRLS(tbl); len(missing) > 0 {
+			t.Errorf("merchant-scoped table %q missing %v — every merchant_id table needs the standard "+
+				"merchant_isolation RLS, or an explicit '%s ...' table COMMENT", tbl, missing, rlsExemptMarker)
 		}
-		if !strings.Contains(c, "CREATE POLICY merchant_isolation ON openrails."+tbl) {
-			t.Errorf("001 schema missing merchant_isolation policy for %q", tbl)
+	}
+}
+
+// TestRLSExemptionsAreClassifiedAndReviewed: every table without a
+// merchant_isolation policy must declare itself RLS-exempt in a table COMMENT,
+// and the exempt set must be exactly the reviewed list — a new global table
+// fails here until it is added deliberately.
+func TestRLSExemptionsAreClassifiedAndReviewed(t *testing.T) {
+	s := deriveSchemaTables(t, loadAllSchema(t))
+
+	var unpoliced []string
+	for tbl := range s.blocks {
+		if !s.policy[tbl] {
+			unpoliced = append(unpoliced, tbl)
+		}
+	}
+	sort.Strings(unpoliced)
+
+	want := append([]string{}, rlsExemptTables...)
+	sort.Strings(want)
+	if strings.Join(unpoliced, ",") != strings.Join(want, ",") {
+		t.Errorf("tables without a merchant_isolation policy = %v, reviewed exemption list = %v; "+
+			"a merchant-scoped table needs RLS, a global one needs adding here plus an '%s ...' table COMMENT",
+			unpoliced, want, rlsExemptMarker)
+	}
+	for _, tbl := range rlsExemptTables {
+		if _, ok := s.blocks[tbl]; !ok {
+			t.Errorf("exempt table %q does not exist in the schema", tbl)
+		}
+		if !s.rlsExemptMarked[tbl] {
+			t.Errorf("exempt table %q lacks a COMMENT ON TABLE ... '%s ...' marker", tbl, rlsExemptMarker)
+		}
+		if s.merchantScoped[tbl] {
+			t.Errorf("exempt table %q carries merchant_id: it is tenant data and must be RLS-protected", tbl)
 		}
 	}
 }
 
 func TestConsolidatedSchemaClassifiesGlobalTables(t *testing.T) {
-	c := loadSchema001(t)
+	c := loadAllSchema(t)
 	for _, want := range []string{
 		"COMMENT ON TABLE openrails.merchants IS 'Merchant / billing-namespace directory",
 		"GLOBAL (control-plane) table",
@@ -141,7 +292,7 @@ func TestConsolidatedSchemaClassifiesGlobalTables(t *testing.T) {
 		"RLS-exempt by design: instance-level credential state, not tenant data",
 	} {
 		if !strings.Contains(c, want) {
-			t.Errorf("001 schema missing global/control-plane table classification %q", want)
+			t.Errorf("schema missing global/control-plane table classification %q", want)
 		}
 	}
 }
@@ -157,55 +308,6 @@ func TestConsolidatedSchemaHasNoMerchantSettingsTable(t *testing.T) {
 	if !strings.Contains(c, "CREATE POLICY merchant_isolation ON openrails.merchant_configurations") {
 		t.Error("merchant_configurations must remain RLS protected")
 	}
-}
-
-func TestEveryMerchantIDTableRequiresRLS(t *testing.T) {
-	c := loadSchema001(t)
-	covered := make(map[string]bool, len(merchantOwnedTables))
-	for _, tbl := range merchantOwnedTables {
-		covered[tbl] = true
-	}
-	for tbl, body := range createTableBlocks(c) {
-		if !strings.Contains(body, "merchant_id") {
-			continue
-		}
-		if !covered[tbl] {
-			t.Errorf("table %q has merchant_id but is not listed in merchantOwnedTables", tbl)
-			continue
-		}
-		for _, want := range []string{
-			"ALTER TABLE ONLY openrails." + tbl + " FORCE ROW LEVEL SECURITY",
-			"ALTER TABLE openrails." + tbl + " ENABLE ROW LEVEL SECURITY",
-			"CREATE POLICY merchant_isolation ON openrails." + tbl,
-		} {
-			if !strings.Contains(c, want) {
-				t.Errorf("merchant_id table %q missing %q", tbl, want)
-			}
-		}
-	}
-	for _, tbl := range merchantOwnedTables {
-		if _, ok := createTableBlocks(c)[tbl]; !ok {
-			t.Errorf("merchantOwnedTables includes missing table %q", tbl)
-		}
-	}
-}
-
-func createTableBlocks(schema string) map[string]string {
-	re := regexp.MustCompile(`(?s)CREATE TABLE openrails\.([a-z0-9_]+) \((.*?)\n\);`)
-	out := map[string]string{}
-	for _, m := range re.FindAllStringSubmatch(schema, -1) {
-		out[m[1]] = m[2]
-	}
-	return out
-}
-
-func tableBlock(t *testing.T, schema, table string) string {
-	t.Helper()
-	block, ok := createTableBlocks(schema)[table]
-	if !ok {
-		t.Fatalf("missing CREATE TABLE block for %s", table)
-	}
-	return block
 }
 
 func TestConsolidatedSchemaUsesCustomerUniques(t *testing.T) {

--- a/migrations/postgres/merchant_rls_encryption_schema_test.go
+++ b/migrations/postgres/merchant_rls_encryption_schema_test.go
@@ -24,17 +24,22 @@ func TestConsolidatedSchemaEnablesRLSAndAppRole(t *testing.T) {
 	}
 }
 
-func TestConsolidatedSchemaCoversTenantOwnedRLSTables(t *testing.T) {
-	c := loadSchema001(t)
-	tables := append([]string{}, merchantOwnedTables...)
-	tables = append(tables,
+// Named sentinels on top of the derived guard in merchant_aware_schema_test.go:
+// these tables must always be merchant-isolated, whatever the derivation says.
+func TestSchemaCoversTenantOwnedRLSTables(t *testing.T) {
+	s := deriveSchemaTables(t, loadAllSchema(t))
+	for _, tbl := range []string{
 		"usage_events",
 		"invoices",
 		"payer_spend_limits",
-	)
-	for _, tbl := range tables {
-		if !strings.Contains(c, "CREATE POLICY merchant_isolation ON openrails."+tbl) {
-			t.Errorf("001 schema missing RLS policy for %q", tbl)
+		"payments",
+		"customers",
+		"merchant_secrets",
+		"payment_settlement_events",
+		"psps", // renamed from rail_merchant_accounts in 0003: RLS state follows the rename
+	} {
+		if missing := s.missingRLS(tbl); len(missing) > 0 {
+			t.Errorf("schema missing RLS %v for %q", missing, tbl)
 		}
 	}
 }

--- a/pkg/embedded/controlplane/payment_settlements.go
+++ b/pkg/embedded/controlplane/payment_settlements.go
@@ -8,28 +8,34 @@ import (
 
 	"github.com/open-rails/openrails/internal/app"
 	internalcp "github.com/open-rails/openrails/internal/controlplane"
+	"github.com/open-rails/openrails/pkg/merchant"
 )
 
 // PaymentSettlement is a durable successful-payment event for an embedding
 // host.
 type PaymentSettlement = internalcp.PaymentSettlement
 
+// ErrPaymentSettlementNotFound indicates the settlement id does not exist
+// under the given merchant scope.
+var ErrPaymentSettlementNotFound = internalcp.ErrPaymentSettlementNotFound
+
 // ListPendingPaymentSettlements returns successful payments not yet
-// acknowledged by the embedding host.
-func ListPendingPaymentSettlements(ctx context.Context, a *app.App, limit int) ([]PaymentSettlement, error) {
+// acknowledged by the embedding host, scoped to one merchant. This is a
+// privileged host seam; callers must authorize the merchant ID before use.
+func ListPendingPaymentSettlements(ctx context.Context, a *app.App, id merchant.ID, limit int) ([]PaymentSettlement, error) {
 	cp := Get(a)
 	if cp == nil {
 		return nil, fmt.Errorf("control plane: no control plane attached (call Attach first)")
 	}
-	return cp.ListPendingPaymentSettlements(ctx, limit)
+	return cp.ListPendingPaymentSettlements(ctx, id, limit)
 }
 
-// AcknowledgePaymentSettlement marks one event as processed by the embedding
-// host.
-func AcknowledgePaymentSettlement(ctx context.Context, a *app.App, id uuid.UUID) error {
+// AcknowledgePaymentSettlement marks one of the merchant's events as processed
+// by the embedding host.
+func AcknowledgePaymentSettlement(ctx context.Context, a *app.App, id merchant.ID, settlementID uuid.UUID) error {
 	cp := Get(a)
 	if cp == nil {
 		return fmt.Errorf("control plane: no control plane attached (call Attach first)")
 	}
-	return cp.AcknowledgePaymentSettlement(ctx, id)
+	return cp.AcknowledgePaymentSettlement(ctx, id, settlementID)
 }

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -139,7 +139,7 @@ type CheckoutPayment struct {
 // CheckoutSession represents a checkout session.
 type CheckoutSession struct {
 	ID             string
-	Status         string // "open", "complete", "expired"
+	Status         string // "created", "requires_action", "succeeded", "failed", "expired"
 	Mode           string // "subscription", "one_off"
 	PriceID        string
 	Amount         int64


### PR DESCRIPTION
Three strands, all review-driven:

- **#826**: the Pool()-inside-RunInMerchantConn RLS-bypass class — six sites fixed (metered rating silently rated \$0 under the app role; payer-rate-card delete silently no-oped), plus an AST-based guard test that fails on any future instance, and an integration test proving non-zero rating under the unprivileged role (bidirectionally verified).
- **#827**: the payment-settlements host feed (PR #165 follow-up) — merchant.ID parameters + predicates, fail-closed RLS policy on payment_settlement_events (migration 0010), 30-day acked-row pruning, cross-merchant isolation integration test. Schema-audit tests now cover ALL migrations (the gap that let #165 ship unpoliced) and RLS-exempt tables must carry explicit exemption comments.
- **Docs/marketing**: README gains Features additions, Who Uses OpenRails archetypes, Failed Payments Are a Revenue Line, and Technical Guarantees; new docs/batch-import.md (legacy-migration playbook); delegated-JWT typ-header requirement documented; assorted doc-rot fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)