### PR TITLE
fix: scope system alerts by merchant

### DIFF
--- a/internal/db/customer.go
+++ b/internal/db/customer.go
@@ -8,15 +8,22 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/open-rails/openrails/internal/db/gen"
+	"github.com/open-rails/openrails/internal/shared/uuidutil"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
 
-// SystemCustomerID is the well-known payable subject that owns
-// platform-initiated rows with no human principal (e.g. ledger repair alerts).
-// It is a fixed, documented constant — deliberately NOT uuid.Nil, which stays
-// the "no subject" zero value — and is materialized through the normal
-// self-issuer path like any other UUID subject (#364).
-var SystemCustomerID = uuid.MustParse("00000000-0000-0000-0000-000000000001")
+// systemCustomerNamespace permanently anchors the per-merchant payable subject
+// that owns platform-initiated rows with no human principal (for example,
+// ledger repair alerts). It must not change after per-merchant IDs ship because
+// persisted notification rows refer to the IDs derived from it.
+var systemCustomerNamespace = uuid.MustParse("00000000-0000-0000-0000-000000000001")
+
+// SystemCustomerID derives the well-known system payable subject for merchantID.
+// The merchant participates in the identity because customers.id is globally
+// unique while customer rows are isolated by merchant RLS (#889).
+func SystemCustomerID(merchantID uuid.UUID) uuid.UUID {
+	return uuidutil.DeterministicID(systemCustomerNamespace, merchantID.String())
+}
 
 // errNonUUIDSubject builds the rejection for non-UUID payable identities.
 // OpenRails is UUID-only (#364): there is no legacy issuer, no generated row

--- a/internal/db/customer_test.go
+++ b/internal/db/customer_test.go
@@ -31,3 +31,14 @@ func TestResolveCustomerID(t *testing.T) {
 	_, err = db.ResolveCustomerID("legacy-user-123")
 	require.ErrorContains(t, err, "UUID-only")
 }
+
+func TestSystemCustomerID(t *testing.T) {
+	merchantA := uuid.MustParse("10000000-0000-4000-8000-000000000001")
+	merchantB := uuid.MustParse("20000000-0000-4000-8000-000000000002")
+
+	idA := db.SystemCustomerID(merchantA)
+	require.Equal(t, idA, db.SystemCustomerID(merchantA), "derivation must be stable")
+	require.NotEqual(t, idA, db.SystemCustomerID(merchantB), "each merchant needs a distinct system customer")
+	require.Equal(t, uuid.Version(5), idA.Version())
+	require.NotEqual(t, uuid.Nil, idA)
+}

--- a/internal/db/gen/notification_queue.sql.go
+++ b/internal/db/gen/notification_queue.sql.go
@@ -110,6 +110,39 @@ func (q *Queries) CreateNotification(ctx context.Context, arg CreateNotification
 	return result.RowsAffected(), nil
 }
 
+const createNotificationIfAbsent = `-- name: CreateNotificationIfAbsent :exec
+INSERT INTO openrails.notification_queue (
+    id, merchant_id, customer_id, event_type, data, seen, created_at
+) VALUES (
+    $1, $5::uuid, $2, $3, COALESCE($6, '{}'::jsonb), $4,
+    COALESCE(NULLIF($7::timestamptz, '0001-01-01 00:00:00+00'::timestamptz), now())
+)
+ON CONFLICT (id) DO NOTHING
+`
+
+type CreateNotificationIfAbsentParams struct {
+	ID         uuid.UUID
+	CustomerID uuid.UUID
+	EventType  string
+	Seen       bool
+	MerchantID uuid.UUID
+	Data       []byte
+	CreatedAt  time.Time
+}
+
+func (q *Queries) CreateNotificationIfAbsent(ctx context.Context, arg CreateNotificationIfAbsentParams) error {
+	_, err := q.db.Exec(ctx, createNotificationIfAbsent,
+		arg.ID,
+		arg.CustomerID,
+		arg.EventType,
+		arg.Seen,
+		arg.MerchantID,
+		arg.Data,
+		arg.CreatedAt,
+	)
+	return err
+}
+
 const deleteNotification = `-- name: DeleteNotification :execrows
 DELETE FROM openrails.notification_queue WHERE id = $1
 `

