### PR TITLE
Fix integration PSP link fixtures

### DIFF
--- a/tests/seed_data.go
+++ b/tests/seed_data.go
@@ -416,9 +416,17 @@ func (suite *TestContainerSuite) upsertProduct(ctx context.Context, p *models.Pr
 // a distinct explicit key; a blank Key still auto-derives via the DB trigger.
 func (suite *TestContainerSuite) insertPriceIfAbsent(ctx context.Context, price *models.Price) {
 	suite.t.Helper()
-	// These shared fixtures key links directly by rail. The PSP hard-cut also
-	// requires every entry to record that rail explicitly.
-	for rail, link := range price.PSPLinks {
+	// Shared fixtures use the NMI rail name as an authoring shorthand. Persist
+	// the runtime's actual PSP key while retaining the gateway in link metadata.
+	if link, ok := price.PSPLinks[string(models.RailNMI)]; ok {
+		delete(price.PSPLinks, string(models.RailNMI))
+		price.PSPLinks[testNMIProviderKey] = link
+	}
+	for psp, link := range price.PSPLinks {
+		rail := psp
+		if psp == testNMIProviderKey {
+			rail = string(models.RailNMI)
+		}
 		link[models.RailKeyRail] = rail
 	}
 	_, err := suite.Pool.Exec(ctx, `

--- a/tests/testcontainer_suite.go
+++ b/tests/testcontainer_suite.go
@@ -81,6 +81,8 @@ type TestContainerSuite struct {
 // TestSuiteOption customizes an integration test suite before it boots.
 type TestSuiteOption func(*TestContainerSuite)
 
+const testNMIProviderKey = "mobius"
+
 // testNMIRailMerchantAccountID is the suite's ONE active NMI provider
 // account (#788: the mobius gateway id from defaultSuiteRails — the harness
 // seeds it as the armed rail state every consumer resolves).
@@ -193,7 +195,7 @@ func defaultSuiteRails(stripeSecretKey string) config.PSPSet {
 		},
 		// Test-only env overrides use the OPENRAILS_TEST_* prefix (#711 — the
 		// runtime RAILS_ config prefix is retired; don't teach operators a dead one).
-		"mobius": {
+		testNMIProviderKey: {
 			Rail:      models.RailNMI,
 			AccountID: envOrDefault("OPENRAILS_TEST_MOBIUS_GATEWAY_ID", "579145"),
 			NMI: &config.NMIRailConfig{


### PR DESCRIPTION
Aligns shared NMI price fixtures with the configured `mobius` PSP key while preserving rail metadata.

Verified with the affected tier/checkout tests on a fresh Docker stack and integration-tag compile/vet.