### PR TITLE
or#817: Solana charges honor configured token decimals (mispricing fix)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -955,7 +955,25 @@ type AuthConfig struct {
 type TokenConfig struct {
 	Mint     string `json:"mint"`     // Token mint address accepted on the configured Solana network.
 	Name     string `json:"name"`     // Token name.
-	Decimals int    `json:"decimals"` // Token decimal places.
+	Decimals int    `json:"decimals"` // Token base-unit precision; REQUIRED (see ValidateTokenDecimals).
+}
+
+// Token base-unit precision bounds. SPL mints top out at 9 in practice; the
+// slack guards the 10^n rescale against absurd configuration.
+const (
+	MinTokenDecimals = 1
+	MaxTokenDecimals = 18
+)
+
+// ValidateTokenDecimals rejects an unusable base-unit precision. Zero is
+// rejected on purpose (#817): an OMITTED `decimals` decodes as 0, and treating
+// that as whole-token precision silently misprices every charge by 10^6.
+func ValidateTokenDecimals(symbol string, decimals int) error {
+	if decimals < MinTokenDecimals || decimals > MaxTokenDecimals {
+		return fmt.Errorf("solana token %s: decimals must be %d..%d (got %d) — declare it in the merchant's solana tokens config",
+			symbol, MinTokenDecimals, MaxTokenDecimals, decimals)
+	}
+	return nil
 }
 
 // RateLimitsConfig is a map of endpoint identifier -> rate limit config