--- a/internal/db/queries/notification_queue.sql
+++ b/internal/db/queries/notification_queue.sql
@@ -8,6 +8,15 @@ INSERT INTO openrails.notification_queue (
     COALESCE(NULLIF(sqlc.arg(created_at)::timestamptz, '0001-01-01 00:00:00+00'::timestamptz), now())
 );
 
+-- name: CreateNotificationIfAbsent :exec
+INSERT INTO openrails.notification_queue (
+    id, merchant_id, customer_id, event_type, data, seen, created_at
+) VALUES (
+    $1, sqlc.arg(merchant_id)::uuid, $2, $3, COALESCE(sqlc.narg(data), '{}'::jsonb), $4,
+    COALESCE(NULLIF(sqlc.arg(created_at)::timestamptz, '0001-01-01 00:00:00+00'::timestamptz), now())
+)
+ON CONFLICT (id) DO NOTHING;
+
 -- name: GetNotificationByID :one
 SELECT * FROM openrails.notification_queue WHERE id = $1;
 

--- a/internal/http/handlers/admin_operations.go
+++ b/internal/http/handlers/admin_operations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/open-rails/openrails/internal/db/gen"
 	"github.com/open-rails/openrails/internal/db/models"
 	httprequest "github.com/open-rails/openrails/internal/http/request"
+	"github.com/open-rails/openrails/pkg/merchant"
 )
 
 const defaultAdminOperationsLimit = 50
