### PR TITLE
or#818: eliminate float money math — integer-only amounts end to end

### DIFF
--- a/internal/db/models/subscription.go
+++ b/internal/db/models/subscription.go
@@ -193,15 +193,17 @@ func (s *Subscription) Cancel(reason string, cancelType *CancelType) error {
 	return nil
 }
 
-func (s *Subscription) Validate(amount float64) error {
+// Validate checks activation preconditions. amountCents is integer minor units
+// (#818) — no monetary value is ever carried as a float.
+func (s *Subscription) Validate(amountCents int64) error {
 	if s.CurrentPeriodEndsAt != nil && s.CurrentPeriodEndsAt.Before(time.Now()) {
 		if s.Status == StatusActive {
 			return fmt.Errorf("cannot activate expired subscription without proper renewal")
 		}
 	}
 
-	if s.Status == StatusActive && amount <= 0 {
-		return fmt.Errorf("cannot activate subscription with invalid amount: %.2f", amount)
+	if s.Status == StatusActive && amountCents <= 0 {
+		return fmt.Errorf("cannot activate subscription with invalid amount: %d cents", amountCents)
 	}
 
 	if s.Status == StatusPastDue {

--- a/internal/integrations/nmi/nmi_test.go
+++ b/internal/integrations/nmi/nmi_test.go
@@ -6,11 +6,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/shared/moneyutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -117,8 +117,10 @@ func probeServer(t *testing.T, authCode string, seen *[]url.Values) *httptest.Se
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/payments/auth":
+			// amount is decoded as json.Number (the exact wire TEXT), never
+			// float64 — a float decode hid the #818 sub-cent under-charge.
 			var req struct {
-				Amount         float64 `json:"amount"`
+				Amount         json.Number `json:"amount"`
 				PaymentDetails struct {
 					CardNumber string `json:"card_number"`
 					CardExp    string `json:"card_exp"`
@@ -130,15 +132,20 @@ func probeServer(t *testing.T, authCode string, seen *[]url.Values) *httptest.Se
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 			// The probe amount must stay in the randomized [$1.01, $1.99]
 			// band and the order id must keep the auditable prefix (#362).
-			require.GreaterOrEqual(t, req.Amount, 1.01)
-			require.LessOrEqual(t, req.Amount, 1.99)
+			// Compared in integer cents parsed from the exact wire text.
+			probeCents, cerr := moneyutil.ParseDecimalToCents(req.Amount.String())
+			require.NoError(t, cerr, "probe amount %q must be an exact decimal", req.Amount.String())
+			require.GreaterOrEqual(t, probeCents, int64(101))
+			require.LessOrEqual(t, probeCents, int64(199))
+			require.Equal(t, moneyutil.FormatCentsDecimal(probeCents), req.Amount.String(),
+				"probe amount must be a whole-cent two-decimal amount")
 			require.True(t, strings.HasPrefix(req.OrderDetails.ID, "openrails-testmode-probe-"),
 				"unexpected probe order id %q", req.OrderDetails.ID)
 			require.Equal(t, probeTestCard, req.PaymentDetails.CardNumber)
 			if seen != nil {
 				form := url.Values{}
 				form.Set("order_id", req.OrderDetails.ID)
-				form.Set("amount", strconv.FormatFloat(req.Amount, 'f', 2, 64))
+				form.Set("amount", req.Amount.String())
 				*seen = append(*seen, form)
 			}
 			_, _ = w.Write([]byte(`{"object":"transaction","id":"99001","response":"` + authCode + `","response_text":"PROBE","response_code":"100"}`))

--- a/internal/integrations/nmi/payments_wire_test.go
+++ b/internal/integrations/nmi/payments_wire_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/open-rails/openrails/internal/shared/moneyutil"
@@ -63,22 +64,58 @@ func TestRefund_WirePinsCentsAmount(t *testing.T) {
 	assert.False(t, hasAmount, "full refund must omit the amount key")
 }
 
-func TestAddRecurringSubscription_WirePinsDollarsAmount(t *testing.T) {
-	var form string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		b, _ := io.ReadAll(r.Body)
-		form = string(b)
-		fmt.Fprint(w, "response=1&responsetext=SUCCESS&subscription_id=sub1&transactionid=t3")
-	}))
-	defer server.Close()
+// The enrollment charge (type=sale + recurring=add_subscription) is real money:
+// known CENTS in ⇒ the literal two-decimal wire string out, identical to the
+// formatter the plan amount uses so the two can never disagree (#818).
+func TestAddRecurringSubscription_WirePinsCentsAmount(t *testing.T) {
+	cases := []struct {
+		name  string
+		cents moneyutil.Cents
+		want  string
+	}{
+		{"whole dollars", 5000, "50.00"},
+		{"dollars and cents", 1999, "19.99"},
+		{"sub-dollar", 5, "0.05"},
+		{"zero", 0, "0.00"},
+		{"negative", -1999, "-19.99"},
+		// The old float path formatted these via FormatFloat and lost the
+		// trailing digit; the integer path renders every cent.
+		{"whole cent above a dollar", 101, "1.01"},
+		{"one cent", 1, "0.01"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var form url.Values
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.NoError(t, r.ParseForm())
+				form = r.Form
+				fmt.Fprint(w, "response=1&responsetext=SUCCESS&subscription_id=sub1&transactionid=t3")
+			}))
+			defer server.Close()
 
-	client := newTestClient(t, server.URL)
-	_, err := client.AddRecurringSubscription(RecurringPaymentData{
-		PlanID:          "plan1",
-		CustomerVaultID: "v1",
-		Currency:        "USD",
-		Amount:          moneyutil.MajorUnits(19.99), // decimal DOLLARS
-	})
+			client := newTestClient(t, server.URL)
+			_, err := client.AddRecurringSubscription(RecurringPaymentData{
+				PlanID:          "plan1",
+				CustomerVaultID: "v1",
+				Currency:        "USD",
+				Amount:          tc.cents,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, form.Get("amount"))
+			// The enrollment charge and the plan amount MUST render identically.
+			assert.Equal(t, centsToDollarString(tc.cents), form.Get("amount"))
+		})
+	}
+}
+
+// A sub-cent price can never reach the wire: the caller-side conversion errors
+// rather than silently rounding a charge down (the #818 under-charge).
+func TestSubCentMicrosNeverReachTheRecurringWire(t *testing.T) {
+	for _, micros := range []int64{1_005_000, 999_999, 12_345, -1} {
+		_, err := moneyutil.MicrosToCentsExact(micros)
+		require.Error(t, err, "%d micros must not be representable in whole cents", micros)
+	}
+	cents, err := moneyutil.MicrosToCentsExact(19_990_000)
 	require.NoError(t, err)
-	assert.Contains(t, form, "amount=19.99", "recurring first-charge amount must be the two-decimal dollars rendering")
+	require.Equal(t, "19.99", centsToDollarString(moneyutil.Cents(cents)))
 }

--- a/internal/integrations/nmi/stored_credential_wire_test.go
+++ b/internal/integrations/nmi/stored_credential_wire_test.go
@@ -127,7 +127,7 @@ func TestAddRecurringSubscription_StoredCredentialRecurringCIT(t *testing.T) {
 		PlanID:          "plan1",
 		CustomerVaultID: "v1",
 		Currency:        "USD",
-		Amount:          moneyutil.MajorUnits(19.99),
+		Amount:          moneyutil.Cents(1999),
 		StoredCredential: &StoredCredential{
 			InitiatedBy: InitiatedByCustomer,
 			Indicator:   IndicatorStored,

--- a/internal/integrations/nmi/subscriptions.go
+++ b/internal/integrations/nmi/subscriptions.go
@@ -32,9 +32,10 @@ type RecurringPaymentData struct {
 	Email        string
 	Currency     string
 	PaymentToken string
-	// Amount is DECIMAL MAJOR UNITS (dollars, typed #671) — NMI classic
-	// recurring takes a decimal amount string.
-	Amount     moneyutil.MajorUnits
+	// Amount is the enrollment first charge in integer CENTS (#818); it is
+	// rendered onto the classic wire by centsToDollarString — the same integer
+	// formatter the plan amount uses, so enrollment and plan never disagree.
+	Amount     moneyutil.Cents
 	OrderID    string
 	PONumber   string
 	CustomerID string
@@ -110,10 +111,9 @@ func (c *NMIClient) AddRecurringSubscription(data RecurringPaymentData) (*AddSub
 		return nil, err
 	}
 
-	amtStr := strconv.FormatFloat(float64(data.Amount), 'f', 2, 64)
 	values := url.Values{
 		"type":              {"sale"},
-		"amount":            {amtStr},
+		"amount":            {centsToDollarString(data.Amount)},
 		"email":             {data.Email},
 		"plan_id":           {data.PlanID},
 		"billing_method":    {"recurring"},

--- a/internal/modules/checkout/model_b_upgrade_test.go
+++ b/internal/modules/checkout/model_b_upgrade_test.go
@@ -194,13 +194,16 @@ func TestUpgradeWirePinning(t *testing.T) {
 		t.Fatalf("NMI sale wire amount: expected %q, got %q", "31.33", wire)
 	}
 
-	// Recurring amount is DOLLARS: create ($19.99 sub) and upgrade paths share
-	// moneyutil.MicrosToMajorUnits, so the same price yields the same wire value.
-	if dollars := moneyutil.MicrosToMajorUnits(19_990_000); dollars != 19.99 {
-		t.Fatalf("recurring dollars: expected 19.99, got %v", dollars)
-	}
-	if dollars := moneyutil.MicrosToMajorUnits(50_000_000); dollars != 50.0 {
-		t.Fatalf("recurring dollars: expected 50, got %v", dollars)
+	// The recurring enrollment amount is CENTS (#818): create and upgrade paths
+	// share MicrosToCentsExact, so the same price yields the same wire value.
+	for micros, want := range map[int64]string{19_990_000: "19.99", 50_000_000: "50.00"} {
+		c, err := moneyutil.MicrosToCentsExact(micros)
+		if err != nil {
+			t.Fatalf("recurring cents for %d micros: %v", micros, err)
+		}
+		if wire := moneyutil.FormatCentsDecimal(c); wire != want {
+			t.Fatalf("recurring wire amount: expected %q, got %q", want, wire)
+		}
 	}
 
 	// A price not representable in whole cents must ERROR at the sale seam,

--- a/internal/modules/checkout/nmi_subscription_intent.go
+++ b/internal/modules/checkout/nmi_subscription_intent.go
@@ -160,6 +160,15 @@ func (h *NMISubscriptionCreateIntentHandler) Execute(ctx context.Context, intent
 		}
 	}
 
+	// NMI charges whole cents; the payload carries micros. Error (never round)
+	// on a sub-cent remainder — same policy as the one-time sale path. Terminal,
+	// not parked: no retry can make an unrepresentable price representable, and
+	// nothing was sent, so the checkout fails clean instead of under-charging.
+	amountCents, err := moneyutil.MicrosToCentsExact(p.AmountMicros)
+	if err != nil {
+		return intents.Terminal("subscription amount must be representable in whole cents: " + err.Error())
+	}
+
 	// #297: subscription enrollment is the cardholder-initiated RECURRING
 	// credential-on-file charge — the sequence's initial CIT when the
 	// instrument has no recurring anchor, a reuse when it does (a second
@@ -181,7 +190,7 @@ func (h *NMISubscriptionCreateIntentHandler) Execute(ctx context.Context, intent
 		},
 		PlanID:           p.PlanID,
 		CustomerVaultID:  p.CustomerVaultID,
-		Amount:           moneyutil.MajorUnits(moneyutil.MicrosToMajorUnits(p.AmountMicros)),
+		Amount:           moneyutil.Cents(amountCents),
 		Currency:         p.Currency,
 		Email:            p.Email,
 		OrderID:          orderID,

--- a/internal/modules/checkout/service.go
+++ b/internal/modules/checkout/service.go
@@ -1816,6 +1816,14 @@ func (s *CheckoutService) processUpgrade(
 		_ = s.IdempotencyService.Fail(ctx, idempOp, idempotencyKey, err)
 		return nil, err
 	}
+	// Same rule for the successor's recurring enrollment charge, converted here
+	// so BOTH money conversions fail before any provider write happens.
+	recurringCents, err := moneyutil.MicrosToCentsExact(newPrice.Amount)
+	if err != nil {
+		err := fmt.Errorf("upgrade recurring amount must be representable in whole cents: %w", err)
+		_ = s.IdempotencyService.Fail(ctx, idempOp, idempotencyKey, err)
+		return nil, err
+	}
 
 	provider := target.Rail
 	if existingSub.CurrentPeriodEndsAt == nil || existingSub.CurrentPeriodEndsAt.IsZero() {
@@ -1904,7 +1912,7 @@ func (s *CheckoutService) processUpgrade(
 			PlanID:          nmiPlanID,
 			CustomerVaultID: customerVaultID,
 			BillingID:       vaultBillingID,
-			Amount:          moneyutil.MajorUnits(moneyutil.MicrosToMajorUnits(newPrice.Amount)), // NMI recurring amount is DOLLARS
+			Amount:          moneyutil.Cents(recurringCents),
 			Currency:        newPrice.Currency,
 			Email:           req.Email,
 			OrderID:         successorOrderID,

--- a/internal/modules/subscriptions/email_service.go
+++ b/internal/modules/subscriptions/email_service.go
@@ -41,8 +41,11 @@ type EmailService struct {
 
 // OneOffPurchaseEmailData contains data for one-off purchase receipts
 type OneOffPurchaseEmailData struct {
-	UserEmail     string
-	Amount        int64 // Amount in cents (smallest currency unit)
+	UserEmail string
+	// AmountMicros is the purchase amount in MICROS — the system-wide money
+	// unit and what FormatDisplay renders (#818: the field was documented cents
+	// but rendered as micros, a latent 10,000x).
+	AmountMicros  int64
 	Currency      string
 	ProductName   string
 	PaymentMethod string
@@ -241,7 +244,7 @@ func (s *EmailService) SendOneOffPurchaseReceipt(ctx context.Context, data OneOf
 		productName = "Premium content"
 	}
 
-	amountLine := moneyutil.FormatDisplay(data.Amount, data.Currency)
+	amountLine := moneyutil.FormatDisplay(data.AmountMicros, data.Currency)
 
 	issuedAt := s.now().Format("Jan 2, 2006 15:04 MST")
 

--- a/internal/modules/subscriptions/notification_service.go
+++ b/internal/modules/subscriptions/notification_service.go
@@ -2,7 +2,10 @@ package subscriptions
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -204,14 +207,21 @@ func (s *NotificationService) sendEmailNotification(ctx context.Context, notific
 			return nil
 		}
 
-		amountFloat, _ := notification.Data["amount"].(float64)
+		// amount_micros is a decimal INTEGER STRING, never a JSON number: a
+		// JSONB round-trip decodes numbers as float64, and no monetary value
+		// may pass through a float (#818). A malformed amount fails the
+		// delivery rather than emailing a fabricated one.
+		amountMicros, err := notificationAmountMicros(notification.Data["amount_micros"])
+		if err != nil {
+			return fmt.Errorf("one-off purchase notification amount: %w", err)
+		}
 		currency, _ := notification.Data["currency"].(string)
 		productName, _ := notification.Data["product_name"].(string)
 		paymentMethod, _ := notification.Data["payment_method"].(string)
 
 		return s.emailService.SendOneOffPurchaseReceipt(ctx, OneOffPurchaseEmailData{
 			UserEmail:     email,
-			Amount:        int64(amountFloat),
+			AmountMicros:  amountMicros,
 			Currency:      currency,
 			ProductName:   productName,
 			PaymentMethod: paymentMethod,
@@ -229,6 +239,27 @@ func (s *NotificationService) sendEmailNotification(ctx context.Context, notific
 	default:
 		log.WithContext(ctx).WithField("event_type", notification.EventType).Warn("unknown notification event type for email delivery")
 		return nil
+	}
+}
+
+// notificationAmountMicros reads a money field out of a notification payload
+// without ever touching a float. json.Number keeps the exact source text, so a
+// producer that wrote a JSON integer still round-trips; anything else must be a
+// decimal integer string.
+func notificationAmountMicros(raw any) (int64, error) {
+	switch v := raw.(type) {
+	case nil:
+		return 0, fmt.Errorf("missing amount_micros")
+	case string:
+		return strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+	case json.Number:
+		return v.Int64()
+	case int64:
+		return v, nil
+	case int:
+		return int64(v), nil
+	default:
+		return 0, fmt.Errorf("amount_micros must be a decimal integer string, got %T", raw)
 	}
 }
 

--- a/internal/modules/webhooks/ccbill.go
+++ b/internal/modules/webhooks/ccbill.go
@@ -152,7 +152,7 @@ func validateCCBillBilledAmount(ctx context.Context, svc *CCBillWebhookService, 
 	if err != nil {
 		return err
 	}
-	tolerance := int64(float64(expectedAmountCents) * 0.02) // 2% tolerance.
+	tolerance := expectedAmountCents * 2 / 100 // 2% tolerance, integer-only (#818)
 	if billedAmountCents >= expectedAmountCents-tolerance && billedAmountCents <= expectedAmountCents+tolerance {
 		return nil
 	}
@@ -893,12 +893,11 @@ func (s *CCBillWebhookService) handleUpgradeSuccess(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		billedAmount := moneyutil.CentsToMajorUnits(billedAmountCents)
 		expectedAmountCents, err := moneyutil.MicrosToCentsExact(expectedAmountMicros)
 		if err != nil {
 			return err
 		}
-		tolerance := int64(float64(expectedAmountCents) * 0.02) // 2% tolerance
+		tolerance := expectedAmountCents * 2 / 100 // 2% tolerance, integer-only (#818)
 		if billedAmountCents < (expectedAmountCents-tolerance) || billedAmountCents > (expectedAmountCents+tolerance) {
 			billingErr := newBillingError(ErrorTypeAmount,
 				"Upgrade billed amount does not match expected price",
@@ -971,7 +970,7 @@ func (s *CCBillWebhookService) handleUpgradeSuccess(ctx context.Context) error {
 
 		subscription.RailSubscriptionID = ccBillSubID
 
-		if err = subscription.Validate(billedAmount); err != nil {
+		if err = subscription.Validate(billedAmountCents); err != nil {
 			return fmt.Errorf("failed to validate subscription: %w", err)
 		}
 
@@ -1002,7 +1001,7 @@ func (s *CCBillWebhookService) handleUpgradeSuccess(ctx context.Context) error {
 			"userID":                 subscription.CustomerID.String(),
 			"oldPriceID":             oldPriceID,
 			"newPriceID":             newPrice.ID,
-			"billedAmount":           billedAmount,
+			"billedAmountCents":      billedAmountCents,
 			"transactionID":          transactionID,
 			"newFlexID":              flexID,
 			"originalSubscriptionID": originalSubscriptionID,
@@ -1399,7 +1398,6 @@ func (s *CCBillWebhookService) handleRefund(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	refundAmount := moneyutil.CentsToMajorUnits(refundAmountCents)
 	if _, err := requireCCBillCurrency(data.CurrencyCode, "currencyCode"); err != nil {
 		return err
 	}
@@ -1531,7 +1529,7 @@ func (s *CCBillWebhookService) handleRefund(ctx context.Context) error {
 					Err:               refundLedgerErr,
 					Metadata: map[string]any{
 						"rail_subscription_id": pSubscriptionID,
-						"refund_amount":        refundAmount,
+						"refund_amount_cents":  refundAmountCents,
 						"refund_reason":        refundReason,
 					},
 				}
@@ -1553,7 +1551,7 @@ func (s *CCBillWebhookService) handleRefund(ctx context.Context) error {
 			// Don't terminate, but log the refund for record keeping
 			log.WithContext(ctx).WithFields(log.Fields{
 				"subscriptionID":      sub.ID,
-				"refundAmount":        refundAmount,
+				"refundAmountCents":   refundAmountCents,
 				"refundType":          "auto_detected",
 				"refundTransactionID": refundTransactionID,
 			}).Info("Partial refund processed - subscription remains active")
@@ -1566,7 +1564,7 @@ func (s *CCBillWebhookService) handleRefund(ctx context.Context) error {
 		log.WithContext(ctx).WithFields(log.Fields{
 			"subscriptionID":         sub.ID,
 			"userID":                 sub.CustomerID.String(),
-			"refundAmount":           refundAmount,
+			"refundAmountCents":      refundAmountCents,
 			"refundType":             "auto_detected",
 			"refundTransactionID":    refundTransactionID,
 			"subscriptionTerminated": shouldTerminate,
@@ -1602,7 +1600,6 @@ func (s *CCBillWebhookService) handleVoid(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	voidAmount := moneyutil.CentsToMajorUnits(voidAmountCents)
 	if _, err := requireCCBillCurrency(data.CurrencyCode, "currencyCode"); err != nil {
 		return err
 	}
@@ -1626,7 +1623,7 @@ func (s *CCBillWebhookService) handleVoid(ctx context.Context) error {
 				// sale create entitlements for an already-voided charge.
 				log.WithContext(ctx).WithFields(log.Fields{
 					"rail_subscription_id": pSubscriptionID,
-					"void_amount":          voidAmount,
+					"void_amount_cents":    voidAmountCents,
 					"void_transaction_id":  voidTransactionID,
 				}).Warn("Void event for unknown subscription; retrying until the sale materializes")
 				return fmt.Errorf("subscription %q not found for CCBill void: %w", pSubscriptionID, err)
@@ -1637,7 +1634,7 @@ func (s *CCBillWebhookService) handleVoid(ctx context.Context) error {
 		log.WithContext(ctx).WithFields(log.Fields{
 			"subscriptionID":        sub.ID,
 			"userID":                sub.CustomerID.String(),
-			"voidAmount":            voidAmount,
+			"voidAmountCents":       voidAmountCents,
 			"voidTransactionID":     voidTransactionID,
 			"originalTransactionID": voidTransactionID,
 		}).Info("Void event for existing subscription")
@@ -1676,7 +1673,7 @@ func (s *CCBillWebhookService) handleVoid(ctx context.Context) error {
 		log.WithContext(ctx).WithFields(log.Fields{
 			"subscriptionID":    sub.ID,
 			"userID":            sub.CustomerID.String(),
-			"voidAmount":        voidAmount,
+			"voidAmountCents":   voidAmountCents,
 			"voidTransactionID": voidTransactionID,
 		}).Info("Processed void successfully")
 
@@ -1719,7 +1716,6 @@ func (s *CCBillWebhookService) handleChargeback(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	chargebackAmount := moneyutil.CentsToMajorUnits(chargebackAmountCents)
 	if _, err := requireCCBillCurrency(data.CurrencyCode, "currencyCode"); err != nil {
 		return err
 	}
@@ -1743,8 +1739,8 @@ func (s *CCBillWebhookService) handleChargeback(ctx context.Context) error {
 				// subscription once the sale materializes; a plain ACK left the
 				// charged-back access standing.
 				log.WithContext(ctx).WithFields(log.Fields{
-					"rail_subscription_id": pSubscriptionID,
-					"chargeback_amount":    chargebackAmount,
+					"rail_subscription_id":    pSubscriptionID,
+					"chargeback_amount_cents": chargebackAmountCents,
 				}).Error("Chargeback event for unknown subscription; retrying until the sale materializes")
 				return fmt.Errorf("subscription %q not found for CCBill chargeback: %w", pSubscriptionID, err)
 			}
@@ -1837,17 +1833,17 @@ func (s *CCBillWebhookService) handleChargeback(ctx context.Context) error {
 				SubscriptionID:    &subscriptionID,
 				Err:               ledgerErr,
 				Metadata: map[string]any{
-					"rail_subscription_id": pSubscriptionID,
-					"chargeback_amount":    chargebackAmount,
-					"chargeback_reason":    chargebackReason,
+					"rail_subscription_id":    pSubscriptionID,
+					"chargeback_amount_cents": chargebackAmountCents,
+					"chargeback_reason":       chargebackReason,
 				},
 			}
 		}
 
 		log.WithContext(ctx).WithFields(log.Fields{
-			"user_id":           sub.CustomerID.String(),
-			"chargeback_amount": chargebackAmount,
-			"dispute_id":        "unknown",
+			"user_id":                 sub.CustomerID.String(),
+			"chargeback_amount_cents": chargebackAmountCents,
+			"dispute_id":              "unknown",
 		}).Warn("User account involved in chargeback - consider fraud review")
 
 		// Add system alert notification for chargeback (admin notification)
@@ -1867,7 +1863,7 @@ func (s *CCBillWebhookService) handleChargeback(ctx context.Context) error {
 		log.WithContext(ctx).WithFields(log.Fields{
 			"subscriptionID":          sub.ID,
 			"userID":                  sub.CustomerID.String(),
-			"chargebackAmount":        chargebackAmount,
+			"chargebackAmountCents":   chargebackAmountCents,
 			"chargebackTransactionID": chargebackTransactionID,
 			"chargebackReasonCode":    "unknown",
 			"disputeID":               "unknown",
@@ -1927,7 +1923,6 @@ func (s *CCBillWebhookService) handleRenewalSuccessInternal(ctx context.Context,
 	if err != nil {
 		return err
 	}
-	billedAmount := moneyutil.CentsToMajorUnits(billedAmountCents)
 
 	currencyValue, err := requireCCBillCurrency(data.BilledCurrencyCode, "billedCurrencyCode")
 	if err != nil {
@@ -2037,10 +2032,10 @@ func (s *CCBillWebhookService) handleRenewalSuccessInternal(ctx context.Context,
 	}
 
 	log.WithContext(ctx).WithFields(log.Fields{
-		"subscriptionID": subscription.ID,
-		"userID":         subscription.CustomerID.String(),
-		"billedAmount":   billedAmount,
-		"transactionID":  transactionID,
+		"subscriptionID":    subscription.ID,
+		"userID":            subscription.CustomerID.String(),
+		"billedAmountCents": billedAmountCents,
+		"transactionID":     transactionID,
 	}).Info("Processed subscription renewal successfully")
 
 	return nil

--- a/internal/modules/webhooks/nmi.go
+++ b/internal/modules/webhooks/nmi.go
@@ -169,7 +169,7 @@ func nmiAmountMatchesExpected(amountCents, expectedAmountMicros int64) bool {
 	if err != nil {
 		return false
 	}
-	tolerance := int64(float64(expectedAmountCents) * 0.02)
+	tolerance := expectedAmountCents * 2 / 100 // 2% tolerance, integer-only (#818)
 	return amountCents >= expectedAmountCents-tolerance && amountCents <= expectedAmountCents+tolerance
 }
 
@@ -896,7 +896,6 @@ func (s *NMIWebhookService) handleRefundSuccess(ctx context.Context) error {
 	if refundAmountCents < 0 {
 		refundAmountCents = -refundAmountCents
 	}
-	refundAmount := moneyutil.CentsToMajorUnits(refundAmountCents)
 
 	if _, err := s.normalizedRail(); err != nil {
 		return err
@@ -998,9 +997,9 @@ func (s *NMIWebhookService) handleRefundSuccess(ctx context.Context) error {
 
 	if shouldTerminate && subscription != nil {
 		log.WithContext(ctx).WithFields(log.Fields{
-			"subscription_id":  subscription.ID,
-			"refund_amount":    refundAmount,
-			"subscription_fee": moneyutil.MicrosToMajorUnits(subscription.Price.Amount), // #671 1f: micros, not cents
+			"subscription_id":         subscription.ID,
+			"refund_amount_cents":     refundAmountCents,
+			"subscription_fee_micros": subscription.Price.Amount,
 		}).Warn("Terminating subscription due to significant refund (>=80%)")
 
 		// Use lifecycle service to cancel membership with immediate revocation
@@ -1028,7 +1027,7 @@ func (s *NMIWebhookService) handleRefundSuccess(ctx context.Context) error {
 
 	log.WithContext(ctx).WithFields(log.Fields{
 		"transaction_id":          txnID,
-		"refund_amount":           refundAmount,
+		"refund_amount_cents":     refundAmountCents,
 		"subscription_terminated": shouldTerminate,
 	}).Info("NMI refund processed")
 

--- a/internal/modules/webhooks/types.go
+++ b/internal/modules/webhooks/types.go
@@ -70,15 +70,6 @@ func (s Stringish) IsEmpty() bool {
 	return strings.TrimSpace(string(s)) == ""
 }
 
-// Float64 parses the value as a float64 when present.
-func (s Stringish) Float64() (float64, error) {
-	trimmed := strings.TrimSpace(string(s))
-	if trimmed == "" {
-		return 0, errors.New("value is empty")
-	}
-	return strconv.ParseFloat(trimmed, 64)
-}
-
 // Intish models integer-like fields that may arrive as strings or numbers.
 type Intish int
 

--- a/internal/reconcile/history.go
+++ b/internal/reconcile/history.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/open-rails/openrails/internal/db"
 	"github.com/open-rails/openrails/internal/db/gen"
-	"github.com/open-rails/openrails/internal/shared/moneyutil"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
 
@@ -29,8 +28,10 @@ type HistoryEvent struct {
 	RailSubscriptionID string
 	RailTransactionID  string
 	Status             string
-	Amount             *float64
-	OccurredAt         time.Time
+	// AmountMicros is the raw row amount in micros; nil when the row has none.
+	// Display/forensics only — format at the edge, never compute on it.
+	AmountMicros *int64
+	OccurredAt   time.Time
 }
 
 // HistoryEventSource supplies the history evidence for the dunning forensics.
@@ -111,8 +112,8 @@ func (s *PGHistorySource) ListEvents(ctx context.Context, railNames []string, si
 			ev.RailTransactionID = *r.RailTransactionID
 		}
 		if r.AmountMicros != nil {
-			amount := moneyutil.MicrosToMajorUnits(*r.AmountMicros)
-			ev.Amount = &amount
+			micros := *r.AmountMicros
+			ev.AmountMicros = &micros
 		}
 		out = append(out, ev)
 	}

--- a/internal/reconcile/history_integration_test.go
+++ b/internal/reconcile/history_integration_test.go
@@ -126,8 +126,8 @@ func TestPGHistorySource(t *testing.T) {
 		require.Equal(t, "legacy-sub-"+sfx, imported.RailSubscriptionID)
 		require.Equal(t, "legacy-txn-"+sfx, imported.RailTransactionID)
 		require.Equal(t, "declined", imported.Status)
-		require.NotNil(t, imported.Amount)
-		require.InDelta(t, 9.99, *imported.Amount, 0.0001)
+		require.NotNil(t, imported.AmountMicros)
+		require.Equal(t, int64(9_990_000), *imported.AmountMicros)
 		require.True(t, imported.OccurredAt.Equal(t1))
 
 		failed := events[1]

--- a/internal/shared/moneyutil/moneyutil.go
+++ b/internal/shared/moneyutil/moneyutil.go
@@ -21,11 +21,6 @@ type Micros int64
 // most card rails (NMI, Stripe) charge in for 2-decimal currencies.
 type Cents int64
 
-// MajorUnits is a float amount in major currency units (dollars for USD) —
-// used only where a provider wire format genuinely takes a decimal amount
-// (e.g. NMI classic recurring). Never do ledger math in this type.
-type MajorUnits float64
-
 func ParseDecimalToCents(value string) (int64, error) {
 	return parseDecimalScaled(value, CentsPerMajorUnit)
 }
@@ -43,14 +38,6 @@ func parseDecimalScaled(value string, scale int64) (int64, error) {
 
 	scaled := new(big.Rat).Mul(parsed, big.NewRat(scale, 1))
 	return roundHalfAwayFromZero(scaled)
-}
-
-func MicrosToMajorUnits(micros int64) float64 {
-	return float64(micros) / float64(MicrosPerMajorUnit)
-}
-
-func CentsToMajorUnits(cents int64) float64 {
-	return float64(cents) / float64(CentsPerMajorUnit)
 }
 
 func CentsToMicros(cents int64) int64 {

--- a/pkg/service/catalog_provider_nmi_test.go
+++ b/pkg/service/catalog_provider_nmi_test.go
@@ -92,16 +92,18 @@ func TestMobiusAdapter_AutoCreateFreshCreate(t *testing.T) {
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/plans":
 			addCalled = true
+			// plan_amount is pinned as the exact wire TEXT (json.Number), not a
+			// float64 — a float decode hides sub-cent rounding (#818).
 			var req struct {
-				PlanAmount   float64 `json:"plan_amount"`
-				DayFrequency int     `json:"day_frequency"`
+				PlanAmount   json.Number `json:"plan_amount"`
+				DayFrequency int         `json:"day_frequency"`
 			}
 			_ = json.NewDecoder(r.Body).Decode(&req)
 			if req.DayFrequency != 30 {
 				t.Errorf("day_frequency: got %d want 30", req.DayFrequency)
 			}
-			if req.PlanAmount != 9.99 {
-				t.Errorf("plan_amount: got %v want 9.99", req.PlanAmount)
+			if req.PlanAmount.String() != "9.99" {
+				t.Errorf("plan_amount: got %q want %q", req.PlanAmount.String(), "9.99")
 			}
 			_, _ = w.Write([]byte(`{"object":"plan","id":"x"}`))
 		case r.Method == http.MethodGet:


### PR DESCRIPTION
Implementation of tracker #818 (repo-audit finding): float64 money bridges deleted from moneyutil, webhook amount-tolerance checks rewritten as integer arithmetic, subscription validation + logs operate in cents natively. webhooks/nmi/checkout/subscriptions/moneyutil/reconcile suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)