### PR TITLE
Reuse Solana runtime during catalog push

### DIFF
--- a/embed/manifest_mode_integration_test.go
+++ b/embed/manifest_mode_integration_test.go
@@ -95,7 +95,7 @@ func bootManifestRuntime(t *testing.T, ctx context.Context, dsn, slug string, ma
 	require.NoError(t, err)
 	require.False(t, id.IsZero())
 	require.NoError(t, embedded.PushMerchantCatalog(ctx, embedded.CatalogPushOptions{
-		Config:   cfg,
+		Runtime:  rt.Embedded(),
 		Manifest: catalogRaw,
 		Insert:   true, Overwrite: true, Prune: true,
 	}))

--- a/embed/manifest_mode_integration_test.go
+++ b/embed/manifest_mode_integration_test.go
@@ -94,6 +94,8 @@ func bootManifestRuntime(t *testing.T, ctx context.Context, dsn, slug string, ma
 	id, err := rt.UpsertMerchantConfig(ctx, slug, manifest.Merchants[slug])
 	require.NoError(t, err)
 	require.False(t, id.IsZero())
+	require.NotNil(t, rt.Embedded().App().Runtime.SolanaPlanService,
+		"embedded provisioning arms recurring Solana services")
 	require.NoError(t, embedded.PushMerchantCatalog(ctx, embedded.CatalogPushOptions{
 		Runtime:  rt.Embedded(),
 		Manifest: catalogRaw,

--- a/embed/provision.go
+++ b/embed/provision.go
@@ -82,6 +82,7 @@ func (rt *Runtime) UpsertMerchantConfig(ctx context.Context, slug string, m Merc
 		Merchant: m,
 		Options:  boot.MerchantManifestReconcileOptions{Insert: true},
 	}
+	var secretBackend *merchantsecrets.Store
 	switch {
 	case conf.IsManifestMerchantSource():
 		// MODE 1 (#723): this call IS the manifest. Identity/config/account rows
@@ -97,6 +98,7 @@ func (rt *Runtime) UpsertMerchantConfig(ctx context.Context, slug string, m Merc
 		if err != nil {
 			return merchant.ID{}, fmt.Errorf("openrails embed: %w", err)
 		}
+		secretBackend = backend
 		req.SolanaTransit = backend.SolanaTransit
 		// Write routes stay mounted so mode-1 mutation calls receive the pointed
 		// 405 rejection (not a bare 404); Solana signing keys can live in memory.
@@ -127,6 +129,9 @@ func (rt *Runtime) UpsertMerchantConfig(ctx context.Context, slug string, m Merc
 			return merchant.ID{}, fmt.Errorf("openrails embed: build merchants service: %w", err)
 		}
 		a.Runtime.ArmMerchantsService(svc, a.Runtime.ManifestSecrets)
+	}
+	if conf.IsManifestMerchantSource() {
+		a.Runtime.ArmSolanaRecurringServices(secretBackend.Secrets, secretBackend.SolanaTransit)
 	}
 	return tn.ID, nil
 }

--- a/internal/app/solana_recurring_wiring.go
+++ b/internal/app/solana_recurring_wiring.go
@@ -1,0 +1,94 @@
+package app
+
+import (
+	"github.com/open-rails/openrails/config"
+	solanaint "github.com/open-rails/openrails/internal/integrations/solana"
+	"github.com/open-rails/openrails/internal/merchants"
+	"github.com/open-rails/openrails/internal/modules/solana/recurring"
+	"github.com/open-rails/openrails/internal/modules/solana/solanasubs"
+	solanatokens "github.com/open-rails/openrails/internal/modules/solana/tokens"
+)
+
+// ArmSolanaRecurringServices assembles the recurring Solana runtime from the
+// merchant secret plane. Both standalone and embedded composition roots call
+// this after merchant secrets are available.
+func (r *Runtime) ArmSolanaRecurringServices(
+	secretStore merchants.MerchantSecretStore,
+	solanaTransit solanaint.TransitClient,
+) {
+	if r == nil || r.DB == nil || r.Config == nil || r.SolanaRPCResolver == nil {
+		return
+	}
+
+	solanaSigner := recurring.NewSignerFromRailMerchantAccounts(
+		secretStore,
+		solanaTransit,
+		r.DB,
+		0,
+		config.ExpectedProviderEnvironment(r.Config.IsTestMode()),
+	)
+	submitter := recurring.NewSignerSubmitterWithResolver(solanaSigner, r.SolanaRPCResolver.Resolve)
+	network := "mainnet"
+	if r.Config.IsTestMode() {
+		network = "devnet"
+	}
+	tokens := solanatokens.ForNetwork(network)
+	r.SetSolanaCranker(recurring.NewCrankService(submitter))
+
+	if r.SubscriptionLifecycleService == nil {
+		return
+	}
+	chainReader := r.SolanaRPCResolver.ChainReader()
+	subscriptions := solanasubs.NewSolanaSubscriptionRepo(r.DB)
+	plan := recurring.NewPlanServiceWithReader(submitter, chainReader, network, tokens)
+	enroll := recurring.NewEnrollService(
+		r.SubscriptionLifecycleService,
+		subscriptions,
+		chainReader,
+		submitter,
+		network,
+		tokens,
+	)
+	r.SetSolanaRecurringServices(plan, enroll)
+	r.SetSolanaPrepareCancelService(recurring.NewPrepareCancelService(
+		subscriptions,
+		chainReader,
+	))
+	r.SetSolanaPrepareTierChangeService(recurring.NewPrepareTierChangeService(
+		solanaSigner,
+		chainReader,
+		network,
+		tokens,
+	))
+
+	if r.CheckoutSessionService == nil {
+		return
+	}
+	prepare := recurring.NewPrepareSubscribeService(
+		submitter,
+		solanaSigner,
+		chainReader,
+		network,
+		tokens,
+	)
+	r.CheckoutSessionService.SetSolanaRecurring(prepare, enroll)
+	confirmCancel := recurring.NewConfirmCancelService(
+		chainReader,
+		r.SubscriptionLifecycleService,
+	)
+	confirmTierChange := recurring.NewConfirmTierChangeService(
+		chainReader,
+		r.SubscriptionLifecycleService,
+		subscriptions,
+		network,
+		tokens,
+	)
+	r.CheckoutSessionService.SetSolanaLifecycle(
+		r.SolanaPrepareCancelService,
+		r.SolanaPrepareTierChangeService,
+		confirmCancel,
+		confirmTierChange,
+		r.SubscriptionService,
+		subscriptions,
+	)
+}

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -18,9 +18,6 @@ import (
 	"github.com/open-rails/openrails/internal/merchants"
 	"github.com/open-rails/openrails/internal/merchantsecrets"
 	"github.com/open-rails/openrails/internal/modules/idempotency"
-	"github.com/open-rails/openrails/internal/modules/solana/recurring"
-	"github.com/open-rails/openrails/internal/modules/solana/solanasubs"
-	solanatokens "github.com/open-rails/openrails/internal/modules/solana/tokens"
 	"github.com/open-rails/openrails/internal/shared/iputil"
 	"github.com/open-rails/openrails/pkg/billingauth"
 	"github.com/open-rails/openrails/pkg/cache"
@@ -267,103 +264,8 @@ func New(deps Dependencies) (*Server, error) {
 			}
 		}
 
-		// Recurring Solana services (#254/#255/#256): build one per-merchant
-		// Submitter (Transit when configured so the key never leaves Vault, else a
-		// keypair signer over the secret store) and share it across the cranker,
-		// plan-publish, and enroll services. The cranker MUST be injected BEFORE
-		// workers start (InitRiver). The Submitter's RPC resolves PER MERCHANT at
-		// submit time (#728: store settings win, boot client fallback), so the
-		// cranker arms even for store-only merchants (no boot Solana rail).
 		if deps.Runtime != nil {
-			// solanaSigner is the SAME per-merchant signer the Submitter wraps. The
-			// tier-change prepare service (#272) co-signs the merchant/cranker slot
-			// with it directly, so it MUST be the same key as the cranker.
-			solanaSigner := recurring.NewSignerFromRailMerchantAccounts(secretStore, solanaTransit, deps.Runtime.DB, 0, config.ExpectedProviderEnvironment(s.cfg.IsTestMode()))
-			submitter := recurring.NewSignerSubmitterWithResolver(solanaSigner, deps.Runtime.SolanaRPCResolver.Resolve)
-			// #788: network derives from test_mode alone (#349); the token set
-			// is the network's curated default (a merchant's rail-account
-			// settings refine tokens at request-time resolution seams).
-			network := "mainnet"
-			if s.cfg.IsTestMode() {
-				network = "devnet"
-			}
-			solanaTokens := solanatokens.ForNetwork(network)
-			cranker := recurring.NewCrankService(submitter)
-			deps.Runtime.SetSolanaCranker(cranker)
-			// Plan-publish (#254) + enroll-confirm (#255) HTTP surfaces. Chain
-			// reads arm PER MERCHANT through the #728 resolver at request time.
-			chainReader := deps.Runtime.SolanaRPCResolver.ChainReader()
-			if deps.Runtime.SubscriptionLifecycleService != nil && deps.Runtime.DB != nil {
-				planSvc := recurring.NewPlanServiceWithReader(submitter, chainReader, network, solanaTokens)
-				enrollSvc := recurring.NewEnrollService(
-					deps.Runtime.SubscriptionLifecycleService,
-					solanasubs.NewSolanaSubscriptionRepo(deps.Runtime.DB),
-					chainReader,
-					submitter,
-					network,
-					solanaTokens,
-				)
-				deps.Runtime.SetSolanaRecurringServices(planSvc, enrollSvc)
-
-				// App-driven on-chain cancel (#266): builds the unsigned
-				// cancel_subscription tx the subscriber signs to trustlessly revoke a
-				// recurring subscription on-chain (additive to the soft cancel #264).
-				deps.Runtime.SetSolanaPrepareCancelService(recurring.NewPrepareCancelService(
-					solanasubs.NewSolanaSubscriptionRepo(deps.Runtime.DB),
-					chainReader,
-				))
-
-				// App-driven on-chain tier change (#272): the prepare/confirm pair.
-				// PrepareTierChangeService builds the SINGLE ATOMIC tx (cancel-old +
-				// subscribe-new [+ prorated transfer for an upgrade]); for an upgrade it
-				// co-signs the merchant/cranker slot with the SAME signer + RPC + network
-				// as the cranker, so the slot it pre-signs is the merchant's own key.
-				deps.Runtime.SetSolanaPrepareTierChangeService(recurring.NewPrepareTierChangeService(
-					solanaSigner,
-					chainReader,
-					network,
-					solanaTokens,
-				))
-
-				// Subscribe-via-checkout (#261/#262): the prepare service builds the
-				// unsigned init/subscribe txns; enroll confirms. Wire both into the
-				// checkout session service so /v1/me/checkout(+confirm) drives the
-				// recurring Solana subscription flow.
-				if deps.Runtime.CheckoutSessionService != nil {
-					// The subscribe step is now an ATOMIC co-signed bundle (#286):
-					// [subscribe + transfer(first period)]. The cranker pre-signs the
-					// transfer slot, so the prepare service takes the SAME signer + RPC +
-					// network as the cranker (the slot it pre-signs is the merchant's key).
-					prepareSvc := recurring.NewPrepareSubscribeService(submitter, solanaSigner, chainReader, network, solanaTokens)
-					deps.Runtime.CheckoutSessionService.SetSolanaRecurring(prepareSvc, enrollSvc)
-
-					// Cancel + tier-change as Solana Pay checkout modes: reuse the same
-					// prepare services as the auth-gated #271/#272 handlers, and build the
-					// confirm services (mirrors) for the reference poller to invoke on
-					// confirmation. This extends the existing Solana Pay machinery to the
-					// solana_cancel / solana_tier_change modes — no parallel protocol.
-					solanaSubRepo := solanasubs.NewSolanaSubscriptionRepo(deps.Runtime.DB)
-					confirmCancelSvc := recurring.NewConfirmCancelService(
-						chainReader,
-						deps.Runtime.SubscriptionLifecycleService,
-					)
-					confirmTierChangeSvc := recurring.NewConfirmTierChangeService(
-						chainReader,
-						deps.Runtime.SubscriptionLifecycleService,
-						solanaSubRepo,
-						network,
-						solanaTokens,
-					)
-					deps.Runtime.CheckoutSessionService.SetSolanaLifecycle(
-						deps.Runtime.SolanaPrepareCancelService,
-						deps.Runtime.SolanaPrepareTierChangeService,
-						confirmCancelSvc,
-						confirmTierChangeSvc,
-						deps.Runtime.SubscriptionService,
-						solanaSubRepo,
-					)
-				}
-			}
+			deps.Runtime.ArmSolanaRecurringServices(secretStore, solanaTransit)
 		}
 
 	}

--- a/pkg/embedded/catalog_push.go
+++ b/pkg/embedded/catalog_push.go
@@ -26,8 +26,13 @@ import (
 
 // CatalogPushOptions configures PushMerchantCatalog.
 type CatalogPushOptions struct {
-	Config   *config.Config
-	PGXPool  *pgxpool.Pool
+	Config  *config.Config
+	PGXPool *pgxpool.Pool
+	// Runtime lends an already-bootstrapped embedded engine's Solana plan/RPC
+	// services to the otherwise isolated catalog helper. This lets a host's
+	// configured signer publish recurring plans without activating unrelated
+	// provider clients in the helper runtime. Its config is authoritative.
+	Runtime  *Embedded
 	File     string
 	Manifest []byte
 	Out      io.Writer
@@ -68,7 +73,8 @@ func PushMerchantCatalog(ctx context.Context, opts CatalogPushOptions) error {
 	if err != nil {
 		return err
 	}
-	if opts.Config == nil {
+	cfg := catalogPushConfig(opts)
+	if cfg == nil {
 		return fmt.Errorf("config not loaded; in-process mode requires config")
 	}
 	// #723 two-mode doctrine. MODE 2 (api): the catalog is API-owned DB data —
@@ -77,7 +83,7 @@ func PushMerchantCatalog(ctx context.Context, opts CatalogPushOptions) error {
 	// a mutating push always runs the full converge (Insert+Overwrite+Prune),
 	// so partial flags cannot leave the DB projection drifted from the file.
 	if !opts.planOnly() {
-		if !opts.Config.IsManifestMerchantSource() {
+		if !cfg.IsManifestMerchantSource() {
 			return fmt.Errorf("merchant_source=api refuses a mutating catalog push (two truths, #723/#724): mutate the catalog via the API, or run merchant_source=manifest; plan-only remains available")
 		}
 		if !opts.Insert || !opts.Overwrite || !opts.Prune {
@@ -90,7 +96,7 @@ func PushMerchantCatalog(ctx context.Context, opts CatalogPushOptions) error {
 	for _, target := range targets {
 		manifests = append(manifests, target.Manifest)
 	}
-	rt, svc, cleanup, err := newCatalogPushRuntime(opts.Config, opts.PGXPool, manifests...)
+	rt, svc, cleanup, err := catalogPushRuntime(opts, manifests...)
 	if err != nil {
 		return err
 	}
@@ -144,6 +150,36 @@ func PushMerchantCatalog(ctx context.Context, opts CatalogPushOptions) error {
 
 func (o CatalogPushOptions) planOnly() bool {
 	return o.DryRun || (!o.Insert && !o.Overwrite && !o.Prune)
+}
+
+func catalogPushConfig(opts CatalogPushOptions) *config.Config {
+	if opts.Runtime != nil {
+		return opts.Runtime.Config()
+	}
+	return opts.Config
+}
+
+func catalogPushRuntime(
+	opts CatalogPushOptions,
+	manifests ...*catalog.Manifest,
+) (*app.Runtime, *billingservice.Service, func(), error) {
+	if opts.Runtime != nil && (opts.Runtime.app == nil || opts.Runtime.app.Runtime == nil) {
+		return nil, nil, nil, fmt.Errorf("catalog runtime is not initialized")
+	}
+	rt, svc, cleanup, err := newCatalogPushRuntime(
+		catalogPushConfig(opts),
+		opts.PGXPool,
+		manifests...,
+	)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if opts.Runtime != nil {
+		source := opts.Runtime.app.Runtime
+		rt.SolanaPlanService = source.SolanaPlanService
+		rt.SolanaRPCResolver = source.SolanaRPCResolver
+	}
+	return rt, svc, cleanup, nil
 }
 
 func loadCatalogPushTargets(opts CatalogPushOptions) ([]catalogPushTarget, error) {


### PR DESCRIPTION
## Summary
Reuse embedded Solana services during catalog convergence.

## Test
- go test ./...
- manifest integration test
- Doujins Vault/devnet E2E