### PR TITLE
Add embedded legacy import writers

### DIFF
--- a/internal/billingimport/billingimport.go
+++ b/internal/billingimport/billingimport.go
@@ -43,21 +43,27 @@ type DeclaredCustomer struct {
 // DeclaredPaymentMethod is a stored instrument fact (e.g. an NMI vault entry).
 // Idempotent by (rail, rail_customer_ref, rail_method_ref).
 type DeclaredPaymentMethod struct {
-	Customer             uuid.UUID `json:"customer"`
-	Rail                 string    `json:"rail"`
-	RailCustomerRef      string    `json:"rail_customer_ref"` // e.g. NMI customer_vault_id
-	RailMethodRef        string    `json:"rail_method_ref"`   // e.g. NMI billing_id; "" for one-instrument vaults
-	InitialTransactionID string    `json:"initial_transaction_id,omitempty"`
-	LastFour             string    `json:"last_four,omitempty"`
-	CardType             string    `json:"card_type,omitempty"`
-	ExpiryDate           string    `json:"expiry_date,omitempty"`
-	CreatedAt            time.Time `json:"created_at,omitempty"`
+	SourceID             string          `json:"source_id"`
+	ID                   uuid.UUID       `json:"id,omitempty"`
+	PSPKey               string          `json:"psp_key,omitempty"`
+	Customer             uuid.UUID       `json:"customer"`
+	Rail                 string          `json:"rail"`
+	RailCustomerRef      string          `json:"rail_customer_ref"` // e.g. NMI customer_vault_id
+	RailMethodRef        string          `json:"rail_method_ref"`   // e.g. NMI billing_id; "" for one-instrument vaults
+	InitialTransactionID string          `json:"initial_transaction_id,omitempty"`
+	LastFour             string          `json:"last_four,omitempty"`
+	CardType             string          `json:"card_type,omitempty"`
+	ExpiryDate           string          `json:"expiry_date,omitempty"`
+	CreatedAt            time.Time       `json:"created_at,omitempty"`
+	UpdatedAt            time.Time       `json:"updated_at,omitempty"`
+	Metadata             json.RawMessage `json:"metadata,omitempty"`
 }
 
 // PaymentMethodRef links a DeclaredSubscription to a DeclaredPaymentMethod
 // (dunning rebills need the subscription→vault linkage).
 type PaymentMethodRef struct {
 	Rail            string `json:"rail"`
+	PSPKey          string `json:"psp_key,omitempty"`
 	RailCustomerRef string `json:"rail_customer_ref"`
 	RailMethodRef   string `json:"rail_method_ref"`
 }
@@ -104,9 +110,9 @@ type DeclaredSubscription struct {
 	Price              uuid.UUID `json:"price"`
 	Rail               string    `json:"rail"`
 	RailSubscriptionID string    `json:"rail_subscription_id"` // required; synthesize a stable id for rail-less legacy rows
-	// PspID binds the row to its operator-declared
-	// openrails.psps row (nil = unbound legacy lane).
-	PspID         *uuid.UUID        `json:"psp_id,omitempty"`
+	// PSPKey resolves the merchant manifest key (for example mobius) inside
+	// OpenRails.
+	PSPKey        string            `json:"psp_key,omitempty"`
 	UserEmail     string            `json:"user_email,omitempty"`
 	StartedAt     time.Time         `json:"started_at"`
 	PaidThrough   *time.Time        `json:"paid_through,omitempty"`
@@ -116,6 +122,36 @@ type DeclaredSubscription struct {
 	// Evidence is the host's verbatim legacy payload, stored on
 	// subscriptions.gateway_response at seed (forensics; never re-parsed).
 	Evidence json.RawMessage `json:"evidence,omitempty"`
+}
+
+// DeclaredPayment is one successful historical charge that is not represented
+// by the subscription transaction facts above.
+type DeclaredPayment struct {
+	SourceID      string          `json:"source_id"`
+	Customer      uuid.UUID       `json:"customer"`
+	Price         uuid.UUID       `json:"price"`
+	Subscription  *uuid.UUID      `json:"subscription,omitempty"`
+	Rail          string          `json:"rail"`
+	PSPKey        string          `json:"psp_key,omitempty"`
+	TransactionID string          `json:"transaction_id"`
+	AmountMicros  int64           `json:"amount_micros"`
+	Currency      string          `json:"currency"`
+	OccurredAt    time.Time       `json:"occurred_at"`
+	Metadata      json.RawMessage `json:"metadata,omitempty"`
+}
+
+// DeclaredDunningEvent is display/forensics evidence from a legacy billing
+// system. It never drives money or entitlement decisions.
+type DeclaredDunningEvent struct {
+	SourceID     string          `json:"source_id"`
+	ID           uuid.UUID       `json:"id"`
+	Subscription *uuid.UUID      `json:"subscription,omitempty"`
+	Customer     *uuid.UUID      `json:"customer,omitempty"`
+	EventType    string          `json:"event_type"`
+	Rail         string          `json:"rail"`
+	OccurredAt   time.Time       `json:"occurred_at"`
+	Source       string          `json:"source"`
+	Detail       json.RawMessage `json:"detail,omitempty"`
 }
 
 // DeclaredBilling is the import body: one merchant's book (or one batch of it).
@@ -131,6 +167,8 @@ type DeclaredBilling struct {
 	PaymentMethods          []DeclaredPaymentMethod `json:"payment_methods,omitempty"`
 	Subscriptions           []DeclaredSubscription  `json:"subscriptions,omitempty"`
 	Transactions            []DeclaredTransaction   `json:"transactions,omitempty"`
+	Payments                []DeclaredPayment       `json:"payments,omitempty"`
+	DunningEvents           []DeclaredDunningEvent  `json:"dunning_events,omitempty"`
 }
 
 // Options configures Import. Merchant scoping: MerchantID when the caller
@@ -143,13 +181,22 @@ type Options struct {
 	Book         DeclaredBilling
 }
 
-// Result reports per-SourceID outcomes (subscriptions only; customers/payment
-// methods are idempotent upserts with no per-row audit).
+// Result reports per-SourceID outcomes for each declared writer lane.
 type Result struct {
 	Imported []string          `json:"imported"`
 	Skipped  []string          `json:"skipped"` // already present (idempotent re-run)
 	Blocked  []string          `json:"blocked"`
 	Reasons  map[string]string `json:"reasons"` // SourceID → block reason
+
+	PaymentsImported []string `json:"payments_imported,omitempty"`
+	PaymentsSkipped  []string `json:"payments_skipped,omitempty"`
+	DunningImported  []string `json:"dunning_imported,omitempty"`
+	DunningSkipped   []string `json:"dunning_skipped,omitempty"`
+
+	PaymentMethodsImported []string          `json:"payment_methods_imported,omitempty"`
+	PaymentMethodsSkipped  []string          `json:"payment_methods_skipped,omitempty"`
+	PaymentMethodsBlocked  []string          `json:"payment_methods_blocked,omitempty"`
+	PaymentMethodReasons   map[string]string `json:"payment_method_reasons,omitempty"`
 }
 
 // Import lands a host-declared billing book. Explicitly-cancelled facts
@@ -159,7 +206,10 @@ type Result struct {
 // hold server-side by construction. Charges land idempotently by
 // (rail, transaction_id). Runs in a single merchant-scoped connection (RLS).
 func Import(ctx context.Context, opts Options) (Result, error) {
-	res := Result{Reasons: map[string]string{}}
+	res := Result{
+		Reasons:              map[string]string{},
+		PaymentMethodReasons: map[string]string{},
+	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -199,51 +249,131 @@ func Import(ctx context.Context, opts Options) (Result, error) {
 		qx := database.Qx(ctx)
 		q := database.Gen(ctx)
 
+		pspIDs := map[string]*uuid.UUID{}
+		resolvePSPID := func(rail, key string) (*uuid.UUID, error) {
+			key = strings.TrimSpace(key)
+			if key == "" {
+				return nil, nil
+			}
+			rail = strings.ToLower(strings.TrimSpace(rail))
+			cacheKey := rail + "\x1f" + key
+			if id, ok := pspIDs[cacheKey]; ok {
+				return id, nil
+			}
+			rows, err := q.ListPSPsForMerchant(ctx, gen.ListPSPsForMerchantParams{
+				MerchantID: merchantID.UUID(),
+				Rail:       &rail,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("list psps for rail %q: %w", rail, err)
+			}
+			var found *uuid.UUID
+			for _, row := range rows {
+				if row.Archived || row.Environment != "live" || row.Key == nil ||
+					strings.TrimSpace(*row.Key) != key {
+					continue
+				}
+				if found != nil {
+					return nil, fmt.Errorf("multiple active live psps %q for rail %q", key, rail)
+				}
+				id := row.ID
+				found = &id
+			}
+			if found != nil {
+				pspIDs[cacheKey] = found
+				return found, nil
+			}
+			return nil, fmt.Errorf("active live psp %q for rail %q not found", key, rail)
+		}
+
 		// Customers first (subscriptions FK them).
 		seen := map[uuid.UUID]struct{}{}
+		ensureCustomer := func(customer uuid.UUID) error {
+			if customer == uuid.Nil {
+				return nil
+			}
+			if _, ok := seen[customer]; ok {
+				return nil
+			}
+			if err := db.EnsureCustomerRow(ctx, qx, merchantID.UUID(), customer); err != nil {
+				return fmt.Errorf("ensure customer %s: %w", customer, err)
+			}
+			seen[customer] = struct{}{}
+			return nil
+		}
 		for _, c := range opts.Book.Customers {
-			if c.Customer == uuid.Nil {
-				continue
+			if err := ensureCustomer(c.Customer); err != nil {
+				return err
 			}
-			if err := db.EnsureCustomerRow(ctx, qx, merchantID.UUID(), c.Customer); err != nil {
-				return fmt.Errorf("ensure customer %s: %w", c.Customer, err)
-			}
-			seen[c.Customer] = struct{}{}
 		}
 		for _, s := range opts.Book.Subscriptions {
-			if s.Customer == uuid.Nil {
-				continue
+			if err := ensureCustomer(s.Customer); err != nil {
+				return err
 			}
-			if _, ok := seen[s.Customer]; ok {
-				continue
+		}
+		for _, pm := range opts.Book.PaymentMethods {
+			if err := ensureCustomer(pm.Customer); err != nil {
+				return err
 			}
-			if err := db.EnsureCustomerRow(ctx, qx, merchantID.UUID(), s.Customer); err != nil {
-				return fmt.Errorf("ensure customer %s: %w", s.Customer, err)
+		}
+		for _, payment := range opts.Book.Payments {
+			if err := ensureCustomer(payment.Customer); err != nil {
+				return err
 			}
-			seen[s.Customer] = struct{}{}
+		}
+		for _, event := range opts.Book.DunningEvents {
+			if event.Customer != nil {
+				if err := ensureCustomer(*event.Customer); err != nil {
+					return err
+				}
+			}
 		}
 
 		// Payment methods: idempotent by (rail, rail_customer_ref, rail_method_ref).
 		pmIDs := map[string]uuid.UUID{}
-		pmKey := func(rail, custRef, methodRef string) string { return rail + "\x1f" + custRef + "\x1f" + methodRef }
-		for _, pm := range opts.Book.PaymentMethods {
-			if pm.Rail == "" || pm.RailCustomerRef == "" || pm.Customer == uuid.Nil {
-				return fmt.Errorf("declared payment method requires rail, rail_customer_ref and customer")
+		pmKey := func(rail string, pspID *uuid.UUID, custRef, methodRef string) string {
+			psp := ""
+			if pspID != nil {
+				psp = pspID.String()
 			}
-			var id uuid.UUID
-			err := qx.QueryRow(ctx,
-				`SELECT id FROM openrails.payment_methods
-				 WHERE merchant_id = $1 AND rail = $2 AND rail_customer_ref = $3 AND rail_method_ref = $4`,
-				merchantID.UUID(), pm.Rail, pm.RailCustomerRef, pm.RailMethodRef).Scan(&id)
+			return rail + "\x1f" + psp + "\x1f" + custRef + "\x1f" + methodRef
+		}
+		for _, pm := range opts.Book.PaymentMethods {
+			if strings.TrimSpace(pm.SourceID) == "" || pm.Rail == "" ||
+				pm.RailCustomerRef == "" || pm.Customer == uuid.Nil {
+				return fmt.Errorf("declared payment method requires source_id, rail, rail_customer_ref and customer")
+			}
+			pspID, err := resolvePSPID(pm.Rail, pm.PSPKey)
+			if err != nil {
+				return fmt.Errorf("resolve payment method psp %s/%s: %w", pm.Rail, pm.RailCustomerRef, err)
+			}
+			var (
+				id         uuid.UUID
+				customerID uuid.UUID
+			)
+			err = qx.QueryRow(ctx,
+				`SELECT id, customer_id FROM openrails.payment_methods
+				 WHERE merchant_id = $1 AND rail = $2 AND rail_customer_ref = $3
+				   AND rail_method_ref = $4 AND psp_id IS NOT DISTINCT FROM $5::uuid`,
+				merchantID.UUID(), pm.Rail, pm.RailCustomerRef, pm.RailMethodRef, pspID).
+				Scan(&id, &customerID)
 			if err == pgx.ErrNoRows {
-				id = uuid.New()
+				id = pm.ID
+				if id == uuid.Nil {
+					id = uuid.New()
+				}
 				created := pm.CreatedAt.UTC()
 				if created.IsZero() {
 					created = asOf
 				}
+				updated := pm.UpdatedAt.UTC()
+				if updated.IsZero() {
+					updated = created
+				}
 				if _, err := q.CreatePaymentMethod(ctx, gen.CreatePaymentMethodParams{
 					ID:                   id,
 					MerchantID:           merchantID.UUID(),
+					PspID:                pspID,
 					CustomerID:           pm.Customer,
 					Rail:                 pm.Rail,
 					RailCustomerRef:      pm.RailCustomerRef,
@@ -252,16 +382,24 @@ func Import(ctx context.Context, opts Options) (Result, error) {
 					LastFour:             nilIfEmpty(pm.LastFour),
 					CardType:             nilIfEmpty(pm.CardType),
 					ExpiryDate:           nilIfEmpty(pm.ExpiryDate),
+					Metadata:             pm.Metadata,
 					CreatedAt:            created,
-					UpdatedAt:            created,
+					UpdatedAt:            updated,
 					RebillDriver:         "",
 				}); err != nil {
 					return fmt.Errorf("create payment method %s/%s: %w", pm.Rail, pm.RailCustomerRef, err)
 				}
+				res.PaymentMethodsImported = append(res.PaymentMethodsImported, pm.SourceID)
 			} else if err != nil {
 				return fmt.Errorf("lookup payment method %s/%s: %w", pm.Rail, pm.RailCustomerRef, err)
+			} else if customerID != pm.Customer {
+				res.PaymentMethodsBlocked = append(res.PaymentMethodsBlocked, pm.SourceID)
+				res.PaymentMethodReasons[pm.SourceID] = "payment method belongs to a different customer"
+				continue
+			} else {
+				res.PaymentMethodsSkipped = append(res.PaymentMethodsSkipped, pm.SourceID)
 			}
-			pmIDs[pmKey(pm.Rail, pm.RailCustomerRef, pm.RailMethodRef)] = id
+			pmIDs[pmKey(pm.Rail, pspID, pm.RailCustomerRef, pm.RailMethodRef)] = id
 		}
 
 		// Transactions → the declared snapshot's charge events.
@@ -284,13 +422,17 @@ func Import(ctx context.Context, opts Options) (Result, error) {
 
 		facts := make([]reconcile.DeclaredSubscriptionFact, 0, len(opts.Book.Subscriptions))
 		for _, s := range opts.Book.Subscriptions {
+			pspID, err := resolvePSPID(s.Rail, s.PSPKey)
+			if err != nil {
+				return fmt.Errorf("resolve subscription psp %s: %w", s.SourceID, err)
+			}
 			f := reconcile.DeclaredSubscriptionFact{
 				SourceID:           s.SourceID,
 				Customer:           s.Customer,
 				PriceID:            s.Price,
 				Rail:               s.Rail,
 				RailSubscriptionID: s.RailSubscriptionID,
-				PspID:              s.PspID,
+				PspID:              pspID,
 				UserEmail:          nilIfEmpty(s.UserEmail),
 				StartedAt:          s.StartedAt.UTC(),
 				PaidThrough:        s.PaidThrough,
@@ -305,7 +447,11 @@ func Import(ctx context.Context, opts Options) (Result, error) {
 				f.DunningLastRetryAt = s.Dunning.LastRetryAt
 			}
 			if s.PaymentMethod != nil {
-				key := pmKey(s.PaymentMethod.Rail, s.PaymentMethod.RailCustomerRef, s.PaymentMethod.RailMethodRef)
+				refPSPID, err := resolvePSPID(s.PaymentMethod.Rail, s.PaymentMethod.PSPKey)
+				if err != nil {
+					return fmt.Errorf("resolve payment method ref psp %s: %w", s.SourceID, err)
+				}
+				key := pmKey(s.PaymentMethod.Rail, refPSPID, s.PaymentMethod.RailCustomerRef, s.PaymentMethod.RailMethodRef)
 				id, ok := pmIDs[key]
 				if !ok {
 					// Ref to an instrument that already exists locally (e.g. a
@@ -313,8 +459,10 @@ func Import(ctx context.Context, opts Options) (Result, error) {
 					var existing uuid.UUID
 					err := qx.QueryRow(ctx,
 						`SELECT id FROM openrails.payment_methods
-						 WHERE merchant_id = $1 AND rail = $2 AND rail_customer_ref = $3 AND rail_method_ref = $4`,
-						merchantID.UUID(), s.PaymentMethod.Rail, s.PaymentMethod.RailCustomerRef, s.PaymentMethod.RailMethodRef).Scan(&existing)
+						 WHERE merchant_id = $1 AND rail = $2 AND rail_customer_ref = $3
+						   AND rail_method_ref = $4 AND psp_id IS NOT DISTINCT FROM $5::uuid`,
+						merchantID.UUID(), s.PaymentMethod.Rail, s.PaymentMethod.RailCustomerRef,
+						s.PaymentMethod.RailMethodRef, refPSPID).Scan(&existing)
 					if err == nil {
 						id, ok = existing, true
 						pmIDs[key] = existing
@@ -347,6 +495,92 @@ func Import(ctx context.Context, opts Options) (Result, error) {
 		sort.Strings(res.Imported)
 		sort.Strings(res.Skipped)
 		sort.Strings(res.Blocked)
+
+		writer := &reconcile.PGLocalWriter{DB: database, Now: func() time.Time { return asOf }}
+		for _, payment := range opts.Book.Payments {
+			if strings.TrimSpace(payment.SourceID) == "" || payment.Customer == uuid.Nil ||
+				payment.Price == uuid.Nil || strings.TrimSpace(payment.Rail) == "" ||
+				strings.TrimSpace(payment.TransactionID) == "" || payment.AmountMicros <= 0 ||
+				strings.TrimSpace(payment.Currency) == "" || payment.OccurredAt.IsZero() {
+				return fmt.Errorf("declared payment requires source_id, customer, price, rail, transaction_id, positive amount_micros, currency and occurred_at")
+			}
+			pspID, err := resolvePSPID(payment.Rail, payment.PSPKey)
+			if err != nil {
+				return fmt.Errorf("resolve payment psp %s: %w", payment.SourceID, err)
+			}
+			metadata, err := metadataMap(payment.Metadata)
+			if err != nil {
+				return fmt.Errorf("decode payment metadata %s: %w", payment.SourceID, err)
+			}
+			changed, err := writer.BackfillPayment(ctx, reconcile.BackfillPaymentAction{
+				PspID:          pspID,
+				Rail:           payment.Rail,
+				TransactionID:  payment.TransactionID,
+				AmountMicros:   &payment.AmountMicros,
+				Currency:       payment.Currency,
+				PurchasedAt:    payment.OccurredAt.UTC(),
+				PriceID:        payment.Price,
+				SubscriptionID: payment.Subscription,
+				CustomerID:     payment.Customer,
+				Metadata:       metadata,
+			})
+			if err != nil {
+				return fmt.Errorf("import payment %s: %w", payment.SourceID, err)
+			}
+			if !changed {
+				var customerID uuid.UUID
+				err := qx.QueryRow(ctx,
+					`SELECT customer_id FROM openrails.payments
+					 WHERE merchant_id = $1 AND rail = $2 AND transaction_id = $3
+					   AND psp_id IS NOT DISTINCT FROM $4::uuid`,
+					merchantID.UUID(), payment.Rail, payment.TransactionID, pspID).
+					Scan(&customerID)
+				if err != nil {
+					return fmt.Errorf("resolve existing payment %s: %w", payment.SourceID, err)
+				}
+				if customerID != payment.Customer {
+					return fmt.Errorf("payment %s belongs to a different customer", payment.SourceID)
+				}
+			}
+			if changed {
+				res.PaymentsImported = append(res.PaymentsImported, payment.SourceID)
+			} else {
+				res.PaymentsSkipped = append(res.PaymentsSkipped, payment.SourceID)
+			}
+		}
+		for _, event := range opts.Book.DunningEvents {
+			if strings.TrimSpace(event.SourceID) == "" || event.ID == uuid.Nil ||
+				strings.TrimSpace(event.EventType) == "" || strings.TrimSpace(event.Rail) == "" ||
+				event.OccurredAt.IsZero() || strings.TrimSpace(event.Source) == "" {
+				return fmt.Errorf("declared dunning event requires source_id, id, event_type, rail, occurred_at and source")
+			}
+			changed, err := q.InsertImportedDunningHistory(ctx, gen.InsertImportedDunningHistoryParams{
+				ID:             event.ID,
+				MerchantID:     merchantID.UUID(),
+				SubscriptionID: event.Subscription,
+				CustomerID:     event.Customer,
+				EventType:      event.EventType,
+				Rail:           event.Rail,
+				OccurredAt:     event.OccurredAt.UTC(),
+				Source:         event.Source,
+				Detail:         event.Detail,
+			})
+			if err != nil {
+				return fmt.Errorf("import dunning event %s: %w", event.SourceID, err)
+			}
+			if changed > 0 {
+				res.DunningImported = append(res.DunningImported, event.SourceID)
+			} else {
+				res.DunningSkipped = append(res.DunningSkipped, event.SourceID)
+			}
+		}
+		sort.Strings(res.PaymentsImported)
+		sort.Strings(res.PaymentsSkipped)
+		sort.Strings(res.DunningImported)
+		sort.Strings(res.DunningSkipped)
+		sort.Strings(res.PaymentMethodsImported)
+		sort.Strings(res.PaymentMethodsSkipped)
+		sort.Strings(res.PaymentMethodsBlocked)
 		return nil
 	})
 	return res, err
@@ -376,4 +610,18 @@ func nilIfEmpty(s string) *string {
 		return nil
 	}
 	return &s
+}
+
+func metadataMap(raw json.RawMessage) (map[string]any, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		return nil, err
+	}
+	if metadata == nil {
+		return nil, fmt.Errorf("metadata must be a json object")
+	}
+	return metadata, nil
 }

--- a/internal/db/gen/imported_dunning_history.sql.go
+++ b/internal/db/gen/imported_dunning_history.sql.go
@@ -12,42 +12,50 @@ import (
 	"github.com/google/uuid"
 )
 
-const insertImportedDunningHistory = `-- name: InsertImportedDunningHistory :exec
+const insertImportedDunningHistory = `-- name: InsertImportedDunningHistory :execrows
 
 INSERT INTO openrails.imported_dunning_history (
-    merchant_id, subscription_id, customer_id, event_type, rail,
+    id, merchant_id, subscription_id, customer_id, event_type, rail,
     occurred_at, source, detail
 ) VALUES (
-    $1, $6, $7, $2, $3, $4, $5,
-    $8
+    $1, $2, $3,
+    $4, $5, $6,
+    $7, $8,
+    $9
 )
+ON CONFLICT (id) DO NOTHING
 `
 
 type InsertImportedDunningHistoryParams struct {
+	ID             uuid.UUID
 	MerchantID     uuid.UUID
+	SubscriptionID *uuid.UUID
+	CustomerID     *uuid.UUID
 	EventType      string
 	Rail           string
 	OccurredAt     time.Time
 	Source         string
-	SubscriptionID *uuid.UUID
-	CustomerID     *uuid.UUID
 	Detail         []byte
 }
 
 // openrails.imported_dunning_history — append-only legacy dunning forensics
 // (#735; doujins #387 import target). Display/report evidence only.
-func (q *Queries) InsertImportedDunningHistory(ctx context.Context, arg InsertImportedDunningHistoryParams) error {
-	_, err := q.db.Exec(ctx, insertImportedDunningHistory,
+func (q *Queries) InsertImportedDunningHistory(ctx context.Context, arg InsertImportedDunningHistoryParams) (int64, error) {
+	result, err := q.db.Exec(ctx, insertImportedDunningHistory,
+		arg.ID,
 		arg.MerchantID,
+		arg.SubscriptionID,
+		arg.CustomerID,
 		arg.EventType,
 		arg.Rail,
 		arg.OccurredAt,
 		arg.Source,
-		arg.SubscriptionID,
-		arg.CustomerID,
 		arg.Detail,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const listDunningHistoryEvents = `-- name: ListDunningHistoryEvents :many

--- a/internal/db/queries/imported_dunning_history.sql
+++ b/internal/db/queries/imported_dunning_history.sql
@@ -1,14 +1,17 @@
 -- openrails.imported_dunning_history — append-only legacy dunning forensics
 -- (#735; doujins #387 import target). Display/report evidence only.
 
--- name: InsertImportedDunningHistory :exec
+-- name: InsertImportedDunningHistory :execrows
 INSERT INTO openrails.imported_dunning_history (
-    merchant_id, subscription_id, customer_id, event_type, rail,
+    id, merchant_id, subscription_id, customer_id, event_type, rail,
     occurred_at, source, detail
 ) VALUES (
-    $1, sqlc.narg(subscription_id), sqlc.narg(customer_id), $2, $3, $4, $5,
+    sqlc.arg(id), sqlc.arg(merchant_id), sqlc.narg(subscription_id),
+    sqlc.narg(customer_id), sqlc.arg(event_type), sqlc.arg(rail),
+    sqlc.arg(occurred_at), sqlc.arg(source),
     sqlc.narg(detail)
-);
+)
+ON CONFLICT (id) DO NOTHING;
 
 -- Dunning-forensics history feed (#735): imported legacy rows ∪ failed
 -- payments, merchant-scoped, oldest first. Structured so #733's

--- a/internal/reconcile/appliers.go
+++ b/internal/reconcile/appliers.go
@@ -60,6 +60,10 @@ func (w *PGLocalWriter) BackfillPayment(ctx context.Context, a BackfillPaymentAc
 	if currency == "" {
 		return false, fmt.Errorf("payment currency required")
 	}
+	amount := moneyutil.CentsToMicros(a.AmountCents)
+	if a.AmountMicros != nil {
+		amount = *a.AmountMicros
+	}
 	tid, err := merchant.Require(ctx)
 	if err != nil {
 		return false, err
@@ -69,7 +73,7 @@ func (w *PGLocalWriter) BackfillPayment(ctx context.Context, a BackfillPaymentAc
 		PriceID:        a.PriceID,
 		Rail:           string(a.Rail),
 		TransactionID:  a.TransactionID,
-		Amount:         moneyutil.CentsToMicros(a.AmountCents),
+		Amount:         amount,
 		Currency:       currency,
 		SubscriptionID: a.SubscriptionID,
 		Metadata:       metadataJSON(a.Metadata),

--- a/internal/reconcile/findings.go
+++ b/internal/reconcile/findings.go
@@ -179,10 +179,13 @@ type MaterializeResult struct {
 // charge (PS-4), deduped on (tenant, rail, transaction_id), and grants
 // the subscription's entitlements when the period is current.
 type BackfillPaymentAction struct {
-	PspID          *uuid.UUID
-	Rail           string
-	TransactionID  string
-	AmountCents    int64
+	PspID         *uuid.UUID
+	Rail          string
+	TransactionID string
+	AmountCents   int64
+	// AmountMicros preserves exact host-ledger amounts for embedded historical
+	// imports. Nil keeps the provider-wire cents conversion used by reconcile.
+	AmountMicros   *int64
 	Currency       string
 	PurchasedAt    time.Time
 	PriceID        uuid.UUID

--- a/pkg/embedded/billing_import.go
+++ b/pkg/embedded/billing_import.go
@@ -18,6 +18,8 @@ type (
 	DeclaredPaymentMethod = billingimport.DeclaredPaymentMethod
 	PaymentMethodRef      = billingimport.PaymentMethodRef
 	CancelEvidence        = billingimport.CancelEvidence
+	DeclaredPayment       = billingimport.DeclaredPayment
+	DeclaredDunningEvent  = billingimport.DeclaredDunningEvent
 	DunningEvidence       = billingimport.DunningEvidence
 	DeclaredTransaction   = billingimport.DeclaredTransaction
 	DeclaredSubscription  = billingimport.DeclaredSubscription

--- a/pkg/embedded/billing_import_integration_test.go
+++ b/pkg/embedded/billing_import_integration_test.go
@@ -34,7 +34,8 @@ func TestImportBilling_DeclaredBookClassifiesAtAsOf(t *testing.T) {
 	require.NoError(t, err)
 
 	sfx := uuid.NewString()[:8]
-	prod, price := uuid.New(), uuid.New()
+	prod, price, pspID := uuid.New(), uuid.New(), uuid.New()
+	pspKey := "import-mobius-" + sfx
 	asOf := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
 	day := 24 * time.Hour
 
@@ -51,6 +52,11 @@ func TestImportBilling_DeclaredBookClassifiesAtAsOf(t *testing.T) {
 			`INSERT INTO openrails.prices (id,product_id,amount,currency,access_duration_hours,auto_renew,merchant_id) VALUES ($1,$2,23000000,'usd',720,true,$3)`,
 			price, prod, merchantID)
 		require.NoError(t, e)
+		_, e = appDB.Qx(ctx).Exec(ctx,
+			`INSERT INTO openrails.psps (id,merchant_id,rail,environment,account_id,key,archived)
+			 VALUES ($1,$2,'nmi','live',$3,$4,false)`,
+			pspID, merchantID, "acct-"+sfx, pspKey)
+		require.NoError(t, e)
 		return nil
 	}))
 	t.Cleanup(func() {
@@ -64,6 +70,7 @@ func TestImportBilling_DeclaredBookClassifiesAtAsOf(t *testing.T) {
 			}
 			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.prices WHERE id=$1`, price)
 			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.products WHERE id=$1`, prod)
+			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.psps WHERE id=$1`, pspID)
 			return nil
 		})
 	})
@@ -77,6 +84,7 @@ func TestImportBilling_DeclaredBookClassifiesAtAsOf(t *testing.T) {
 	chargebackAt := asOf.Add(-30 * day)
 	parkedPaid := asOf.Add(-3 * 365 * day)
 	paidIncr := asOf.Add(10 * day)
+	dunningEventID := uuid.New()
 
 	book := DeclaredBilling{
 		AsOf: asOf,
@@ -85,7 +93,7 @@ func TestImportBilling_DeclaredBookClassifiesAtAsOf(t *testing.T) {
 			{Customer: cUserNMI}, {Customer: cChargeback}, {Customer: cParked}, {Customer: cIncr},
 		},
 		PaymentMethods: []DeclaredPaymentMethod{{
-			Customer: cDunning, Rail: "nmi", RailCustomerRef: "vault-" + sfx, RailMethodRef: "",
+			SourceID: "vault", PSPKey: pspKey, Customer: cDunning, Rail: "nmi", RailCustomerRef: "vault-" + sfx, RailMethodRef: "",
 			InitialTransactionID: "itx-" + sfx, LastFour: "4242",
 		}},
 		Subscriptions: []DeclaredSubscription{
@@ -97,7 +105,7 @@ func TestImportBilling_DeclaredBookClassifiesAtAsOf(t *testing.T) {
 				SourceID: "dunning", Customer: cDunning, Price: price, Rail: "nmi",
 				RailSubscriptionID: "sub-dunning-" + sfx, StartedAt: asOf.Add(-200 * day), PaidThrough: &paidDunning,
 				Dunning:       &DunningEvidence{Retries: 2, LastRetryAt: &lastRetryAt, ScheduleLive: true},
-				PaymentMethod: &PaymentMethodRef{Rail: "nmi", RailCustomerRef: "vault-" + sfx, RailMethodRef: ""},
+				PaymentMethod: &PaymentMethodRef{Rail: "nmi", PSPKey: pspKey, RailCustomerRef: "vault-" + sfx, RailMethodRef: ""},
 				Evidence:      json.RawMessage(`{"legacy_source":"subscriptions","legacy_id":42}`),
 			},
 			{
@@ -143,6 +151,16 @@ func TestImportBilling_DeclaredBookClassifiesAtAsOf(t *testing.T) {
 			// Chargeback's reversal.
 			{RailSubscriptionID: "sub-cb-" + sfx, TransactionID: "tx-cb-" + sfx, Type: "chargeback", Success: false, AmountCents: 2300, Currency: "usd", OccurredAt: chargebackAt},
 		},
+		Payments: []DeclaredPayment{{
+			SourceID: "oneoff", Customer: cRunway, Price: price, Rail: "solana",
+			TransactionID: "tx-oneoff-" + sfx, AmountMicros: 23_000_001, Currency: "usd",
+			OccurredAt: asOf.Add(-2 * day), Metadata: json.RawMessage(`{"legacy_source":"wallet_transactions"}`),
+		}},
+		DunningEvents: []DeclaredDunningEvent{{
+			SourceID: "history", ID: dunningEventID, Customer: &cDunning,
+			EventType: "charge_failure", Rail: "nmi", OccurredAt: asOf.Add(-3 * day),
+			Source: "test", Detail: json.RawMessage(`{"status":"failed"}`),
+		}},
 	}
 
 	res, err := ImportBilling(context.Background(), BillingImportOptions{
@@ -151,6 +169,22 @@ func TestImportBilling_DeclaredBookClassifiesAtAsOf(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, res.Blocked, "no blocks expected: %v", res.Reasons)
 	require.ElementsMatch(t, []string{"runway", "dunning", "lapsed", "usercancel", "usercancel-nmi-live", "chargeback", "parked", "incremental"}, res.Imported)
+	require.Equal(t, []string{"vault"}, res.PaymentMethodsImported)
+	require.Equal(t, []string{"oneoff"}, res.PaymentsImported)
+	require.Equal(t, []string{"history"}, res.DunningImported)
+	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
+		var gotPSP uuid.UUID
+		require.NoError(t, appDB.Qx(ctx).QueryRow(ctx,
+			`SELECT psp_id FROM openrails.payment_methods WHERE rail_customer_ref=$1`,
+			"vault-"+sfx).Scan(&gotPSP))
+		require.Equal(t, pspID, gotPSP)
+		var amount int64
+		require.NoError(t, appDB.Qx(ctx).QueryRow(ctx,
+			`SELECT amount FROM openrails.payments WHERE transaction_id=$1`,
+			"tx-oneoff-"+sfx).Scan(&amount))
+		require.Equal(t, int64(23_000_001), amount)
+		return nil
+	}))
 
 	type subRow struct {
 		status, cancelType             string
@@ -267,12 +301,15 @@ func TestImportBilling_DeclaredBookClassifiesAtAsOf(t *testing.T) {
 	require.Empty(t, res2.Imported)
 	require.Empty(t, res2.Blocked, "re-import blocks: %v", res2.Reasons)
 	require.ElementsMatch(t, []string{"runway", "dunning", "lapsed", "usercancel", "usercancel-nmi-live", "chargeback", "parked", "incremental"}, res2.Skipped)
+	require.Equal(t, []string{"vault"}, res2.PaymentMethodsSkipped)
+	require.Equal(t, []string{"oneoff"}, res2.PaymentsSkipped)
+	require.Equal(t, []string{"history"}, res2.DunningSkipped)
 
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
 		var n int
 		require.NoError(t, appDB.Qx(ctx).QueryRow(ctx,
 			`SELECT count(*) FROM openrails.payments WHERE transaction_id LIKE '%'||$1`, sfx).Scan(&n))
-		require.Equal(t, 3, n, "payments idempotent by (rail, transaction_id)")
+		require.Equal(t, 4, n, "payments idempotent by (rail, transaction_id)")
 		r := load(ctx, "sub-user-"+sfx)
 		require.Equal(t, "user", r.cancelType, "re-import never regresses settled history")
 		r = load(ctx, "sub-runway-"+sfx)


### PR DESCRIPTION
Summary: add PSP-keyed imports for legacy customers, payment methods, payments, and dunning history.

Verification: focused tests, vet, sqlc generate/vet, and integration-tag compilation.