--- a/config/solana_settings.go
+++ b/config/solana_settings.go
@@ -186,8 +186,8 @@ func settingTokens(raw any) (map[string]TokenConfig, error) {
 		if strings.TrimSpace(token.Mint) == "" {
 			return nil, fmt.Errorf("solana settings: tokens.%s requires mint", symbol)
 		}
-		if token.Decimals < 0 {
-			return nil, fmt.Errorf("solana settings: tokens.%s decimals must be >= 0", symbol)
+		if err := ValidateTokenDecimals(symbol, token.Decimals); err != nil {
+			return nil, fmt.Errorf("solana settings: tokens.%s: %w", symbol, err)
 		}
 		out[symbol] = token
 	}

--- a/docs/rails/solana.md
+++ b/docs/rails/solana.md
@@ -41,6 +41,8 @@ psps:
         rpc_provider: helius     # helius | public; empty defaults to helius
         rpc_api_key: replace-with-helius-api-key   # forbidden with rpc_provider: public
         tokens:                  # accepted tokens: SYMBOL -> { name, mint, decimals }
+                                 # decimals is REQUIRED (the mint's base-unit precision);
+                                 # it scales every charge, so omitting it is rejected.
           SOL:  { name: Solana,   mint: So11111111111111111111111111111111111111112, decimals: 9 }
           USDC: { name: USD Coin, mint: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v, decimals: 6 }
       secrets:

--- a/internal/http/handlers/solana_recurring.go
+++ b/internal/http/handlers/solana_recurring.go
@@ -382,7 +382,8 @@ func resolveSolanaTierChange(r *httprequest.Request, subscriptionID uuid.UUID, n
 
 	if isUpgrade {
 		// Model-B prorated first charge (new_full - old_unused) in micros, then
-		// micros -> stablecoin base units at the $1 peg (depeg failsafe inside).
+		// micros -> base units at the token's CONFIGURED decimals (#817), $1 peg
+		// (depeg failsafe inside).
 		firstChargeMicros, _ := checkout.CalculateModelBUpgradeCharge(
 			oldPrice.Amount,
 			newPrice.Amount,
@@ -390,9 +391,16 @@ func resolveSolanaTierChange(r *httprequest.Request, subscriptionID uuid.UUID, n
 			newPrice.RecurringCycleHours(),
 			nowOrDefault(r),
 		)
-		firstChargeBaseUnits := solanamodule.FiatMicrosToStablecoinBaseUnits(
-			r.Request.Context(), moneyutil.Micros(firstChargeMicros), newTerms.mintSymbol, r.State.SolanaPriceProvider,
+		decimals, err := solanamodule.RequireTokenDecimals(r.Request.Context(), r.State.RailConfigs, newTerms.mintSymbol)
+		if err != nil {
+			return nil, http.StatusInternalServerError, err.Error()
+		}
+		firstChargeBaseUnits, err := solanamodule.FiatMicrosToStablecoinBaseUnits(
+			r.Request.Context(), moneyutil.Micros(firstChargeMicros), newTerms.mintSymbol, decimals, r.State.SolanaPriceProvider,
 		)
+		if err != nil {
+			return nil, http.StatusInternalServerError, err.Error()
+		}
 		// A genuine upgrade can round to 0 base units only when the unused old credit
 		// fully covers the new price; we still need a non-zero pull to activate the
 		// new on-chain subscription, so charge the smallest unit (a fraction of a

--- a/internal/http/handlers/solana_supported_tokens.go
+++ b/internal/http/handlers/solana_supported_tokens.go
@@ -8,7 +8,6 @@ import (
 	solanarpc "github.com/open-rails/openrails/internal/integrations/solana"
 	"github.com/open-rails/openrails/internal/railresolve"
 	"github.com/open-rails/openrails/pkg/merchant"
-	"math"
 	"net/http"
 	"sort"
 	"strings"
@@ -418,7 +417,7 @@ func calculateQuoteForToken(ctx context.Context, r *httprequest.Request, tokenSy
 	}
 
 	return &TokenQuote{
-		Amount:        fmt.Sprintf("%.6f", quote.Decimal),
+		Amount:        quote.Amount, // rendered from Units (integer), display only
 		Units:         quote.Units,
 		TokenPriceUSD: quote.TokenPriceUSD,
 		FXRate:        quote.FXRate,
@@ -437,11 +436,8 @@ func calculateBalanceForToken(tokenSymbol string, tokenCfg config.TokenConfig, m
 		units = balances[mint]
 	}
 
-	scale := math.Pow10(tokenCfg.Decimals)
-	amount := float64(units) / scale
-
 	return &TokenBalance{
-		Amount:     fmt.Sprintf("%.6f", amount),
+		Amount:     solanamodule.FormatBaseUnits(units, tokenCfg.Decimals), // display only
 		Units:      units,
 		Sufficient: false,
 	}

--- a/internal/integrationharness/solana_money_movement_proof_test.go
+++ b/internal/integrationharness/solana_money_movement_proof_test.go
@@ -185,7 +185,8 @@ func TestSolanaDevnetMoneyMovementProof(t *testing.T) {
 	reference, err := solanaint.GenerateReference()
 	require.NoError(t, err, "generate Solana Pay reference id")
 
-	tokenUnits := solanamod.FiatMicrosToStablecoinBaseUnits(ctx, moneyutil.Micros(priceMicros), "USDC", nil)
+	tokenUnits, err := solanamod.FiatMicrosToStablecoinBaseUnits(ctx, moneyutil.Micros(priceMicros), "USDC", 6, nil)
+	require.NoError(t, err)
 	require.Equal(t, uint64(19_990_000), tokenUnits, "$19.99 in micro-USD at the $1 USDC peg = 19.99 USDC base units")
 
 	rpcClient := solanaint.NewRPCClientWithConfig(solanaint.RPCClientConfig{Network: "devnet"})

--- a/internal/modules/checkout/session_service.go
+++ b/internal/modules/checkout/session_service.go
@@ -1499,7 +1499,14 @@ func (s *CheckoutSessionService) resolveSolanaTierChange(ctx context.Context, ol
 			newPrice.RecurringCycleHours(),
 			s.now(),
 		)
-		firstChargeBaseUnits := solanamodule.FiatMicrosToStablecoinBaseUnits(ctx, moneyutil.Micros(firstChargeMicros), newTerms.mintSymbol, s.priceProvider)
+		decimals, err := solanamodule.RequireTokenDecimals(ctx, s.rails, newTerms.mintSymbol)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrCheckoutSessionValidation, err)
+		}
+		firstChargeBaseUnits, err := solanamodule.FiatMicrosToStablecoinBaseUnits(ctx, moneyutil.Micros(firstChargeMicros), newTerms.mintSymbol, decimals, s.priceProvider)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrCheckoutSessionValidation, err)
+		}
 		if firstChargeBaseUnits == 0 {
 			firstChargeBaseUnits = 1
 		}

--- a/internal/modules/checkout/solana_upgrade_proration_test.go
+++ b/internal/modules/checkout/solana_upgrade_proration_test.go
@@ -73,11 +73,53 @@ func TestSolanaUpgradeReducedFirstCharge(t *testing.T) {
 			if tt.wantFirstMicros < tt.newFull && firstMicros >= tt.newFull {
 				t.Fatalf("expected a REDUCED first charge below the full new price")
 			}
-			gotUnits := solanamodule.FiatMicrosToStablecoinBaseUnits(ctx, moneyutil.Micros(firstMicros), "USDC", nil)
+			gotUnits, err := solanamodule.FiatMicrosToStablecoinBaseUnits(ctx, moneyutil.Micros(firstMicros), "USDC", 6, nil)
+			if err != nil {
+				t.Fatalf("convert first charge: %v", err)
+			}
 			if gotUnits != tt.wantBaseUnits {
 				t.Fatalf("first pull base units: expected %d, got %d", tt.wantBaseUnits, gotUnits)
 			}
 		})
+	}
+}
+
+// TestSolanaUpgradeFirstChargeHonoursTokenDecimals pins #817 on the
+// recurring/first-charge path: the SAME prorated micros must become different
+// base units per the merchant's configured token decimals. The old code
+// hardcoded 6, so a 9-decimal mint pulled 1/1000th of the intended charge.
+func TestSolanaUpgradeFirstChargeHonoursTokenDecimals(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+	cycle := 30 * 24
+
+	// $20 -> $50 with 28 days left => 31_330_000 micros (see above).
+	firstMicros, _ := CalculateModelBUpgradeCharge(20_000_000, 50_000_000, timePtr(now.Add(28*24*time.Hour)), &cycle, now)
+	if firstMicros != 31_330_000 {
+		t.Fatalf("first charge micros: got %d", firstMicros)
+	}
+
+	cases := []struct {
+		decimals int
+		want     uint64
+	}{
+		{6, 31_330_000},
+		{8, 3_133_000_000},
+		{9, 31_330_000_000},
+	}
+	for _, tc := range cases {
+		got, err := solanamodule.FiatMicrosToStablecoinBaseUnits(ctx, moneyutil.Micros(firstMicros), "USDC", tc.decimals, nil)
+		if err != nil {
+			t.Fatalf("@%d decimals: %v", tc.decimals, err)
+		}
+		if got != tc.want {
+			t.Fatalf("@%d decimals: got %d base units, want %d", tc.decimals, got, tc.want)
+		}
+	}
+
+	// Missing decimals must fail loudly, never silently price at 10^0.
+	if _, err := solanamodule.FiatMicrosToStablecoinBaseUnits(ctx, moneyutil.Micros(firstMicros), "USDC", 0, nil); err == nil {
+		t.Fatal("expected an error for a token with no configured decimals")
 	}
 }
 
@@ -98,7 +140,10 @@ func TestSolanaDowngradeHasZeroFirstCharge(t *testing.T) {
 	if firstMicros != 0 {
 		t.Fatalf("a downgrade must not produce a positive Model-B first charge, got %d micros", firstMicros)
 	}
-	gotUnits := solanamodule.FiatMicrosToStablecoinBaseUnits(context.Background(), moneyutil.Micros(firstMicros), "USDC", nil)
+	gotUnits, err := solanamodule.FiatMicrosToStablecoinBaseUnits(context.Background(), moneyutil.Micros(firstMicros), "USDC", 6, nil)
+	if err != nil {
+		t.Fatalf("convert first charge: %v", err)
+	}
 	if gotUnits != 0 {
 		t.Fatalf("downgrade FirstChargeBaseUnits must be 0, got %d", gotUnits)
 	}

--- a/internal/modules/solana/fiat_conversion_test.go
+++ b/internal/modules/solana/fiat_conversion_test.go
@@ -7,56 +7,46 @@ import (
 	"github.com/open-rails/openrails/internal/shared/moneyutil"
 )
 
-// TestFiatMicrosToStablecoinBaseUnits pins the native micro-USD -> stablecoin
-// base-unit conversion at the $1 peg plus the depeg failsafe.
+// TestFiatMicrosToStablecoinBaseUnits pins the micro-USD -> stablecoin base-unit
+// conversion at the merchant's CONFIGURED decimals (#817) plus the depeg failsafe.
 func TestFiatMicrosToStablecoinBaseUnits(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
 		name     string
 		micros   moneyutil.Micros
+		decimals int
 		symbol   string
 		provider TokenPriceProvider
 		want     uint64
 	}{
+		{name: "one dollar at 6 decimals", micros: 1_000_000, decimals: 6, want: 1_000_000},
+		{name: "sub-cent micros at 6 decimals", micros: 1, decimals: 6, want: 1},
+		{name: "nineteen ninety nine at 6 decimals", micros: 19_990_000, decimals: 6, want: 19_990_000},
+		{name: "zero micros", micros: 0, decimals: 6, want: 0},
+		{name: "negative micros clamp", micros: -500, decimals: 6, want: 0},
+
+		// #817: a 9-decimal mint needs 1000x the base units of a 6-decimal one.
+		{name: "ten dollars at 9 decimals", micros: 10_000_000, decimals: 9, want: 10_000_000_000},
+		{name: "one dollar at 9 decimals", micros: 1_000_000, decimals: 9, want: 1_000_000_000},
+		// 8 decimals: 100x.
+		{name: "ten dollars at 8 decimals", micros: 10_000_000, decimals: 8, want: 1_000_000_000},
+		{name: "nineteen ninety nine at 8 decimals", micros: 19_990_000, decimals: 8, want: 1_999_000_000},
+		// Below micro precision: exact divide, rounded UP (never under-charge).
+		{name: "two decimals exact", micros: 10_000_000, decimals: 2, want: 1_000},
+		{name: "two decimals rounds up", micros: 10_000_001, decimals: 2, want: 1_001},
+
 		{
-			name:   "one dollar at peg",
-			micros: 1_000_000,
-			want:   1_000_000,
+			name: "minor depeg within tolerance ignored", micros: 1_000_000, decimals: 6,
+			symbol: "USDC", provider: fakeTokenPriceProvider{"USDC": 0.995}, want: 1_000_000,
 		},
 		{
-			name:   "sub-cent micros at peg",
-			micros: 1,
-			want:   1,
+			name: "depeg failsafe scales up", micros: 1_000_000, decimals: 6,
+			symbol: "USDC", provider: fakeTokenPriceProvider{"USDC": 0.95}, want: 1_052_632,
 		},
 		{
-			name:   "nineteen ninety nine at peg",
-			micros: 19_990_000,
-			want:   19_990_000,
-		},
-		{
-			name:   "zero micros",
-			micros: 0,
-			want:   0,
-		},
-		{
-			name:   "negative micros clamp",
-			micros: -500,
-			want:   0,
-		},
-		{
-			name:     "minor depeg within tolerance ignored",
-			micros:   1_000_000,
-			symbol:   "USDC",
-			provider: fakeTokenPriceProvider{"USDC": 0.995},
-			want:     1_000_000,
-		},
-		{
-			name:     "depeg failsafe scales up",
-			micros:   1_000_000,
-			symbol:   "USDC",
-			provider: fakeTokenPriceProvider{"USDC": 0.95},
-			want:     1_052_632,
+			name: "depeg failsafe honours decimals", micros: 1_000_000, decimals: 9,
+			symbol: "USDC", provider: fakeTokenPriceProvider{"USDC": 0.95}, want: 1_052_631_579,
 		},
 	}
 
@@ -66,10 +56,82 @@ func TestFiatMicrosToStablecoinBaseUnits(t *testing.T) {
 			if symbol == "" {
 				symbol = "USDC"
 			}
-			got := FiatMicrosToStablecoinBaseUnits(ctx, tt.micros, symbol, tt.provider)
+			got, err := FiatMicrosToStablecoinBaseUnits(ctx, tt.micros, symbol, tt.decimals, tt.provider)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if got != tt.want {
 				t.Fatalf("expected %d base units, got %d", tt.want, got)
 			}
 		})
+	}
+}
+
+// TestFiatMicrosRejectsMissingDecimals pins #817: an OMITTED `decimals` decodes
+// as 0 and must fail loudly instead of mispricing by 10^6.
+func TestFiatMicrosRejectsMissingDecimals(t *testing.T) {
+	for _, d := range []int{0, -1, 19} {
+		if _, err := FiatMicrosToStablecoinBaseUnits(context.Background(), 1_000_000, "USDC", d, nil); err == nil {
+			t.Fatalf("decimals=%d: expected an error", d)
+		}
+		if _, err := FiatMicrosToBaseUnitsAtPeg(1_000_000, "USDC", d); err == nil {
+			t.Fatalf("decimals=%d (at peg): expected an error", d)
+		}
+	}
+}
+
+// TestPegConversionHasNoFloatOffByOne is the #818 V2 regression: the old float
+// chain — (float64(micros)/1e6) * math.Pow10(decimals) fed to math.Ceil —
+// overcharged 1.19% of whole-cent amounts by exactly one base unit. These are
+// the first failures found by exhaustive scan. The peg conversion is now an
+// exact integer rescale, so every amount must be micros*10^(d-6) EXACTLY.
+func TestPegConversionHasNoFloatOffByOne(t *testing.T) {
+	knownBad := []moneyutil.Micros{4_030_000, 4_070_000, 4_110_000, 4_150_000, 4_190_000, 8_050_000, 8_060_000, 8_130_000}
+	for _, micros := range knownBad {
+		for _, d := range []int{6, 8, 9} {
+			got, err := FiatMicrosToBaseUnitsAtPeg(micros, "USDC", d)
+			if err != nil {
+				t.Fatalf("%d micros @%d: %v", micros, d, err)
+			}
+			want := uint64(micros) * pow10(d-6).Uint64()
+			if got != want {
+				t.Fatalf("%d micros @%d decimals: got %d base units, want %d (off by %d)", micros, d, got, want, int64(got)-int64(want))
+			}
+		}
+	}
+}
+
+// TestPegConversionExhaustiveWholeCents sweeps the whole-cent range that the
+// float chain corrupted (2,382 of the first 200,000 amounts) and asserts an
+// exact rescale for every one.
+func TestPegConversionExhaustiveWholeCents(t *testing.T) {
+	for cents := int64(1); cents <= 200_000; cents++ {
+		micros := moneyutil.Micros(cents * 10_000)
+		got, err := FiatMicrosToBaseUnitsAtPeg(micros, "USDC", 6)
+		if err != nil {
+			t.Fatalf("%d micros: %v", micros, err)
+		}
+		if got != uint64(micros) {
+			t.Fatalf("%d micros: got %d base units, want %d", micros, got, uint64(micros))
+		}
+	}
+}
+
+func TestFormatBaseUnits(t *testing.T) {
+	cases := []struct {
+		units    uint64
+		decimals int
+		want     string
+	}{
+		{10_000_000, 6, "10.000000"},
+		{19_990_000, 6, "19.990000"},
+		{1, 6, "0.000001"},
+		{10_000_000_000, 9, "10.000000000"},
+		{0, 6, "0.000000"},
+	}
+	for _, c := range cases {
+		if got := FormatBaseUnits(c.units, c.decimals); got != c.want {
+			t.Fatalf("FormatBaseUnits(%d, %d) = %q, want %q", c.units, c.decimals, got, c.want)
+		}
 	}
 }

