### PR TITLE
Fix CCBill integration source allowlist

### DIFF
--- a/embed/ccbill_webhook_integration_test.go
+++ b/embed/ccbill_webhook_integration_test.go
@@ -40,10 +40,11 @@ func sandboxModeConfig(dsn string, source string) *config.Config {
 		// Sandbox posture: the CCBill IP allowlist bypass engages (no live
 		// ccbill accounts exist for these merchants) — same as hentai0's
 		// compose suite.
-		TestMode:          config.CredentialPostureSandbox,
-		MerchantSource:    source,
-		ProviderWriteMode: config.ProviderWriteModeFull,
-		DB:                &config.DBConfig{URL: dsn},
+		TestMode:                 config.CredentialPostureSandbox,
+		CCBillWebhookIPAllowlist: []string{"127.0.0.1/32", "::1/128"},
+		MerchantSource:           source,
+		ProviderWriteMode:        config.ProviderWriteModeFull,
+		DB:                       &config.DBConfig{URL: dsn},
 	}
 }
 

--- a/internal/integrationharness/harness.go
+++ b/internal/integrationharness/harness.go
@@ -386,8 +386,9 @@ func (h *Harness) startStandalone(currency, appDSN, name string, opts ...Standal
 	dbtest.EnsureTestMerchant(h.ctx, h.t, h.sharedPool())
 
 	cfg := &config.Config{
-		Env:      "dev",
-		TestMode: config.CredentialPostureSandbox,
+		Env:                      "dev",
+		TestMode:                 config.CredentialPostureSandbox,
+		CCBillWebhookIPAllowlist: []string{"127.0.0.1/32", "::1/128"},
 		// MODE 2 (#723): the standalone harness IS the API-driven SaaS shape —
 		// merchants/secrets/catalog mutate over the HTTP surface it exercises.
 		// Manifest-mode standalone behavior is tested per-case, not here.


### PR DESCRIPTION
Declares loopback CIDRs for sandbox CCBill webhook integration fixtures.

Verified with all previously failing CCBill tests and integration compile/vet.