### PR TITLE
fix(catalog): separate Solana settlement tokens

### DIFF
--- a/internal/integrationharness/merchant_catalog_http_test.go
+++ b/internal/integrationharness/merchant_catalog_http_test.go
@@ -1437,6 +1437,16 @@ func (a httpCatalogApplier) CreatePrice(_ context.Context, req billingservice.Cr
 	return &out, nil
 }
 
+func (a httpCatalogApplier) UpdatePrice(_ context.Context, id uuid.UUID, req billingservice.UpdatePriceRequest) (*billingservice.CatalogPrice, error) {
+	status, body := requestJSON(a.t, http.MethodPatch, a.baseURL+"/v1/merchant/catalog/prices/"+id.String(), a.token, req)
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("update price: status %d: %s", status, string(body))
+	}
+	var out billingservice.CatalogPrice
+	require.NoError(a.t, json.Unmarshal(body, &out))
+	return &out, nil
+}
+
 func (a httpCatalogApplier) ActivatePrice(_ context.Context, id uuid.UUID) (*billingservice.CatalogPrice, error) {
 	status, body := requestJSON(a.t, http.MethodPost, a.baseURL+"/v1/merchant/catalog/prices/"+id.String()+"/activate", a.token, nil)
 	if status != http.StatusOK {

--- a/pkg/catalog/applier.go
+++ b/pkg/catalog/applier.go
@@ -21,6 +21,9 @@ type Applier interface {
 
 	ListPricesByProduct(ctx context.Context, productID uuid.UUID, activeOnly bool) ([]billingservice.CatalogPrice, error)
 	CreatePrice(ctx context.Context, req billingservice.CreatePriceRequest) (*billingservice.CatalogPrice, error)
+	// UpdatePrice converges declared PSP link/config values onto an existing
+	// price (#745 settlement-token rotation and the like).
+	UpdatePrice(ctx context.Context, id uuid.UUID, req billingservice.UpdatePriceRequest) (*billingservice.CatalogPrice, error)
 	ActivatePrice(ctx context.Context, id uuid.UUID) (*billingservice.CatalogPrice, error)
 	DeactivatePrice(ctx context.Context, id uuid.UUID) (*billingservice.CatalogPrice, error)
 	// SetPriceKey relabels a price's #774 key in place (a plain rename — never

--- a/pkg/catalog/apply.go
+++ b/pkg/catalog/apply.go
@@ -18,6 +18,7 @@ type ApplyResult struct {
 	ProductsUpdated  int                `json:"products_updated"`
 	ProductsArchived int                `json:"products_archived"`
 	PricesCreated    int                `json:"prices_created"`
+	PricesUpdated    int                `json:"prices_updated"`
 	PricesActivated  int                `json:"prices_activated"`
 	PricesArchived   int                `json:"prices_archived"`
 	PendingActions   []PendingActionFor `json:"pending_actions,omitempty"`
@@ -155,8 +156,30 @@ func applyPrices(ctx context.Context, applier Applier, pp *ProductPlan, productI
 				return fmt.Errorf("archive price %s: %w", plp.Label, err)
 			}
 			res.PricesArchived++
+		case PriceUpdate:
+			// Provider link/config convergence runs below.
 		case PriceUnchanged:
 			// nothing to do beyond a possible key relabel below.
+		}
+		if plp.Action != PriceCreate && len(plp.UpdateReq.PSPLinks) > 0 && opts.Overwrite {
+			updater, ok := applier.(interface {
+				UpdatePrice(context.Context, uuid.UUID, billingservice.UpdatePriceRequest) (*billingservice.CatalogPrice, error)
+			})
+			if !ok {
+				return fmt.Errorf("update price %s: applier does not support price updates", plp.Label)
+			}
+			out, err := updater.UpdatePrice(ctx, plp.ExistingID, plp.UpdateReq)
+			if err != nil {
+				return fmt.Errorf("update price %s: %w", plp.Label, err)
+			}
+			res.PricesUpdated++
+			for _, pa := range out.PendingManualActions {
+				res.PendingActions = append(res.PendingActions, PendingActionFor{
+					ProductKey: pp.Key,
+					PriceLabel: plp.Label,
+					Action:     pa,
+				})
+			}
 		}
 		// #774: a substance-matched price declared under a renamed key (plp.Key
 		// set only when it differs from the matched row's current key) gets
@@ -174,9 +197,9 @@ func applyPrices(ctx context.Context, applier Applier, pp *ProductPlan, productI
 // Print writes a human summary of the apply result, including any pending
 // manual actions, to out.
 func (r *ApplyResult) Print(out io.Writer) {
-	fmt.Fprintf(out, "applied: products +%d ~%d -%d | prices +%d activated %d archived %d\n",
+	fmt.Fprintf(out, "applied: products +%d ~%d -%d | prices +%d updated %d activated %d archived %d\n",
 		r.ProductsCreated, r.ProductsUpdated, r.ProductsArchived,
-		r.PricesCreated, r.PricesActivated, r.PricesArchived)
+		r.PricesCreated, r.PricesUpdated, r.PricesActivated, r.PricesArchived)
 	if len(r.PendingActions) == 0 {
 		return
 	}

--- a/pkg/catalog/apply.go
+++ b/pkg/catalog/apply.go
@@ -165,13 +165,7 @@ func applyPrices(ctx context.Context, applier Applier, pp *ProductPlan, productI
 		// braces): link sync must never publish provider objects for a price
 		// this run is retiring.
 		if plp.Action != PriceCreate && plp.Action != PriceArchive && len(plp.UpdateReq.PSPLinks) > 0 && opts.Overwrite {
-			updater, ok := applier.(interface {
-				UpdatePrice(context.Context, uuid.UUID, billingservice.UpdatePriceRequest) (*billingservice.CatalogPrice, error)
-			})
-			if !ok {
-				return fmt.Errorf("update price %s: applier does not support price updates", plp.Label)
-			}
-			out, err := updater.UpdatePrice(ctx, plp.ExistingID, plp.UpdateReq)
+			out, err := applier.UpdatePrice(ctx, plp.ExistingID, plp.UpdateReq)
 			if err != nil {
 				return fmt.Errorf("update price %s: %w", plp.Label, err)
 			}

--- a/pkg/catalog/apply.go
+++ b/pkg/catalog/apply.go
@@ -169,7 +169,13 @@ func applyPrices(ctx context.Context, applier Applier, pp *ProductPlan, productI
 			if err != nil {
 				return fmt.Errorf("update price %s: %w", plp.Label, err)
 			}
-			res.PricesUpdated++
+			// Count an update only when at least one requested provider link
+			// actually applied. When every requested slot deferred to a pending
+			// action nothing was stored, and reporting "updated" would claim
+			// convergence an unconfigured deployment never made.
+			if len(out.PendingManualActions) < len(plp.UpdateReq.PSPLinks) {
+				res.PricesUpdated++
+			}
 			for _, pa := range out.PendingManualActions {
 				res.PendingActions = append(res.PendingActions, PendingActionFor{
 					ProductKey: pp.Key,

--- a/pkg/catalog/apply.go
+++ b/pkg/catalog/apply.go
@@ -161,7 +161,10 @@ func applyPrices(ctx context.Context, applier Applier, pp *ProductPlan, productI
 		case PriceUnchanged:
 			// nothing to do beyond a possible key relabel below.
 		}
-		if plp.Action != PriceCreate && len(plp.UpdateReq.PSPLinks) > 0 && opts.Overwrite {
+		// PriceArchive is excluded on top of plan.go's own gate (belt and
+		// braces): link sync must never publish provider objects for a price
+		// this run is retiring.
+		if plp.Action != PriceCreate && plp.Action != PriceArchive && len(plp.UpdateReq.PSPLinks) > 0 && opts.Overwrite {
 			updater, ok := applier.(interface {
 				UpdatePrice(context.Context, uuid.UUID, billingservice.UpdatePriceRequest) (*billingservice.CatalogPrice, error)
 			})

--- a/pkg/catalog/load.go
+++ b/pkg/catalog/load.go
@@ -500,12 +500,23 @@ func (m *Manifest) validatePrice(product Product, price *Price, idx int, meterKi
 		for _, provider := range price.PSPs {
 			declared[provider] = struct{}{}
 		}
-		for provider := range price.PSPLinks {
+		// Normalize the psp_links keys IN PLACE (psps above are already
+		// normalized): every later lookup — the eligibility checks below,
+		// plan-time drift detection — reads by the canonical lowercase key, so
+		// a cased manifest key like "Solana:" must not survive as a distinct,
+		// invisible entry.
+		normalizedLinks := make(map[string]map[string]string, len(price.PSPLinks))
+		for provider, link := range price.PSPLinks {
 			key := strings.ToLower(strings.TrimSpace(provider))
 			if _, ok := declared[key]; !ok {
 				return fmt.Errorf("product %q price %s: psp_links.%s requires psps to include %q", product.Key, PriceLabel(product.Key, *price), provider, key)
 			}
+			if _, dup := normalizedLinks[key]; dup {
+				return fmt.Errorf("product %q price %s: psp_links declares %q more than once (differing only in case)", product.Key, PriceLabel(product.Key, *price), key)
+			}
+			normalizedLinks[key] = link
 		}
+		price.PSPLinks = normalizedLinks
 	}
 
 	// Per-provider eligibility (shape-only; no chain calls). One-off Solana

--- a/pkg/catalog/load.go
+++ b/pkg/catalog/load.go
@@ -532,8 +532,14 @@ func (m *Manifest) validatePrice(product Product, price *Price, idx int, meterKi
 		}
 		if price.AutoRenew {
 			if price.Currency != "usd" {
-				return fmt.Errorf("product %q price %s: recurring solana currently requires USD billing currency, got %q",
-					product.Key, PriceLabel(product.Key, *price), price.Currency)
+				hint := ""
+				if _, legacy := stablecoinCurrencies[price.Currency]; legacy {
+					// Pre-#745 manifests declared the settlement token AS the
+					// billing currency; point the operator at the new shape.
+					hint = fmt.Sprintf("; pre-#745 manifests billed in the token — redeclare as currency: usd with psp_links.solana.mint_symbol: %s", strings.ToUpper(price.Currency))
+				}
+				return fmt.Errorf("product %q price %s: recurring solana currently requires USD billing currency, got %q%s",
+					product.Key, PriceLabel(product.Key, *price), price.Currency, hint)
 			}
 			symbol := strings.ToUpper(strings.TrimSpace(price.PSPLinks[provider]["mint_symbol"]))
 			if _, ok := recurringSolanaTokenSymbols[symbol]; !ok {

--- a/pkg/catalog/load.go
+++ b/pkg/catalog/load.go
@@ -53,13 +53,17 @@ func normalizeCurrency(value string) string {
 	return strings.ToLower(strings.TrimSpace(value))
 }
 
-// stablecoinCurrencies are the currencies eligible for the Solana provider.
-// Solana settles on-chain in stablecoins pegged $1; a recurring fiat price is
-// only Solana-eligible if its currency is one of these.
+// stablecoinCurrencies are explicit ledger currency identifiers accepted
+// alongside generic three-letter currency codes.
 var stablecoinCurrencies = map[string]struct{}{
-	"usd":  {}, // priced in USD, settled in a $1-pegged stablecoin
+	"usd":  {},
 	"usdc": {},
 	"usdg": {},
+}
+
+var recurringSolanaTokenSymbols = map[string]struct{}{
+	"USDC": {},
+	"USD1": {},
 }
 
 // Load reads, parses and validates a manifest from disk. Validation normalizes
@@ -504,18 +508,25 @@ func (m *Manifest) validatePrice(product Product, price *Price, idx int, meterKi
 		}
 	}
 
-	// Per-provider eligibility (shape-only; no chain calls). Solana settles
-	// on-chain in $1-pegged stablecoins, so a Solana price must be priced in a
-	// stablecoin currency (one-off finite windows and recurring are both allowed).
+	// Per-provider eligibility (shape-only; no chain calls). One-off Solana
+	// checkout quotes the selected token at payment time. A recurring plan is
+	// mint-specific, so it must declare its settlement token independently from
+	// the price's billing currency.
 	if price.Metered != nil && len(price.PSPs) > 0 {
 		return fmt.Errorf("product %q price %s: metered prices are OpenRails-native and must not declare external providers", product.Key, PriceLabel(product.Key, *price))
 	}
 	for _, provider := range price.PSPs {
-		if provider == "solana" {
-			if _, ok := stablecoinCurrencies[price.Currency]; !ok {
-				return fmt.Errorf("product %q price %s: solana requires a stablecoin currency (usd/usdc/usdg), got %q",
+		if provider == "solana" && price.AutoRenew {
+			if price.Currency != "usd" {
+				return fmt.Errorf("product %q price %s: recurring solana currently requires USD billing currency, got %q",
 					product.Key, PriceLabel(product.Key, *price), price.Currency)
 			}
+			symbol := strings.ToUpper(strings.TrimSpace(price.PSPLinks[provider]["mint_symbol"]))
+			if _, ok := recurringSolanaTokenSymbols[symbol]; !ok {
+				return fmt.Errorf("product %q price %s: recurring solana requires psp_links.solana.mint_symbol (USDC/USD1), got %q",
+					product.Key, PriceLabel(product.Key, *price), symbol)
+			}
+			price.PSPLinks[provider]["mint_symbol"] = symbol
 		}
 	}
 	return nil

--- a/pkg/catalog/load.go
+++ b/pkg/catalog/load.go
@@ -527,7 +527,10 @@ func (m *Manifest) validatePrice(product Product, price *Price, idx int, meterKi
 		return fmt.Errorf("product %q price %s: metered prices are OpenRails-native and must not declare external providers", product.Key, PriceLabel(product.Key, *price))
 	}
 	for _, provider := range price.PSPs {
-		if provider == "solana" && price.AutoRenew {
+		if provider != "solana" {
+			continue
+		}
+		if price.AutoRenew {
 			if price.Currency != "usd" {
 				return fmt.Errorf("product %q price %s: recurring solana currently requires USD billing currency, got %q",
 					product.Key, PriceLabel(product.Key, *price), price.Currency)
@@ -538,6 +541,15 @@ func (m *Manifest) validatePrice(product Product, price *Price, idx int, meterKi
 					product.Key, PriceLabel(product.Key, *price), symbol)
 			}
 			price.PSPLinks[provider]["mint_symbol"] = symbol
+			continue
+		}
+		// One-off Solana settles as a direct transfer quoted at checkout: it
+		// has no plan and consumes no link keys. Silently accepting (and then
+		// dropping) a declared link would leave the plan flagging the same
+		// "drift" on every run — reject it loudly instead.
+		if len(price.PSPLinks[provider]) > 0 {
+			return fmt.Errorf("product %q price %s: one-off solana prices take no psp_links (the settlement token is chosen at checkout); remove psp_links.solana",
+				product.Key, PriceLabel(product.Key, *price))
 		}
 	}
 	return nil

--- a/pkg/catalog/load_test.go
+++ b/pkg/catalog/load_test.go
@@ -324,20 +324,85 @@ func ranksByKey(m *Manifest) map[string]int {
 	return ranks
 }
 
-func TestLoad_SolanaNonStablecoinRejected(t *testing.T) {
-	body := `
+func TestLoad_SolanaSettlementToken(t *testing.T) {
+	tests := []struct {
+		name    string
+		price   string
+		wantErr string
+	}{
+		{
+			name: "one-off may quote a non-USD billing currency",
+			price: `
+      - {currency: eur, unit_amount: 1000, duration: 30d, psps: [solana]}
+`,
+		},
+		{
+			name: "recurring requires a settlement token",
+			price: `
+      - {currency: usd, unit_amount: 1000, duration: 30d, auto_renew: true, psps: [solana]}
+`,
+			wantErr: "recurring solana requires psp_links.solana.mint_symbol",
+		},
+		{
+			name: "recurring rejects an ineligible settlement token",
+			price: `
+      - currency: usd
+        unit_amount: 1000
+        duration: 30d
+        auto_renew: true
+        psps: [solana]
+        psp_links:
+          solana: {mint_symbol: SOL}
+`,
+			wantErr: `got "SOL"`,
+		},
+		{
+			name: "recurring requires USD billing currency",
+			price: `
+      - currency: eur
+        unit_amount: 1000
+        duration: 30d
+        auto_renew: true
+        psps: [solana]
+        psp_links:
+          solana: {mint_symbol: USDC}
+`,
+			wantErr: "recurring solana currently requires USD billing currency",
+		},
+		{
+			name: "recurring accepts USDC independently from USD",
+			price: `
+      - currency: usd
+        unit_amount: 1000
+        duration: 30d
+        auto_renew: true
+        psps: [solana]
+        psp_links:
+          solana: {mint_symbol: USDC}
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := `
 version: 1
 products:
   - key: p
     display_name: P
-    tier_group: g
-    tier_rank: 1
     prices:
-      - {currency: eur, unit_amount: 1000, duration: 30d, psps: [solana]}
-`
-	_, err := Load(writeManifest(t, body))
-	if err == nil || !strings.Contains(err.Error(), "solana requires a stablecoin") {
-		t.Fatalf("want solana eligibility error, got %v", err)
+` + tt.price
+			_, err := Load(writeManifest(t, body))
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Load: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("want error containing %q, got %v", tt.wantErr, err)
+			}
+		})
 	}
 }
 
@@ -589,10 +654,16 @@ products:
     tier_group: g
     tier_rank: 1
     prices:
-      - {currency: usdc, unit_amount: 1000, duration: 30d, auto_renew: true, psps: [solana]}
+      - currency: usd
+        unit_amount: 1000
+        duration: 30d
+        auto_renew: true
+        psps: [solana]
+        psp_links:
+          solana: {mint_symbol: USDC}
 `
 	if _, err := Load(writeManifest(t, body)); err != nil {
-		t.Fatalf("usdc + solana should be accepted, got %v", err)
+		t.Fatalf("usd billed + usdc settled should be accepted, got %v", err)
 	}
 }
 

--- a/pkg/catalog/manifest.go
+++ b/pkg/catalog/manifest.go
@@ -151,19 +151,21 @@ type Price struct {
 	// only: no external provider sync.
 	PSPs []string `json:"psps,omitempty" yaml:"psps,omitempty"`
 
-	// PSPLinks pre-supplies PSP-specific link ids, mapping
+	// PSPLinks supplies PSP-specific link/config values, mapping
 	// PSP key -> key/value pairs. Maps straight onto
 	// service.CreatePriceRequest.PSPLinks. A supplied link is VALIDATED
 	// against the provider (object exists + matches the price's money terms)
 	// before it is accepted; a mismatch fails the apply loudly. An existing
-	// object is never duplicated. A MISSING object is created where the linked id
-	// is client-creatable (NMI plan_id, Stripe lookup_key) and errors where it is
-	// provider-generated (Stripe price_id, Solana plan_pda). Canonical keys:
+	// object is never duplicated. A MISSING object is created where the supplied
+	// value is declarative (NMI plan_id, Stripe lookup_key, Solana mint_symbol)
+	// and errors where it is provider-generated (Stripe price_id, Solana
+	// plan_pda). Canonical keys:
 	//   psp_links:
 	//     stripe: {lookup_key: premium}                        # recommended: find-or-create at a chosen key ...
 	//     stripe: {price_id: price_xxx, product_id: prod_xxx}  # ... or pin an exact existing Price (require-exists)
 	//     mobius: {plan_id: premium}                           # NMI recurring plan on the "mobius" PSP; find-or-create
-	//     solana: {plan_pda: 7Xy...PdA}                        # existing on-chain plan account
+	//     solana: {mint_symbol: USDC}                          # publish/find a recurring plan in USDC
+	//     solana: {plan_pda: 7Xy...PdA, mint_symbol: USDC}     # attach an existing on-chain plan account
 	//     ccbill: {form_name: premium, flex_id: abc-123}       # operator-owned, unvalidated
 	PSPLinks map[string]map[string]string `json:"psp_links,omitempty" yaml:"psp_links,omitempty"`
 

--- a/pkg/catalog/plan.go
+++ b/pkg/catalog/plan.go
@@ -368,6 +368,15 @@ func planPrices(ctx context.Context, applier Applier, m *Manifest, product Produ
 		}
 
 		// No financial match -> create.
+		psps := price.PSPs
+		pspLinks := price.PSPLinks
+		if price.Archived {
+			// Historical prices are local records only. Do not let CreatePrice
+			// publish provider objects for a price that starts archived; the
+			// declarations converge if the price is later activated.
+			psps = nil
+			pspLinks = nil
+		}
 		createReq := billingservice.CreatePriceRequest{
 			// ProductID is filled at apply time once the product exists.
 			ProductID:           productID(existing),
@@ -378,8 +387,8 @@ func planPrices(ctx context.Context, applier Applier, m *Manifest, product Produ
 			AutoRenew:           price.AutoRenew,
 			TrialUnitAmount:     trialAmount,
 			TrialDurationHours:  trialHours,
-			PSPs:                price.PSPs,
-			PSPLinks:            price.PSPLinks,
+			PSPs:                psps,
+			PSPLinks:            pspLinks,
 			Archived:            price.Archived,
 		}
 		pp.Prices = append(pp.Prices, PricePlan{

--- a/pkg/catalog/plan.go
+++ b/pkg/catalog/plan.go
@@ -345,10 +345,16 @@ func planPrices(ctx context.Context, applier Applier, m *Manifest, product Produ
 			default: // active desired but currently archived
 				plp.Action = PriceActivate
 			}
-			if links := pspLinksNeedingSync(match.Providers, price.PSPLinks); len(links) > 0 {
-				plp.UpdateReq.PSPLinks = links
-				if plp.Action == PriceUnchanged {
-					plp.Action = PriceUpdate
+			// Never plan link work for a price this run is archiving: syncing
+			// links drives adapter.Attach, which can PUBLISH (e.g. a Solana
+			// plan from mint_symbol) — minting a live provider object for a
+			// dead price. The declared links converge if it is ever unarchived.
+			if !price.Archived {
+				if links := pspLinksNeedingSync(match.Providers, price.PSPLinks); len(links) > 0 {
+					plp.UpdateReq.PSPLinks = links
+					if plp.Action == PriceUnchanged {
+						plp.Action = PriceUpdate
+					}
 				}
 			}
 			// #774: a substance-unchanged price declared under a DIFFERENT key

--- a/pkg/catalog/plan.go
+++ b/pkg/catalog/plan.go
@@ -28,6 +28,7 @@ type PriceAction string
 
 const (
 	PriceCreate    PriceAction = "create"
+	PriceUpdate    PriceAction = "update"
 	PriceActivate  PriceAction = "activate"
 	PriceArchive   PriceAction = "archive"
 	PriceUnchanged PriceAction = "unchanged"
@@ -82,6 +83,7 @@ type PricePlan struct {
 	// ExistingID is the matched OpenRails price (uuid.Nil when creating).
 	ExistingID uuid.UUID                         `json:"existing_id,omitempty"`
 	CreateReq  billingservice.CreatePriceRequest `json:"create_req,omitempty"`
+	UpdateReq  billingservice.UpdatePriceRequest `json:"update_req,omitempty"`
 
 	// Key (#774) is this declared price's resolved key (explicit or
 	// auto-defaulted). For Action==PriceCreate it rides CreateReq.Key; for a
@@ -343,6 +345,12 @@ func planPrices(ctx context.Context, applier Applier, m *Manifest, product Produ
 			default: // active desired but currently archived
 				plp.Action = PriceActivate
 			}
+			if links := pspLinksNeedingSync(match.Providers, price.PSPLinks); len(links) > 0 {
+				plp.UpdateReq.PSPLinks = links
+				if plp.Action == PriceUnchanged {
+					plp.Action = PriceUpdate
+				}
+			}
 			// #774: a substance-unchanged price declared under a DIFFERENT key
 			// is a plain rename — signal apply to relabel via SetPriceKey. Never
 			// set for an unchanged key (nothing to do).
@@ -394,6 +402,44 @@ func planPrices(ctx context.Context, applier Applier, m *Manifest, product Produ
 		}
 	}
 	return nil
+}
+
+// pspLinksNeedingSync returns the desired provider link/config values that are
+// not already present in the stored provider state. Generated provider fields
+// may coexist with the desired subset and do not count as drift.
+func pspLinksNeedingSync(
+	current map[string]billingservice.ProviderState,
+	desired map[string]map[string]string,
+) map[string]map[string]string {
+	var out map[string]map[string]string
+	for rawPSP, rawLink := range desired {
+		psp := strings.ToLower(strings.TrimSpace(rawPSP))
+		if psp == "" {
+			continue
+		}
+		link := make(map[string]string, len(rawLink))
+		state := current[psp]
+		needsSync := false
+		for rawKey, rawValue := range rawLink {
+			key := strings.TrimSpace(rawKey)
+			value := strings.TrimSpace(rawValue)
+			if key == "" || value == "" {
+				continue
+			}
+			link[key] = value
+			if strings.TrimSpace(state.IDs[key]) != value {
+				needsSync = true
+			}
+		}
+		if !needsSync || len(link) == 0 {
+			continue
+		}
+		if out == nil {
+			out = map[string]map[string]string{}
+		}
+		out[psp] = link
+	}
+	return out
 }
 
 // matchPrice finds an existing OpenRails price with the same financial identity

--- a/pkg/catalog/plan_test.go
+++ b/pkg/catalog/plan_test.go
@@ -20,6 +20,8 @@ type fakeApplier struct {
 	updatedProducts  []uuid.UUID
 	deactivatedProds []uuid.UUID
 	createdPrices    []billingservice.CreatePriceRequest
+	updatedPriceIDs  []uuid.UUID
+	updatedPriceReqs []billingservice.UpdatePriceRequest
 	activatedPrices  []uuid.UUID
 	archivedPrices   []uuid.UUID
 	relabeledPrices  map[uuid.UUID]string
@@ -115,6 +117,12 @@ func (f *fakeApplier) ListPricesByProduct(_ context.Context, productID uuid.UUID
 func (f *fakeApplier) CreatePrice(_ context.Context, req billingservice.CreatePriceRequest) (*billingservice.CatalogPrice, error) {
 	f.createdPrices = append(f.createdPrices, req)
 	return &billingservice.CatalogPrice{ID: uuid.New(), Key: req.Key, ProductID: req.ProductID, UnitAmount: req.UnitAmount, Currency: req.Currency, Archived: req.Archived}, nil
+}
+
+func (f *fakeApplier) UpdatePrice(_ context.Context, id uuid.UUID, req billingservice.UpdatePriceRequest) (*billingservice.CatalogPrice, error) {
+	f.updatedPriceIDs = append(f.updatedPriceIDs, id)
+	f.updatedPriceReqs = append(f.updatedPriceReqs, req)
+	return &billingservice.CatalogPrice{ID: id}, nil
 }
 
 func (f *fakeApplier) ActivatePrice(_ context.Context, id uuid.UUID) (*billingservice.CatalogPrice, error) {
@@ -295,33 +303,91 @@ func TestPlan_PriceSetSemantics_ArchiveAndCreate(t *testing.T) {
 }
 
 // A declared price matches an existing one on financial substance alone; a
-// provider-set drift must NOT spawn a second row — the
+// provider-set drift must update the matched row, not spawn a second row — the
 // unique_prices_product_amount_window key (no provider column) would reject it,
-// crashing the converge. The declared price below differs from the stored one
-// only by provider set, so it must match (here: archive, since archived:true).
-func TestPlan_SameTermsDifferentProvidersMatchExistingPrice(t *testing.T) {
+// crashing the converge.
+func TestPlan_ExistingPriceSyncsDeclaredPSPLinks(t *testing.T) {
 	m := loadFrom(t, `
 version: 1
 products:
   - key: premium
     display_name: Premium
     prices:
-      - {currency: usd, unit_amount: 23000000, duration: 30d, auto_renew: true, psps: [solana], archived: true}
+      - currency: usd
+        unit_amount: 23000000
+        duration: 30d
+        auto_renew: true
+        psps: [solana]
+        psp_links:
+          solana: {mint_symbol: USDC}
 `)
 	f := newFakeApplier()
 	premium := f.seedProduct("premium", "default", 0, false)
 	premium.DisplayName = "Premium"
-	f.seedPrice(premium.ID, 23_000_000, "usd", 30*24, false, "mobius", "ccbill", "solana")
+	f.seedPrice(premium.ID, 23_000_000, "usd", 30*24, false, "mobius", "ccbill")
 
 	plan, err := Plan(context.Background(), f, m)
 	if err != nil {
 		t.Fatalf("Plan: %v", err)
 	}
 	pp := findProduct(plan, "premium")
-	for _, pr := range pp.Prices {
-		if pr.Action == PriceCreate {
-			t.Fatalf("provider drift must not create a second price: %+v", pp.Prices)
-		}
+	if len(pp.Prices) != 1 || pp.Prices[0].Action != PriceUpdate {
+		t.Fatalf("provider drift must update the existing price: %+v", pp.Prices)
+	}
+	if got := pp.Prices[0].UpdateReq.PSPLinks["solana"]["mint_symbol"]; got != "USDC" {
+		t.Fatalf("Solana settlement token update = %q, want USDC", got)
+	}
+	if !plan.HasChanges() {
+		t.Fatal("provider link drift must make the plan actionable")
+	}
+
+	res, err := Apply(context.Background(), f, plan)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if res.PricesUpdated != 1 || len(f.updatedPriceReqs) != 1 {
+		t.Fatalf("provider sync updates = result %d calls %d, want 1/1", res.PricesUpdated, len(f.updatedPriceReqs))
+	}
+}
+
+func TestPlan_ExistingPriceWithDeclaredPSPLinksIsUnchanged(t *testing.T) {
+	m := loadFrom(t, `
+version: 1
+products:
+  - key: premium
+    display_name: Premium
+    prices:
+      - currency: usd
+        unit_amount: 23000000
+        duration: 30d
+        auto_renew: true
+        psps: [solana]
+        psp_links:
+          solana: {mint_symbol: usdc}
+`)
+	f := newFakeApplier()
+	premium := f.seedProduct("premium", "default", 0, false)
+	premium.DisplayName = "Premium"
+	f.seedPrice(premium.ID, 23_000_000, "usd", 30*24, false, "solana")
+	prices := f.prices[premium.ID]
+	prices[0].Providers["solana"] = billingservice.ProviderState{
+		Status: billingservice.ProviderStatusLinked,
+		IDs: map[string]string{
+			"mint_symbol": "USDC",
+			"plan_pda":    "existing-plan",
+		},
+	}
+
+	plan, err := Plan(context.Background(), f, m)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	pp := findProduct(plan, "premium")
+	if len(pp.Prices) != 1 || pp.Prices[0].Action != PriceUnchanged {
+		t.Fatalf("converged provider link should be unchanged: %+v", pp.Prices)
+	}
+	if plan.HasChanges() {
+		t.Fatal("generated provider fields beyond the desired subset must not cause drift")
 	}
 }
 
@@ -484,7 +550,7 @@ func TestApply_Idempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
-	if res.ProductsCreated+res.ProductsUpdated+res.ProductsArchived+res.PricesCreated+res.PricesActivated+res.PricesArchived != 0 {
+	if res.ProductsCreated+res.ProductsUpdated+res.ProductsArchived+res.PricesCreated+res.PricesUpdated+res.PricesActivated+res.PricesArchived != 0 {
 		t.Fatalf("idempotent apply mutated something: %+v", res)
 	}
 }

--- a/pkg/catalog/plan_test.go
+++ b/pkg/catalog/plan_test.go
@@ -220,6 +220,11 @@ products:
     prices:
       - currency: usd
         unit_amount: 1200
+        duration: 30d
+        auto_renew: true
+        psps: [solana]
+        psp_links:
+          solana: {mint_symbol: USDC}
         archived: true
 `)
 	f := newFakeApplier()
@@ -234,6 +239,9 @@ products:
 	}
 	if !pp.Prices[0].CreateReq.Archived {
 		t.Fatal("price create must be archived")
+	}
+	if len(pp.Prices[0].CreateReq.PSPs) != 0 || len(pp.Prices[0].CreateReq.PSPLinks) != 0 {
+		t.Fatalf("archived price create must not publish provider objects: %+v", pp.Prices[0].CreateReq)
 	}
 }
 

--- a/pkg/service/catalog_provider_solana.go
+++ b/pkg/service/catalog_provider_solana.go
@@ -115,6 +115,9 @@ func (a *solanaAdapter) createRecurringPlan(ctx context.Context, in autoCreateCo
 	plan, ok := a.planService()
 	if !ok {
 		// Solana recurring not configured here: defer to a manual/late publish.
+		if in.RemoteWritesDisabled {
+			return nil, errRemoteWritesDisabled
+		}
 		return nil, errPendingManualLink
 	}
 	tid, ok := merchant.FromContext(ctx)
@@ -146,6 +149,11 @@ func (a *solanaAdapter) createRecurringPlan(ctx context.Context, in autoCreateCo
 	// on re-apply we attach to the existing on-chain plan instead of republishing.
 	if existing, found := a.findExistingPlan(ctx, plan, tid, planID, symbol); found {
 		return existing, nil
+	}
+	if in.RemoteWritesDisabled {
+		// Existing-plan discovery above is read-only and remains available in
+		// limited/readonly mode. Gate only the actual publish boundary.
+		return nil, errRemoteWritesDisabled
 	}
 
 	handle, err := plan.PublishPlan(ctx, recurring.PublishPlanInput{
@@ -214,8 +222,8 @@ func (a *solanaAdapter) Attach(ctx context.Context, link map[string]string, in a
 	pda := strings.TrimSpace(link[solanaKeyPlanPDA])
 	symbol := strings.ToUpper(strings.TrimSpace(link[solanaKeyMintSymbol]))
 	if pda == "" {
-		// The guard lives here — not on the plan_pda path — so pre-#745 rows
-		// (billed in usdc/usdg with the mint derived from the currency) stay
+		// The guard lives here — not on the plan_pda path — so eligible
+		// pre-#745 USDC rows can derive the token from their currency and stay
 		// operable for link verification and rotation.
 		if in.BillingCycleDays != nil {
 			if err := requireUSDBillingForSolanaPublish(in.Currency); err != nil {
@@ -233,15 +241,15 @@ func (a *solanaAdapter) Attach(ctx context.Context, link map[string]string, in a
 		if symbol == "" {
 			return nil, fmt.Errorf("solana recurring link requires psp_links.solana.mint_symbol")
 		}
-		if in.RemoteWritesDisabled {
-			return nil, errRemoteWritesDisabled
-		}
 		return a.createRecurringPlan(ctx, in, symbol)
 	}
-	// Attaching an EXISTING plan handle does not require mint_symbol: pre-#745
-	// rows derived the token from the billing currency and must stay operable.
-	// Without a symbol the mint/amount verification below is skipped (the old
-	// soft behavior); period and merchant are still verified when possible.
+	if in.BillingCycleDays != nil {
+		var err error
+		symbol, err = existingSolanaSettlementSymbol(in.Currency, symbol)
+		if err != nil {
+			return nil, err
+		}
+	}
 	out := map[string]string{solanaKeyPlanPDA: pda}
 	for _, k := range []string{
 		solanaKeyPlanID, solanaKeyMint, solanaKeyMintSymbol,
@@ -318,6 +326,31 @@ func (a *solanaAdapter) Attach(ctx context.Context, link map[string]string, in a
 	out[solanaKeyCreatedAt] = strconv.FormatInt(acct.CreatedAt, 10)
 	out[solanaKeyMerchant] = acct.Owner.String()
 	return out, nil
+}
+
+// existingSolanaSettlementSymbol keeps safely translatable pre-#745 USDC
+// prices operable while preserving strict validation for the #745 model.
+// Before #745, currency=usdc identified both the billing denomination and the
+// settlement token. New prices bill in USD and must declare their token.
+func existingSolanaSettlementSymbol(currency, declared string) (string, error) {
+	currency = strings.ToLower(strings.TrimSpace(currency))
+	declared = strings.ToUpper(strings.TrimSpace(declared))
+	switch currency {
+	case "usd":
+		if declared == "" {
+			return "", fmt.Errorf("solana recurring link requires psp_links.solana.mint_symbol")
+		}
+	case "usdc":
+		if declared == "" {
+			return "USDC", nil
+		}
+		if declared != "USDC" {
+			return "", fmt.Errorf("legacy solana price billed in USDC cannot settle in %s", declared)
+		}
+	default:
+		return "", fmt.Errorf("solana recurring existing-plan links require USD billing currency or a legacy USDC price, got %q", currency)
+	}
+	return declared, nil
 }
 
 // Verify reads the on-chain Plan account and diffs its immutable terms against the

--- a/pkg/service/catalog_provider_solana.go
+++ b/pkg/service/catalog_provider_solana.go
@@ -202,10 +202,14 @@ func (a *solanaAdapter) Attach(ctx context.Context, link map[string]string, in a
 	link = normalizeLinkMap(link)
 	pda := strings.TrimSpace(link[solanaKeyPlanPDA])
 	symbol := strings.ToUpper(strings.TrimSpace(link[solanaKeyMintSymbol]))
-	if in.BillingCycleDays != nil && !strings.EqualFold(strings.TrimSpace(in.Currency), "usd") {
-		return nil, fmt.Errorf("solana recurring currently requires USD billing currency, got %q", in.Currency)
-	}
 	if pda == "" {
+		// Publishing a NEW plan is the #745 model: bill in USD, settle in the
+		// declared token. The guard lives here — not on the plan_pda path — so
+		// pre-#745 rows (billed in usdc/usdg with the mint derived from the
+		// currency) stay operable for link verification and rotation.
+		if in.BillingCycleDays != nil && !strings.EqualFold(strings.TrimSpace(in.Currency), "usd") {
+			return nil, fmt.Errorf("solana recurring currently requires USD billing currency, got %q", in.Currency)
+		}
 		if in.BillingCycleDays == nil {
 			// A one-off price consumes no link keys (it settles as a direct
 			// transfer quoted at checkout). Callers only reach Attach with a
@@ -222,9 +226,10 @@ func (a *solanaAdapter) Attach(ctx context.Context, link map[string]string, in a
 		}
 		return a.createRecurringPlan(ctx, in, symbol)
 	}
-	if in.BillingCycleDays != nil && symbol == "" {
-		return nil, fmt.Errorf("solana recurring link requires psp_links.solana.mint_symbol")
-	}
+	// Attaching an EXISTING plan handle does not require mint_symbol: pre-#745
+	// rows derived the token from the billing currency and must stay operable.
+	// Without a symbol the mint/amount verification below is skipped (the old
+	// soft behavior); period and merchant are still verified when possible.
 	out := map[string]string{solanaKeyPlanPDA: pda}
 	for _, k := range []string{
 		solanaKeyPlanID, solanaKeyMint, solanaKeyMintSymbol,
@@ -233,6 +238,12 @@ func (a *solanaAdapter) Attach(ctx context.Context, link map[string]string, in a
 		if v := strings.TrimSpace(link[k]); v != "" {
 			out[k] = v
 		}
+	}
+	// Store the canonical uppercase symbol: manifests normalize it at Load, so
+	// a verbatim lowercase copy from the direct API would read as permanent
+	// case-only "drift" to every future catalog plan.
+	if symbol != "" {
+		out[solanaKeyMintSymbol] = symbol
 	}
 
 	if a.svc == nil || a.svc.rt == nil || a.svc.rt.SolanaRPCResolver == nil {

--- a/pkg/service/catalog_provider_solana.go
+++ b/pkg/service/catalog_provider_solana.go
@@ -207,7 +207,12 @@ func (a *solanaAdapter) Attach(ctx context.Context, link map[string]string, in a
 	}
 	if pda == "" {
 		if in.BillingCycleDays == nil {
-			return map[string]string{"provider": "solana"}, nil
+			// A one-off price consumes no link keys (it settles as a direct
+			// transfer quoted at checkout). Callers only reach Attach with a
+			// non-empty link, so silently returning the bare rail marker would
+			// drop the operator's declared values and leave catalog plans
+			// re-flagging the same drift forever — reject loudly instead.
+			return nil, fmt.Errorf("solana one-off prices take no psp_links (the settlement token is chosen at checkout); remove psp_links.solana")
 		}
 		if symbol == "" {
 			return nil, fmt.Errorf("solana recurring link requires psp_links.solana.mint_symbol")

--- a/pkg/service/catalog_provider_solana.go
+++ b/pkg/service/catalog_provider_solana.go
@@ -25,10 +25,10 @@ import (
 // stores the plan handle in rails["solana"]. Verify reads the Plan account
 // back and diffs its immutable terms (amount / period / mint) for drift.
 //
-//   - AutoCreate: publish (or idempotently attach to) the on-chain plan. Requires a
-//     merchant-scoped context, a configured SolanaPlanService, a recurring interval,
-//     and a stablecoin currency (USDC/USD1). Unconfigured -> pending_manual_link.
-//   - Attach: store an operator-supplied existing plan handle (plan_pda required).
+//   - AutoCreate: one-off prices need no plan; recurring prices without a declared
+//     settlement token remain pending_manual_link.
+//   - Attach: mint_symbol without plan_pda publishes (or idempotently attaches to)
+//     a plan; plan_pda + mint_symbol attaches an existing plan.
 //   - Verify: GetAccountData(plan_pda) -> DecodePlanAccount -> diff vs the stored
 //     snapshot. RPC unavailable -> sync_disabled.
 //   - Update: no-op. Plan core terms are immutable on-chain; an amount/period change
@@ -54,7 +54,7 @@ func (a *solanaAdapter) PendingActionTemplate(priceID uuid.UUID) PendingAction {
 	return PendingAction{
 		Provider: "solana",
 		Action:   "configure_solana_recurring",
-		Hint:     "Configure the merchant's Solana provider-account signer and set this price's currency to an allowlisted recurring stablecoin (USDC/USD1), then re-apply to publish the on-chain plan for price " + priceID.String(),
+		Hint:     "Configure the merchant's Solana provider-account signer and set psp_links.solana.mint_symbol to an allowlisted recurring stablecoin (USDC/USD1), then re-apply to publish the on-chain plan for price " + priceID.String(),
 	}
 }
 
@@ -88,9 +88,19 @@ func (a *solanaAdapter) AutoCreate(ctx context.Context, in autoCreateContext) (m
 	// A one-off Solana price (no recurring cadence, #622) needs no on-chain Plan
 	// PDA — it settles as a direct transfer validated at payment time. Mark the
 	// rail present so checkout offers Solana; publish nothing on-chain.
-	if in.AccessDurationHours == nil || *in.AccessDurationHours <= 0 {
+	if in.BillingCycleDays == nil {
 		return map[string]string{"provider": "solana"}, nil
 	}
+	if !strings.EqualFold(strings.TrimSpace(in.Currency), "usd") {
+		return nil, fmt.Errorf("solana recurring currently requires USD billing currency, got %q", in.Currency)
+	}
+	// A recurring plan is mint-specific. The billing currency cannot identify
+	// its settlement token, so require psp_links.solana.mint_symbol through the
+	// Attach path instead of guessing from in.Currency.
+	return nil, errPendingManualLink
+}
+
+func (a *solanaAdapter) createRecurringPlan(ctx context.Context, in autoCreateContext, symbol string) (map[string]string, error) {
 	plan, ok := a.planService()
 	if !ok {
 		// Solana recurring not configured here: defer to a manual/late publish.
@@ -103,8 +113,11 @@ func (a *solanaAdapter) AutoCreate(ctx context.Context, in autoCreateContext) (m
 	if in.UnitAmount <= 0 {
 		return nil, fmt.Errorf("solana create-mode requires a positive unit_amount (micros)")
 	}
+	if in.AccessDurationHours == nil || *in.AccessDurationHours <= 0 {
+		return nil, fmt.Errorf("solana create-mode requires a positive recurring interval")
+	}
 
-	symbol := strings.ToUpper(strings.TrimSpace(in.Currency))
+	symbol = strings.ToUpper(strings.TrimSpace(symbol))
 	mint, decimals, err := plan.ResolveMint(symbol)
 	if err != nil {
 		return nil, err
@@ -176,19 +189,36 @@ func (a *solanaAdapter) findExistingPlan(ctx context.Context, plan *recurring.Pl
 	return handle.ToRailConfig(), true
 }
 
-// Attach stores an operator-supplied existing on-chain plan handle. When the
-// Solana RPC is available the plan account is read back and its IMMUTABLE terms
-// are verified against the OpenRails price: the account must exist and match
-// amount (base units), period (billing cycle * 24h), mint (resolved from the
-// price currency), and — when a merchant is in context — the merchant/owner. A
+// Attach publishes a plan from a declarative mint_symbol or stores an
+// operator-supplied existing plan handle. When the Solana RPC is available the
+// plan account is read back and its IMMUTABLE terms are verified against the
+// OpenRails price: the account must exist and match
+// amount (base units), period (billing cycle * 24h), mint (resolved from
+// mint_symbol), and — when a merchant is in context — the merchant/owner. A
 // missing or mismatched plan is a loud error. On a successful read the verified
 // on-chain terms are stamped onto the stored ids so Verify has a snapshot. When
 // RPC is unavailable the operator-supplied fields are stored as-is.
 func (a *solanaAdapter) Attach(ctx context.Context, link map[string]string, in autoCreateContext) (map[string]string, error) {
 	link = normalizeLinkMap(link)
 	pda := strings.TrimSpace(link[solanaKeyPlanPDA])
+	symbol := strings.ToUpper(strings.TrimSpace(link[solanaKeyMintSymbol]))
+	if in.BillingCycleDays != nil && !strings.EqualFold(strings.TrimSpace(in.Currency), "usd") {
+		return nil, fmt.Errorf("solana recurring currently requires USD billing currency, got %q", in.Currency)
+	}
 	if pda == "" {
-		return nil, fmt.Errorf("solana link requires provider_links.solana.plan_pda")
+		if in.BillingCycleDays == nil {
+			return map[string]string{"provider": "solana"}, nil
+		}
+		if symbol == "" {
+			return nil, fmt.Errorf("solana recurring link requires psp_links.solana.mint_symbol")
+		}
+		if in.RemoteWritesDisabled {
+			return nil, errRemoteWritesDisabled
+		}
+		return a.createRecurringPlan(ctx, in, symbol)
+	}
+	if in.BillingCycleDays != nil && symbol == "" {
+		return nil, fmt.Errorf("solana recurring link requires psp_links.solana.mint_symbol")
 	}
 	out := map[string]string{solanaKeyPlanPDA: pda}
 	for _, k := range []string{
@@ -210,7 +240,7 @@ func (a *solanaAdapter) Attach(ctx context.Context, link map[string]string, in a
 	}
 	data, err := a.svc.rt.SolanaRPCResolver.ChainReader().GetAccountData(ctx, pubkey)
 	if err != nil || len(data) == 0 {
-		return nil, fmt.Errorf("solana plan account %q not found on-chain; publish it or fix provider_links.solana.plan_pda", pda)
+		return nil, fmt.Errorf("solana plan account %q not found on-chain; publish it or fix psp_links.solana.plan_pda", pda)
 	}
 	acct, err := subscriptions.DecodePlanAccount(data)
 	if err != nil {
@@ -227,19 +257,21 @@ func (a *solanaAdapter) Attach(ctx context.Context, link map[string]string, in a
 	// unconfigured — the price is in MICROS and only the token's decimals turn
 	// that into the plan's base units (#817).
 	if plan, ok := a.planService(); ok {
-		if symbol := strings.ToUpper(strings.TrimSpace(in.Currency)); symbol != "" {
-			if mint, decimals, err := plan.ResolveMint(symbol); err == nil {
-				if !strings.EqualFold(acct.Mint.String(), strings.TrimSpace(mint)) {
-					return nil, fmt.Errorf("solana plan %q mint (%s) does not match catalog currency %s mint (%s)", pda, acct.Mint, symbol, mint)
+		if symbol != "" {
+			mint, decimals, err := plan.ResolveMint(symbol)
+			if err != nil {
+				return nil, err
+			}
+			if !strings.EqualFold(acct.Mint.String(), strings.TrimSpace(mint)) {
+				return nil, fmt.Errorf("solana plan %q mint (%s) does not match settlement token %s mint (%s)", pda, acct.Mint, symbol, mint)
+			}
+			if in.UnitAmount > 0 {
+				want, err := solanamodule.FiatMicrosToBaseUnitsAtPeg(moneyutil.Micros(in.UnitAmount), symbol, decimals)
+				if err != nil {
+					return nil, err
 				}
-				if in.UnitAmount > 0 {
-					want, err := solanamodule.FiatMicrosToBaseUnitsAtPeg(moneyutil.Micros(in.UnitAmount), symbol, decimals)
-					if err != nil {
-						return nil, err
-					}
-					if acct.Amount != want {
-						return nil, fmt.Errorf("solana plan %q amount (%d base units) does not match catalog price (%d micros = %d base units)", pda, acct.Amount, in.UnitAmount, want)
-					}
+				if acct.Amount != want {
+					return nil, fmt.Errorf("solana plan %q amount (%d base units) does not match catalog price (%d micros = %d base units)", pda, acct.Amount, in.UnitAmount, want)
 				}
 			}
 		}

--- a/pkg/service/catalog_provider_solana.go
+++ b/pkg/service/catalog_provider_solana.go
@@ -91,13 +91,24 @@ func (a *solanaAdapter) AutoCreate(ctx context.Context, in autoCreateContext) (m
 	if in.BillingCycleDays == nil {
 		return map[string]string{"provider": "solana"}, nil
 	}
-	if !strings.EqualFold(strings.TrimSpace(in.Currency), "usd") {
-		return nil, fmt.Errorf("solana recurring currently requires USD billing currency, got %q", in.Currency)
+	if err := requireUSDBillingForSolanaPublish(in.Currency); err != nil {
+		return nil, err
 	}
 	// A recurring plan is mint-specific. The billing currency cannot identify
 	// its settlement token, so require psp_links.solana.mint_symbol through the
 	// Attach path instead of guessing from in.Currency.
 	return nil, errPendingManualLink
+}
+
+// requireUSDBillingForSolanaPublish gates publishing a NEW recurring plan on
+// the #745 model: the price bills in USD and the settlement token is declared
+// separately via psp_links.solana.mint_symbol. Pre-#745 rows attached by
+// plan_pda are exempt (see Attach).
+func requireUSDBillingForSolanaPublish(currency string) error {
+	if !strings.EqualFold(strings.TrimSpace(currency), "usd") {
+		return fmt.Errorf("solana recurring currently requires USD billing currency, got %q", currency)
+	}
+	return nil
 }
 
 func (a *solanaAdapter) createRecurringPlan(ctx context.Context, in autoCreateContext, symbol string) (map[string]string, error) {
@@ -117,7 +128,7 @@ func (a *solanaAdapter) createRecurringPlan(ctx context.Context, in autoCreateCo
 		return nil, fmt.Errorf("solana create-mode requires a positive recurring interval")
 	}
 
-	symbol = strings.ToUpper(strings.TrimSpace(symbol))
+	// symbol arrives already normalized (uppercased/trimmed) by Attach.
 	mint, decimals, err := plan.ResolveMint(symbol)
 	if err != nil {
 		return nil, err
@@ -203,12 +214,13 @@ func (a *solanaAdapter) Attach(ctx context.Context, link map[string]string, in a
 	pda := strings.TrimSpace(link[solanaKeyPlanPDA])
 	symbol := strings.ToUpper(strings.TrimSpace(link[solanaKeyMintSymbol]))
 	if pda == "" {
-		// Publishing a NEW plan is the #745 model: bill in USD, settle in the
-		// declared token. The guard lives here — not on the plan_pda path — so
-		// pre-#745 rows (billed in usdc/usdg with the mint derived from the
-		// currency) stay operable for link verification and rotation.
-		if in.BillingCycleDays != nil && !strings.EqualFold(strings.TrimSpace(in.Currency), "usd") {
-			return nil, fmt.Errorf("solana recurring currently requires USD billing currency, got %q", in.Currency)
+		// The guard lives here — not on the plan_pda path — so pre-#745 rows
+		// (billed in usdc/usdg with the mint derived from the currency) stay
+		// operable for link verification and rotation.
+		if in.BillingCycleDays != nil {
+			if err := requireUSDBillingForSolanaPublish(in.Currency); err != nil {
+				return nil, err
+			}
 		}
 		if in.BillingCycleDays == nil {
 			// A one-off price consumes no link keys (it settles as a direct

--- a/pkg/service/catalog_provider_solana_decimals_test.go
+++ b/pkg/service/catalog_provider_solana_decimals_test.go
@@ -25,14 +25,15 @@ func (s *planSubmitterStub) Submit(context.Context, merchant.ID, []solanago.Inst
 	return solanago.Signature{1}, nil
 }
 
-// TestSolanaAdapter_AutoCreateHonoursTokenDecimals pins #817 on the plan-PUBLISH
-// path: the catalog price is MICROS, the on-chain plan amount is token BASE
-// UNITS, and the merchant's configured decimals is the only thing that converts
-// between them. Shipping micros verbatim (the old bug) was a 1000x undercharge
-// on a 9-decimal mint.
-func TestSolanaAdapter_AutoCreateHonoursTokenDecimals(t *testing.T) {
+// TestSolanaAdapter_DeclarativeMintHonoursTokenDecimals pins #817 on the
+// plan-publish path: the catalog price is MICROS, the on-chain plan amount is
+// token BASE UNITS, and the merchant's configured decimals is the only thing
+// that converts between them. Shipping micros verbatim (the old bug) was a
+// 1000x undercharge on a 9-decimal mint.
+func TestSolanaAdapter_DeclarativeMintHonoursTokenDecimals(t *testing.T) {
 	const usdcMint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
 	hours := 30 * 24
+	days := 30
 
 	cases := []struct {
 		decimals int
@@ -62,28 +63,35 @@ func TestSolanaAdapter_AutoCreateHonoursTokenDecimals(t *testing.T) {
 			a := &solanaAdapter{svc: &Service{rt: &app.Runtime{SolanaPlanService: plan}}}
 			ctx := merchant.WithID(context.Background(), merchant.ID(uuid.New()))
 
-			out, err := a.AutoCreate(ctx, autoCreateContext{
+			out, err := a.Attach(ctx, map[string]string{
+				solanaKeyMintSymbol: "USDC",
+			}, autoCreateContext{
 				PriceID:             uuid.New(),
 				ProductKey:          "premium",
-				Currency:            "USDC",
+				Currency:            "usd",
 				UnitAmount:          tc.micros,
 				AccessDurationHours: &hours,
+				BillingCycleDays:    &days,
 			})
 			if err != nil {
-				t.Fatalf("AutoCreate: %v", err)
+				t.Fatalf("Attach: %v", err)
 			}
 			if got := out[solanaKeyAmountBaseUnits]; got != strconv.FormatUint(tc.want, 10) {
 				t.Fatalf("%d micros @%d decimals: plan amount_base_units = %s, want %d", tc.micros, tc.decimals, got, tc.want)
+			}
+			if got := out[solanaKeyMintSymbol]; got != "USDC" {
+				t.Fatalf("plan mint_symbol = %q, want USDC", got)
 			}
 		})
 	}
 }
 
-// TestSolanaAdapter_AutoCreateRejectsMissingDecimals: an omitted `decimals`
+// TestSolanaAdapter_DeclarativeMintRejectsMissingDecimals: an omitted `decimals`
 // decodes as 0 and must fail loudly rather than publish a 10^6-off plan.
-func TestSolanaAdapter_AutoCreateRejectsMissingDecimals(t *testing.T) {
+func TestSolanaAdapter_DeclarativeMintRejectsMissingDecimals(t *testing.T) {
 	key, _ := solanago.NewRandomPrivateKey()
 	hours := 30 * 24
+	days := 30
 	plan := recurring.NewPlanServiceWithReader(
 		&planSubmitterStub{merchantPub: key.PublicKey()}, nil, "mainnet",
 		map[string]config.TokenConfig{"USDC": {Mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"}},
@@ -91,13 +99,16 @@ func TestSolanaAdapter_AutoCreateRejectsMissingDecimals(t *testing.T) {
 	a := &solanaAdapter{svc: &Service{rt: &app.Runtime{SolanaPlanService: plan}}}
 	ctx := merchant.WithID(context.Background(), merchant.ID(uuid.New()))
 
-	if _, err := a.AutoCreate(ctx, autoCreateContext{
+	if _, err := a.Attach(ctx, map[string]string{
+		solanaKeyMintSymbol: "USDC",
+	}, autoCreateContext{
 		PriceID:             uuid.New(),
 		ProductKey:          "premium",
-		Currency:            "USDC",
+		Currency:            "usd",
 		UnitAmount:          10_000_000,
 		AccessDurationHours: &hours,
+		BillingCycleDays:    &days,
 	}); err == nil {
-		t.Fatal("expected AutoCreate to reject a token with no configured decimals")
+		t.Fatal("expected Attach to reject a token with no configured decimals")
 	}
 }

--- a/pkg/service/catalog_provider_solana_test.go
+++ b/pkg/service/catalog_provider_solana_test.go
@@ -5,7 +5,13 @@ import (
 	"errors"
 	"testing"
 
+	solanago "github.com/gagliardetto/solana-go"
 	"github.com/google/uuid"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/app"
+	"github.com/open-rails/openrails/internal/modules/solana/recurring"
+	"github.com/open-rails/openrails/pkg/merchant"
 )
 
 // The solana adapter's on-chain paths (PublishPlan / Verify-with-RPC) are covered
@@ -69,6 +75,84 @@ func TestSolanaAdapter_AttachRequiresRecurringSettlementToken(t *testing.T) {
 	}
 	if _, ok := got["junk"]; ok {
 		t.Errorf("empty link values should be dropped, got %v", got)
+	}
+
+	legacy, err := a.Attach(context.Background(), map[string]string{
+		solanaKeyPlanPDA: "LegacyPdA111",
+	}, autoCreateContext{BillingCycleDays: &days, Currency: "usdc"})
+	if err != nil {
+		t.Fatalf("Attach legacy USDC plan: %v", err)
+	}
+	if got := legacy[solanaKeyMintSymbol]; got != "USDC" {
+		t.Fatalf("legacy USDC mint_symbol = %q, want USDC", got)
+	}
+
+	if _, err := a.Attach(context.Background(), map[string]string{
+		solanaKeyPlanPDA: "PdAWithoutToken111",
+	}, autoCreateContext{BillingCycleDays: &days, Currency: "usd"}); err == nil {
+		t.Fatal("new USD existing-plan link without mint_symbol should error")
+	}
+}
+
+func TestExistingSolanaSettlementSymbol(t *testing.T) {
+	tests := []struct {
+		name     string
+		currency string
+		declared string
+		want     string
+		wantErr  bool
+	}{
+		{name: "new USD price requires symbol", currency: "usd", wantErr: true},
+		{name: "new USD price accepts USDC", currency: "usd", declared: "usdc", want: "USDC"},
+		{name: "legacy USDC derives symbol", currency: " USDC ", want: "USDC"},
+		{name: "legacy USDC cannot change token", currency: "usdc", declared: "USD1", wantErr: true},
+		{name: "unsupported legacy currency fails", currency: "usdg", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := existingSolanaSettlementSymbol(tt.currency, tt.declared)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("existingSolanaSettlementSymbol(%q, %q) = %q, want error", tt.currency, tt.declared, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("existingSolanaSettlementSymbol(%q, %q): %v", tt.currency, tt.declared, err)
+			}
+			if got != tt.want {
+				t.Fatalf("existingSolanaSettlementSymbol(%q, %q) = %q, want %q", tt.currency, tt.declared, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSolanaAdapter_RemoteWritesDisabledDefersPublish(t *testing.T) {
+	const usdcMint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+	hours := 30 * 24
+	days := 30
+	plan := recurring.NewPlanServiceWithReader(
+		&planSubmitterStub{merchantPub: solanago.NewWallet().PublicKey()},
+		nil,
+		"mainnet",
+		map[string]config.TokenConfig{"USDC": {Mint: usdcMint, Decimals: 6}},
+	)
+	a := &solanaAdapter{svc: &Service{rt: &app.Runtime{SolanaPlanService: plan}}}
+	ctx := merchant.WithID(context.Background(), merchant.ID(uuid.New()))
+
+	_, err := a.Attach(ctx, map[string]string{
+		solanaKeyMintSymbol: "USDC",
+	}, autoCreateContext{
+		ProductKey:           "premium",
+		Currency:             "usd",
+		UnitAmount:           23_000_000,
+		AccessDurationHours:  &hours,
+		BillingCycleDays:     &days,
+		RemoteWritesDisabled: true,
+	})
+	if !errors.Is(err, errRemoteWritesDisabled) {
+		t.Fatalf("Attach with remote writes disabled = %v, want errRemoteWritesDisabled", err)
 	}
 }
 

--- a/pkg/service/catalog_provider_solana_test.go
+++ b/pkg/service/catalog_provider_solana_test.go
@@ -16,28 +16,51 @@ import (
 func TestSolanaAdapter_AutoCreateUnconfiguredIsPending(t *testing.T) {
 	a := &solanaAdapter{svc: &Service{}} // no runtime -> SolanaPlanService nil
 	hours := 30 * 24
+	days := 30
 	_, err := a.AutoCreate(context.Background(), autoCreateContext{
 		PriceID:             uuid.New(),
-		Currency:            "USDC",
+		Currency:            "usd",
 		UnitAmount:          29_000_000,
 		AccessDurationHours: &hours,
+		BillingCycleDays:    &days,
 	})
 	if !errors.Is(err, errPendingManualLink) {
 		t.Fatalf("unconfigured Solana AutoCreate = %v, want errPendingManualLink", err)
 	}
 }
 
-func TestSolanaAdapter_AttachRequiresPlanPDA(t *testing.T) {
+func TestSolanaAdapter_AutoCreateOneOffNeedsNoPlan(t *testing.T) {
 	a := &solanaAdapter{}
-	if _, err := a.Attach(context.Background(), map[string]string{"mint": "x"}, autoCreateContext{}); err == nil {
-		t.Error("Attach without plan_pda should error")
+	hours := 30 * 24
+	got, err := a.AutoCreate(context.Background(), autoCreateContext{
+		Currency:            "eur",
+		UnitAmount:          29_000_000,
+		AccessDurationHours: &hours,
+	})
+	if err != nil {
+		t.Fatalf("AutoCreate one-off: %v", err)
+	}
+	if got["provider"] != "solana" {
+		t.Fatalf("AutoCreate one-off = %v, want Solana provider marker", got)
+	}
+}
+
+func TestSolanaAdapter_AttachRequiresRecurringSettlementToken(t *testing.T) {
+	a := &solanaAdapter{}
+	days := 30
+	if _, err := a.Attach(
+		context.Background(),
+		map[string]string{"mint": "x"},
+		autoCreateContext{BillingCycleDays: &days, Currency: "usd"},
+	); err == nil {
+		t.Error("Attach recurring plan without mint_symbol should error")
 	}
 	got, err := a.Attach(context.Background(), map[string]string{
 		solanaKeyPlanPDA:         "PdA111",
 		solanaKeyMintSymbol:      "USDC",
 		solanaKeyAmountBaseUnits: "29000000",
 		"junk":                   "", // empty values are dropped
-	}, autoCreateContext{})
+	}, autoCreateContext{BillingCycleDays: &days, Currency: "usd"})
 	if err != nil {
 		t.Fatalf("Attach: %v", err)
 	}

--- a/pkg/service/catalog_providers.go
+++ b/pkg/service/catalog_providers.go
@@ -340,6 +340,27 @@ func (s *Service) resolveProviders(ctx context.Context, product *models.Product,
 		return ids
 	}
 
+	// deferPending parks this target's slot on a pending manual action: the
+	// declared key gets a pending state and the adapter's action template is
+	// queued for the operator. An empty message means "use the template hint";
+	// callers pass remoteWritesDisabledMessage when the block is the operating
+	// mode rather than the provider itself.
+	deferPending := func(t attachTarget, message string) {
+		template := t.adapter.PendingActionTemplate(priceID)
+		if template.Provider == "" {
+			template.Provider = t.rail
+		}
+		if message == "" {
+			message = template.Hint
+		}
+		states[t.declared] = ProviderState{
+			Status:     ProviderStatusPendingManualLink,
+			SyncStatus: SyncStatusNeverSynced,
+			Message:    message,
+		}
+		pending = append(pending, template)
+	}
+
 	for _, t := range targets {
 		link := req.PSPLinks[t.declared]
 		// Pin provider calls to THIS account's credentials; empty means the
@@ -352,32 +373,14 @@ func (s *Service) resolveProviders(ctx context.Context, product *models.Product,
 		if len(normalizeLinkMap(link)) > 0 {
 			ids, attachErr := t.adapter.Attach(ctx, link, tctx)
 			if errors.Is(attachErr, errPendingManualLink) {
-				template := t.adapter.PendingActionTemplate(priceID)
-				states[t.declared] = ProviderState{
-					Status:     ProviderStatusPendingManualLink,
-					SyncStatus: SyncStatusNeverSynced,
-					Message:    template.Hint,
-				}
-				if template.Provider == "" {
-					template.Provider = t.rail
-				}
-				pending = append(pending, template)
+				deferPending(t, "")
 				continue
 			}
 			if errors.Is(attachErr, errRemoteWritesDisabled) {
 				// The link verified as MISSING remotely and creating it is blocked
 				// by the operating mode: defer, don't fail the apply. The slot
 				// converges on a later apply once writes are allowed.
-				template := t.adapter.PendingActionTemplate(priceID)
-				if template.Provider == "" {
-					template.Provider = t.rail
-				}
-				states[t.declared] = ProviderState{
-					Status:     ProviderStatusPendingManualLink,
-					SyncStatus: SyncStatusNeverSynced,
-					Message:    remoteWritesDisabledMessage,
-				}
-				pending = append(pending, template)
+				deferPending(t, remoteWritesDisabledMessage)
 				continue
 			}
 			if attachErr != nil {
@@ -398,31 +401,13 @@ func (s *Service) resolveProviders(ctx context.Context, product *models.Product,
 		// the find-half of find-or-create is not worth a special case here; the
 		// slot converges on a later apply.
 		if pctx.RemoteWritesDisabled {
-			template := t.adapter.PendingActionTemplate(priceID)
-			if template.Provider == "" {
-				template.Provider = t.rail
-			}
-			states[t.declared] = ProviderState{
-				Status:     ProviderStatusPendingManualLink,
-				SyncStatus: SyncStatusNeverSynced,
-				Message:    remoteWritesDisabledMessage,
-			}
-			pending = append(pending, template)
+			deferPending(t, remoteWritesDisabledMessage)
 			continue
 		}
 		ids, createErr := t.adapter.AutoCreate(ctx, tctx)
 		switch {
 		case errors.Is(createErr, errPendingManualLink):
-			template := t.adapter.PendingActionTemplate(priceID)
-			states[t.declared] = ProviderState{
-				Status:     ProviderStatusPendingManualLink,
-				SyncStatus: SyncStatusNeverSynced,
-				Message:    template.Hint,
-			}
-			if template.Provider == "" {
-				template.Provider = t.rail
-			}
-			pending = append(pending, template)
+			deferPending(t, "")
 		case createErr != nil:
 			return nil, nil, nil, fmt.Errorf("%s: %w", t.declared, createErr)
 		default:

--- a/pkg/service/catalog_providers.go
+++ b/pkg/service/catalog_providers.go
@@ -547,6 +547,10 @@ func (s *Service) priceLinkContext(ctx context.Context, price *models.Price) (au
 		Currency:            price.Currency,
 		BillingCycleDays:    price.RecurringCycleDays(),
 		AccessDurationHours: price.AccessDurationHours,
+		// Attach can publish (e.g. a Solana plan from mint_symbol), so the
+		// link-rotation path must carry the same write gate resolveProviders
+		// does — otherwise limited/readonly deployments submit provider writes.
+		RemoteWritesDisabled: s.catalogRemoteWritesDisabled(),
 	}
 	if products, err := s.requireProductService(); err == nil {
 		if product, err := products.GetByID(ctx, price.ProductID); err == nil && product != nil {

--- a/pkg/service/catalog_providers.go
+++ b/pkg/service/catalog_providers.go
@@ -85,10 +85,11 @@ type providerAdapter interface {
 	// providerAdapters is the source of truth.
 	Name() string
 
-	// Attach validates and stores caller-supplied link ids on a freshly created
-	// OpenRails price. Returns the canonical IDs that should be written to the
-	// rails[provider] map. Called when the caller provided
-	// provider_links[provider] in the create/update request.
+	// Attach interprets caller-supplied provider link/config on a freshly created
+	// OpenRails price. It validates an existing remote object or find-or-creates
+	// one from a client-declarative key, then returns the canonical IDs to write
+	// to rails[provider]. Called when the caller provided psp_links[provider] in
+	// the create/update request.
 	//
 	// in carries the OpenRails price substance (product key + immutable money terms) so
 	// the adapter can VERIFY the linked remote object actually exists AND matches
@@ -345,12 +346,24 @@ func (s *Service) resolveProviders(ctx context.Context, product *models.Product,
 		// rail's armed default.
 		tctx := pctx
 		tctx.TargetAccountID = t.accountID
-		// Try the user-supplied attach path first. Attach VERIFIES the linked
-		// remote object exists and matches the price substance (pctx) — a wrong
-		// or missing link is a loud error, never a silent accept — and no provider
-		// object is created when a valid link is supplied.
+		// Try the user-supplied link/config path first. Attach verifies an exact
+		// remote id or find-or-creates from a declarative key such as lookup_key,
+		// plan_id, or Solana mint_symbol.
 		if len(normalizeLinkMap(link)) > 0 {
 			ids, attachErr := t.adapter.Attach(ctx, link, tctx)
+			if errors.Is(attachErr, errPendingManualLink) {
+				template := t.adapter.PendingActionTemplate(priceID)
+				states[t.declared] = ProviderState{
+					Status:     ProviderStatusPendingManualLink,
+					SyncStatus: SyncStatusNeverSynced,
+					Message:    template.Hint,
+				}
+				if template.Provider == "" {
+					template.Provider = t.rail
+				}
+				pending = append(pending, template)
+				continue
+			}
 			if errors.Is(attachErr, errRemoteWritesDisabled) {
 				// The link verified as MISSING remotely and creating it is blocked
 				// by the operating mode: defer, don't fail the apply. The slot
@@ -528,11 +541,12 @@ func (s *Service) priceLinkContext(ctx context.Context, price *models.Price) (au
 		return autoCreateContext{}, fmt.Errorf("price required")
 	}
 	pctx := autoCreateContext{
-		PriceID:          price.ID,
-		ProductID:        price.ProductID,
-		UnitAmount:       price.Amount,
-		Currency:         price.Currency,
-		BillingCycleDays: price.RecurringCycleDays(),
+		PriceID:             price.ID,
+		ProductID:           price.ProductID,
+		UnitAmount:          price.Amount,
+		Currency:            price.Currency,
+		BillingCycleDays:    price.RecurringCycleDays(),
+		AccessDurationHours: price.AccessDurationHours,
 	}
 	if products, err := s.requireProductService(); err == nil {
 		if product, err := products.GetByID(ctx, price.ProductID); err == nil && product != nil {

--- a/pkg/service/catalog_providers_test.go
+++ b/pkg/service/catalog_providers_test.go
@@ -221,6 +221,41 @@ func TestResolveProviders_MixedLinkedAndPending(t *testing.T) {
 	}
 }
 
+func TestResolveProviders_SolanaSettlementTokenPendingWhenUnconfigured(t *testing.T) {
+	s := newUnconfiguredService()
+	hours := 30 * 24
+	req := CreatePriceRequest{
+		ProductID:           uuid.New(),
+		UnitAmount:          23_000_000,
+		Currency:            "usd",
+		AccessDurationHours: &hours,
+		AutoRenew:           true,
+		PSPs:                []string{"solana"},
+		PSPLinks: map[string]map[string]string{
+			"solana": {solanaKeyMintSymbol: "USDC"},
+		},
+	}
+
+	rails, states, pending, err := s.resolveProviders(
+		context.Background(),
+		&models.Product{ID: req.ProductID, Key: "premium"},
+		req,
+		uuid.New(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(rails) != 0 {
+		t.Fatalf("unconfigured Solana should not have a rails entry, got %v", rails)
+	}
+	if states["solana"].Status != ProviderStatusPendingManualLink {
+		t.Fatalf("expected pending_manual_link, got %+v", states["solana"])
+	}
+	if len(pending) != 1 || pending[0].Provider != "solana" {
+		t.Fatalf("expected one Solana pending action, got %v", pending)
+	}
+}
+
 func TestResolveProviders_AllPending(t *testing.T) {
 	s := newUnconfiguredService()
 	productID := uuid.New()

--- a/pkg/service/service_definition_catalog.go
+++ b/pkg/service/service_definition_catalog.go
@@ -416,11 +416,12 @@ type CreatePriceRequest struct {
 	// links" — useful for testing or for prices that are not sold externally.
 	PSPs []string `json:"psps,omitempty"`
 
-	// PSPLinks maps PSP key -> pre-existing link key/value pairs.
+	// PSPLinks maps PSP key -> provider-specific link/config key/value pairs.
 	// Schema is per-provider:
 	//   stripe : {"price_id": "price_xxx", "product_id": "prod_xxx" (optional)}
 	//   ccbill : {"form_name": "...", "flex_id": "..."}
 	//   nmi : {"plan_id": "..."}
+	//   solana : {"mint_symbol": "USDC"} or {"plan_pda": "...", "mint_symbol": "USDC"}
 	// Any provider with a non-empty link here is implicitly added to the
 	// attach set even if absent from Providers.
 	PSPLinks map[string]map[string]string `json:"psp_links,omitempty"`
@@ -686,6 +687,7 @@ func (s *Service) UpdatePrice(ctx context.Context, priceID uuid.UUID, req Update
 	// Declarative PSP link rotation. ReplacePSPLinks=true overwrites the
 	// entire psp_links map; otherwise the supplied entries are merged
 	// into the existing map (partial PATCH). Empty inner maps clear a provider.
+	var pending []PendingAction
 	if req.PSPLinks != nil {
 		// The existing price + its product give the substance (product key + money terms)
 		// each adapter's Attach validates the supplied link against. Fetch it
@@ -734,6 +736,14 @@ func (s *Service) UpdatePrice(ctx context.Context, priceID uuid.UUID, req Update
 				return nil, fmt.Errorf("unknown PSP %q: not a rail or a declared PSP key", psp)
 			}
 			ids, attachErr := adapter.Attach(ctx, normalized, pctx)
+			if errors.Is(attachErr, errPendingManualLink) || errors.Is(attachErr, errRemoteWritesDisabled) {
+				template := adapter.PendingActionTemplate(priceID)
+				if template.Provider == "" {
+					template.Provider = rail
+				}
+				pending = append(pending, template)
+				continue
+			}
 			if attachErr != nil {
 				return nil, fmt.Errorf("%s: %w", psp, attachErr)
 			}
@@ -776,7 +786,9 @@ func (s *Service) UpdatePrice(ctx context.Context, priceID uuid.UUID, req Update
 		}
 	}
 
-	return priceToCatalogPrice(updated), nil
+	out := priceToCatalogPrice(updated)
+	out.PendingManualActions = pending
+	return out, nil
 }
 
 // priceToCatalogPrice maps the DB row into the response shape, including the

--- a/pkg/service/service_definition_catalog.go
+++ b/pkg/service/service_definition_catalog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 	"time"
@@ -742,6 +743,14 @@ func (s *Service) UpdatePrice(ctx context.Context, priceID uuid.UUID, req Update
 					template.Provider = rail
 				}
 				pending = append(pending, template)
+				// The rotation did NOT take effect. Keep the previously stored
+				// (verified) link so a ReplacePSPLinks pass never deletes it
+				// while the response only reports a pending action.
+				if prev, ok := existing.PSPLinks[psp]; ok {
+					if _, kept := next[psp]; !kept {
+						next[psp] = maps.Clone(prev)
+					}
+				}
 				continue
 			}
 			if attachErr != nil {


### PR DESCRIPTION
Summary:
- Separate USD billing currency from Solana recurring settlement tokens.
- Converge existing price links while keeping archived and read-only paths side-effect free.

Verification:
- `go test ./...`
- `go vet ./...`