--- a/internal/modules/solana/support.go
+++ b/internal/modules/solana/support.go
@@ -3,15 +3,17 @@ package solana
 import (
 	"context"
 	"fmt"
-	"github.com/open-rails/openrails/internal/db/models"
-	"github.com/open-rails/openrails/internal/railresolve"
 	"math"
+	"math/big"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/integrations/fx"
 	solanatokens "github.com/open-rails/openrails/internal/modules/solana/tokens"
+	"github.com/open-rails/openrails/internal/railresolve"
 	"github.com/open-rails/openrails/internal/shared/moneyutil"
 	log "github.com/sirupsen/logrus"
 )
@@ -21,48 +23,178 @@ import (
 // price is used as a failsafe — 1%, rarely triggered.
 const stablecoinPegTolerance = 0.01
 
-// stablecoinPriceUSD returns the USD price for a stablecoin: $1.00 by default, or
-// the live price when a feed shows the peg has diverged by more than
-// stablecoinPegTolerance (the failsafe — e.g. a $0.95 USDC yields a ~5% higher
-// token charge so the merchant still nets the USD amount). Feedless stablecoins,
-// a nil provider, or an unavailable/invalid feed all fall back to the $1.00 peg.
-func stablecoinPriceUSD(ctx context.Context, symbol string, priceProvider TokenPriceProvider) float64 {
+// stablecoinPriceUSD returns the USD price for a stablecoin plus whether the $1
+// peg holds. pegged=true means "use the peg verbatim" — the caller then converts
+// with pure integer arithmetic, no rate involved. pegged=false is the depeg
+// failsafe: a feed shows divergence beyond stablecoinPegTolerance, so the live
+// price is returned (a $0.95 USDC yields a ~5% higher token charge so the
+// merchant still nets the USD amount). Feedless stablecoins, a nil provider, or
+// an unavailable/invalid feed all hold the peg.
+func stablecoinPriceUSD(ctx context.Context, symbol string, priceProvider TokenPriceProvider) (priceUSD float64, pegged bool) {
 	if priceProvider == nil || solanatokens.IsFeedlessStablecoin(symbol) {
-		return 1.0
+		return 1.0, true
 	}
 	p, err := priceProvider.PriceUSD(ctx, symbol)
 	if err != nil || p <= 0 {
 		log.WithField("token", symbol).WithError(err).Warn("stablecoin price feed unavailable; using $1.00 peg")
-		return 1.0
+		return 1.0, true
 	}
 	if math.Abs(p-1.0) <= stablecoinPegTolerance {
-		return 1.0
+		return 1.0, true
 	}
 	log.WithFields(log.Fields{"token": symbol, "price_usd": p}).
 		Warn("stablecoin depeg beyond tolerance; using live price (failsafe)")
-	return p
+	return p, false
 }
 
-// USDCDecimals is the SPL decimal precision for USDC (and the other $1-pegged
-// stablecoins OpenRails recurring-bills in): 6. One micro-USD therefore equals
-// one base unit at the $1 peg.
-const USDCDecimals = 6
+// microDecimals is the decimal precision of MICROS (millionths) — the scale every
+// fiat amount in OpenRails carries.
+const microDecimals = 6
 
-// FiatMicrosToStablecoinBaseUnits converts a micro-USD amount into stablecoin
-// base units for a $1-pegged token. With 6-decimal USD micros and 6-decimal USDC
-// base units, the at-peg conversion is 1:1. The depeg failsafe rounds UP so a
-// fractional base unit never under-charges the merchant.
-func FiatMicrosToStablecoinBaseUnits(ctx context.Context, micros moneyutil.Micros, symbol string, priceProvider TokenPriceProvider) uint64 {
+// pow10 returns 10^n (n >= 0) as an exact integer.
+func pow10(n int) *big.Int {
+	return new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(n)), nil)
+}
+
+// ceilQuo returns ceil(n/d) for n >= 0, d > 0.
+func ceilQuo(n, d *big.Int) *big.Int {
+	q, r := new(big.Int).QuoRem(n, d, new(big.Int))
+	if r.Sign() > 0 {
+		q.Add(q, big.NewInt(1))
+	}
+	return q
+}
+
+// ceilRat returns ceil(r) for r >= 0.
+func ceilRat(r *big.Rat) *big.Int {
+	return ceilQuo(r.Num(), r.Denom())
+}
+
+func baseUnitsToUint64(n *big.Int, symbol string) (uint64, error) {
+	if !n.IsUint64() {
+		return 0, fmt.Errorf("solana token %s: converted amount %s overflows uint64 base units", symbol, n.String())
+	}
+	return n.Uint64(), nil
+}
+
+// ratFromRate converts a price/FX RATE (legitimately a float) to the exact
+// rational of its shortest DECIMAL form — 1.08 becomes 108/100, not the binary
+// double 1.0800000000000000710… whose ceiling would add a phantom base unit.
+// From here on the arithmetic is exact and no amount touches a float.
+func ratFromRate(rate float64, what string) (*big.Rat, error) {
+	if math.IsNaN(rate) || math.IsInf(rate, 0) || rate <= 0 {
+		return nil, fmt.Errorf("invalid %s %v", what, rate)
+	}
+	r, ok := new(big.Rat).SetString(strconv.FormatFloat(rate, 'g', -1, 64))
+	if !ok || r.Sign() <= 0 {
+		return nil, fmt.Errorf("invalid %s %v", what, rate)
+	}
+	return r, nil
+}
+
+// FiatMicrosToBaseUnitsAtPeg converts micro-USD into base units of a $1-pegged
+// token with `decimals` base-unit precision. At the peg this is a pure integer
+// rescale — micros * 10^(decimals-6) — and an exact CEILING divide when
+// decimals < 6, so a fractional base unit never under-charges. No float touches
+// this path: float64(micros)/1e6*1e6 is not the identity in IEEE-754 and
+// overcharged 1.19% of whole-cent amounts by one base unit (#818 V2).
+func FiatMicrosToBaseUnitsAtPeg(micros moneyutil.Micros, symbol string, decimals int) (uint64, error) {
+	if err := config.ValidateTokenDecimals(symbol, decimals); err != nil {
+		return 0, err
+	}
 	if micros <= 0 {
-		return 0
+		return 0, nil
 	}
-	priceUSD := stablecoinPriceUSD(ctx, symbol, priceProvider)
-	if priceUSD <= 0 {
-		priceUSD = 1.0
+	n := new(big.Int).SetInt64(int64(micros))
+	if decimals >= microDecimals {
+		n.Mul(n, pow10(decimals-microDecimals))
+	} else {
+		n = ceilQuo(n, pow10(microDecimals-decimals))
 	}
-	scale := math.Pow10(USDCDecimals)
-	usd := float64(micros) / scale
-	return uint64(math.Ceil((usd / priceUSD) * scale))
+	return baseUnitsToUint64(n, symbol)
+}
+
+// fiatMicrosToBaseUnitsAtRate is the depeg/FX branch: base units =
+// ceil(micros * fxRate * 10^decimals / (10^6 * tokenPriceUSD)), evaluated as an
+// exact rational (rates converted to their exact rational value) with a single
+// final ceiling — never a float multiply followed by math.Ceil.
+func fiatMicrosToBaseUnitsAtRate(micros moneyutil.Micros, symbol string, decimals int, fxRate, tokenPriceUSD float64) (uint64, error) {
+	if err := config.ValidateTokenDecimals(symbol, decimals); err != nil {
+		return 0, err
+	}
+	if micros <= 0 {
+		return 0, nil
+	}
+	fxr, err := ratFromRate(fxRate, "fx rate")
+	if err != nil {
+		return 0, err
+	}
+	price, err := ratFromRate(tokenPriceUSD, "token price")
+	if err != nil {
+		return 0, err
+	}
+	q := new(big.Rat).SetInt64(int64(micros))
+	q.Mul(q, fxr)
+	q.Mul(q, new(big.Rat).SetInt(pow10(decimals)))
+	q.Quo(q, new(big.Rat).SetInt(pow10(microDecimals)))
+	q.Quo(q, price)
+	return baseUnitsToUint64(ceilRat(q), symbol)
+}
+
+// FiatMicrosToStablecoinBaseUnits converts a micro-USD amount into base units of
+// a $1-pegged token with the merchant's configured `decimals` precision (#817 —
+// hardcoding 6 undercharged a 9-decimal mint 1000x). At the peg the conversion
+// is an exact integer rescale; the depeg failsafe rounds UP so a fractional base
+// unit never under-charges the merchant.
+func FiatMicrosToStablecoinBaseUnits(ctx context.Context, micros moneyutil.Micros, symbol string, decimals int, priceProvider TokenPriceProvider) (uint64, error) {
+	if err := config.ValidateTokenDecimals(symbol, decimals); err != nil {
+		return 0, err
+	}
+	if micros <= 0 {
+		return 0, nil
+	}
+	priceUSD, pegged := stablecoinPriceUSD(ctx, symbol, priceProvider)
+	if pegged {
+		return FiatMicrosToBaseUnitsAtPeg(micros, symbol, decimals)
+	}
+	return fiatMicrosToBaseUnitsAtRate(micros, symbol, decimals, 1.0, priceUSD)
+}
+
+// FormatBaseUnits renders base units as a fixed-point decimal string with
+// `decimals` fractional digits. Display only — pure integer, no float rounding.
+func FormatBaseUnits(units uint64, decimals int) string {
+	if decimals <= 0 {
+		return strconv.FormatUint(units, 10)
+	}
+	div := pow10(decimals)
+	whole, frac := new(big.Int).QuoRem(new(big.Int).SetUint64(units), div, new(big.Int))
+	return fmt.Sprintf("%s.%0*s", whole.String(), decimals, frac.String())
+}
+
+// RequireTokenDecimals resolves the ctx merchant's configured base-unit
+// precision for symbol from its armed Solana rail config. Fails closed: an
+// unarmed rail, an unknown token, or a missing/zero decimals value are errors —
+// guessing the scale is a 10^n mispricing.
+func RequireTokenDecimals(ctx context.Context, src railresolve.Source, symbol string) (int, error) {
+	sym := strings.ToUpper(strings.TrimSpace(symbol))
+	if sym == "" {
+		return 0, fmt.Errorf("solana: token symbol is required")
+	}
+	proc, err := RequireSolanaRailConfig(ctx, src)
+	if err != nil {
+		return 0, err
+	}
+	if proc.Solana == nil {
+		return 0, fmt.Errorf("solana rail is not configured")
+	}
+	tok, ok := proc.Solana.Tokens[sym]
+	if !ok {
+		return 0, fmt.Errorf("solana: token %s is not configured for this merchant", sym)
+	}
+	if err := config.ValidateTokenDecimals(sym, tok.Decimals); err != nil {
+		return 0, err
+	}
+	return tok.Decimals, nil
 }
 
 // RequireSolanaRailConfig resolves the ctx merchant's armed Solana rail
@@ -88,14 +220,16 @@ func IsNativeSOLMint(tokenMint string) bool {
 
 // TokenQuote represents a complete quote for converting fiat to a Solana token.
 // It includes all the information needed to audit and verify the quote.
+// Units is the authoritative amount; Amount is its display rendering. Only the
+// RATES are floats — every amount here is an integer.
 type TokenQuote struct {
-	Units         uint64
-	Decimal       float64
-	TokenPriceUSD float64
-	FXRate        float64
-	FXCurrency    string
-	AmountUSD     float64
-	QuotedAt      time.Time
+	Units           uint64           // base units to transfer (authoritative)
+	Amount          string           // display only: Units at the token's decimals
+	TokenPriceUSD   float64          // rate
+	FXRate          float64          // rate
+	FXCurrency      string           // the quoted price's currency
+	AmountUSDMicros moneyutil.Micros // FX-converted price, ceilinged to whole micros
+	QuotedAt        time.Time
 }
 
 type TokenPriceProvider interface {
@@ -105,28 +239,26 @@ type TokenPriceProvider interface {
 // CalculateTokenQuote converts a fiat amount in MICROS (millionths of a major
 // currency unit, any currency) into token units based on live prices.
 func CalculateTokenQuote(ctx context.Context, tokenSymbol string, tokenCfg config.TokenConfig, amountMicros moneyutil.Micros, currency string, fxProvider fx.Provider, priceProvider TokenPriceProvider) (*TokenQuote, error) {
-	if amountMicros <= 0 {
-		return &TokenQuote{Units: 0, Decimal: 0, FXRate: 1.0, FXCurrency: strings.ToLower(currency), QuotedAt: time.Now()}, nil
-	}
 	tokenSymbol = strings.ToUpper(strings.TrimSpace(tokenSymbol))
 	if tokenSymbol == "" {
 		return nil, fmt.Errorf("token symbol is required")
+	}
+	if err := config.ValidateTokenDecimals(tokenSymbol, tokenCfg.Decimals); err != nil {
+		return nil, err
 	}
 
 	currency = strings.ToLower(strings.TrimSpace(currency))
 	if currency == "" {
 		currency = "usd"
 	}
+	if amountMicros <= 0 {
+		return &TokenQuote{Units: 0, Amount: FormatBaseUnits(0, tokenCfg.Decimals), FXRate: 1.0, FXCurrency: currency, QuotedAt: time.Now()}, nil
+	}
 
 	quotedAt := time.Now()
-	amountInCurrency := float64(amountMicros) / float64(moneyutil.MicrosPerMajorUnit)
 
-	var amountUSD float64
-	var fxRate float64
-	if currency == "usd" {
-		amountUSD = amountInCurrency
-		fxRate = 1.0
-	} else {
+	fxRate := 1.0
+	if currency != "usd" {
 		if fxProvider == nil {
 			return nil, fmt.Errorf("FX conversion required for currency %s but no FX provider configured", currency)
 		}
@@ -135,7 +267,6 @@ func CalculateTokenQuote(ctx context.Context, tokenSymbol string, tokenCfg confi
 			return nil, fmt.Errorf("failed to get FX rate for %s: %w", currency, err)
 		}
 		fxRate = fxQuote.Rate
-		amountUSD = amountInCurrency * fxRate
 	}
 
 	if strings.TrimSpace(tokenCfg.Mint) == "" {
@@ -148,8 +279,9 @@ func CalculateTokenQuote(ctx context.Context, tokenSymbol string, tokenCfg confi
 	// custom-symbol token pointing at a known USD-pegged mint still gets parity
 	// pricing. Everything else (SOL, EURC, ...) always requires a live price.
 	var tokenPriceUSD float64
+	atPeg := false
 	if solanatokens.IsUSDPeggedToken(tokenSymbol, tokenCfg.Mint) {
-		tokenPriceUSD = stablecoinPriceUSD(ctx, tokenSymbol, priceProvider)
+		tokenPriceUSD, atPeg = stablecoinPriceUSD(ctx, tokenSymbol, priceProvider)
 	} else {
 		if priceProvider == nil {
 			return nil, fmt.Errorf("token price provider is not configured")
@@ -164,18 +296,49 @@ func CalculateTokenQuote(ctx context.Context, tokenSymbol string, tokenCfg confi
 		tokenPriceUSD = p
 	}
 
-	scale := math.Pow10(tokenCfg.Decimals)
-	tokenAmountFloat := amountUSD / tokenPriceUSD
-	tokenUnits := uint64(math.Ceil(tokenAmountFloat * scale))
-	tokenDecimal := float64(tokenUnits) / scale
+	// USD price + held peg => pure integer rescale. Anything else (FX, depeg, a
+	// volatile token) goes through the exact-rational rate path.
+	var (
+		tokenUnits uint64
+		err        error
+	)
+	if atPeg && currency == "usd" {
+		tokenUnits, err = FiatMicrosToBaseUnitsAtPeg(amountMicros, tokenSymbol, tokenCfg.Decimals)
+	} else {
+		tokenUnits, err = fiatMicrosToBaseUnitsAtRate(amountMicros, tokenSymbol, tokenCfg.Decimals, fxRate, tokenPriceUSD)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	amountUSDMicros, err := microsAtRate(amountMicros, fxRate)
+	if err != nil {
+		return nil, err
+	}
 
 	return &TokenQuote{
-		Units:         tokenUnits,
-		Decimal:       tokenDecimal,
-		TokenPriceUSD: tokenPriceUSD,
-		FXRate:        fxRate,
-		FXCurrency:    currency,
-		AmountUSD:     amountUSD,
-		QuotedAt:      quotedAt,
+		Units:           tokenUnits,
+		Amount:          FormatBaseUnits(tokenUnits, tokenCfg.Decimals),
+		TokenPriceUSD:   tokenPriceUSD,
+		FXRate:          fxRate,
+		FXCurrency:      currency,
+		AmountUSDMicros: amountUSDMicros,
+		QuotedAt:        quotedAt,
 	}, nil
+}
+
+// microsAtRate applies an FX rate to a micros amount exactly, ceilinged to whole
+// micros (audit value; the charge itself is computed from the unrounded rate).
+func microsAtRate(micros moneyutil.Micros, rate float64) (moneyutil.Micros, error) {
+	r, err := ratFromRate(rate, "fx rate")
+	if err != nil {
+		return 0, err
+	}
+	q := new(big.Rat).SetInt64(int64(micros))
+	q.Mul(q, r)
+	n := ceilRat(q)
+	if !n.IsInt64() {
+		return 0, fmt.Errorf("fx-converted amount %s overflows micros", n.String())
+	}
+	return moneyutil.Micros(n.Int64()), nil
 }

--- a/internal/modules/solana/support_test.go
+++ b/internal/modules/solana/support_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/open-rails/openrails/config"
 	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/integrations/fx"
+	"github.com/open-rails/openrails/internal/shared/moneyutil"
 	"github.com/open-rails/openrails/pkg/identity"
 	"github.com/stretchr/testify/require"
 )
@@ -32,7 +33,7 @@ func TestCalculateTokenQuote_USDPrice(t *testing.T) {
 	quote, err := CalculateTokenQuote(context.Background(), "USDC", tokenCfg, 10_000_000, "usd", nil, fakeTokenPriceProvider{"USDC": 1.0})
 	require.NoError(t, err)
 	require.Equal(t, uint64(10_000_000), quote.Units)
-	require.Equal(t, 10.0, quote.Decimal)
+	require.Equal(t, "10.000000", quote.Amount)
 	require.Equal(t, 1.0, quote.FXRate)
 	require.Equal(t, "usd", quote.FXCurrency)
 }
@@ -49,8 +50,8 @@ func TestCalculateTokenQuote_MicrosWirePin(t *testing.T) {
 	quote, err := CalculateTokenQuote(context.Background(), "USDC", tokenCfg, 19_990_000, "usd", nil, fakeTokenPriceProvider{"USDC": 1.0})
 	require.NoError(t, err)
 	require.Equal(t, uint64(19_990_000), quote.Units) // 19.99 USDC in base units
-	require.Equal(t, 19.99, quote.Decimal)
-	require.Equal(t, 19.99, quote.AmountUSD)
+	require.Equal(t, "19.990000", quote.Amount)
+	require.Equal(t, moneyutil.Micros(19_990_000), quote.AmountUSDMicros)
 }
 
 func TestCalculateTokenQuote_NonUSDPrice_RequiresFXProvider(t *testing.T) {
@@ -72,7 +73,7 @@ func TestCalculateTokenQuote_ZeroAmount(t *testing.T) {
 	quote, err := CalculateTokenQuote(context.Background(), "USDC", tokenCfg, 0, "usd", nil, nil)
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), quote.Units)
-	require.Equal(t, float64(0), quote.Decimal)
+	require.Equal(t, "0.000000", quote.Amount)
 }
 
 func TestCalculateTokenQuote_EmptyCurrencyDefaultsToUSD(t *testing.T) {
@@ -106,7 +107,7 @@ func TestCalculateTokenQuote_WithMockFXProvider(t *testing.T) {
 
 	quote, err := CalculateTokenQuote(context.Background(), "USDC", tokenCfg, 10_000_000, "eur", mockFX, fakeTokenPriceProvider{"USDC": 1.0})
 	require.NoError(t, err)
-	require.Equal(t, 10.80, quote.AmountUSD)
+	require.Equal(t, moneyutil.Micros(10_800_000), quote.AmountUSDMicros)
 	require.Equal(t, 1.08, quote.FXRate)
 	require.Equal(t, "eur", quote.FXCurrency)
 }

--- a/internal/modules/solana/tokens/normalize.go
+++ b/internal/modules/solana/tokens/normalize.go
@@ -35,8 +35,8 @@ func NormalizeForNetwork(network string, tokens map[string]config.TokenConfig) m
 			log.Warnf("⚠️  solana token %s has no mint configured; payments in %s unavailable", normalizedSymbol, normalizedSymbol)
 			continue
 		}
-		if token.Decimals < 0 {
-			log.Warnf("⚠️  solana token %s has invalid decimals (%d); payments in %s unavailable", normalizedSymbol, token.Decimals, normalizedSymbol)
+		if err := config.ValidateTokenDecimals(normalizedSymbol, token.Decimals); err != nil {
+			log.Warnf("⚠️  %v; payments in %s unavailable", err, normalizedSymbol)
 			continue
 		}
 		if strings.TrimSpace(token.Name) == "" {

--- a/pkg/service/catalog_provider_solana.go
+++ b/pkg/service/catalog_provider_solana.go
@@ -12,7 +12,9 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/open-rails/openrails/internal/integrations/solana/subscriptions"
+	solanamodule "github.com/open-rails/openrails/internal/modules/solana"
 	"github.com/open-rails/openrails/internal/modules/solana/recurring"
+	"github.com/open-rails/openrails/internal/shared/moneyutil"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
 
@@ -99,11 +101,17 @@ func (a *solanaAdapter) AutoCreate(ctx context.Context, in autoCreateContext) (m
 		return nil, fmt.Errorf("solana create-mode requires a merchant-scoped context")
 	}
 	if in.UnitAmount <= 0 {
-		return nil, fmt.Errorf("solana create-mode requires a positive unit_amount (stablecoin base units)")
+		return nil, fmt.Errorf("solana create-mode requires a positive unit_amount (micros)")
 	}
 
 	symbol := strings.ToUpper(strings.TrimSpace(in.Currency))
-	mint, _, err := plan.ResolveMint(symbol)
+	mint, decimals, err := plan.ResolveMint(symbol)
+	if err != nil {
+		return nil, err
+	}
+	// #817: the price is MICROS; the plan amount is token BASE UNITS at the
+	// token's configured decimals — shipping micros verbatim only worked at 6.
+	amountBaseUnits, err := solanamodule.FiatMicrosToBaseUnitsAtPeg(moneyutil.Micros(in.UnitAmount), symbol, decimals)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +128,7 @@ func (a *solanaAdapter) AutoCreate(ctx context.Context, in autoCreateContext) (m
 		MerchantID:        tid,
 		PlanID:            planID,
 		TokenSymbol:       symbol, // PublishPlan rejects non-allowlisted (non-stablecoin) tokens
-		AmountBaseUnits:   uint64(in.UnitAmount),
+		AmountBaseUnits:   amountBaseUnits,
 		PeriodHours:       periodHours,
 		BillingCycleHours: *in.AccessDurationHours,
 		EndTs:             0, // perpetual; OpenRails models open-ended subscriptions
@@ -208,21 +216,31 @@ func (a *solanaAdapter) Attach(ctx context.Context, link map[string]string, in a
 	if err != nil {
 		return nil, fmt.Errorf("decode solana plan account %q: %w", pda, err)
 	}
-	if in.UnitAmount > 0 && acct.Amount != uint64(in.UnitAmount) {
-		return nil, fmt.Errorf("solana plan %q amount (%d base units) does not match catalog price (%d)", pda, acct.Amount, in.UnitAmount)
-	}
 	if in.AccessDurationHours != nil && *in.AccessDurationHours > 0 {
 		wantPeriod := uint64(*in.AccessDurationHours)
 		if acct.PeriodHours != wantPeriod {
 			return nil, fmt.Errorf("solana plan %q period (%d hours) does not match catalog price (%d hours)", pda, acct.PeriodHours, wantPeriod)
 		}
 	}
-	// Mint + merchant validation requires the plan service (mint allowlist +
-	// merchant merchant resolution); skip gracefully when it is unconfigured.
+	// Amount + mint + merchant validation requires the plan service (token
+	// decimals, mint allowlist, merchant resolution); skip gracefully when it is
+	// unconfigured — the price is in MICROS and only the token's decimals turn
+	// that into the plan's base units (#817).
 	if plan, ok := a.planService(); ok {
 		if symbol := strings.ToUpper(strings.TrimSpace(in.Currency)); symbol != "" {
-			if mint, _, err := plan.ResolveMint(symbol); err == nil && !strings.EqualFold(acct.Mint.String(), strings.TrimSpace(mint)) {
-				return nil, fmt.Errorf("solana plan %q mint (%s) does not match catalog currency %s mint (%s)", pda, acct.Mint, symbol, mint)
+			if mint, decimals, err := plan.ResolveMint(symbol); err == nil {
+				if !strings.EqualFold(acct.Mint.String(), strings.TrimSpace(mint)) {
+					return nil, fmt.Errorf("solana plan %q mint (%s) does not match catalog currency %s mint (%s)", pda, acct.Mint, symbol, mint)
+				}
+				if in.UnitAmount > 0 {
+					want, err := solanamodule.FiatMicrosToBaseUnitsAtPeg(moneyutil.Micros(in.UnitAmount), symbol, decimals)
+					if err != nil {
+						return nil, err
+					}
+					if acct.Amount != want {
+						return nil, fmt.Errorf("solana plan %q amount (%d base units) does not match catalog price (%d micros = %d base units)", pda, acct.Amount, in.UnitAmount, want)
+					}
+				}
 			}
 		}
 		if tid, ok := merchant.FromContext(ctx); ok {

--- a/pkg/service/catalog_provider_solana_decimals_test.go
+++ b/pkg/service/catalog_provider_solana_decimals_test.go
@@ -1,0 +1,103 @@
+package service
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	solanago "github.com/gagliardetto/solana-go"
+	"github.com/google/uuid"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/app"
+	"github.com/open-rails/openrails/internal/modules/solana/recurring"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// planSubmitterStub satisfies recurring.Submitter without touching a chain.
+type planSubmitterStub struct{ merchantPub solanago.PublicKey }
+
+func (s *planSubmitterStub) MerchantAddress(context.Context, merchant.ID) (solanago.PublicKey, error) {
+	return s.merchantPub, nil
+}
+
+func (s *planSubmitterStub) Submit(context.Context, merchant.ID, []solanago.Instruction) (solanago.Signature, error) {
+	return solanago.Signature{1}, nil
+}
+
+// TestSolanaAdapter_AutoCreateHonoursTokenDecimals pins #817 on the plan-PUBLISH
+// path: the catalog price is MICROS, the on-chain plan amount is token BASE
+// UNITS, and the merchant's configured decimals is the only thing that converts
+// between them. Shipping micros verbatim (the old bug) was a 1000x undercharge
+// on a 9-decimal mint.
+func TestSolanaAdapter_AutoCreateHonoursTokenDecimals(t *testing.T) {
+	const usdcMint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+	hours := 30 * 24
+
+	cases := []struct {
+		decimals int
+		micros   int64
+		want     uint64
+	}{
+		{decimals: 6, micros: 10_000_000, want: 10_000_000},
+		{decimals: 9, micros: 10_000_000, want: 10_000_000_000},
+		{decimals: 8, micros: 10_000_000, want: 1_000_000_000},
+		{decimals: 6, micros: 4_030_000, want: 4_030_000},       // #818 float off-by-one amounts
+		{decimals: 9, micros: 8_050_000, want: 8_050_000_000},   //
+		{decimals: 8, micros: 8_130_000, want: 813_000_000},     //
+		{decimals: 9, micros: 19_990_000, want: 19_990_000_000}, // $19.99
+	}
+
+	key, err := solanago.NewRandomPrivateKey()
+	if err != nil {
+		t.Fatalf("key: %v", err)
+	}
+
+	for _, tc := range cases {
+		t.Run(strconv.Itoa(tc.decimals)+"-decimals", func(t *testing.T) {
+			plan := recurring.NewPlanServiceWithReader(
+				&planSubmitterStub{merchantPub: key.PublicKey()}, nil, "mainnet",
+				map[string]config.TokenConfig{"USDC": {Mint: usdcMint, Decimals: tc.decimals}},
+			)
+			a := &solanaAdapter{svc: &Service{rt: &app.Runtime{SolanaPlanService: plan}}}
+			ctx := merchant.WithID(context.Background(), merchant.ID(uuid.New()))
+
+			out, err := a.AutoCreate(ctx, autoCreateContext{
+				PriceID:             uuid.New(),
+				ProductKey:          "premium",
+				Currency:            "USDC",
+				UnitAmount:          tc.micros,
+				AccessDurationHours: &hours,
+			})
+			if err != nil {
+				t.Fatalf("AutoCreate: %v", err)
+			}
+			if got := out[solanaKeyAmountBaseUnits]; got != strconv.FormatUint(tc.want, 10) {
+				t.Fatalf("%d micros @%d decimals: plan amount_base_units = %s, want %d", tc.micros, tc.decimals, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSolanaAdapter_AutoCreateRejectsMissingDecimals: an omitted `decimals`
+// decodes as 0 and must fail loudly rather than publish a 10^6-off plan.
+func TestSolanaAdapter_AutoCreateRejectsMissingDecimals(t *testing.T) {
+	key, _ := solanago.NewRandomPrivateKey()
+	hours := 30 * 24
+	plan := recurring.NewPlanServiceWithReader(
+		&planSubmitterStub{merchantPub: key.PublicKey()}, nil, "mainnet",
+		map[string]config.TokenConfig{"USDC": {Mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"}},
+	)
+	a := &solanaAdapter{svc: &Service{rt: &app.Runtime{SolanaPlanService: plan}}}
+	ctx := merchant.WithID(context.Background(), merchant.ID(uuid.New()))
+
+	if _, err := a.AutoCreate(ctx, autoCreateContext{
+		PriceID:             uuid.New(),
+		ProductKey:          "premium",
+		Currency:            "USDC",
+		UnitAmount:          10_000_000,
+		AccessDurationHours: &hours,
+	}); err == nil {
+		t.Fatal("expected AutoCreate to reject a token with no configured decimals")
+	}
+}


### PR DESCRIPTION
Implementation of tracker #817 (repo-audit finding): omitted/zero token decimals silently mispriced every Solana charge by 10^6. Now: decimals REQUIRED (1..18) with fail-loud validation at config load; all fiat→token conversion rescales via exact integer arithmetic; stablecoins hold the $1 peg unless a price feed shows divergence beyond tolerance (depeg failsafe charges the live rate so the merchant nets the fiat amount). All solana/checkout/config/service tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)