### PR TITLE
Model Solana recurring settlement tokens

### DIFF
--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -293,7 +293,7 @@ manifest and reboot instead. Reads stay live.
 | PATCH | `/v1/merchant/catalog/products/{id}` | Update definition fields |
 | POST | `/v1/merchant/catalog/products/{id}/activate` | Activate |
 | POST | `/v1/merchant/catalog/products/{id}/deactivate` | Deactivate |
-| POST | `/v1/merchant/catalog/prices` | Create a price with per-PSP links (`psp_links`: link existing provider ids, or `create` where the provider supports auto-create — Stripe only; NMI/CCBill are link-only) |
+| POST | `/v1/merchant/catalog/prices` | Create a price with per-PSP links (`psp_links`: link existing provider ids or select declarative provider config; recurring Solana defaults to USDC, accepts `token: USD1`, or resolves an attached `plan_pda`) |
 | GET | `/v1/merchant/catalog/prices` | List prices |
 | GET | `/v1/merchant/catalog/prices/by-key/{key}` | Price by key |
 | GET | `/v1/merchant/catalog/prices/by-key/{key}/history` | The key's version chain, most-recent-first |

--- a/docs/merchant-guide.md
+++ b/docs/merchant-guide.md
@@ -19,7 +19,8 @@ declared state:
 
 - **Push** creates provider objects: Stripe Products/Prices/Features are auto-created;
   NMI recurring plans are found-or-created by `plan_id`; CCBill form links are stored
-  as operator-owned identifiers; Solana plan accounts must already exist on-chain.
+  as operator-owned identifiers; Solana recurring plans are found-or-created in USDC
+  by default, or attached by `plan_pda`.
 - **Pull** (the scheduled reconciliation job) is **alert-only**: it detects drift and
   orphans and records events for you to review. It never mutates providers.
 - Identity is content-addressed: a product's identity is its `key`; a price's identity
@@ -131,16 +132,17 @@ accruable from another meter) and `payment_term` (`in_advance`/`in_arrears`). Us
 products declare no billing cadence — the invoice period is the window. See the
 `digital-ocean` example in `config/catalog.example.yaml` for the full pattern.
 
-**psp_links** — pre-supply provider-side ids per PSP key. Supplied links are validated
-against the provider (object exists + money terms match) and never duplicated; a
-mismatch fails the apply loudly:
+**psp_links** — supply provider-side ids or declarative provider config per PSP key.
+Supplied links are validated against the provider (object exists + money terms match)
+and never duplicated; a mismatch fails the apply loudly:
 
 ```yaml
             psp_links:
               stripe: {lookup_key: premium}         # find-or-create at a chosen key
               mobius: {plan_id: premium}            # NMI recurring plan; find-or-create
               ccbill: {form_name: premium, flex_id: abc-123}  # operator-owned, unvalidated
-              solana: {plan_pda: "..."}             # must already exist on-chain
+              solana: {token: USD1}                 # optional override; recurring defaults to USDC
+              # solana: {plan_pda: "..."}           # alternatively attach and resolve the token on-chain
 ```
 
 ### Pushing and verifying
@@ -170,7 +172,7 @@ Provider side per rail:
 | stripe | auto-creates Products, Prices, and entitlement Features (`lookup_key` = the entitlement string); financial terms are immutable, so amount changes re-mint a new price and archive the old |
 | nmi PSPs | recurring `plan_id` found-or-created; otherwise link-only |
 | ccbill | link-only: you supply `form_name` + `flex_id` from the CCBill admin |
-| solana | link-only: `plan_pda` must reference an existing on-chain plan |
+| solana | recurring plans default to USDC and are found-or-created; `token: USD1` selects USD1; `plan_pda` attaches an existing plan and resolves its token on-chain |
 
 A link-only price pushed without its ids is still created in OpenRails and recorded as
 `pending_manual_link`, with a `pending_manual_actions` entry telling you what to PATCH

--- a/docs/rails/solana.md
+++ b/docs/rails/solana.md
@@ -84,6 +84,32 @@ delegates a spending allowance on their token account. OpenRails then pulls one
 plan-amount per period via `transfer_subscription` — the merchant signer signs
 and pays gas; funds move from the subscriber's ATA to the merchant's ATA.
 
+- Catalog prices bill in `currency: usd`. Declaring `psps: [solana]` creates or
+  reattaches a USDC plan by default. Use `psp_links.solana.token: USD1` to select
+  USD1 instead, or supply `plan_pda` to attach an existing plan and resolve its
+  configured token from the on-chain mint:
+
+  ```yaml
+  prices:
+    - currency: usd
+      unit_amount: 23_000_000
+      duration: 30d
+      auto_renew: true
+      psps: [solana]
+      # Optional:
+      # psp_links:
+      #   solana: {token: USD1}
+      # Or attach an existing plan:
+      #   solana: {plan_pda: 7Xy...PdA}
+  ```
+
+- `currency` is the price and ledger denomination; stablecoins remain Solana
+  payment assets, not billing currencies. A recurring price has one immutable
+  Solana Plan and therefore one token. `token` selects creation of a new Plan;
+  `plan_pda` instead attaches an existing Plan and must be supplied without
+  `token`, because its mint is authoritative on-chain. `mint_symbol` is stored
+  snapshot metadata and is not manifest input.
+
 - **Stablecoins only**: recurring plans are limited to an allowlist (currently
   `USDC`, `USD1`). On-chain plan amounts are immutable, so only a stablecoin
   keeps a fixed base-unit amount ≈ a fixed fiat amount. One-off purchases are

