### PR TITLE
or#825: gated-premium-page example — live-proven against real NMI sandbox

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,14 @@ jobs:
         # v0.78.0, v0.80.0) broke them silently twice because default builds
         # never compile these files.
         run: go vet -tags integration ./...
+      - name: Build examples
+        # Each example is its own module (replace => ../..), invisible to the
+        # root ./... patterns — build them explicitly so engine changes that
+        # break an example fail the same PR.
+        run: |
+          for d in examples/*/; do
+            (cd "$d" && go build ./... && go vet ./...)
+          done
       - name: Test
         run: go test -race ./...
 

--- a/examples/gated-premium-page/.gitignore
+++ b/examples/gated-premium-page/.gitignore
@@ -1,0 +1,7 @@
+issuer_key.pem
+issuer_key.pem.pub
+go.work
+go.work.sum
+gated-premium-page
+mintadmin
+e2e/.state/

--- a/examples/gated-premium-page/E2E.md
+++ b/examples/gated-premium-page/E2E.md
@@ -1,0 +1,126 @@
+# E2E proof — gated-premium-page against a real local stack + real NMI sandbox
+
+Proven 2026-07-28 (tracker #825): the full six-step demo runs end-to-end against
+`task docker-up`'s stack and the real NMI sandbox account — including the REAL
+browser flow (Collect.js tokenized in headless Chromium via Playwright; charge
+approved synchronously by NMI; `/premium` unlocked; no inbound webhook needed).
+
+## Run it
+
+Prereqs: repo-root `.env` with `NMI_SANDBOX_SECURITY_KEY`, `NMI_TOKENIZATION_KEY`
+(and optionally `NMI_WEBHOOK_SIGNING_SECRET`, `NMI_TOKENIZATION_URL`,
+`NMI_ACCOUNT_ID`); docker; `jq`; Go.
+
+```bash
+cd examples/gated-premium-page
+bash e2e/provision.sh   # stack up + merchant + PSP creds + catalog + NMI plan + API key
+bash e2e/run-e2e.sh     # scripted six-step proof (server-side-token variant)
+```
+
+`e2e/provision.sh` leaves state in `e2e/.state/` (issuer key, manifests,
+compose override, `apikey.env`). Re-running is idempotent; each run
+version-bumps the price onto a fresh randomized-amount NMI plan so repeat
+purchases dodge NMI's duplicate-transaction window. Teardown: `task docker-down`.
+
+For the interactive demo (real browser, real Collect.js):
+
+```bash
+set -a; source ../../.env; source e2e/.state/apikey.env; set +a
+ISSUER_KEY_FILE=e2e/.state/issuer_key.pem go run .
+# open http://localhost:8080, log in, buy with 4111 1111 1111 1111 / 10/29
+```
+
+## What is scripted vs manual
+
+- **Scripted** (`run-e2e.sh`): steps 1–6 with ONE substitution — browser
+  Collect.js tokenization is replaced by its server-side equivalent (vault the
+  card directly at NMI + insert the payment-method row, the same pattern as
+  `tests/nmi_live_lifecycle_e2e_test.go`), then the REAL
+  `POST /v1/me/checkout` runs with `payment_method_id`. Plus a step 7: remote
+  verification at NMI (`query.php`).
+- **Manual/browser** (works headlessly under Playwright, verified): the actual
+  `/buy` page — Collect.js iframes accept the sandbox card, the one-time
+  `payment_token` goes to `/v1/me/checkout`, NMI approves synchronously,
+  `/premium` serves 200. Renewals are the only part that needs the NMI webhook
+  (see README).
+
+## Deviations from the README quickstart (all forced by engine gaps)
+
+Verified against commit `fc3ebc41`; each has a precise pointer.
+
+1. **`openrails server` never loads the MODE-1 boot merchant manifest.**
+   `reconcileBootMerchantManifest` exists only in
+   `internal/bootstrap/serverboot/serverboot.go:109` (used by the test
+   harness); the shipped CLI path (`cmd/openrails/main.go:runServer` →
+   `embedded.New` → `StandaloneHandler`) applies only the AuthKit
+   `bootstrap.yaml` (`cmd/openrails/bootstrap_apply.go:applyStartupBootstrap`,
+   whose comment says merchant config is "never reconciled from normal server
+   startup"). docs/self-hosting-mode1.md ("Loaded by standalone server boot,
+   every boot") and docs/standalone-integration.md ("step 2 is simply mount
+   the file and boot") describe behavior the binary does not implement.
+   Consequence: MODE-1 standalone can never arm PSP secrets — the CLI push
+   explicitly discards them ("secrets validate in memory only and are NOT
+   persisted"). **Workaround**: the server runs `MERCHANT_SOURCE=api`; the
+   push CLIs run `MERCHANT_SOURCE=manifest` (they refuse under api — while
+   docs/merchant-provisioning.md claims the push CLIs seed MODE-2 stores, see
+   `cmd/openrails/bootstrap_apply.go:163`); NMI credentials are then seeded
+   through `PUT /v1/merchant/payment-providers/nmi` into the MODE-2 DB store.
+2. **Checkout rejects PSP-key wire values.** `checkoutRailConfigured`
+   (`internal/http/handlers/checkout_session.go:133`) passes the wire `rail`
+   into `merchants.ActivePSPScope`, which resolves by rail KIND — so the
+   frozen PSP vocabulary (`mobius-sandbox`) 400s "unsupported rail" although
+   `checkout.resolveRailTarget`
+   (`internal/modules/checkout/merchant_rail_secrets.go:112`) explicitly
+   supports account keys. Repro: `POST /v1/me/checkout` with
+   `payment.rail="mobius-sandbox"` → 400; `"nmi"` → 200. **Workaround**: the
+   example sends the rail name (`NMI_RAIL`, default `nmi`).
+3. **Docker image does not build.** The console stage crashes:
+   `ERR_PNPM_VERIFY_DEPS_BEFORE_RUN opts2.currentPnpmfiles is not iterable`
+   (pnpm 11.0.0 + `verifyDepsBeforeRun: error` in `web/admin/pnpm-workspace.yaml`,
+   tripped by `COPY web/admin/ ./` after `pnpm install`). So `task docker-up`
+   cannot build the image. **Workaround** (build env only): flip
+   `verifyDepsBeforeRun: false` inside the console build stage before
+   `pnpm run build`.
+4. **`merchants.api_host` has no API/manifest/CLI surface** (Go-only
+   `merchants.Service.SetHostConfig`), yet the public catalog
+   (`GET /v1/products`, which `/buy` fetches) resolves the merchant from the
+   request Host and 500s until it is set. **Workaround**: provision.sh applies
+   the same row update via psql (`api_host='localhost'`).
+5. **Issuer-key rotation via the CLI needs a server restart** — the delegated
+   verifier caches registered issuer keys in process memory; a key
+   (re)registered by `push-merchant-config` from another process is not
+   picked up live.
+6. **Catalog `psps: [mobius-sandbox]` alone cannot sell on NMI.** NMI is
+   link-only: without `psp_links.<psp>.plan_id` the price lands
+   `pending_manual_link` and checkout fails
+   ("missing NMI plan configuration", `requireNMIPlanForTarget`,
+   `internal/modules/checkout/service.go`). provision.sh creates the sandbox
+   plan (`recurring=add_plan`) and links it.
+
+## What was proven, step by step
+
+1. `GET /` → 200 (public page).
+2. `GET /login` → signed demo session cookie.
+3. `GET /premium` with no entitlement → 302 `/buy`
+   (`openrails.ListActiveEntitlements` over the SDK, API-key auth).
+4. Purchase, twice:
+   - server-side-token variant → NMI approved synchronously
+     (e.g. txn `12356389049`, $5.23);
+   - REAL browser (headless Chromium + Collect.js) → NMI approved
+     (txn `12356402185`, $6.87), page redirected to `/premium`.
+   A same-amount repeat inside NMI's duplicate window correctly surfaced as a
+   declined checkout + failed payment row.
+5. `GET /premium` → 200, "Premium unlocked".
+6. Self surface: `/v1/me/subscriptions` → status `active`;
+   `/v1/me/entitlements/active` → `premium` (source: the subscription).
+   Merchant surface (API key): `/v1/merchant/payments` shows the succeeded
+   payment with the NMI transaction id; `/v1/merchant/customers/{id}/entitlements`
+   and `/v1/merchant/entitlements/premium/customers` both show the grant.
+7. Remote state at NMI (`query.php`): transaction present
+   (`pendingsettlement`, exact amount) and the recurring subscription exists
+   (`rail_subscription_id` matches).
+
+## Not provable headlessly
+
+Nothing in the six-step demo. Only **renewals** (NMI rebill webhooks) need an
+inbound tunnel — out of scope here, see docs/dev/local-webhooks.md.

--- a/examples/gated-premium-page/README.md
+++ b/examples/gated-premium-page/README.md
@@ -1,0 +1,139 @@
+# Gated premium page — OpenRails standalone demo
+
+A ~300-line Go webserver showing the whole standalone integration:
+
+- `/` — public page
+- `/premium` — gated on an OpenRails **entitlement** (`ListActiveEntitlements`
+  via the root SDK); no entitlement → redirect to `/buy`
+- `/buy` — browser-direct checkout against OpenRails' `/v1/me/*` surface:
+  delegated token from `/api/token`, NMI Collect.js tokenized-vault flow,
+  sandbox test card
+- `/api/token` — the ONE backend endpoint the frontend needs: swaps the (fake,
+  signed-cookie) session for a short-lived delegated JWT
+
+It is the living companion to
+[docs/standalone-integration.md](../../docs/standalone-integration.md),
+[docs/frontend-integration.md](../../docs/frontend-integration.md) and
+[docs/rails/nmi.md](../../docs/rails/nmi.md).
+
+## Setup
+
+> **Shortcut / proven path**: `bash e2e/provision.sh` provisions everything
+> below against the local compose stack (and `e2e/run-e2e.sh` proves the whole
+> demo headlessly against the real NMI sandbox). [E2E.md](E2E.md) documents
+> the walkthrough and the engine gaps the script routes around — read it if a
+> step below misbehaves.
+
+You need a running OpenRails with a merchant, an NMI sandbox PSP, a catalog,
+and an API key. The deployment must run with `PROVIDER_WRITE_MODE=full`
+(unset fail-closes to readonly and every charge is refused). Locally:
+
+1. **Stack**: `task docker-up` in the repo root, then
+   `curl localhost:3053/health/ready`.
+2. **Issuer key**: run the app once (`go run .`) — it generates
+   `issuer_key.pem` + `issuer_key.pem.pub` and exits (no API key yet). Register
+   the public key on your merchant in `merchants.yaml`:
+
+   ```yaml
+   merchants:
+     demo:
+       display_name: Demo
+       remote_application:
+         issuer: https://gated-premium-page.example
+         public_keys:
+           - kid: demo-1
+             public_key_pem: |
+               <contents of issuer_key.pem.pub>
+       psps:
+         mobius-sandbox:
+           nmi:
+             environment: test
+             account_id: "<dashboard Gateway ID>"
+             settings:
+               tokenization_key: <public Collect.js key>
+             secrets:
+               security_key: <sandbox security key>
+               webhook_signing_secret: <sandbox webhook secret>
+   ```
+
+   Sandbox credentials come from your ISO — see
+   [docs/rails/nmi.md](../../docs/rails/nmi.md). Push it (and the auth
+   bootstrap) per the "First run" section of
+   [docs/standalone-integration.md](../../docs/standalone-integration.md).
+3. **Catalog** (`push-merchant-catalog --insert --overwrite`):
+
+   ```yaml
+   catalogs:
+     - merchant: demo
+       products:
+         - key: premium
+           display_name: Premium
+           entitlements: [premium]
+           prices:
+             - currency: usd
+               unit_amount: 5_000_000   # $5.00 — micros everywhere
+               duration: 30d
+               auto_renew: true
+               psps: [mobius-sandbox]
+               # NMI is link-only: a recurring price sells ONLY once it is
+               # linked to an existing NMI plan (create one with the direct-post
+               # `recurring=add_plan` API — same amount + day_frequency):
+               psp_links:
+                 mobius-sandbox:
+                   plan_id: openrails_demo_premium_500_d30
+   ```
+
+   Also set the merchant's `api_host` (Host→merchant resolution for the
+   public catalog `GET /v1/products` the buy page fetches) — locally
+   `api_host='localhost'`; see E2E.md for the how (no API surface yet).
+4. **API key**: `POST /v1/merchant/api-keys {"name":"demo","role":"owner"}`,
+   authenticated per [docs/merchant-provisioning.md](../../docs/merchant-provisioning.md)
+   (delegated JWT from the issuer you just registered, an operator session, or
+   the admin console). Export the returned `openrails_st_…` secret.
+5. **Run**:
+
+   ```bash
+   OPENRAILS_API_KEY=openrails_st_... NMI_TOKENIZATION_KEY=<Collect.js key> go run .
+   ```
+
+Renewals (not the first charge — that is synchronous) need the NMI webhook
+pointed at OpenRails; for local tunnels see
+[docs/dev/local-webhooks.md](../../docs/dev/local-webhooks.md).
+
+## The six-step demo
+
+1. Open http://localhost:8080 — the public page.
+2. Click **Log in** — a signed cookie holding the demo user id (this is the
+   stand-in for your app's real auth).
+3. Visit **/premium** — the backend asks OpenRails for the user's active
+   entitlements, finds none, and redirects to **/buy**.
+4. Pick the plan and pay with the sandbox test card
+   `4111 1111 1111 1111`, expiry `10/29`, any CVV. The card goes browser →
+   NMI (Collect.js); OpenRails only ever sees the one-time token.
+5. Checkout succeeds synchronously; the page redirects to **/premium** —
+   the entitlement is active, the page unlocks.
+6. Verify from the outside: `GET /v1/me/status` with a delegated token from
+   `/api/token`, or the merchant admin console.
+
+## Environment
+
+| Var | Default | Meaning |
+|---|---|---|
+| `OPENRAILS_BASE_URL` | `http://localhost:3053` | OpenRails origin |
+| `OPENRAILS_API_KEY` | — (required) | merchant API key (`openrails_st_…`) |
+| `MERCHANT_SLUG` | `demo` | merchant this demo belongs to |
+| `DEMO_USER_ID` | fixed UUID | the fake logged-in user (must be a UUID) |
+| `NMI_PSP` | `mobius-sandbox` | the merchant's PSP key (price filtering) |
+| `NMI_RAIL` | `nmi` | checkout wire `rail` value (should be the PSP key, but the engine's checkout gate currently rejects PSP keys — E2E.md bug 2) |
+| `ENTITLEMENT` | `premium` | entitlement string gating `/premium` |
+| `NMI_TOKENIZATION_KEY` | — (required for /buy) | public Collect.js key |
+| `NMI_TOKENIZATION_URL` | NMI's Collect.js URL | tokenization script |
+| `DEMO_ISSUER` | `https://gated-premium-page.example` | registered `remote_application.issuer` |
+| `ISSUER_KEY_FILE` | `issuer_key.pem` | RS256 signing key (generated on first run) |
+| `SESSION_SECRET` | random per boot | HMAC key for the demo session cookie |
+| `PORT` | `8080` | listen port |
+
+## Local dev against the parent checkout
+
+`go.mod` already carries `replace github.com/open-rails/openrails => ../..`,
+so the example always builds against the repo checkout — no `go.work` needed.

--- a/examples/gated-premium-page/e2e/mintadmin/main.go
+++ b/examples/gated-premium-page/e2e/mintadmin/main.go
@@ -1,0 +1,53 @@
+// Command mintadmin mints a merchant-ADMIN delegated access token from the
+// demo's issuer key (issuer-as-owner: the manifest-registered
+// remote_application is merchant owner, so a delegated token carrying a
+// merchant:* permissions claim administers exactly that merchant).
+// E2E-harness helper: used once at provisioning time to authenticate
+// POST /v1/merchant/api-keys. Prints the JWT to stdout.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/open-rails/authkit/jwtkit"
+)
+
+func main() {
+	key := flag.String("key", "issuer_key.pem", "RS256 private key PEM (the demo's issuer key)")
+	issuer := flag.String("issuer", "https://gated-premium-page.example", "registered remote_application issuer")
+	sub := flag.String("sub", "9e6f5f7a-1111-4e0e-9c39-000000000e2e", "acting admin subject (delegated_sub, any UUID)")
+	perms := flag.String("perms", "merchant:credentials:manage", "comma-separated permissions claim")
+	ttl := flag.Duration("ttl", 10*time.Minute, "token TTL")
+	flag.Parse()
+
+	pemBytes, err := os.ReadFile(*key)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "read key:", err)
+		os.Exit(1)
+	}
+	signer, err := jwtkit.NewSignerFromPEM("demo-1", pemBytes)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "signer:", err)
+		os.Exit(1)
+	}
+	now := time.Now()
+	tok, err := jwtkit.SignWithType(context.Background(), signer, jwt.MapClaims{
+		"iss":           *issuer,
+		"aud":           []string{"openrails"},
+		"iat":           now.Unix(),
+		"exp":           now.Add(*ttl).Unix(),
+		"delegated_sub": *sub,
+		"permissions":   strings.Split(*perms, ","),
+	}, jwtkit.DelegatedAccessTokenType, true)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "sign:", err)
+		os.Exit(1)
+	}
+	fmt.Println(tok)
+}

