### PR TITLE
Fix validation CI regressions

### DIFF
--- a/config/env_boundary_test.go
+++ b/config/env_boundary_test.go
@@ -21,6 +21,7 @@ func TestNoLibraryEnvReads(t *testing.T) {
 	// justification per entry — anything else that reads env FAILS.
 	allowedPrefixes := map[string]string{
 		"cmd/":                                   "binary boundary: the process entrypoint owns flags and env",
+		"examples/":                              "executable examples are process entrypoints and own their env",
 		"config/":                                "the config-loading pipeline — the ONE place env is read",
 		"tests/":                                 "test binaries own their env (OPENRAILS_TEST_*, RAILS_* fixtures)",
 		"scripts/":                               "operational tooling run as its own process, not importable library code",

--- a/internal/controlplane/payment_settlements_integration_test.go
+++ b/internal/controlplane/payment_settlements_integration_test.go
@@ -147,7 +147,10 @@ func TestPaymentSettlementsCrossMerchantIsolation(t *testing.T) {
 	_, err = super.Exec(ctx, `UPDATE openrails.payment_settlement_events SET delivered_at = now() - interval '31 days' WHERE payment_id = $1`, payB)
 	require.NoError(t, err)
 	appTx(&mB, func(tx gen.DBTX) {
-		n, err := gen.New(tx).DeleteDeliveredPaymentSettlementsBefore(ctx, time.Now().Add(-30*24*time.Hour))
+		n, err := gen.New(tx).DeleteDeliveredPaymentSettlementsBefore(ctx, gen.DeleteDeliveredPaymentSettlementsBeforeParams{
+			MerchantID: mB,
+			Cutoff:     time.Now().Add(-30 * 24 * time.Hour),
+		})
 		require.NoError(t, err)
 		require.EqualValues(t, 1, n)
 	})

--- a/internal/db/gen/models.go
+++ b/internal/db/gen/models.go
@@ -536,7 +536,7 @@ type OpenrailsLedgerTransfer struct {
 	CreatedAt  time.Time
 }
 
-// Merchant / billing-namespace directory: a dumb billing bucket (whose books a row goes on). GLOBAL (control-plane) table, not tenant-scoped. Carries ONLY billing/money-rail state, NO auth. Merchants are registered explicitly; there is no default merchant.
+// Merchant / billing-namespace directory: a dumb billing bucket (whose books a row goes on). GLOBAL (control-plane) table, not tenant-scoped. Carries ONLY billing/money-rail state, NO auth. Merchants are registered explicitly; there is no default merchant. RLS-exempt by design: it IS the tenant directory — the scope, not a scoped row.
 type OpenrailsMerchant struct {
 	ID uuid.UUID
 	// Stable merchant slug used in merchant-scoped routes and resolution.
@@ -1239,7 +1239,7 @@ type OpenrailsWebhookHealthDaily struct {
 	Drift      int64
 }
 
-// #689 per-River-worker-kind health: last success/error + failure streak, written by the worker middleware. Operator-global control-plane table (no merchant scope, no RLS — see merchants).
+// #689 per-River-worker-kind health: last success/error + failure streak, written by the worker middleware. Operator-global control-plane table. RLS-exempt by design: process health per worker kind, not tenant data.
 type OpenrailsWorkerHealth struct {
 	WorkerKind string
 	// First time this kind was seeded (deploy that introduced it) — anchors the never-succeeded-since-deploy alert.

--- a/internal/db/gen/payment_settlements.sql.go
+++ b/internal/db/gen/payment_settlements.sql.go
@@ -34,12 +34,18 @@ func (q *Queries) AcknowledgePaymentSettlement(ctx context.Context, arg Acknowle
 
 const deleteDeliveredPaymentSettlementsBefore = `-- name: DeleteDeliveredPaymentSettlementsBefore :execrows
 DELETE FROM openrails.payment_settlement_events
- WHERE delivered_at IS NOT NULL
-   AND delivered_at < $1::timestamptz
+ WHERE merchant_id = $1
+   AND delivered_at IS NOT NULL
+   AND delivered_at < $2::timestamptz
 `
 
-func (q *Queries) DeleteDeliveredPaymentSettlementsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
-	result, err := q.db.Exec(ctx, deleteDeliveredPaymentSettlementsBefore, cutoff)
+type DeleteDeliveredPaymentSettlementsBeforeParams struct {
+	MerchantID uuid.UUID
+	Cutoff     time.Time
+}
+
+func (q *Queries) DeleteDeliveredPaymentSettlementsBefore(ctx context.Context, arg DeleteDeliveredPaymentSettlementsBeforeParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteDeliveredPaymentSettlementsBefore, arg.MerchantID, arg.Cutoff)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/queries/EXEMPTIONS.md
+++ b/internal/db/queries/EXEMPTIONS.md
@@ -127,5 +127,11 @@ Nothing about them requires raw SQL.
 transaction. The nine existing migrations are excluded by path: `0001` is the
 squashed baseline (creates the schema from nothing, so lock-safety rules are
 vacuous) and `0002`-`0009` predate this gate. New migrations are **not**
-excluded and must pass clean — including `require-lock-timeout` and
-`require-statement-timeout`, which only `0001` currently sets.
+excluded and must pass clean.
+
+`0011_query_audit_indexes.up.sql` has one file-specific exception:
+`require-concurrent-index-creation`. PostgreSQL forbids `CREATE INDEX
+CONCURRENTLY` inside the transaction migratekit always opens, so these two
+narrow partial indexes use regular creation bounded by a five-second lock
+timeout and five-minute statement timeout. The lint script still applies every
+other Squawk rule to that file.

--- a/internal/db/queries/payment_settlements.sql
+++ b/internal/db/queries/payment_settlements.sql
@@ -14,5 +14,6 @@ UPDATE openrails.payment_settlement_events
 
 -- name: DeleteDeliveredPaymentSettlementsBefore :execrows
 DELETE FROM openrails.payment_settlement_events
- WHERE delivered_at IS NOT NULL
+ WHERE merchant_id = sqlc.arg(merchant_id)
+   AND delivered_at IS NOT NULL
    AND delivered_at < sqlc.arg(cutoff)::timestamptz;

--- a/internal/integrationharness/rail_seeding.go
+++ b/internal/integrationharness/rail_seeding.go
@@ -38,6 +38,8 @@ func SeedRailMerchantAccounts(ctx context.Context, t *testing.T, rt *app.Runtime
 		if proc == nil {
 			continue
 		}
+		pspKey := strings.ToLower(strings.TrimSpace(name))
+		require.NotEmpty(t, pspKey, "PSP key required")
 		rail := string(proc.EffectiveRail(name))
 		require.NotEmpty(t, rail, "rail for account %q", name)
 		accountID := proc.EffectiveAccountID()
@@ -61,6 +63,7 @@ func SeedRailMerchantAccounts(ctx context.Context, t *testing.T, rt *app.Runtime
 				Rail:        nRail,
 				Environment: &nEnv,
 				AccountID:   nAccount,
+				Key:         &pspKey,
 				Archived:    &archived,
 				Evidence:    evidence,
 			})

--- a/internal/river/jobs_cleanup.go
+++ b/internal/river/jobs_cleanup.go
@@ -220,7 +220,10 @@ func (w CleanupExpiredDataWorker) cleanupPaymentSettlements(ctx context.Context,
 	for _, mid := range merchantIDs {
 		mctx := merchant.WithID(ctx, merchant.ID(mid))
 		if err := w.DB.MerchantTx(mctx, func(ctx context.Context, tx pgx.Tx) error {
-			n, err := gen.New(tx).DeleteDeliveredPaymentSettlementsBefore(ctx, cutoff)
+			n, err := gen.New(tx).DeleteDeliveredPaymentSettlementsBefore(ctx, gen.DeleteDeliveredPaymentSettlementsBeforeParams{
+				MerchantID: mid,
+				Cutoff:     cutoff,
+			})
 			total += n
 			return err
 		}); err != nil {

--- a/migrations/postgres/0010_payment_settlement_events_rls.up.sql
+++ b/migrations/postgres/0010_payment_settlement_events_rls.up.sql
@@ -2,6 +2,9 @@
 -- in a shared DB any openrails_app connection could read/ack every merchant's
 -- settlement events. Fail-closed merchant_isolation, same pattern as 0001/0002.
 
+SET lock_timeout = '5s';
+SET statement_timeout = '5min';
+
 ALTER TABLE openrails.payment_settlement_events ENABLE ROW LEVEL SECURITY;
 ALTER TABLE ONLY openrails.payment_settlement_events FORCE ROW LEVEL SECURITY;
 

--- a/migrations/postgres/0011_query_audit_indexes.down.sql
+++ b/migrations/postgres/0011_query_audit_indexes.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX openrails.idx_grants_credit_customer_currency;
+DROP INDEX openrails.idx_payment_settlement_events_delivered;

--- a/migrations/postgres/0011_query_audit_indexes.up.sql
+++ b/migrations/postgres/0011_query_audit_indexes.up.sql
@@ -1,0 +1,10 @@
+SET lock_timeout = '5s';
+SET statement_timeout = '5min';
+
+CREATE INDEX idx_payment_settlement_events_delivered
+    ON openrails.payment_settlement_events (merchant_id, delivered_at)
+    WHERE delivered_at IS NOT NULL;
+
+CREATE INDEX idx_grants_credit_customer_currency
+    ON openrails.grants (merchant_id, customer_id, currency, starts_at, ends_at)
+    WHERE kind = 'credit' AND event = 'grant';

--- a/scripts/migration-lint.sh
+++ b/scripts/migration-lint.sh
@@ -23,10 +23,25 @@ if [ ! -x "$BIN" ]; then
     chmod +x "$BIN"
 fi
 
+# migratekit wraps every migration in a transaction, so PostgreSQL cannot build
+# 0011's two indexes CONCURRENTLY. Lint that file separately with only that
+# incompatible rule disabled; every other rule remains enforcing.
+TRANSACTIONAL_INDEX_MIGRATION="migrations/postgres/0011_query_audit_indexes.up.sql"
+migration_files=()
+for file in migrations/postgres/*.up.sql; do
+    if [ "$file" != "$TRANSACTIONAL_INDEX_MIGRATION" ]; then
+        migration_files+=("$file")
+    fi
+done
+
 # squawk exits 0 even when it reports issues; count them instead.
-count="$("$BIN" --reporter json 'migrations/postgres/*.up.sql' 2>/dev/null | tr ',' '\n' | grep -c '"rule_name"' || true)"
+count="$({
+    "$BIN" --reporter json "${migration_files[@]}"
+    "$BIN" --reporter json --exclude require-concurrent-index-creation "$TRANSACTIONAL_INDEX_MIGRATION"
+} 2>/dev/null | tr ',' '\n' | grep -c '"rule_name"' || true)"
 if [ "$count" -gt 0 ]; then
-    "$BIN" 'migrations/postgres/*.up.sql' 1>&2
+    "$BIN" "${migration_files[@]}" 1>&2
+    "$BIN" --exclude require-concurrent-index-creation "$TRANSACTIONAL_INDEX_MIGRATION" 1>&2
     echo "" 1>&2
     echo "migration-lint: $count issue(s) in new migrations. Fix them, or — if the" 1>&2
     echo "operation is genuinely safe here — record why in" 1>&2

--- a/tests/entitlements_dunning_ccbill_terminal_and_dupe_test.go
+++ b/tests/entitlements_dunning_ccbill_terminal_and_dupe_test.go
@@ -127,6 +127,7 @@ func TestEntitlementsDunningStateMachine_CCBill_TerminalExpiration(t *testing.T)
 			},
 			DB:                  rt.DB,
 			Clock:               clock,
+			CCBillClient:        testCCBillWebhookClient(),
 			SubscriptionService: rt.SubscriptionService,
 		}
 		require.NoError(t, svc.HandleCCBillWebhook(ctx))
@@ -166,6 +167,7 @@ func TestEntitlementsDunningStateMachine_CCBill_TerminalExpiration(t *testing.T)
 		},
 		DB:                           rt.DB,
 		Clock:                        clock,
+		CCBillClient:                 testCCBillWebhookClient(),
 		SubscriptionService:          rt.SubscriptionService,
 		SubscriptionLifecycleService: rt.SubscriptionLifecycleService,
 		NotificationService:          rt.NotificationService,
@@ -301,6 +303,7 @@ func TestEntitlementsDunningStateMachine_CCBill_DuplicateRenewalSuccess(t *testi
 		},
 		DB:                           rt.DB,
 		Clock:                        clock,
+		CCBillClient:                 testCCBillWebhookClient(),
 		DeduplicationService:         rt.DeduplicationService,
 		SubscriptionService:          rt.SubscriptionService,
 		SubscriptionLifecycleService: rt.SubscriptionLifecycleService,

--- a/tests/entitlements_dunning_state_machine_test.go
+++ b/tests/entitlements_dunning_state_machine_test.go
@@ -146,6 +146,7 @@ func TestEntitlementsDunningStateMachine_CCBill(t *testing.T) {
 			},
 			DB:                  rt.DB,
 			Clock:               clock,
+			CCBillClient:        testCCBillWebhookClient(),
 			SubscriptionService: rt.SubscriptionService,
 		}
 		require.NoError(t, svc.HandleCCBillWebhook(ctx))
@@ -198,6 +199,7 @@ func TestEntitlementsDunningStateMachine_CCBill(t *testing.T) {
 		},
 		DB:                           rt.DB,
 		Clock:                        clock,
+		CCBillClient:                 testCCBillWebhookClient(),
 		SubscriptionService:          rt.SubscriptionService,
 		SubscriptionLifecycleService: rt.SubscriptionLifecycleService,
 		MoneyService:                 rt.MoneyService,

--- a/tests/nmi_provider_regression_test.go
+++ b/tests/nmi_provider_regression_test.go
@@ -24,7 +24,8 @@ func TestCheckoutSupportsConfiguredSecondaryNMIProvider(t *testing.T) {
 	suite, mock := SetupSuiteWithMockNMI(t)
 	products := suite.SeedProducts()
 	priceID := products[0].Prices[0].ID
-	configureSecondaryNMIProvider(t, suite, mock, "nmi", priceID)
+	const provider = "secondary-nmi"
+	configureSecondaryNMIProvider(t, suite, mock, provider, priceID)
 
 	userID := uuid.New().String()
 	email := "checkout-nmi-" + uuid.NewString() + "@test.example.com"
@@ -33,7 +34,7 @@ func TestCheckoutSupportsConfiguredSecondaryNMIProvider(t *testing.T) {
 	body := map[string]any{
 		"price_id": priceID.String(),
 		"payment": map[string]any{
-			"rail":          "nmi",
+			"rail":          provider,
 			"payment_token": "tok_test_123",
 			"email":         email,
 			"first_name":    "Test",

--- a/tests/test_helpers.go
+++ b/tests/test_helpers.go
@@ -11,7 +11,9 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/open-rails/openrails/config"
 	server "github.com/open-rails/openrails/internal/http"
+	"github.com/open-rails/openrails/internal/integrations/ccbill"
 )
 
 var (
@@ -20,6 +22,13 @@ var (
 	sharedSuiteOnce sync.Once
 	sharedSuite     *TestContainerSuite
 )
+
+func testCCBillWebhookClient() *ccbill.RESTClient {
+	return ccbill.NewRESTClient(&config.CCBillConfig{
+		ClientAccNum: "1234",
+		ClientSubAcc: "0000",
+	})
+}
 
 // personalOwnerID returns the merchant-subject id for the self-hosted /
 // single-merchant personal case. HARDCUT (#221): this matches the caller-provided


### PR DESCRIPTION
Fixes the failing Validate Code jobs: refreshes SQLC output, corrects PSP/CCBill fixtures, and resolves the newly exposed SQL audit failures.

Verified with race/unit, vet/build, targeted integration, SQLC/query audit, and SQL/migration lint.