### PR TITLE
fix(catalog): reject retired provider keys

### DIFF
--- a/docs/rails/stripe.md
+++ b/docs/rails/stripe.md
@@ -88,7 +88,7 @@ duplicating them:
   One-way, best-effort — OpenRails stays the source of truth; a feature-sync failure
   never fails the price link and surfaces as drift on the next reconcile.
 
-Alternatively, link an existing Stripe Price (`provider_links.stripe.price_id`);
+Alternatively, link an existing Stripe Price (`psp_links.stripe.price_id`);
 OpenRails round-trips it and rejects the link if amount, currency, recurring terms,
 or product association don't match the catalog. The pull reconciliation job is
 alert-only — it reports drift and never mutates your Stripe objects.

--- a/pkg/catalog/load.go
+++ b/pkg/catalog/load.go
@@ -444,6 +444,9 @@ func (m *Manifest) validatePrice(product Product, price *Price, idx int, meterKi
 	if !validPriceCurrency(price.Currency) {
 		return fmt.Errorf("product %q price #%d currency must be an ISO money currency", product.Key, idx+1)
 	}
+	if len(price.LegacyProviders) > 0 || len(price.LegacyProviderLinks) > 0 {
+		return fmt.Errorf("product %q price %s: providers/provider_links were renamed to psps/psp_links", product.Key, PriceLabel(product.Key, *price))
+	}
 	if price.Model != "" {
 		price.PSPs = normalizePSPs(price.PSPs)
 		return nil
@@ -488,9 +491,6 @@ func (m *Manifest) validatePrice(product Product, price *Price, idx int, meterKi
 			return fmt.Errorf("product %q price #%d trial.unit_amount must be >= 0 (0 = free trial)", product.Key, idx+1)
 		}
 		price.Trial.Duration = formatDurationHours(*trialHours)
-	}
-	if len(price.LegacyProviders) > 0 || len(price.LegacyProviderLinks) > 0 {
-		return fmt.Errorf("product %q price %s: providers/provider_links were renamed to psps/psp_links", product.Key, PriceLabel(product.Key, *price))
 	}
 	if price.PSPs != nil {
 		price.PSPs = normalizePSPs(price.PSPs)

--- a/pkg/catalog/load_test.go
+++ b/pkg/catalog/load_test.go
@@ -141,6 +141,30 @@ products:
 	}
 }
 
+func TestLoad_RejectsRetiredProviderKeysForTypedPrice(t *testing.T) {
+	body := `
+version: 1
+products:
+  - key: topup
+    display_name: Topup
+    credits: [{key: credits}]
+    prices:
+      - currency: usd
+        model: tiered
+        providers: [stripe]
+        tiered:
+          mode: graduated
+          tiers:
+            - {unit_amount: 10_000}
+credit_balances:
+  - {key: credits, unit: credit}
+`
+	_, err := Load(writeManifest(t, body))
+	if err == nil || !strings.Contains(err.Error(), "providers/provider_links were renamed to psps/psp_links") {
+		t.Fatalf("want retired provider-key error, got %v", err)
+	}
+}
+
 func TestValidateRejectsTierGroupsOnly(t *testing.T) {
 	m := &Manifest{
 		Version:    SupportedVersion,

--- a/pkg/catalog/manifest.go
+++ b/pkg/catalog/manifest.go
@@ -14,13 +14,13 @@
 //     declared prices are ensured active; an active OpenRails price whose
 //     financial identity is not declared is archived.
 //
-// Each price declares its own `providers:` list and optional `provider_links`
+// Each price declares its own `psps:` list and optional `psp_links`
 // so apply can fan out explicitly across Stripe, NMI, CCBill and Solana.
 package catalog
 
 // Manifest is the root of a catalog-as-code document.
 //
-// Every price declares its own `currency` and `providers` explicitly — there
+// Every price declares its own `currency` and `psps` explicitly — there
 // are no catalog/product-level defaults.
 type Manifest struct {
 	Version        int             `json:"version" yaml:"version"`

--- a/pkg/catalog/ratecard_test.go
+++ b/pkg/catalog/ratecard_test.go
@@ -210,7 +210,7 @@ products:
       - key: ai-image-gen
     prices:
       - currency: usd
-        providers: [stripe]
+        psps: [stripe]
         input_min: 5_000_000
         round: down
         model: tiered


### PR DESCRIPTION
Summary: Reject `providers`/`provider_links` before typed-price validation and refresh current PSP terminology.

Verification: `go test ./pkg/catalog`