--- a/examples/gated-premium-page/e2e/provision.sh
+++ b/examples/gated-premium-page/e2e/provision.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# One-shot provisioning of a LOCAL OpenRails stack for this demo, against the
+# real NMI sandbox. Proven end-to-end 2026-07-28 (see ../E2E.md, tracker #825).
+#
+# Requires in the repo root .env (never printed):
+#   NMI_SANDBOX_SECURITY_KEY  NMI_TOKENIZATION_KEY  [NMI_WEBHOOK_SIGNING_SECRET]
+#
+# What it does (and why it deviates from the README's MODE-1 story — the
+# shipped `openrails server` never loads /etc/openrails/merchants.yaml at boot,
+# see E2E.md "Engine bugs"):
+#   1. builds the demo + mintadmin, generates the issuer keypair
+#   2. writes throwaway merchants/catalog manifests + a compose override
+#      (PROVIDER_WRITE_MODE=full, MERCHANT_SOURCE=api, /etc/openrails mount)
+#   3. docker compose up; push-merchant-config CLI (manifest mode) creates the
+#      merchant + issuer-as-owner + PSP row; catalog push creates the product
+#   4. seeds NMI credentials over PUT /v1/merchant/payment-providers/nmi
+#      (admin auth = delegated JWT from the issuer key, permissions merchant:*)
+#   5. creates a randomized-amount NMI sandbox plan (dup-transaction dodge) and
+#      version-bumps the price onto it via the catalog API
+#   6. sets merchants.api_host='localhost' (psql; no API exists) so the public
+#      catalog (/v1/products) resolves the merchant from Host
+#   7. mints the backend API key -> $STATE/apikey.env
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+DEMO=$(cd "$HERE/.." && pwd)
+REPO=$(cd "$DEMO/../.." && pwd)
+STATE=${STATE:-"$HERE/.state"}
+mkdir -p "$STATE/etc-openrails"
+
+set -a; source "$REPO/.env"; set +a
+: "${NMI_SANDBOX_SECURITY_KEY:?set in $REPO/.env}"
+: "${NMI_TOKENIZATION_KEY:?set in $REPO/.env}"
+NMI_TOKENIZATION_URL=${NMI_TOKENIZATION_URL:-https://secure.networkmerchants.com/token/Collect.js}
+NMI_WEBHOOK_SIGNING_SECRET=${NMI_WEBHOOK_SIGNING_SECRET:-demo-webhook-secret}
+NMI_ACCOUNT_ID=${NMI_ACCOUNT_ID:-579145} # operator-declared label (NMI Gateway ID)
+BASE=${OPENRAILS_BASE_URL:-http://localhost:3053}
+
+echo "== build demo + helpers"
+(cd "$DEMO" && go build . && go build -o "$STATE/mintadmin" ./e2e/mintadmin)
+
+echo "== issuer keypair"
+if [ ! -f "$STATE/issuer_key.pem" ]; then
+  (cd "$STATE" && ISSUER_KEY_FILE="$STATE/issuer_key.pem" OPENRAILS_API_KEY=placeholder \
+    "$DEMO/gated-premium-page" >/dev/null 2>&1 || true)
+  [ -f "$STATE/issuer_key.pem" ] || { echo "issuer key generation failed"; exit 1; }
+fi
+
+echo "== manifests + compose override"
+PUB_INDENTED=$(sed 's/^/            /' "$STATE/issuer_key.pem.pub")
+cat > "$STATE/etc-openrails/merchants.yaml" <<EOF
+version: 1
+merchants:
+  demo:
+    display_name: Demo
+    remote_application:
+      issuer: https://gated-premium-page.example
+      public_keys:
+        - kid: demo-1
+          public_key_pem: |
+$PUB_INDENTED
+    profile:
+      display_name: Demo Billing
+      from_email: billing@demo.example
+    psps:
+      mobius-sandbox:
+        nmi:
+          environment: test
+          account_id: "$NMI_ACCOUNT_ID"
+          settings:
+            tokenization_url: $NMI_TOKENIZATION_URL
+            tokenization_key: $NMI_TOKENIZATION_KEY
+          secrets:
+            security_key: $NMI_SANDBOX_SECURITY_KEY
+            webhook_signing_secret: $NMI_WEBHOOK_SIGNING_SECRET
+EOF
+cat > "$STATE/etc-openrails/catalog.yaml" <<'EOF'
+version: 1
+catalogs:
+  - merchant: demo
+    products:
+      - key: premium
+        display_name: Premium
+        description: Premium access subscription.
+        entitlements: [premium]
+        prices:
+          - currency: usd
+            unit_amount: 5_230_000
+            duration: 30d
+            auto_renew: true
+            psps: [mobius-sandbox]   # NMI is link-only: the plan link is added in step 5
+EOF
+cat > "$STATE/override.yaml" <<EOF
+services:
+  openrails:
+    environment:
+      PROVIDER_WRITE_MODE: "full"   # unset fail-closes to readonly; sandbox account, no real money
+      MERCHANT_SOURCE: "api"        # engine gap: 'server' never loads the MODE-1 boot manifest
+    volumes:
+      - $STATE/etc-openrails:/etc/openrails:ro
+EOF
+
+echo "== stack up"
+(cd "$REPO" && nice -n 10 docker compose -f docker-compose.yaml -f "$STATE/override.yaml" --profile all up -d)
+for i in $(seq 1 60); do curl -sf -m 2 "$BASE/health/ready" >/dev/null && break; sleep 2; done
+curl -sf -m 2 "$BASE/health/ready" >/dev/null || { echo "stack not ready"; exit 1; }
+
+echo "== push merchant + catalog (CLI runs in manifest mode; server stays api mode)"
+docker compose -f "$REPO/docker-compose.yaml" exec -T -e MERCHANT_SOURCE=manifest openrails \
+  openrails push-merchant-config -f /etc/openrails/merchants.yaml --insert --overwrite >/dev/null
+docker compose -f "$REPO/docker-compose.yaml" exec -T -e MERCHANT_SOURCE=manifest openrails \
+  openrails push-merchant-catalog -f /etc/openrails/catalog.yaml --insert --overwrite >/dev/null
+
+# The server's delegated-token verifier caches registered issuer keys in
+# process memory; a key (re)registered by the CLI is only picked up on restart.
+(cd "$REPO" && docker compose -f docker-compose.yaml restart openrails >/dev/null 2>&1)
+for i in $(seq 1 30); do curl -sf -m 2 "$BASE/health/ready" >/dev/null && break; sleep 2; done
+
+ADMIN_JWT=$("$STATE/mintadmin" -key "$STATE/issuer_key.pem" -perms 'merchant:*')
+
+echo "== seed NMI credentials via merchant API (MODE 2 store)"
+jq -n --arg sk "$NMI_SANDBOX_SECURITY_KEY" --arg ws "$NMI_WEBHOOK_SIGNING_SECRET" \
+      --arg tk "$NMI_TOKENIZATION_KEY" --arg tu "$NMI_TOKENIZATION_URL" --arg id "$NMI_ACCOUNT_ID" \
+  '{environment:"test",account_id:$id,public_config:{tokenization_key:$tk,tokenization_url:$tu},credentials:{security_key:$sk,webhook_signing_secret:$ws}}' |
+curl -sf -X PUT "$BASE/v1/merchant/payment-providers/nmi" \
+  -H "Authorization: Bearer $ADMIN_JWT" -H 'Content-Type: application/json' --data @- >/dev/null
+
+echo "== NMI plan (randomized amount vs the duplicate-transaction window) + price link"
+CENTS=$((500 + RANDOM % 500))
+AMT="$((CENTS / 100)).$(printf %02d $((CENTS % 100)))"
+PLAN="openrails_demo_premium_${CENTS}_d30"
+RESP=$(curl -s https://secure.networkmerchants.com/api/transact.php \
+  --data-urlencode "security_key=$NMI_SANDBOX_SECURITY_KEY" \
+  -d "recurring=add_plan&plan_id=$PLAN&plan_name=OpenRails Demo Premium&plan_amount=$AMT&day_frequency=30&plan_payments=0")
+case "$RESP" in *response=1*|*exist*|*already*|*uplicate*) ;; *) echo "add_plan failed"; exit 1;; esac
+PRODUCT_ID=$(curl -sf "$BASE/v1/products" | jq -r '.data[] | select(.key=="premium").id' | sed 's/^prod_//')
+# Same key + different amount = version bump: old substance archives, checkout
+# sells the fresh amount (Attach verifies the plan at NMI before accepting).
+curl -sf -X POST "$BASE/v1/merchant/catalog/prices" \
+  -H "Authorization: Bearer $ADMIN_JWT" -H 'Content-Type: application/json' \
+  -d "{\"product_id\":\"$PRODUCT_ID\",\"key\":\"premium-monthly\",\"unit_amount\":$((CENTS * 10000)),\"currency\":\"usd\",\"access_duration_hours\":720,\"auto_renew\":true,\"psp_links\":{\"mobius-sandbox\":{\"rail\":\"nmi\",\"plan_id\":\"$PLAN\"}}}" >/dev/null
+
+echo "== api_host (no API surface exists; same row update SetHostConfig performs)"
+docker compose -f "$REPO/docker-compose.yaml" exec -T postgres \
+  psql -U admin -d openrails_db -qc "UPDATE openrails.merchants SET api_host='localhost' WHERE slug='demo';"
+
+echo "== mint backend API key"
+KEY=$(curl -sf -X POST "$BASE/v1/merchant/api-keys" \
+  -H "Authorization: Bearer $ADMIN_JWT" -H 'Content-Type: application/json' \
+  -d '{"name":"demo-e2e","role":"owner"}' | jq -r .secret)
+umask 077; echo "OPENRAILS_API_KEY=$KEY" > "$STATE/apikey.env"
+
+echo "provisioned. Run the demo:"
+echo "  set -a; source $REPO/.env; source $STATE/apikey.env; set +a"
+echo "  ISSUER_KEY_FILE=$STATE/issuer_key.pem $DEMO/gated-premium-page"
+echo "or the headless proof: e2e/run-e2e.sh"