--- a/pkg/catalog/load.go
+++ b/pkg/catalog/load.go
@@ -521,8 +521,8 @@ func (m *Manifest) validatePrice(product Product, price *Price, idx int, meterKi
 
 	// Per-provider eligibility (shape-only; no chain calls). One-off Solana
 	// checkout quotes the selected token at payment time. A recurring plan is
-	// mint-specific, so it must declare its settlement token independently from
-	// the price's billing currency.
+	// mint-specific: USDC is the default settlement token, while token selects
+	// another supported stablecoin and plan_pda resolves its token on-chain.
 	if price.Metered != nil && len(price.PSPs) > 0 {
 		return fmt.Errorf("product %q price %s: metered prices are OpenRails-native and must not declare external providers", product.Key, PriceLabel(product.Key, *price))
 	}
@@ -536,17 +536,39 @@ func (m *Manifest) validatePrice(product Product, price *Price, idx int, meterKi
 				if _, legacy := stablecoinCurrencies[price.Currency]; legacy {
 					// Pre-#745 manifests declared the settlement token AS the
 					// billing currency; point the operator at the new shape.
-					hint = fmt.Sprintf("; pre-#745 manifests billed in the token — redeclare as currency: usd with psp_links.solana.mint_symbol: %s", strings.ToUpper(price.Currency))
+					hint = fmt.Sprintf("; pre-#745 manifests billed in the token — redeclare as currency: usd with psp_links.solana.token: %s", strings.ToUpper(price.Currency))
 				}
 				return fmt.Errorf("product %q price %s: recurring solana currently requires USD billing currency, got %q%s",
 					product.Key, PriceLabel(product.Key, *price), price.Currency, hint)
 			}
-			symbol := strings.ToUpper(strings.TrimSpace(price.PSPLinks[provider]["mint_symbol"]))
-			if _, ok := recurringSolanaTokenSymbols[symbol]; !ok {
-				return fmt.Errorf("product %q price %s: recurring solana requires psp_links.solana.mint_symbol (USDC/USD1), got %q",
-					product.Key, PriceLabel(product.Key, *price), symbol)
+			link := price.PSPLinks[provider]
+			if link == nil {
+				link = map[string]string{}
+				if price.PSPLinks == nil {
+					price.PSPLinks = map[string]map[string]string{}
+				}
+				price.PSPLinks[provider] = link
 			}
-			price.PSPLinks[provider]["mint_symbol"] = symbol
+			if _, retired := link["mint_symbol"]; retired {
+				return fmt.Errorf("product %q price %s: psp_links.solana.mint_symbol is output metadata; use psp_links.solana.token",
+					product.Key, PriceLabel(product.Key, *price))
+			}
+			symbol := strings.ToUpper(strings.TrimSpace(link["token"]))
+			planPDA := strings.TrimSpace(link["plan_pda"])
+			if symbol != "" && planPDA != "" {
+				return fmt.Errorf("product %q price %s: psp_links.solana.token selects a new plan; omit it when plan_pda is supplied because the existing plan's token is resolved on-chain",
+					product.Key, PriceLabel(product.Key, *price))
+			}
+			if symbol == "" && planPDA == "" {
+				symbol = "USDC"
+			}
+			if symbol != "" {
+				if _, ok := recurringSolanaTokenSymbols[symbol]; !ok {
+					return fmt.Errorf("product %q price %s: psp_links.solana.token must be USDC or USD1, got %q",
+						product.Key, PriceLabel(product.Key, *price), symbol)
+				}
+				link["token"] = symbol
+			}
 			continue
 		}
 		// One-off Solana settles as a direct transfer quoted at checkout: it

--- a/pkg/catalog/load_test.go
+++ b/pkg/catalog/load_test.go
@@ -337,11 +337,10 @@ func TestLoad_SolanaSettlementToken(t *testing.T) {
 `,
 		},
 		{
-			name: "recurring requires a settlement token",
+			name: "recurring defaults to USDC",
 			price: `
       - {currency: usd, unit_amount: 1000, duration: 30d, auto_renew: true, psps: [solana]}
 `,
-			wantErr: "recurring solana requires psp_links.solana.mint_symbol",
 		},
 		{
 			name: "recurring rejects an ineligible settlement token",
@@ -352,7 +351,7 @@ func TestLoad_SolanaSettlementToken(t *testing.T) {
         auto_renew: true
         psps: [solana]
         psp_links:
-          solana: {mint_symbol: SOL}
+          solana: {token: SOL}
 `,
 			wantErr: `got "SOL"`,
 		},
@@ -365,7 +364,7 @@ func TestLoad_SolanaSettlementToken(t *testing.T) {
         auto_renew: true
         psps: [solana]
         psp_links:
-          solana: {mint_symbol: USDC}
+          solana: {token: USDC}
 `,
 			wantErr: "recurring solana currently requires USD billing currency",
 		},
@@ -378,8 +377,57 @@ func TestLoad_SolanaSettlementToken(t *testing.T) {
         auto_renew: true
         psps: [solana]
         psp_links:
+          solana: {token: USDC}
+`,
+		},
+		{
+			name: "recurring existing plan resolves its token on-chain",
+			price: `
+      - currency: usd
+        unit_amount: 1000
+        duration: 30d
+        auto_renew: true
+        psps: [solana]
+        psp_links:
+          solana: {plan_pda: 7XyPdA}
+`,
+		},
+		{
+			name: "recurring existing plan rejects duplicate token input",
+			price: `
+      - currency: usd
+        unit_amount: 1000
+        duration: 30d
+        auto_renew: true
+        psps: [solana]
+        psp_links:
+          solana: {plan_pda: 7XyPdA, token: USD1}
+`,
+			wantErr: "token selects a new plan; omit it when plan_pda is supplied",
+		},
+		{
+			name: "mint symbol is output only",
+			price: `
+      - currency: usd
+        unit_amount: 1000
+        duration: 30d
+        auto_renew: true
+        psps: [solana]
+        psp_links:
           solana: {mint_symbol: USDC}
 `,
+			wantErr: "mint_symbol is output metadata",
+		},
+		{
+			name: "legacy stablecoin currency gets a migration hint",
+			price: `
+      - currency: usdc
+        unit_amount: 1000
+        duration: 30d
+        auto_renew: true
+        psps: [solana]
+`,
+			wantErr: "redeclare as currency: usd with psp_links.solana.token: USDC",
 		},
 	}
 