@@ -32,7 +33,12 @@ func adminOperationsPagination(r *httprequest.Request) (int, int) {
 func GetAdminRepairAlerts(r *httprequest.Request) {
 	ctx := r.Request.Context()
 	limit, offset := adminOperationsPagination(r)
-	tsid := db.SystemCustomerID
+	merchantID, err := merchant.Require(ctx)
+	if err != nil {
+		r.ErrorJSON(http.StatusInternalServerError, "merchant scope required")
+		return
+	}
+	tsid := db.SystemCustomerID(merchantID.UUID())
 
 	var seen *bool
 	seenParam := strings.ToLower(strings.TrimSpace(r.Request.URL.Query().Get("seen")))

--- a/internal/modules/subscriptions/notification_repo.go
+++ b/internal/modules/subscriptions/notification_repo.go
@@ -39,26 +39,11 @@ func notificationsFromGen(rows []gen.OpenrailsNotificationQueue) ([]*models.Noti
 }
 
 func (r *NotificationQueueRepo) Create(ctx context.Context, notification *models.NotificationQueue) error {
-	if err := db.EnsureCustomerRow(ctx, r.db.Qx(ctx), uuid.Nil, notification.CustomerID); err != nil {
-		return err
-	}
-	data, err := models.ToJSONB(notification.Data)
+	params, err := r.createParams(ctx, notification)
 	if err != nil {
 		return err
 	}
-	tid, err := merchant.Require(ctx)
-	if err != nil {
-		return err
-	}
-	rows, err := r.db.Gen(ctx).CreateNotification(ctx, gen.CreateNotificationParams{
-		ID:         notification.ID,
-		MerchantID: tid.UUID(),
-		CustomerID: notification.CustomerID,
-		EventType:  string(notification.EventType),
-		Data:       data,
-		Seen:       notification.Seen,
-		CreatedAt:  notification.CreatedAt,
-	})
+	rows, err := r.db.Gen(ctx).CreateNotification(ctx, params)
 	if err != nil {
 		return err
 	}
@@ -66,6 +51,48 @@ func (r *NotificationQueueRepo) Create(ctx context.Context, notification *models
 		return errors.New("no rows affected")
 	}
 	return nil
+}
+
+// CreateIfAbsent inserts notification once by its caller-supplied ID. An
+// existing ID is success, which lets retrying fan-out jobs converge without
+// duplicating deliveries that already succeeded.
+func (r *NotificationQueueRepo) CreateIfAbsent(ctx context.Context, notification *models.NotificationQueue) error {
+	params, err := r.createParams(ctx, notification)
+	if err != nil {
+		return err
+	}
+	return r.db.Gen(ctx).CreateNotificationIfAbsent(ctx, gen.CreateNotificationIfAbsentParams{
+		ID:         params.ID,
+		MerchantID: params.MerchantID,
+		CustomerID: params.CustomerID,
+		EventType:  params.EventType,
+		Data:       params.Data,
+		Seen:       params.Seen,
+		CreatedAt:  params.CreatedAt,
+	})
+}
+
+func (r *NotificationQueueRepo) createParams(ctx context.Context, notification *models.NotificationQueue) (gen.CreateNotificationParams, error) {
+	if err := db.EnsureCustomerRow(ctx, r.db.Qx(ctx), uuid.Nil, notification.CustomerID); err != nil {
+		return gen.CreateNotificationParams{}, err
+	}
+	data, err := models.ToJSONB(notification.Data)
+	if err != nil {
+		return gen.CreateNotificationParams{}, err
+	}
+	tid, err := merchant.Require(ctx)
+	if err != nil {
+		return gen.CreateNotificationParams{}, err
+	}
+	return gen.CreateNotificationParams{
+		ID:         notification.ID,
+		MerchantID: tid.UUID(),
+		CustomerID: notification.CustomerID,
+		EventType:  string(notification.EventType),
+		Data:       data,
+		Seen:       notification.Seen,
+		CreatedAt:  notification.CreatedAt,
+	}, nil
 }
 
 func (r *NotificationQueueRepo) GetByID(ctx context.Context, id uuid.UUID) (*models.NotificationQueue, error) {

--- a/internal/modules/subscriptions/notification_service.go
+++ b/internal/modules/subscriptions/notification_service.go
@@ -42,6 +42,11 @@ func (s *NotificationService) Create(ctx context.Context, notification *models.N
 	return s.repo.Create(ctx, notification)
 }
 
+// CreateIfAbsent stores a notification once by its caller-supplied ID.
+func (s *NotificationService) CreateIfAbsent(ctx context.Context, notification *models.NotificationQueue) error {
+	return s.repo.CreateIfAbsent(ctx, notification)
+}
+
 func (s *NotificationService) GetByID(ctx context.Context, id uuid.UUID) (*models.NotificationQueue, error) {
 	return s.repo.GetByID(ctx, id)
 }

--- a/internal/modules/webhooks/ledger_repair_alert.go
+++ b/internal/modules/webhooks/ledger_repair_alert.go
@@ -11,6 +11,7 @@ import (
 	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/modules/subscriptions"
 	"github.com/open-rails/openrails/internal/shared/uuidutil"
+	"github.com/open-rails/openrails/pkg/merchant"
 )
 
 // LedgerRepairAlert describes a durable system alert for operator-led billing repair.
@@ -19,6 +20,7 @@ type LedgerRepairAlert struct {
 	Operation         string
 	TransactionID     string
 	UserID            string
+	IdempotencyKey    string
 	OriginalPaymentID *uuid.UUID
 	SubscriptionID    *uuid.UUID
 	Err               error
@@ -69,23 +71,50 @@ func recordLedgerRepairAlert(ctx context.Context, notificationService *subscript
 	if now.IsZero() {
 		now = time.Now()
 	}
+	idempotencyKey := strings.TrimSpace(alert.IdempotencyKey)
+	notificationID := uuidutil.NewV7()
 	notification := &models.NotificationQueue{
-		ID:        uuidutil.NewV7(),
+		ID:        notificationID,
 		EventType: models.NotificationSystemAlert,
 		Data:      data,
 		CreatedAt: now.UTC(),
 	}
-	// The alert is owned by the well-known system merchant subject
-	// (db.SystemCustomerID) — materialize its row through the normal
-	// self-issuer path like any other UUID subject (#364).
+	// The alert is owned by this merchant's well-known system subject. Its ID is
+	// merchant-derived because customers.id is globally unique under RLS (#889).
 	if database != nil {
-		sysTSID, err := db.EnsureCustomerID(ctx, database.Qx(ctx), uuid.Nil, db.SystemCustomerID.String())
+		merchantID, err := merchant.Require(ctx)
+		if err != nil {
+			return fmt.Errorf("resolve merchant for ledger repair alert: %w", err)
+		}
+		systemCustomerID := db.SystemCustomerID(merchantID.UUID())
+		sysTSID, err := db.EnsureCustomerID(
+			ctx,
+			database.Qx(ctx),
+			merchantID.UUID(),
+			systemCustomerID.String(),
+		)
 		if err != nil {
 			return fmt.Errorf("resolve system merchant subject for ledger repair alert: %w", err)
 		}
 		notification.CustomerID = sysTSID
+		if idempotencyKey != "" {
+			notification.ID = uuidutil.DeterministicID(
+				uuidutil.DeterministicNamespace,
+				"ledger_repair_alert",
+				merchantID.String(),
+				idempotencyKey,
+			)
+		}
+	} else if idempotencyKey != "" {
+		return fmt.Errorf("database is required for idempotent ledger repair alert")
 	}
-	if err := notificationService.Create(ctx, notification); err != nil {
+	var err error
+	if idempotencyKey != "" {
+		err = notificationService.CreateIfAbsent(ctx, notification)
+	} else {
+		err = notificationService.Create(ctx, notification)
+	}
+	if err != nil {
 		return fmt.Errorf("create ledger repair alert: %w", err)
 	}
 	return nil

--- a/internal/river/worker_health.go
+++ b/internal/river/worker_health.go
@@ -16,6 +16,7 @@ import (
 	"github.com/open-rails/openrails/internal/db/gen"
 	"github.com/open-rails/openrails/internal/modules/subscriptions"
 	"github.com/open-rails/openrails/internal/modules/webhooks"
+	"github.com/open-rails/openrails/internal/shared/uuidutil"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
 
@@ -303,6 +304,29 @@ func workerAlertDue(row gen.OpenrailsWorkerHealth, now time.Time, reAlertEvery t
 	return now.Sub(*row.LastAlertedAt) >= reAlertEvery
 }
 
+// workerHealthAlertIdempotencyKey identifies one alerting incident. Retry-
+// volatile health details are deliberately excluded so a partial merchant
+// fan-out retries only the deliveries that did not already persist.
+func workerHealthAlertIdempotencyKey(row gen.OpenrailsWorkerHealth, reason string) string {
+	lastSuccessAt := ""
+	if row.LastSuccessAt != nil {
+		lastSuccessAt = row.LastSuccessAt.UTC().Format(time.RFC3339Nano)
+	}
+	lastAlertedAt := ""
+	if row.LastAlertedAt != nil {
+		lastAlertedAt = row.LastAlertedAt.UTC().Format(time.RFC3339Nano)
+	}
+	return uuidutil.DeterministicID(
+		uuidutil.DeterministicNamespace,
+		"worker_health_alert",
+		row.WorkerKind,
+		reason,
+		row.RegisteredAt.UTC().Format(time.RFC3339Nano),
+		lastSuccessAt,
+		lastAlertedAt,
+	).String()
+}
+
 // raiseAlert routes one unhealthy kind to the existing repair-alert channel.
 // Worker health is operator-global but the channel is merchant-scoped, so the
 // alert fans out to every active merchant (embedded deployments have exactly
@@ -333,25 +357,24 @@ func (w *WorkerHealthCheckWorker) raiseAlert(ctx context.Context, row gen.Openra
 	if row.LastError != nil && *row.LastError != "" {
 		alertErr = fmt.Errorf("worker %s unhealthy (%s): %s", row.WorkerKind, reason, *row.LastError)
 	}
-	var lastErr error
-	var wrote int
+	alertErrors := make([]error, 0)
+	idempotencyKey := workerHealthAlertIdempotencyKey(row, reason)
 	for _, mid := range merchantIDs {
 		mctx := merchant.WithID(ctx, merchant.ID(mid))
 		if err := w.DB.RunInMerchantConn(mctx, func(ctx context.Context) error {
 			return webhooks.RecordLedgerRepairAlert(ctx, w.NotificationService, w.DB, now, webhooks.LedgerRepairAlert{
-				Provider:  "openrails",
-				Operation: "worker_health",
-				Err:       alertErr,
-				Metadata:  metadata,
+				Provider:       "openrails",
+				Operation:      "worker_health",
+				IdempotencyKey: idempotencyKey,
+				Err:            alertErr,
+				Metadata:       metadata,
 			})
 		}); err != nil {
-			lastErr = err
-			continue
+			alertErrors = append(alertErrors, fmt.Errorf("merchant %s: %w", mid, err))
 		}
-		wrote++
 	}
-	if wrote == 0 {
-		return fmt.Errorf("record repair alert: %w", lastErr)
+	if err := errors.Join(alertErrors...); err != nil {
+		return fmt.Errorf("record repair alerts: %w", err)
 	}
 	return nil
 }

--- a/internal/river/worker_health_integration_test.go
+++ b/internal/river/worker_health_integration_test.go
@@ -8,12 +8,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/riverqueue/river"
 	riverpgxv5 "github.com/riverqueue/river/riverdriver/riverpgxv5"
 	"github.com/riverqueue/river/rivertype"
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-rails/openrails/internal/db"
+	"github.com/open-rails/openrails/internal/db/gen"
 	"github.com/open-rails/openrails/internal/dbtest"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
@@ -71,6 +73,14 @@ func (whNoMerchWorker) Work(ctx context.Context, _ *river.Job[whNoMerchArgs]) er
 
 func cleanupWorkerHealth(t *testing.T, dbi *db.DB, kinds ...string) {
 	t.Helper()
+	mctx := dbtest.WithTestMerchant(context.Background())
+	systemCustomerID := db.SystemCustomerID(dbtest.TestMerchantID.UUID())
+	var systemCustomerExisted bool
+	require.NoError(t, dbi.RunInMerchantConn(mctx, func(ctx context.Context) error {
+		return dbi.Qx(ctx).QueryRow(ctx,
+			`SELECT EXISTS (SELECT 1 FROM openrails.customers WHERE id = $1)`, systemCustomerID,
+		).Scan(&systemCustomerExisted)
+	}))
 	t.Cleanup(func() {
 		ctx := context.Background()
 		for _, kind := range kinds {
@@ -79,8 +89,58 @@ func cleanupWorkerHealth(t *testing.T, dbi *db.DB, kinds ...string) {
 		mctx := dbtest.WithTestMerchant(ctx)
 		_ = dbi.RunInMerchantConn(mctx, func(ctx context.Context) error {
 			_, _ = dbi.Qx(ctx).Exec(ctx, `DELETE FROM openrails.notification_queue WHERE event_type = 'system_alert' AND data->>'operation' = 'worker_health'`)
+			if !systemCustomerExisted {
+				_, _ = dbi.Qx(ctx).Exec(ctx,
+					`DELETE FROM openrails.customers c
+					 WHERE c.id = $1
+					   AND NOT EXISTS (SELECT 1 FROM openrails.notification_queue nq WHERE nq.customer_id = c.id)`,
+					systemCustomerID,
+				)
+			}
 			return nil
 		})
+	})
+}
+
+// cleanupNewFanoutSystemCustomers removes system subjects created for active
+// merchants that predated this test. Per-test merchants are removed by each
+// test's primary cleanup; this helper prevents shared fixture pollution.
+func cleanupNewFanoutSystemCustomers(t *testing.T, super *db.DB, kind string) {
+	t.Helper()
+	ctx := context.Background()
+	rows, err := super.Pool().Query(ctx,
+		`SELECT id FROM openrails.merchants WHERE status = 'active'`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var createdCandidates []uuid.UUID
+	for rows.Next() {
+		var merchantID uuid.UUID
+		require.NoError(t, rows.Scan(&merchantID))
+		systemCustomerID := db.SystemCustomerID(merchantID)
+		var existed bool
+		require.NoError(t, super.Pool().QueryRow(ctx,
+			`SELECT EXISTS (SELECT 1 FROM openrails.customers WHERE id = $1)`, systemCustomerID,
+		).Scan(&existed))
+		if !existed {
+			createdCandidates = append(createdCandidates, systemCustomerID)
+		}
+	}
+	require.NoError(t, rows.Err())
+
+	t.Cleanup(func() {
+		_, err := super.Pool().Exec(ctx,
+			`DELETE FROM openrails.notification_queue WHERE data->>'worker_kind' = $1`, kind)
+		require.NoError(t, err)
+		for _, customerID := range createdCandidates {
+			_, err = super.Pool().Exec(ctx,
+				`DELETE FROM openrails.customers c
+				 WHERE c.id = $1
+				   AND NOT EXISTS (SELECT 1 FROM openrails.notification_queue nq WHERE nq.customer_id = c.id)`,
+				customerID,
+			)
+			require.NoError(t, err)
+		}
 	})
 }
 
@@ -108,14 +168,19 @@ func workerHealthRow(t *testing.T, dbi *db.DB, kind string) (lastSuccess, lastEr
 
 func countWorkerHealthAlerts(t *testing.T, dbi *db.DB, kind string) int {
 	t.Helper()
-	mctx := dbtest.WithTestMerchant(context.Background())
+	return countWorkerHealthAlertsForMerchant(t, dbi, dbtest.TestMerchantID, kind)
+}
+
+func countWorkerHealthAlertsForMerchant(t *testing.T, dbi *db.DB, merchantID merchant.ID, kind string) int {
+	t.Helper()
+	mctx := merchant.WithID(context.Background(), merchantID)
 	var n int
 	require.NoError(t, dbi.RunInMerchantConn(mctx, func(ctx context.Context) error {
 		return dbi.Qx(ctx).QueryRow(ctx,
 			`SELECT count(*) FROM openrails.notification_queue
 			 WHERE merchant_id = $1 AND event_type = 'system_alert'
 			   AND data->>'operation' = 'worker_health' AND data->>'worker_kind' = $2`,
-			dbtest.TestMerchantID.UUID(), kind).Scan(&n)
+			merchantID.UUID(), kind).Scan(&n)
 	}))
 	return n
 }
@@ -296,4 +361,130 @@ func TestWorkerHealth_NeverSucceededMerchantRequire(t *testing.T) {
 
 	require.Equal(t, 1, countWorkerHealthAlerts(t, dbi, whNoMerchKind))
 	require.Equal(t, "never_succeeded", alertReason(t, dbi, whNoMerchKind))
+}
+
+func TestWorkerHealth_AlertFanoutReachesEveryMerchantUnderRLS(t *testing.T) {
+	ctx := context.Background()
+	superDSN, appDSN := dbtest.SharedRLSPostgres(t)
+	super := dbtest.OpenAppDB(t, superDSN)
+	appDB := dbtest.OpenAppDB(t, appDSN)
+
+	posture, err := appDB.CheckRLSPosture(ctx)
+	require.NoError(t, err)
+	require.True(t, posture.Enforcing, "test must use the RLS-enforcing app role")
+
+	suffix := uuid.NewString()[:8]
+	merchantA := merchant.ID(uuid.New())
+	merchantB := merchant.ID(uuid.New())
+	kind := "test.wh_multi_merchant_" + suffix
+	t.Cleanup(func() {
+		_, err := super.Pool().Exec(ctx,
+			`DELETE FROM openrails.notification_queue WHERE data->>'worker_kind' = $1`, kind)
+		require.NoError(t, err)
+		_, err = super.Pool().Exec(ctx,
+			`DELETE FROM openrails.customers WHERE merchant_id IN ($1, $2)`,
+			merchantA.UUID(), merchantB.UUID(),
+		)
+		require.NoError(t, err)
+		_, err = super.Pool().Exec(ctx,
+			`DELETE FROM openrails.merchants WHERE id IN ($1, $2)`,
+			merchantA.UUID(), merchantB.UUID(),
+		)
+		require.NoError(t, err)
+	})
+	for label, merchantID := range map[string]merchant.ID{"a": merchantA, "b": merchantB} {
+		_, err := super.Pool().Exec(ctx,
+			`INSERT INTO openrails.merchants (id, slug, status) VALUES ($1, $2, 'active')`,
+			merchantID.UUID(), "wh-"+suffix+"-"+label,
+		)
+		require.NoError(t, err)
+	}
+	cleanupNewFanoutSystemCustomers(t, super, kind)
+
+	checker := &WorkerHealthCheckWorker{DB: appDB}
+	err = checker.raiseAlert(ctx, gen.OpenrailsWorkerHealth{WorkerKind: kind}, "stale", time.Now().UTC())
+	require.NoError(t, err)
+
+	for _, merchantID := range []merchant.ID{merchantA, merchantB} {
+		require.Equal(t, 1, countWorkerHealthAlertsForMerchant(t, appDB, merchantID, kind))
+
+		mctx := merchant.WithID(ctx, merchantID)
+		require.NoError(t, appDB.RunInMerchantConn(mctx, func(ctx context.Context) error {
+			var customerID uuid.UUID
+			err := appDB.Qx(ctx).QueryRow(ctx,
+				`SELECT customer_id FROM openrails.notification_queue
+				 WHERE data->>'worker_kind' = $1`, kind,
+			).Scan(&customerID)
+			if err != nil {
+				return err
+			}
+			require.Equal(t, db.SystemCustomerID(merchantID.UUID()), customerID)
+			return nil
+		}))
+	}
+	require.NotEqual(t, db.SystemCustomerID(merchantA.UUID()), db.SystemCustomerID(merchantB.UUID()))
+}
+
+func TestWorkerHealth_AlertFanoutReportsPartialFailure(t *testing.T) {
+	ctx := context.Background()
+	superDSN, appDSN := dbtest.SharedRLSPostgres(t)
+	super := dbtest.OpenAppDB(t, superDSN)
+	appDB := dbtest.OpenAppDB(t, appDSN)
+
+	suffix := uuid.NewString()[:8]
+	merchantA := merchant.ID(uuid.New())
+	merchantB := merchant.ID(uuid.New())
+	kind := "test.wh_partial_failure_" + suffix
+	t.Cleanup(func() {
+		_, err := super.Pool().Exec(ctx,
+			`DELETE FROM openrails.notification_queue WHERE data->>'worker_kind' = $1`, kind)
+		require.NoError(t, err)
+		_, err = super.Pool().Exec(ctx,
+			`DELETE FROM openrails.customers WHERE merchant_id IN ($1, $2)`,
+			merchantA.UUID(), merchantB.UUID(),
+		)
+		require.NoError(t, err)
+		_, err = super.Pool().Exec(ctx,
+			`DELETE FROM openrails.merchants WHERE id IN ($1, $2)`,
+			merchantA.UUID(), merchantB.UUID(),
+		)
+		require.NoError(t, err)
+	})
+	for label, merchantID := range map[string]merchant.ID{"a": merchantA, "b": merchantB} {
+		_, err := super.Pool().Exec(ctx,
+			`INSERT INTO openrails.merchants (id, slug, status) VALUES ($1, $2, 'active')`,
+			merchantID.UUID(), "wh-partial-"+suffix+"-"+label,
+		)
+		require.NoError(t, err)
+	}
+	cleanupNewFanoutSystemCustomers(t, super, kind)
+
+	// Corrupt B's derived system-customer identity by assigning it to A. The
+	// RLS-enforcing B connection cannot see or update that conflicting row.
+	conflictingID := db.SystemCustomerID(merchantB.UUID())
+	_, err := super.Pool().Exec(ctx,
+		`INSERT INTO openrails.customers (id, merchant_id, subject) VALUES ($1, $2, $3)`,
+		conflictingID, merchantA.UUID(), conflictingID.String(),
+	)
+	require.NoError(t, err)
+
+	checker := &WorkerHealthCheckWorker{DB: appDB}
+	row := gen.OpenrailsWorkerHealth{WorkerKind: kind, RegisteredAt: time.Now().Add(-time.Hour).UTC()}
+	now := time.Now().UTC()
+	err = checker.raiseAlert(ctx, row, "stale", now)
+	require.Error(t, err)
+	require.ErrorContains(t, err, merchantB.String())
+	require.Equal(t, 1, countWorkerHealthAlertsForMerchant(t, appDB, merchantA, kind),
+		"successful merchant delivery remains durable")
+	require.Equal(t, 0, countWorkerHealthAlertsForMerchant(t, appDB, merchantB, kind),
+		"failed merchant delivery must not be reported as successful")
+
+	// River retries the entire checker job after a partial fan-out failure. The
+	// successful merchant must not receive another copy of the same incident.
+	err = checker.raiseAlert(ctx, row, "stale", now.Add(time.Minute))
+	require.Error(t, err)
+	require.ErrorContains(t, err, merchantB.String())
+	require.Equal(t, 1, countWorkerHealthAlertsForMerchant(t, appDB, merchantA, kind),
+		"retry must reuse the incident ID for deliveries that already succeeded")
+	require.Equal(t, 0, countWorkerHealthAlertsForMerchant(t, appDB, merchantB, kind))
 }

--- a/internal/river/worker_health_test.go
+++ b/internal/river/worker_health_test.go
@@ -55,6 +55,36 @@ func TestWorkerAlertDue(t *testing.T) {
 	require.True(t, workerAlertDue(gen.OpenrailsWorkerHealth{LastAlertedAt: agoAt(2 * time.Hour), LastSuccessAt: agoAt(time.Hour)}, now, every))
 }
 
+func TestWorkerHealthAlertIdempotencyKey(t *testing.T) {
+	lastErrorAt := healthNow().Add(-time.Minute)
+	row := gen.OpenrailsWorkerHealth{
+		WorkerKind:          "test.worker",
+		RegisteredAt:        healthNow().Add(-48 * time.Hour),
+		LastSuccessAt:       agoAt(4 * time.Hour),
+		LastErrorAt:         &lastErrorAt,
+		ConsecutiveFailures: 3,
+	}
+
+	key := workerHealthAlertIdempotencyKey(row, "consecutive_failures")
+	retryRow := row
+	retryRow.ConsecutiveFailures = 4
+	retryErrorAt := healthNow()
+	retryRow.LastErrorAt = &retryErrorAt
+	require.Equal(t, key, workerHealthAlertIdempotencyKey(retryRow, "consecutive_failures"),
+		"retry-volatile health details must not mint a duplicate alert")
+
+	newSuccessAt := healthNow().Add(time.Hour)
+	retryRow.LastSuccessAt = &newSuccessAt
+	require.NotEqual(t, key, workerHealthAlertIdempotencyKey(retryRow, "consecutive_failures"),
+		"a recovery followed by a fresh incident must mint a new alert")
+
+	realertRow := row
+	realertAt := healthNow()
+	realertRow.LastAlertedAt = &realertAt
+	require.NotEqual(t, key, workerHealthAlertIdempotencyKey(realertRow, "consecutive_failures"),
+		"a paced re-alert must mint a new alert")
+}
+
 func TestWorkerRegistrations(t *testing.T) {
 	regs := NewWorkerRegistrations()
 	regs.NoteKind("a")


### PR DESCRIPTION
## Summary

- derive the system customer identity per merchant
- keep repair-alert reads forward-only on the derived identity
- report every worker-health fan-out failure and deduplicate retries per merchant and incident
- cover multi-merchant RLS fan-out, partial-failure retries, and stable identity derivation

## Verification

- `go test ./...`
- `go vet ./...`
- `go test -tags integration ./internal/river -run '^$'`