--- a/examples/gated-premium-page/e2e/run-e2e.sh
+++ b/examples/gated-premium-page/e2e/run-e2e.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Headless six-step demo proof (server-side-token variant). Prereq: provision.sh.
+#
+# Browser Collect.js tokenization can't run without a browser, so the ONE
+# browser-only step is replaced by its server-side equivalent (same pattern as
+# tests/nmi_live_lifecycle_e2e_test.go): vault the sandbox card directly at NMI
+# and record the payment method row, then drive the REAL checkout API with
+# payment_method_id. Everything else is the demo's actual HTTP surface.
+set -euo pipefail
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+DEMO=$(cd "$HERE/.." && pwd)
+REPO=$(cd "$DEMO/../.." && pwd)
+STATE=${STATE:-"$HERE/.state"}
+BASE=${OPENRAILS_BASE_URL:-http://localhost:3053}
+PORT=${DEMO_PORT:-8093}
+
+set -a; source "$REPO/.env"; source "$STATE/apikey.env"; set +a
+USER_ID=$(uuidgen | tr 'A-Z' 'a-z')   # fresh user every run
+JAR=$(mktemp); trap 'rm -f "$JAR"; kill "$APP_PID" 2>/dev/null || true' EXIT
+
+echo "== start demo app (user $USER_ID)"
+(cd "$DEMO" && go build .)
+ISSUER_KEY_FILE="$STATE/issuer_key.pem" PORT=$PORT DEMO_USER_ID=$USER_ID \
+  "$DEMO/gated-premium-page" >"$STATE/app.log" 2>&1 & APP_PID=$!
+sleep 1
+
+step() { echo "-- $*"; }
+expect() { [ "$1" = "$2" ] || { echo "FAIL: want $2 got $1 ($3)"; exit 1; }; }
+
+step "1. public page"
+expect "$(curl -s -o /dev/null -w '%{http_code}' localhost:$PORT/)" 200 "GET /"
+step "2. login"
+curl -s -c "$JAR" -o /dev/null localhost:$PORT/login
+step "3. /premium without entitlement redirects to /buy"
+LOC=$(curl -s -b "$JAR" -o /dev/null -w '%{redirect_url}' localhost:$PORT/premium)
+case "$LOC" in */buy) ;; *) echo "FAIL: expected /buy redirect, got $LOC"; exit 1;; esac
+
+step "4. purchase (server-side-token variant)"
+TOK=$(curl -sf -b "$JAR" localhost:$PORT/api/token | jq -r .token)
+# the premium-monthly key: provision.sh version-bumps it to a fresh random
+# amount, which keeps repeat runs outside NMI's duplicate-transaction window
+PRICE=$(curl -sf "$BASE/v1/products" | jq -r '[.data[].prices[] | select(.active and .key=="premium-monthly")][0].id')
+# materialize the customer row (TouchCustomer) before inserting the payment method
+curl -sf -H "Authorization: Bearer $TOK" "$BASE/v1/me/subscriptions" >/dev/null
+VAULT=$(curl -s https://secure.networkmerchants.com/api/transact.php \
+  --data-urlencode "security_key=$NMI_SANDBOX_SECURITY_KEY" \
+  -d "customer_vault=add_customer&ccnumber=4111111111111111&ccexp=1029&cvv=123&first_name=Demo&last_name=User&address1=1 Demo St&city=Testville&state=CA&zip=90001&country=US&email=demo@example.com&test_mode=enabled" |
+  tr '&' '\n' | sed -n 's/^customer_vault_id=//p')
+[ -n "$VAULT" ] || { echo "FAIL: NMI vault"; exit 1; }
+MID=$(docker compose -f "$REPO/docker-compose.yaml" exec -T postgres \
+  psql -U admin -d openrails_db -tAc "SELECT id FROM openrails.merchants WHERE slug='demo'")
+PM=$(docker compose -f "$REPO/docker-compose.yaml" exec -T postgres \
+  psql -U admin -d openrails_db -tAc "INSERT INTO openrails.payment_methods (merchant_id, customer_id, rail, rail_customer_ref, rail_method_ref, rebill_driver, initial_transaction_id, last_four, card_type, expiry_date) VALUES ('$MID','$USER_ID','nmi','$VAULT','','provider','e2e-vault','1111','Visa','10/29') RETURNING id" | head -1)
+OUT=$(curl -s -X POST "$BASE/v1/me/checkout" \
+  -H "Authorization: Bearer $TOK" -H 'Content-Type: application/json' -H "Idempotency-Key: $(uuidgen)" \
+  -d "{\"price_id\":\"$PRICE\",\"payment\":{\"rail\":\"nmi\",\"payment_method_id\":\"$PM\"}}")
+expect "$(echo "$OUT" | jq -r .status)" succeeded "checkout: $OUT"
+TXN=$(echo "$OUT" | jq -r .payment.transaction_id)
+echo "   NMI approved txn=$TXN sub=$(echo "$OUT" | jq -r .subscription_id)"
+
+step "5. /premium now unlocks"
+expect "$(curl -s -b "$JAR" -o /dev/null -w '%{http_code}' localhost:$PORT/premium)" 200 "GET /premium"
+
+step "6a. self view: subscription + entitlement"
+expect "$(curl -sf -H "Authorization: Bearer $TOK" "$BASE/v1/me/subscriptions" | jq -r '.data[0].status')" active "me/subscriptions"
+expect "$(curl -sf -H "Authorization: Bearer $TOK" "$BASE/v1/me/entitlements/active" | jq -r '.data[0].lookup_key')" premium "me/entitlements"
+
+step "6b. merchant view: payment + entitlement (API key)"
+expect "$(curl -sf -H "Authorization: Bearer $OPENRAILS_API_KEY" "$BASE/v1/merchant/payments" | jq -r "[.data[] | select(.transaction_id==\"$TXN\")][0].status")" succeeded "merchant/payments"
+expect "$(curl -sf -H "Authorization: Bearer $OPENRAILS_API_KEY" "$BASE/v1/merchant/customers/$USER_ID/entitlements" | jq -r '.[0].entitlement')" premium "merchant entitlements"
+
+step "7. remote state at NMI (query.php)"
+curl -s https://secure.nmi.com/api/query.php --data-urlencode "security_key=$NMI_SANDBOX_SECURITY_KEY" \
+  -d "report_type=transaction&transaction_id=$TXN" | grep -q "<transaction_id>$TXN</transaction_id>" ||
+  { echo "FAIL: NMI query"; exit 1; }
+
+echo "== PASS: gated-premium-page E2E against real NMI sandbox =="

--- a/examples/gated-premium-page/go.mod
+++ b/examples/gated-premium-page/go.mod
@@ -1,0 +1,15 @@
+module github.com/open-rails/openrails/examples/gated-premium-page
+
+go 1.26.5
+
+// Examples build against the checkout, not a published tag, so breaking
+// engine changes update the example in the same PR (tracker #825).
+replace github.com/open-rails/openrails => ../..
+
+require (
+	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/open-rails/authkit v0.84.0
+	github.com/open-rails/openrails v0.0.0
+)
+
+require github.com/google/uuid v1.6.0 // indirect

--- a/examples/gated-premium-page/go.sum
+++ b/examples/gated-premium-page/go.sum
@@ -1,0 +1,6 @@
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/open-rails/authkit v0.84.0 h1:0gqvVmoi5yaGV69upw00qs/1AL/5LOYIrwin8hKinrM=
+github.com/open-rails/authkit v0.84.0/go.mod h1:gE2+8PyurR+Q6snrFnazBNjNPE34ndO5mdTkwvO9Vzk=

--- a/examples/gated-premium-page/main.go
+++ b/examples/gated-premium-page/main.go
@@ -1,0 +1,268 @@
+// Command gated-premium-page is a minimal standalone-integration demo:
+// a public page, a /premium page gated on an OpenRails entitlement, and a
+// /buy page that runs the NMI tokenized-vault checkout (Collect.js).
+//
+// Living companion to docs/standalone-integration.md + docs/frontend-integration.md.
+package main
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"embed"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/open-rails/authkit/jwtkit"
+	openrails "github.com/open-rails/openrails"
+)
+
+//go:embed static
+var static embed.FS
+
+type config struct {
+	baseURL         string // OPENRAILS_BASE_URL
+	apiKey          string // OPENRAILS_API_KEY (openrails_st_…)
+	merchant        string // MERCHANT_SLUG
+	userID          string // DEMO_USER_ID — the one fake logged-in user (must be a UUID)
+	psp             string // NMI_PSP — the merchant's PSP key (e.g. mobius-sandbox); used to filter prices
+	rail            string // NMI_RAIL — the checkout wire "rail" value. SHOULD be the PSP key (frozen
+	// PSP wire vocabulary), but the engine's checkoutRailConfigured gate
+	// (internal/http/handlers/checkout_session.go) resolves it as a rail KIND and 400s
+	// on PSP keys — so default to "nmi" until that engine bug is fixed.
+	entitlement     string // ENTITLEMENT gating /premium
+	tokenizationKey string // NMI_TOKENIZATION_KEY — public Collect.js key
+	tokenizationURL string // NMI_TOKENIZATION_URL
+	issuer          string // DEMO_ISSUER — must match merchants.yaml remote_application.issuer
+	addr            string
+	sessionSecret   []byte
+}
+
+type app struct {
+	cfg    config
+	client openrails.Client
+	signer jwtkit.Signer
+}
+
+func env(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func main() {
+	cfg := config{
+		baseURL:         env("OPENRAILS_BASE_URL", "http://localhost:3053"),
+		apiKey:          os.Getenv("OPENRAILS_API_KEY"),
+		merchant:        env("MERCHANT_SLUG", "demo"),
+		userID:          env("DEMO_USER_ID", "0b5e9f6e-2f1b-4c5e-9a51-0c9f6a3d7e21"),
+		psp:             env("NMI_PSP", "mobius-sandbox"),
+		rail:            env("NMI_RAIL", "nmi"),
+		entitlement:     env("ENTITLEMENT", "premium"),
+		tokenizationKey: os.Getenv("NMI_TOKENIZATION_KEY"),
+		tokenizationURL: env("NMI_TOKENIZATION_URL", "https://secure.networkmerchants.com/token/Collect.js"),
+		issuer:          env("DEMO_ISSUER", "https://gated-premium-page.example"),
+		addr:            ":" + env("PORT", "8080"),
+	}
+	if s := os.Getenv("SESSION_SECRET"); s != "" {
+		cfg.sessionSecret = []byte(s)
+	} else {
+		cfg.sessionSecret = make([]byte, 32)
+		if _, err := rand.Read(cfg.sessionSecret); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	signer, err := loadOrCreateSigner(env("ISSUER_KEY_FILE", "issuer_key.pem"))
+	if err != nil {
+		log.Fatalf("issuer key: %v", err)
+	}
+
+	// Backend SDK client: API key auth, short per-call deadline, fail fast at
+	// boot (docs/standalone-integration.md "Backend integration").
+	client := openrails.NewRemote(cfg.baseURL,
+		openrails.WithAPIKey(cfg.apiKey),
+		openrails.WithCurrency("usd"),
+		openrails.WithTimeout(5*time.Second),
+	)
+	if err := openrails.Verify(context.Background(), client); err != nil {
+		log.Fatalf("openrails unreachable or bad OPENRAILS_API_KEY: %v", err)
+	}
+
+	a := &app{cfg: cfg, client: client, signer: signer}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /{$}", a.page("static/index.html"))
+	mux.HandleFunc("GET /login", a.login)
+	mux.HandleFunc("GET /logout", a.logout)
+	mux.HandleFunc("GET /premium", a.premium)
+	mux.HandleFunc("GET /buy", a.requireSession(a.page("static/buy.html")))
+	mux.HandleFunc("GET /api/token", a.token)
+	mux.HandleFunc("GET /api/config", a.configJSON)
+	mux.Handle("GET /static/", http.FileServer(http.FS(static)))
+
+	log.Printf("demo up on %s (merchant %s, entitlement %q)", cfg.addr, cfg.merchant, cfg.entitlement)
+	log.Fatal(http.ListenAndServe(cfg.addr, mux))
+}
+
+// ---- fake session auth: a signed cookie holding the demo user id ----------
+
+func (a *app) sign(v string) string {
+	m := hmac.New(sha256.New, a.cfg.sessionSecret)
+	m.Write([]byte(v))
+	return hex.EncodeToString(m.Sum(nil))
+}
+
+func (a *app) sessionUser(r *http.Request) string {
+	c, err := r.Cookie("session")
+	if err != nil {
+		return ""
+	}
+	user, mac, ok := strings.Cut(c.Value, ".")
+	if !ok || !hmac.Equal([]byte(mac), []byte(a.sign(user))) {
+		return ""
+	}
+	return user
+}
+
+func (a *app) login(w http.ResponseWriter, r *http.Request) {
+	u := a.cfg.userID
+	http.SetCookie(w, &http.Cookie{Name: "session", Value: u + "." + a.sign(u), Path: "/", HttpOnly: true})
+	http.Redirect(w, r, "/", http.StatusFound)
+}
+
+func (a *app) logout(w http.ResponseWriter, r *http.Request) {
+	http.SetCookie(w, &http.Cookie{Name: "session", Path: "/", MaxAge: -1})
+	http.Redirect(w, r, "/", http.StatusFound)
+}
+
+func (a *app) requireSession(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if a.sessionUser(r) == "" {
+			http.Redirect(w, r, "/", http.StatusFound)
+			return
+		}
+		next(w, r)
+	}
+}
+
+func (a *app) page(name string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		b, err := static.ReadFile(name)
+		if err != nil {
+			http.Error(w, "missing page", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write(b)
+	}
+}
+
+// ---- the entitlement gate --------------------------------------------------
+
+// premium is the whole point of the demo: one SDK call decides access.
+// Entitlements are the access truth — never inspect subscription rows.
+func (a *app) premium(w http.ResponseWriter, r *http.Request) {
+	user := a.sessionUser(r)
+	if user == "" {
+		http.Redirect(w, r, "/", http.StatusFound)
+		return
+	}
+	ents, err := a.client.ListActiveEntitlements(r.Context(), []string{user}, time.Time{})
+	if err != nil {
+		http.Error(w, "billing lookup failed: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	for _, e := range ents[user] {
+		if e.Entitlement == a.cfg.entitlement {
+			a.page("static/premium.html")(w, r)
+			return
+		}
+	}
+	http.Redirect(w, r, "/buy", http.StatusFound)
+}
+
+// ---- delegated-token exchange (docs/frontend-integration.md) ---------------
+
+// token swaps the demo session for a short-lived delegated JWT the browser
+// sends straight to OpenRails. Claim contract: iss (the registered
+// remote_application issuer), aud ["openrails"], delegated_sub (the user),
+// JOSE typ "delegated-access+jwt", short TTL.
+func (a *app) token(w http.ResponseWriter, r *http.Request) {
+	user := a.sessionUser(r)
+	if user == "" {
+		http.Error(w, `{"error":"not logged in"}`, http.StatusUnauthorized)
+		return
+	}
+	const ttl = 5 * time.Minute
+	now := time.Now()
+	tok, err := jwtkit.SignWithType(r.Context(), a.signer, jwt.MapClaims{
+		"iss":           a.cfg.issuer,
+		"aud":           []string{"openrails"},
+		"iat":           now.Unix(),
+		"exp":           now.Add(ttl).Unix(),
+		"delegated_sub": user,
+	}, jwtkit.DelegatedAccessTokenType, true)
+	if err != nil {
+		http.Error(w, `{"error":"mint failed"}`, http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, map[string]any{"token": tok, "expires_in": int(ttl.Seconds())})
+}
+
+// configJSON hands the buy page what it needs for browser-direct calls.
+// The tokenization key is public (it is Collect.js' browser key).
+func (a *app) configJSON(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, map[string]any{
+		"openrails_base_url": a.cfg.baseURL,
+		"psp":                a.cfg.psp,
+		"rail":               a.cfg.rail,
+		"entitlement":        a.cfg.entitlement,
+		"tokenization_key":   a.cfg.tokenizationKey,
+		"tokenization_url":   a.cfg.tokenizationURL,
+	})
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(v)
+}
+
+// ---- issuer keypair --------------------------------------------------------
+
+// loadOrCreateSigner loads the RS256 issuer key, generating one on first run.
+// The printed public key goes into merchants.yaml
+// remote_application.public_keys (see README step 2).
+func loadOrCreateSigner(path string) (jwtkit.Signer, error) {
+	if pemBytes, err := os.ReadFile(path); err == nil {
+		return jwtkit.NewSignerFromPEM("demo-1", pemBytes)
+	}
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+	priv := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	if err := os.WriteFile(path, priv, 0o600); err != nil {
+		return nil, err
+	}
+	pubDER, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+	pub := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+	if err := os.WriteFile(path+".pub", pub, 0o644); err != nil {
+		return nil, err
+	}
+	log.Printf("generated %s — register the public key with your merchant:\n%s", path, pub)
+	return jwtkit.NewSignerFromPEM("demo-1", priv)
+}

--- a/examples/gated-premium-page/static/buy.html
+++ b/examples/gated-premium-page/static/buy.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Buy premium</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <main>
+    <h1>Buy premium</h1>
+    <p>Sandbox test card: <code>4111 1111 1111 1111</code>, expiry <code>10/29</code>, any CVV.</p>
+
+    <h2>1. Pick a plan</h2>
+    <div id="products">Loading catalog…</div>
+
+    <h2>2. Card</h2>
+    <!-- Collect.js renders NMI-hosted iframes into these divs; the card
+         number never touches this app or OpenRails (SAQ-A). -->
+    <div id="ccnumber" class="field"></div>
+    <div id="ccexp" class="field"></div>
+    <div id="cvv" class="field"></div>
+
+    <button id="pay" disabled>Pay</button>
+    <p id="status"></p>
+    <p><a href="/">Back home</a></p>
+  </main>
+  <script src="/static/buy.js"></script>
+</body>
+</html>

--- a/examples/gated-premium-page/static/buy.js
+++ b/examples/gated-premium-page/static/buy.js
@@ -1,0 +1,111 @@
+// NMI tokenized-vault checkout, per docs/frontend-integration.md:
+// delegated token from our backend -> Collect.js tokenizes the card ->
+// POST /v1/me/checkout with the one-time payment_token -> /premium.
+let cfg, priceID, cached;
+
+// Fetch-and-cache delegated-token helper (docs/frontend-integration.md).
+async function delegatedToken() {
+  if (cached && cached.exp - 30_000 > Date.now()) return cached.token;
+  const res = await fetch("/api/token");
+  if (!res.ok) { location = "/"; throw new Error("not logged in"); }
+  const { token, expires_in } = await res.json();
+  cached = { token, exp: Date.now() + expires_in * 1000 };
+  return token;
+}
+
+function setStatus(msg) { document.getElementById("status").textContent = msg; }
+
+async function main() {
+  cfg = await (await fetch("/api/config")).json();
+
+  // Public catalog, no auth: GET /v1/products (active prices embedded).
+  const res = await fetch(cfg.openrails_base_url + "/v1/products");
+  const products = (await res.json()).data ?? [];
+  const box = document.getElementById("products");
+  box.textContent = "";
+  for (const p of products) {
+    for (const price of p.prices ?? []) {
+      if (price.providers?.length && !price.providers.includes(cfg.psp)) continue;
+      const b = document.createElement("button");
+      b.className = "price";
+      b.textContent = `${p.name} — $${(price.unit_amount / 1_000_000).toFixed(2)} ` +
+        (price.recurring ? "(recurring)" : "(one-time)");
+      b.onclick = () => {
+        priceID = price.id;
+        document.querySelectorAll(".price").forEach(x => x.classList.remove("selected"));
+        b.classList.add("selected");
+        document.getElementById("pay").disabled = false;
+      };
+      box.appendChild(b);
+    }
+  }
+  if (!box.childElementCount) box.textContent = "No purchasable prices for PSP " + cfg.psp;
+
+  // Collect.js needs its public tokenization key as a data- attribute.
+  const s = document.createElement("script");
+  s.src = cfg.tokenization_url;
+  s.dataset.tokenizationKey = cfg.tokenization_key;
+  s.onload = () => CollectJS.configure({
+    variant: "inline",
+    fields: {
+      ccnumber: { selector: "#ccnumber", placeholder: "Card number" },
+      ccexp: { selector: "#ccexp", placeholder: "MM / YY" },
+      cvv: { selector: "#cvv", placeholder: "CVV" },
+    },
+    callback: (resp) => checkout(resp.token, resp.card),
+  });
+  document.head.appendChild(s);
+
+  document.getElementById("pay").onclick = () => {
+    setStatus("Tokenizing card…");
+    CollectJS.startPaymentRequest();
+  };
+}
+
+async function checkout(paymentToken, card) {
+  setStatus("Charging…");
+  // Optional display metadata from Collect.js (masked number/type/exp) so the
+  // saved payment method lists with a brand + last four.
+  const meta = {};
+  if (card?.number) meta.last_four = card.number.slice(-4);
+  if (card?.type) meta.card_type = card.type;
+  if (card?.exp?.length === 4) meta.expiry_date = card.exp.slice(0, 2) + "/" + card.exp.slice(2);
+  const res = await fetch(cfg.openrails_base_url + "/v1/me/checkout", {
+    method: "POST",
+    headers: {
+      "Authorization": "Bearer " + await delegatedToken(),
+      "Content-Type": "application/json",
+      "Idempotency-Key": crypto.randomUUID(), // retries replay, never double-charge
+    },
+    body: JSON.stringify({
+      price_id: priceID,
+      // cfg.rail (not cfg.psp): the engine's checkout gate currently rejects
+      // PSP-key wire values — see the NMI_RAIL note in main.go.
+      payment: { rail: cfg.rail, payment_token: paymentToken, ...meta },
+    }),
+  });
+  const session = await res.json();
+  if (!res.ok) {
+    setStatus("Checkout failed: " + (session.error?.message ?? res.status));
+    return;
+  }
+  // NMI tokenized-vault checkout is synchronous; polling is the generic
+  // fallback for webhook-finalized flows (redirect rails).
+  if (session.status === "succeeded") { location = "/premium"; return; }
+  setStatus("Waiting for payment to finalize…");
+  for (let i = 0; i < 30; i++) {
+    await new Promise(r => setTimeout(r, 2000));
+    const poll = await fetch(cfg.openrails_base_url + "/v1/me/checkout/" + session.id, {
+      headers: { "Authorization": "Bearer " + await delegatedToken() },
+    });
+    const state = await poll.json();
+    if (state.status === "succeeded") { location = "/premium"; return; }
+    if (state.status === "failed" || state.status === "expired") {
+      setStatus("Payment " + state.status);
+      return;
+    }
+  }
+  setStatus("Timed out waiting for payment — check /premium in a moment.");
+}
+
+main().catch(e => setStatus(e.message));

--- a/examples/gated-premium-page/static/index.html
+++ b/examples/gated-premium-page/static/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Gated Premium Page — OpenRails demo</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <main>
+    <h1>Gated Premium Page</h1>
+    <p>A minimal OpenRails standalone-integration demo. The
+      <a href="/premium">premium page</a> is gated on an OpenRails entitlement;
+      without it you are redirected to checkout.</p>
+    <ol>
+      <li><a href="/login">Log in</a> as the demo user (fake signed-cookie session)</li>
+      <li>Visit <a href="/premium">/premium</a> — no entitlement yet, so you land on /buy</li>
+      <li>Pay with the sandbox test card <code>4111 1111 1111 1111</code>, expiry <code>10/29</code></li>
+      <li><a href="/premium">/premium</a> unlocks</li>
+    </ol>
+    <p><a href="/logout">Log out</a></p>
+  </main>
+</body>
+</html>

--- a/examples/gated-premium-page/static/premium.html
+++ b/examples/gated-premium-page/static/premium.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Premium — unlocked</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <main>
+    <h1>Premium unlocked ★</h1>
+    <p>You are seeing this because <code>ListActiveEntitlements</code> returned an
+      active <code>premium</code> entitlement for your user. The subscription,
+      the payment, and the entitlement window all live in OpenRails — this app
+      only asked one question.</p>
+    <p><a href="/">Back home</a></p>
+  </main>
+</body>
+</html>

--- a/examples/gated-premium-page/static/style.css
+++ b/examples/gated-premium-page/static/style.css
@@ -1,0 +1,10 @@
+body { font-family: system-ui, sans-serif; margin: 0; background: #f6f6f4; color: #222; }
+main { max-width: 40rem; margin: 4rem auto; padding: 2rem; background: #fff; border-radius: 8px; box-shadow: 0 1px 4px rgba(0,0,0,.08); }
+h1 { margin-top: 0; }
+code { background: #eee; padding: .1em .3em; border-radius: 3px; }
+button { font: inherit; padding: .5em 1.2em; border: 1px solid #444; border-radius: 5px; background: #222; color: #fff; cursor: pointer; }
+button:disabled { opacity: .5; cursor: default; }
+.field { border: 1px solid #ccc; border-radius: 5px; padding: .2em .5em; margin: .4em 0; height: 2.4em; background: #fff; }
+#status { min-height: 1.5em; font-weight: 600; }
+.price { display: block; width: 100%; text-align: left; margin: .4em 0; background: #fff; color: #222; }
+.price.selected { background: #222; color: #fff; }


### PR DESCRIPTION
The first entry in examples/: a minimal Go webserver + no-framework frontend demonstrating standalone OpenRails integration — entitlement-gated /premium, delegated-token mint, NMI tokenized-vault checkout.

Proven end-to-end against a local compose stack + the real NMI sandbox, TWICE: the scripted server-side-token variant AND the actual browser flow (Collect.js in headless Chromium, test card, one-time token, redirect to unlocked /premium). Duplicate-transaction declines surface correctly; merchant-side visibility verified through the customers/entitlements/payments routes; the transaction and recurring subscription confirmed remotely via NMI's Query API. E2E.md documents the proof; e2e/provision.sh + run-e2e.sh make it repeatable; CI builds every example.

Six engine bugs found during verification are filed as trackers #847–#852 (most serious: MODE-1 standalone never loads the boot merchant manifest, so manifest-mode deployments cannot arm PSPs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)