@@ -645,6 +693,32 @@ products:
 	}
 }
 
+func TestLoad_SolanaSharedUSDPriceDefaultsToUSDC(t *testing.T) {
+	body := `
+version: 1
+products:
+  - key: premium
+    display_name: Premium
+    prices:
+      - currency: usd
+        unit_amount: 23000000
+        duration: 30d
+        auto_renew: true
+        psps: [nmi, ccbill, solana]
+`
+	manifest, err := Load(writeManifest(t, body))
+	if err != nil {
+		t.Fatalf("shared USD price should be accepted: %v", err)
+	}
+	price := manifest.TierGroups[0].Products[0].Prices[0]
+	if price.Currency != "usd" {
+		t.Fatalf("shared price currency = %q, want usd", price.Currency)
+	}
+	if got := price.PSPLinks["solana"]["token"]; got != "USDC" {
+		t.Fatalf("default Solana token = %q, want USDC", got)
+	}
+}
+
 func TestLoad_SolanaStablecoinAccepted(t *testing.T) {
 	body := `
 version: 1
@@ -660,10 +734,14 @@ products:
         auto_renew: true
         psps: [solana]
         psp_links:
-          solana: {mint_symbol: USDC}
+          solana: {token: usd1}
 `
-	if _, err := Load(writeManifest(t, body)); err != nil {
-		t.Fatalf("usd billed + usdc settled should be accepted, got %v", err)
+	manifest, err := Load(writeManifest(t, body))
+	if err != nil {
+		t.Fatalf("usd billed + usd1 settled should be accepted, got %v", err)
+	}
+	if got := manifest.Products[0].Prices[0].PSPLinks["solana"]["token"]; got != "USD1" {
+		t.Fatalf("normalized Solana token = %q, want USD1", got)
 	}
 }
 

--- a/pkg/catalog/manifest.go
+++ b/pkg/catalog/manifest.go
@@ -157,15 +157,15 @@ type Price struct {
 	// against the provider (object exists + matches the price's money terms)
 	// before it is accepted; a mismatch fails the apply loudly. An existing
 	// object is never duplicated. A MISSING object is created where the supplied
-	// value is declarative (NMI plan_id, Stripe lookup_key, Solana mint_symbol)
+	// value is declarative (NMI plan_id, Stripe lookup_key, Solana token)
 	// and errors where it is provider-generated (Stripe price_id, Solana
 	// plan_pda). Canonical keys:
 	//   psp_links:
 	//     stripe: {lookup_key: premium}                        # recommended: find-or-create at a chosen key ...
 	//     stripe: {price_id: price_xxx, product_id: prod_xxx}  # ... or pin an exact existing Price (require-exists)
 	//     mobius: {plan_id: premium}                           # NMI recurring plan on the "mobius" PSP; find-or-create
-	//     solana: {mint_symbol: USDC}                          # publish/find a recurring plan in USDC
-	//     solana: {plan_pda: 7Xy...PdA, mint_symbol: USDC}     # attach an existing on-chain plan account
+	//     solana: {token: USD1}                                # optional override; recurring defaults to USDC
+	//     solana: {plan_pda: 7Xy...PdA}                        # attach a plan and resolve its token on-chain
 	//     ccbill: {form_name: premium, flex_id: abc-123}       # operator-owned, unvalidated
 	PSPLinks map[string]map[string]string `json:"psp_links,omitempty" yaml:"psp_links,omitempty"`
 

--- a/pkg/catalog/plan.go
+++ b/pkg/catalog/plan.go
@@ -347,7 +347,7 @@ func planPrices(ctx context.Context, applier Applier, m *Manifest, product Produ
 			}
 			// Never plan link work for a price this run is archiving: syncing
 			// links drives adapter.Attach, which can PUBLISH (e.g. a Solana
-			// plan from mint_symbol) — minting a live provider object for a
+			// plan from token) — minting a live provider object for a
 			// dead price. The declared links converge if it is ever unarchived.
 			if !price.Archived {
 				if links := pspLinksNeedingSync(match.Providers, price.PSPLinks); len(links) > 0 {

--- a/pkg/catalog/plan_test.go
+++ b/pkg/catalog/plan_test.go
@@ -223,8 +223,6 @@ products:
         duration: 30d
         auto_renew: true
         psps: [solana]
-        psp_links:
-          solana: {mint_symbol: USDC}
         archived: true
 `)
 	f := newFakeApplier()
@@ -326,8 +324,6 @@ products:
         duration: 30d
         auto_renew: true
         psps: [solana]
-        psp_links:
-          solana: {mint_symbol: USDC}
 `)
 	f := newFakeApplier()
 	premium := f.seedProduct("premium", "default", 0, false)
@@ -342,7 +338,7 @@ products:
 	if len(pp.Prices) != 1 || pp.Prices[0].Action != PriceUpdate {
 		t.Fatalf("provider drift must update the existing price: %+v", pp.Prices)
 	}
-	if got := pp.Prices[0].UpdateReq.PSPLinks["solana"]["mint_symbol"]; got != "USDC" {
+	if got := pp.Prices[0].UpdateReq.PSPLinks["solana"]["token"]; got != "USDC" {
 		t.Fatalf("Solana settlement token update = %q, want USDC", got)
 	}
 	if !plan.HasChanges() {
@@ -371,7 +367,7 @@ products:
         auto_renew: true
         psps: [solana]
         psp_links:
-          solana: {mint_symbol: usdc}
+          solana: {token: usdc}
 `)
 	f := newFakeApplier()
 	premium := f.seedProduct("premium", "default", 0, false)
@@ -381,6 +377,7 @@ products:
 	prices[0].Providers["solana"] = billingservice.ProviderState{
 		Status: billingservice.ProviderStatusLinked,
 		IDs: map[string]string{
+			"token":       "USDC",
 			"mint_symbol": "USDC",
 			"plan_pda":    "existing-plan",
 		},

--- a/pkg/embedded/catalog_dump.go
+++ b/pkg/embedded/catalog_dump.go
@@ -461,8 +461,20 @@ func providerLinks(raw []byte) map[string]map[string]string {
 	// The stored blob is account-keyed with the rail stamped inside each
 	// entry; the manifest derives the rail from the account key, so the stamp
 	// is storage detail, not manifest content.
-	for _, cfg := range links {
+	for psp, cfg := range links {
 		delete(cfg, models.RailKeyRail)
+		if strings.EqualFold(strings.TrimSpace(psp), string(models.RailSolana)) {
+			// mint_symbol is the resolved on-chain snapshot. The push manifest
+			// declares token only when selecting a new non-default plan, so
+			// never emit snapshot metadata as input. A stored plan_pda is
+			// authoritative for an attached plan and resolves its token from
+			// chain, so emitting token beside it would duplicate that fact.
+			delete(cfg, "mint_symbol")
+			if strings.TrimSpace(cfg["plan_pda"]) != "" ||
+				strings.EqualFold(strings.TrimSpace(cfg["token"]), "USDC") {
+				delete(cfg, "token")
+			}
+		}
 	}
 	return links
 }

--- a/pkg/embedded/catalog_dump_test.go
+++ b/pkg/embedded/catalog_dump_test.go
@@ -1,0 +1,50 @@
+package embedded
+
+import "testing"
+
+func TestProviderLinksOmitsSolanaMintSnapshot(t *testing.T) {
+	links := providerLinks([]byte(`{
+		"solana": {
+			"rail": "solana",
+			"token": "USD1",
+			"mint_symbol": "USD1",
+			"plan_pda": "plan"
+		}
+	}`))
+
+	solana := links["solana"]
+	if solana["plan_pda"] != "plan" {
+		t.Fatalf("declarative Solana link fields were not preserved: %v", solana)
+	}
+	if _, ok := solana["token"]; ok {
+		t.Fatalf("token must not be dumped beside an authoritative plan_pda: %v", solana)
+	}
+	if _, ok := solana["mint_symbol"]; ok {
+		t.Fatalf("Solana mint snapshot must not be dumped as manifest input: %v", solana)
+	}
+	if _, ok := solana["rail"]; ok {
+		t.Fatalf("storage rail stamp must not be dumped as manifest input: %v", solana)
+	}
+
+	defaultLink := providerLinks([]byte(`{
+		"solana": {
+			"rail": "solana",
+			"token": "USDC",
+			"mint_symbol": "USDC",
+			"plan_pda": "default-plan"
+		}
+	}`))["solana"]
+	if _, ok := defaultLink["token"]; ok {
+		t.Fatalf("default USDC token should be omitted from catalog dumps: %v", defaultLink)
+	}
+
+	tokenOnly := providerLinks([]byte(`{
+		"solana": {
+			"rail": "solana",
+			"token": "USD1"
+		}
+	}`))["solana"]
+	if tokenOnly["token"] != "USD1" {
+		t.Fatalf("USD1 creation intent should be preserved without a plan_pda: %v", tokenOnly)
+	}
+}

--- a/pkg/service/catalog_provider_solana.go
+++ b/pkg/service/catalog_provider_solana.go
@@ -25,10 +25,10 @@ import (
 // stores the plan handle in rails["solana"]. Verify reads the Plan account
 // back and diffs its immutable terms (amount / period / mint) for drift.
 //
-//   - AutoCreate: one-off prices need no plan; recurring prices without a declared
-//     settlement token remain pending_manual_link.
-//   - Attach: mint_symbol without plan_pda publishes (or idempotently attaches to)
-//     a plan; plan_pda + mint_symbol attaches an existing plan.
+//   - AutoCreate: one-off prices need no plan; recurring prices publish (or
+//     idempotently attach to) a USDC plan by default.
+//   - Attach: token selects a non-default token for a published plan; plan_pda
+//     attaches an existing plan and resolves its token on-chain.
 //   - Verify: GetAccountData(plan_pda) -> DecodePlanAccount -> diff vs the stored
 //     snapshot. RPC unavailable -> sync_disabled.
 //   - Update: no-op. Plan core terms are immutable on-chain; an amount/period change
@@ -38,14 +38,17 @@ type solanaAdapter struct{ svc *Service }
 
 // Solana rail-config keys (mirror recurring.PlanHandle.ToRailConfig).
 const (
-	solanaKeyPlanPDA         = "plan_pda"
-	solanaKeyPlanID          = "plan_id"
-	solanaKeyMint            = "mint"
-	solanaKeyMintSymbol      = "mint_symbol"
-	solanaKeyAmountBaseUnits = "amount_base_units"
-	solanaKeyPeriodHours     = "period_hours"
-	solanaKeyCreatedAt       = "created_at"
-	solanaKeyMerchant        = "merchant_address"
+	solanaDefaultRecurringToken = "USDC"
+	solanaUSD1RecurringToken    = "USD1"
+	solanaKeyPlanPDA            = "plan_pda"
+	solanaKeyPlanID             = "plan_id"
+	solanaKeyMint               = "mint"
+	solanaKeyToken              = "token"
+	solanaKeyMintSymbol         = "mint_symbol"
+	solanaKeyAmountBaseUnits    = "amount_base_units"
+	solanaKeyPeriodHours        = "period_hours"
+	solanaKeyCreatedAt          = "created_at"
+	solanaKeyMerchant           = "merchant_address"
 )
 
 func (a *solanaAdapter) Name() string { return "solana" }
@@ -54,7 +57,7 @@ func (a *solanaAdapter) PendingActionTemplate(priceID uuid.UUID) PendingAction {
 	return PendingAction{
 		Provider: "solana",
 		Action:   "configure_solana_recurring",
-		Hint:     "Configure the merchant's Solana provider-account signer and set psp_links.solana.mint_symbol to an allowlisted recurring stablecoin (USDC/USD1), then re-apply to publish the on-chain plan for price " + priceID.String(),
+		Hint:     "Configure the merchant's Solana provider-account signer, then re-apply to publish the on-chain plan for price " + priceID.String() + " (USDC by default; set psp_links.solana.token to use another supported stablecoin)",
 	}
 }
 
@@ -94,15 +97,12 @@ func (a *solanaAdapter) AutoCreate(ctx context.Context, in autoCreateContext) (m
 	if err := requireUSDBillingForSolanaPublish(in.Currency); err != nil {
 		return nil, err
 	}
-	// A recurring plan is mint-specific. The billing currency cannot identify
-	// its settlement token, so require psp_links.solana.mint_symbol through the
-	// Attach path instead of guessing from in.Currency.
-	return nil, errPendingManualLink
+	return a.createRecurringPlan(ctx, in, solanaDefaultRecurringToken)
 }
 
 // requireUSDBillingForSolanaPublish gates publishing a NEW recurring plan on
 // the #745 model: the price bills in USD and the settlement token is declared
-// separately via psp_links.solana.mint_symbol. Pre-#745 rows attached by
+// separately when it differs from the USDC default. Pre-#745 rows attached by
 // plan_pda are exempt (see Attach).
 func requireUSDBillingForSolanaPublish(currency string) error {
 	if !strings.EqualFold(strings.TrimSpace(currency), "usd") {
@@ -131,7 +131,8 @@ func (a *solanaAdapter) createRecurringPlan(ctx context.Context, in autoCreateCo
 		return nil, fmt.Errorf("solana create-mode requires a positive recurring interval")
 	}
 
-	// symbol arrives already normalized (uppercased/trimmed) by Attach.
+	// symbol arrives already normalized (uppercased/trimmed) by Attach or is the
+	// canonical USDC default from AutoCreate.
 	mint, decimals, err := plan.ResolveMint(symbol)
 	if err != nil {
 		return nil, err
@@ -208,19 +209,29 @@ func (a *solanaAdapter) findExistingPlan(ctx context.Context, plan *recurring.Pl
 	return handle.ToRailConfig(), true
 }
 
-// Attach publishes a plan from a declarative mint_symbol or stores an
+// Attach publishes a plan from a declarative token or stores an
 // operator-supplied existing plan handle. When the Solana RPC is available the
 // plan account is read back and its IMMUTABLE terms are verified against the
 // OpenRails price: the account must exist and match
-// amount (base units), period (billing cycle * 24h), mint (resolved from
-// mint_symbol), and — when a merchant is in context — the merchant/owner. A
+// amount (base units), period (billing cycle * 24h), mint (resolved from token
+// or inferred from the plan), and — when a merchant is in context — the merchant/owner. A
 // missing or mismatched plan is a loud error. On a successful read the verified
 // on-chain terms are stamped onto the stored ids so Verify has a snapshot. When
-// RPC is unavailable the operator-supplied fields are stored as-is.
+// RPC is unavailable, plan_pda attachment fails closed.
 func (a *solanaAdapter) Attach(ctx context.Context, link map[string]string, in autoCreateContext) (map[string]string, error) {
+	_, mintSymbolSupplied := link[solanaKeyMintSymbol]
 	link = normalizeLinkMap(link)
+	if mintSymbolSupplied {
+		return nil, fmt.Errorf("psp_links.solana.mint_symbol is output metadata; use psp_links.solana.token")
+	}
 	pda := strings.TrimSpace(link[solanaKeyPlanPDA])
-	symbol := strings.ToUpper(strings.TrimSpace(link[solanaKeyMintSymbol]))
+	symbol := strings.ToUpper(strings.TrimSpace(link[solanaKeyToken]))
+	if symbol != "" && !isSolanaRecurringToken(symbol) {
+		return nil, fmt.Errorf("psp_links.solana.token must be USDC or USD1, got %q", symbol)
+	}
+	if pda != "" && symbol != "" {
+		return nil, fmt.Errorf("psp_links.solana.token selects a new plan; omit it when plan_pda is supplied because the existing plan's token is resolved on-chain")
+	}
 	if pda == "" {
 		// The guard lives here — not on the plan_pda path — so eligible
 		// pre-#745 USDC rows can derive the token from their currency and stay
@@ -239,36 +250,33 @@ func (a *solanaAdapter) Attach(ctx context.Context, link map[string]string, in a
 			return nil, fmt.Errorf("solana one-off prices take no psp_links (the settlement token is chosen at checkout); remove psp_links.solana")
 		}
 		if symbol == "" {
-			return nil, fmt.Errorf("solana recurring link requires psp_links.solana.mint_symbol")
+			symbol = solanaDefaultRecurringToken
 		}
-		return a.createRecurringPlan(ctx, in, symbol)
+		out, err := a.createRecurringPlan(ctx, in, symbol)
+		if err != nil {
+			return nil, err
+		}
+		out[solanaKeyToken] = symbol
+		return out, nil
 	}
 	if in.BillingCycleDays != nil {
 		var err error
-		symbol, err = existingSolanaSettlementSymbol(in.Currency, symbol)
+		symbol, err = existingSolanaSettlementToken(in.Currency)
 		if err != nil {
 			return nil, err
 		}
 	}
 	out := map[string]string{solanaKeyPlanPDA: pda}
 	for _, k := range []string{
-		solanaKeyPlanID, solanaKeyMint, solanaKeyMintSymbol,
+		solanaKeyPlanID, solanaKeyMint,
 		solanaKeyAmountBaseUnits, solanaKeyPeriodHours, solanaKeyCreatedAt, solanaKeyMerchant,
 	} {
 		if v := strings.TrimSpace(link[k]); v != "" {
 			out[k] = v
 		}
 	}
-	// Store the canonical uppercase symbol: manifests normalize it at Load, so
-	// a verbatim lowercase copy from the direct API would read as permanent
-	// case-only "drift" to every future catalog plan.
-	if symbol != "" {
-		out[solanaKeyMintSymbol] = symbol
-	}
-
 	if a.svc == nil || a.svc.rt == nil || a.svc.rt.SolanaRPCResolver == nil {
-		// No RPC to verify against: store the operator-owned handle as-is.
-		return out, nil
+		return nil, fmt.Errorf("solana plan_pda requires an available RPC to resolve and verify its token")
 	}
 	pubkey, err := solanago.PublicKeyFromBase58(pda)
 	if err != nil {
@@ -293,6 +301,12 @@ func (a *solanaAdapter) Attach(ctx context.Context, link map[string]string, in a
 	// unconfigured — the price is in MICROS and only the token's decimals turn
 	// that into the plan's base units (#817).
 	if plan, ok := a.planService(); ok {
+		if symbol == "" {
+			symbol, err = resolveSolanaTokenFromMint(plan, acct.Mint.String())
+			if err != nil {
+				return nil, err
+			}
+		}
 		if symbol != "" {
 			mint, decimals, err := plan.ResolveMint(symbol)
 			if err != nil {
@@ -316,6 +330,8 @@ func (a *solanaAdapter) Attach(ctx context.Context, link map[string]string, in a
 				return nil, fmt.Errorf("solana plan %q merchant (%s) does not match this merchant's merchant (%s)", pda, acct.Owner, merchant)
 			}
 		}
+	} else if symbol == "" {
+		return nil, fmt.Errorf("solana plan_pda mint %s cannot be resolved without configured recurring tokens", acct.Mint)
 	}
 
 	// Stamp the authoritative on-chain terms (override any operator-supplied
@@ -325,32 +341,39 @@ func (a *solanaAdapter) Attach(ctx context.Context, link map[string]string, in a
 	out[solanaKeyPeriodHours] = strconv.FormatUint(acct.PeriodHours, 10)
 	out[solanaKeyCreatedAt] = strconv.FormatInt(acct.CreatedAt, 10)
 	out[solanaKeyMerchant] = acct.Owner.String()
+	out[solanaKeyMintSymbol] = symbol
 	return out, nil
 }
 
-// existingSolanaSettlementSymbol keeps safely translatable pre-#745 USDC
+// existingSolanaSettlementToken keeps safely translatable pre-#745 USDC
 // prices operable while preserving strict validation for the #745 model.
 // Before #745, currency=usdc identified both the billing denomination and the
-// settlement token. New prices bill in USD and must declare their token.
-func existingSolanaSettlementSymbol(currency, declared string) (string, error) {
+// settlement token. New prices bill in USD; an empty token is resolved from the
+// supplied plan_pda.
+func existingSolanaSettlementToken(currency string) (string, error) {
 	currency = strings.ToLower(strings.TrimSpace(currency))
-	declared = strings.ToUpper(strings.TrimSpace(declared))
 	switch currency {
 	case "usd":
-		if declared == "" {
-			return "", fmt.Errorf("solana recurring link requires psp_links.solana.mint_symbol")
-		}
+		return "", nil
 	case "usdc":
-		if declared == "" {
-			return "USDC", nil
-		}
-		if declared != "USDC" {
-			return "", fmt.Errorf("legacy solana price billed in USDC cannot settle in %s", declared)
-		}
+		return "USDC", nil
 	default:
 		return "", fmt.Errorf("solana recurring existing-plan links require USD billing currency or a legacy USDC price, got %q", currency)
 	}
-	return declared, nil
+}
+
+func resolveSolanaTokenFromMint(plan *recurring.PlanService, mint string) (string, error) {
+	for _, symbol := range [...]string{solanaDefaultRecurringToken, solanaUSD1RecurringToken} {
+		configuredMint, _, err := plan.ResolveMint(symbol)
+		if err == nil && strings.EqualFold(strings.TrimSpace(configuredMint), strings.TrimSpace(mint)) {
+			return symbol, nil
+		}
+	}
+	return "", fmt.Errorf("solana plan mint %s is not a configured recurring token", mint)
+}
+
+func isSolanaRecurringToken(symbol string) bool {
+	return symbol == solanaDefaultRecurringToken || symbol == solanaUSD1RecurringToken
 }
 
 // Verify reads the on-chain Plan account and diffs its immutable terms against the

--- a/pkg/service/catalog_provider_solana_decimals_test.go
+++ b/pkg/service/catalog_provider_solana_decimals_test.go
@@ -64,7 +64,7 @@ func TestSolanaAdapter_DeclarativeMintHonoursTokenDecimals(t *testing.T) {
 			ctx := merchant.WithID(context.Background(), merchant.ID(uuid.New()))
 
 			out, err := a.Attach(ctx, map[string]string{
-				solanaKeyMintSymbol: "USDC",
+				solanaKeyToken: "USDC",
 			}, autoCreateContext{
 				PriceID:             uuid.New(),
 				ProductKey:          "premium",
@@ -100,7 +100,7 @@ func TestSolanaAdapter_DeclarativeMintRejectsMissingDecimals(t *testing.T) {
 	ctx := merchant.WithID(context.Background(), merchant.ID(uuid.New()))
 
 	if _, err := a.Attach(ctx, map[string]string{
-		solanaKeyMintSymbol: "USDC",
+		solanaKeyToken: "USDC",
 	}, autoCreateContext{
 		PriceID:             uuid.New(),
 		ProductKey:          "premium",

--- a/pkg/service/catalog_provider_solana_test.go
+++ b/pkg/service/catalog_provider_solana_test.go
@@ -35,6 +35,34 @@ func TestSolanaAdapter_AutoCreateUnconfiguredIsPending(t *testing.T) {
 	}
 }
 
+func TestSolanaAdapter_AutoCreateRecurringDefaultsToUSDC(t *testing.T) {
+	const usdcMint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+	hours := 30 * 24
+	days := 30
+	plan := recurring.NewPlanServiceWithReader(
+		&planSubmitterStub{merchantPub: solanago.NewWallet().PublicKey()},
+		nil,
+		"mainnet",
+		map[string]config.TokenConfig{"USDC": {Mint: usdcMint, Decimals: 6}},
+	)
+	a := &solanaAdapter{svc: &Service{rt: &app.Runtime{SolanaPlanService: plan}}}
+	ctx := merchant.WithID(context.Background(), merchant.ID(uuid.New()))
+
+	got, err := a.AutoCreate(ctx, autoCreateContext{
+		ProductKey:          "premium",
+		Currency:            "usd",
+		UnitAmount:          29_000_000,
+		AccessDurationHours: &hours,
+		BillingCycleDays:    &days,
+	})
+	if err != nil {
+		t.Fatalf("AutoCreate recurring: %v", err)
+	}
+	if got[solanaKeyMintSymbol] != "USDC" {
+		t.Fatalf("AutoCreate recurring mint_symbol = %q, want USDC", got[solanaKeyMintSymbol])
+	}
+}
+
 func TestSolanaAdapter_AutoCreateOneOffNeedsNoPlan(t *testing.T) {
 	a := &solanaAdapter{}
 	hours := 30 * 24
@@ -51,80 +79,100 @@ func TestSolanaAdapter_AutoCreateOneOffNeedsNoPlan(t *testing.T) {
 	}
 }
 
-func TestSolanaAdapter_AttachRequiresRecurringSettlementToken(t *testing.T) {
+func TestSolanaAdapter_AttachUsesTokenInput(t *testing.T) {
 	a := &solanaAdapter{}
 	days := 30
 	if _, err := a.Attach(
 		context.Background(),
-		map[string]string{"mint": "x"},
+		map[string]string{solanaKeyMintSymbol: "USDC"},
 		autoCreateContext{BillingCycleDays: &days, Currency: "usd"},
 	); err == nil {
-		t.Error("Attach recurring plan without mint_symbol should error")
+		t.Error("Attach should reject mint_symbol as input")
 	}
-	got, err := a.Attach(context.Background(), map[string]string{
+	if _, err := a.Attach(
+		context.Background(),
+		map[string]string{solanaKeyToken: "SOL"},
+		autoCreateContext{BillingCycleDays: &days, Currency: "usd"},
+	); err == nil {
+		t.Error("Attach should reject a non-recurring token")
+	}
+	if _, err := a.Attach(
+		context.Background(),
+		map[string]string{solanaKeyPlanPDA: "PdA111", solanaKeyToken: "USDC"},
+		autoCreateContext{BillingCycleDays: &days, Currency: "usd"},
+	); err == nil {
+		t.Error("Attach should reject token beside plan_pda")
+	}
+	if _, err := a.Attach(context.Background(), map[string]string{
 		solanaKeyPlanPDA:         "PdA111",
-		solanaKeyMintSymbol:      "USDC",
 		solanaKeyAmountBaseUnits: "29000000",
 		"junk":                   "", // empty values are dropped
-	}, autoCreateContext{BillingCycleDays: &days, Currency: "usd"})
-	if err != nil {
-		t.Fatalf("Attach: %v", err)
-	}
-	if got[solanaKeyPlanPDA] != "PdA111" || got[solanaKeyMintSymbol] != "USDC" || got[solanaKeyAmountBaseUnits] != "29000000" {
-		t.Errorf("Attach passthrough wrong: %v", got)
-	}
-	if _, ok := got["junk"]; ok {
-		t.Errorf("empty link values should be dropped, got %v", got)
-	}
-
-	legacy, err := a.Attach(context.Background(), map[string]string{
-		solanaKeyPlanPDA: "LegacyPdA111",
-	}, autoCreateContext{BillingCycleDays: &days, Currency: "usdc"})
-	if err != nil {
-		t.Fatalf("Attach legacy USDC plan: %v", err)
-	}
-	if got := legacy[solanaKeyMintSymbol]; got != "USDC" {
-		t.Fatalf("legacy USDC mint_symbol = %q, want USDC", got)
+	}, autoCreateContext{BillingCycleDays: &days, Currency: "usdc"}); err == nil {
+		t.Error("Attach should not accept a legacy plan_pda without on-chain verification")
 	}
 
 	if _, err := a.Attach(context.Background(), map[string]string{
 		solanaKeyPlanPDA: "PdAWithoutToken111",
 	}, autoCreateContext{BillingCycleDays: &days, Currency: "usd"}); err == nil {
-		t.Fatal("new USD existing-plan link without mint_symbol should error")
+		t.Fatal("existing-plan link without RPC should error")
 	}
 }
 
-func TestExistingSolanaSettlementSymbol(t *testing.T) {
+func TestExistingSolanaSettlementToken(t *testing.T) {
 	tests := []struct {
 		name     string
 		currency string
-		declared string
 		want     string
 		wantErr  bool
 	}{
-		{name: "new USD price requires symbol", currency: "usd", wantErr: true},
-		{name: "new USD price accepts USDC", currency: "usd", declared: "usdc", want: "USDC"},
+		{name: "new USD price may infer token", currency: "usd"},
 		{name: "legacy USDC derives symbol", currency: " USDC ", want: "USDC"},
-		{name: "legacy USDC cannot change token", currency: "usdc", declared: "USD1", wantErr: true},
 		{name: "unsupported legacy currency fails", currency: "usdg", wantErr: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := existingSolanaSettlementSymbol(tt.currency, tt.declared)
+			got, err := existingSolanaSettlementToken(tt.currency)
 			if tt.wantErr {
 				if err == nil {
-					t.Fatalf("existingSolanaSettlementSymbol(%q, %q) = %q, want error", tt.currency, tt.declared, got)
+					t.Fatalf("existingSolanaSettlementToken(%q) = %q, want error", tt.currency, got)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("existingSolanaSettlementSymbol(%q, %q): %v", tt.currency, tt.declared, err)
+				t.Fatalf("existingSolanaSettlementToken(%q): %v", tt.currency, err)
 			}
 			if got != tt.want {
-				t.Fatalf("existingSolanaSettlementSymbol(%q, %q) = %q, want %q", tt.currency, tt.declared, got, tt.want)
+				t.Fatalf("existingSolanaSettlementToken(%q) = %q, want %q", tt.currency, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestResolveSolanaTokenFromMint(t *testing.T) {
+	const (
+		usdcMint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+		usd1Mint = "USD1USD1USD1USD1USD1USD1USD1USD1USD1USD1USD"
+	)
+	plan := recurring.NewPlanServiceWithReader(
+		&planSubmitterStub{merchantPub: solanago.NewWallet().PublicKey()},
+		nil,
+		"mainnet",
+		map[string]config.TokenConfig{
+			"USDC": {Mint: usdcMint, Decimals: 6},
+			"USD1": {Mint: usd1Mint, Decimals: 6},
+		},
+	)
+
+	got, err := resolveSolanaTokenFromMint(plan, usd1Mint)
+	if err != nil {
+		t.Fatalf("resolveSolanaTokenFromMint: %v", err)
+	}
+	if got != "USD1" {
+		t.Fatalf("resolveSolanaTokenFromMint = %q, want USD1", got)
+	}
+	if _, err := resolveSolanaTokenFromMint(plan, solanago.NewWallet().PublicKey().String()); err == nil {
+		t.Fatal("unconfigured recurring mint should fail")
 	}
 }
 
@@ -142,7 +190,7 @@ func TestSolanaAdapter_RemoteWritesDisabledDefersPublish(t *testing.T) {
 	ctx := merchant.WithID(context.Background(), merchant.ID(uuid.New()))
 
 	_, err := a.Attach(ctx, map[string]string{
-		solanaKeyMintSymbol: "USDC",
+		solanaKeyToken: "USDC",
 	}, autoCreateContext{
 		ProductKey:           "premium",
 		Currency:             "usd",

--- a/pkg/service/catalog_providers.go
+++ b/pkg/service/catalog_providers.go
@@ -369,7 +369,7 @@ func (s *Service) resolveProviders(ctx context.Context, product *models.Product,
 		tctx.TargetAccountID = t.accountID
 		// Try the user-supplied link/config path first. Attach verifies an exact
 		// remote id or find-or-creates from a declarative key such as lookup_key,
-		// plan_id, or Solana mint_symbol.
+		// plan_id, or a Solana token.
 		if len(normalizeLinkMap(link)) > 0 {
 			ids, attachErr := t.adapter.Attach(ctx, link, tctx)
 			if errors.Is(attachErr, errPendingManualLink) {
@@ -532,7 +532,7 @@ func (s *Service) priceLinkContext(ctx context.Context, price *models.Price) (au
 		Currency:            price.Currency,
 		BillingCycleDays:    price.RecurringCycleDays(),
 		AccessDurationHours: price.AccessDurationHours,
-		// Attach can publish (e.g. a Solana plan from mint_symbol), so the
+		// Attach can publish (e.g. a Solana plan from token), so the
 		// link-rotation path must carry the same write gate resolveProviders
 		// does — otherwise limited/readonly deployments submit provider writes.
 		RemoteWritesDisabled: s.catalogRemoteWritesDisabled(),

--- a/pkg/service/catalog_providers_test.go
+++ b/pkg/service/catalog_providers_test.go
@@ -221,7 +221,7 @@ func TestResolveProviders_MixedLinkedAndPending(t *testing.T) {
 	}
 }
 
-func TestResolveProviders_SolanaSettlementTokenPendingWhenUnconfigured(t *testing.T) {
+func TestResolveProviders_SolanaDefaultTokenPendingWhenUnconfigured(t *testing.T) {
 	s := newUnconfiguredService()
 	hours := 30 * 24
 	req := CreatePriceRequest{
@@ -231,9 +231,6 @@ func TestResolveProviders_SolanaSettlementTokenPendingWhenUnconfigured(t *testin
 		AccessDurationHours: &hours,
 		AutoRenew:           true,
 		PSPs:                []string{"solana"},
-		PSPLinks: map[string]map[string]string{
-			"solana": {solanaKeyMintSymbol: "USDC"},
-		},
 	}
 
 	rails, states, pending, err := s.resolveProviders(

--- a/pkg/service/service_definition_catalog.go
+++ b/pkg/service/service_definition_catalog.go
@@ -422,7 +422,7 @@ type CreatePriceRequest struct {
 	//   stripe : {"price_id": "price_xxx", "product_id": "prod_xxx" (optional)}
 	//   ccbill : {"form_name": "...", "flex_id": "..."}
 	//   nmi : {"plan_id": "..."}
-	//   solana : {"mint_symbol": "USDC"} or {"plan_pda": "...", "mint_symbol": "USDC"}
+	//   solana : {"token": "USD1"} or {"plan_pda": "..."}; omitted token defaults to USDC
 	// Any provider with a non-empty link here is implicitly added to the
 	// attach set even if absent from Providers.
 	PSPLinks map[string]map[string]string `json:"psp_links,omitempty"`


### PR DESCRIPTION
Summary: separate USD billing currency from Solana settlement-token intent, default recurring plans to USDC, and derive attached-plan tokens on-chain. Verification: go test ./...