### PR TITLE
Expose safe card decline errors

### DIFF
--- a/internal/http/handlers/card_error.go
+++ b/internal/http/handlers/card_error.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"net/http"
+	"strings"
+
+	httprequest "github.com/open-rails/openrails/internal/http/request"
+	"github.com/open-rails/openrails/internal/modules/paymentmethods"
+	"github.com/open-rails/openrails/internal/modules/payments"
+	"github.com/open-rails/openrails/pkg/api"
+)
+
+// writeVaultError translates NMI's raw decline vocabulary into OpenRails'
+// stable public categories. Processor text and localization IDs stay in
+// server-side logs; the browser receives only safe actionable copy.
+func writeVaultError(r *httprequest.Request, vaultErr *paymentmethods.VaultError) {
+	reason := payments.NormalizeFailureReason("nmi", strings.TrimSpace(vaultErr.LocalizationID))
+	code, message := publicCardFailure(reason)
+	r.APIError(api.NewAPIError(http.StatusBadRequest, api.ErrorTypeCard, code, message).
+		WithMetadata(map[string]any{"decline_reason": reason}))
+}
+
+func publicCardFailure(reason string) (code, message string) {
+	switch reason {
+	case payments.FailureInsufficientFunds:
+		return reason, "Your card has insufficient funds."
+	case payments.FailureExpiredCard:
+		return reason, "Your card is expired. Use a different card."
+	case payments.FailureCVVAVS:
+		return reason, "Check your card security code and billing details, then try again."
+	case payments.FailureCardUnsupported:
+		return reason, "This card is not supported. Try a different card."
+	case payments.FailureStopRecurring:
+		return reason, "Your bank stopped this recurring payment. Contact your bank or try a different card."
+	case payments.FailureDuplicateTransaction:
+		return reason, "This payment may be a duplicate. Wait a moment before trying again."
+	case payments.FailureFraudSuspected:
+		return reason, "Your bank declined this payment. Contact your bank or try a different card."
+	case payments.FailureProcessorError, payments.FailureConfigError:
+		return payments.FailureProcessorError, "The payment processor could not complete this payment. Please try again."
+	case payments.FailureCardDeclined, payments.FailureGenericDecline:
+		return reason, "Your card was declined. Contact your bank or try a different card."
+	default:
+		return api.CodePaymentFailed, "We could not complete this payment. Please try again or use a different card."
+	}
+}

--- a/internal/http/handlers/change_tier.go
+++ b/internal/http/handlers/change_tier.go
@@ -118,11 +118,7 @@ func writeChangeTierError(r *httprequest.Request, err error) {
 
 	var vaultErr *paymentmethods.VaultError
 	if errors.As(err, &vaultErr) {
-		code := api.CodePaymentFailed
-		if strings.TrimSpace(vaultErr.LocalizationID) != "" {
-			code = vaultErr.LocalizationID
-		}
-		r.APIError(api.NewAPIError(http.StatusBadRequest, api.ErrorTypeCard, code, vaultErr.Error()))
+		writeVaultError(r, vaultErr)
 		return
 	}
 

--- a/internal/http/handlers/checkout_session.go
+++ b/internal/http/handlers/checkout_session.go
@@ -102,7 +102,7 @@ func CreateCheckoutSession(r *httprequest.Request) {
 	svcReq := &checkout.CheckoutSessionCreateRequest{PriceID: req.PriceID, Mode: req.Mode, SubscriptionID: req.SubscriptionID, NewPriceID: req.NewPriceID, SuccessURL: req.SuccessURL, CancelURL: req.CancelURL, Metadata: req.Metadata, IdempotencyKey: req.IdempotencyKey, Payment: checkout.CheckoutSessionPaymentRequest{Rail: req.Payment.Rail, PaymentMethodID: req.Payment.PaymentMethodID, PaymentToken: req.Payment.PaymentToken, TokenSymbol: req.Payment.TokenSymbol, Flow: req.Payment.Flow, Wallet: req.Payment.Wallet, Email: req.Payment.Email, FirstName: req.Payment.FirstName, LastName: req.Payment.LastName, Address1: req.Payment.Address1, City: req.Payment.City, State: req.Payment.State, Zip: req.Payment.Zip, Country: req.Payment.Country, LastFour: req.Payment.LastFour, CardType: req.Payment.CardType, ExpiryDate: req.Payment.ExpiryDate}}
 	resp, err := r.State.CheckoutSessionService.CreateSession(r.Request.Context(), svcReq, user)
 	if err != nil {
-		log.WithError(err).Error("Failed to create checkout session")
+		log.WithError(err).WithField("request_id", r.RequestID()).Error("Failed to create checkout session")
 		// Card-abuse tracking (#371): a vault/card decline is a failed charge
 		// attempt. Record it against this request's rate-limit subjects so
 		// repeated failures escalate to captcha/block (and feed site-wide
@@ -218,11 +218,7 @@ type checkoutSessionErrorContext struct {
 func writeCheckoutSessionError(r *httprequest.Request, err error, ectx checkoutSessionErrorContext) {
 	var vaultErr *paymentmethods.VaultError
 	if errors.As(err, &vaultErr) {
-		code := api.CodePaymentFailed
-		if strings.TrimSpace(vaultErr.LocalizationID) != "" {
-			code = vaultErr.LocalizationID
-		}
-		r.APIError(api.NewAPIError(http.StatusBadRequest, api.ErrorTypeCard, code, vaultErr.Error()))
+		writeVaultError(r, vaultErr)
 		return
 	}
 	// Pre-flight insufficient-USDC (#286): a typed, actionable user state (NOT an

--- a/internal/http/handlers/checkout_session_test.go
+++ b/internal/http/handlers/checkout_session_test.go
@@ -4,12 +4,94 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/open-rails/openrails/internal/app"
 	httprequest "github.com/open-rails/openrails/internal/http/request"
+	"github.com/open-rails/openrails/internal/modules/paymentmethods"
 	"github.com/open-rails/openrails/internal/modules/solana/recurring"
 )
+
+func TestWriteCheckoutSessionErrorSanitizesVaultFailures(t *testing.T) {
+	tests := []struct {
+		name           string
+		localizationID string
+		wantCode       string
+		wantMessage    string
+		wantReason     string
+	}{
+		{
+			name:           "generic decline",
+			localizationID: "do_not_honor",
+			wantCode:       "card_declined",
+			wantMessage:    "Your card was declined. Contact your bank or try a different card.",
+			wantReason:     "card_declined",
+		},
+		{
+			name:           "security code mismatch",
+			localizationID: "invalid_card_security_code",
+			wantCode:       "cvv_avs",
+			wantMessage:    "Check your card security code and billing details, then try again.",
+			wantReason:     "cvv_avs",
+		},
+		{
+			name:           "suspected fraud",
+			localizationID: "fraudulent_card",
+			wantCode:       "fraud_suspected",
+			wantMessage:    "Your bank declined this payment. Contact your bank or try a different card.",
+			wantReason:     "fraud_suspected",
+		},
+		{
+			name:           "unknown response",
+			localizationID: "unmapped_gateway_response",
+			wantCode:       "payment_failed",
+			wantMessage:    "We could not complete this payment. Please try again or use a different card.",
+			wantReason:     "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			httpReq := httptest.NewRequest(http.MethodPost, "/v1/me/checkout", nil)
+			httpReq.Header.Set("X-Request-ID", "req-checkout-149")
+			req := httprequest.NewHTTP(rec, httpReq, &app.Runtime{})
+
+			writeCheckoutSessionError(req, &paymentmethods.VaultError{
+				LocalizationID: tt.localizationID,
+				Message:        "raw processor detail that must stay server-side",
+			}, checkoutSessionErrorContext{})
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+			}
+			var body struct {
+				Error struct {
+					Code      string         `json:"code"`
+					Message   string         `json:"message"`
+					RequestID string         `json:"request_id"`
+					Metadata  map[string]any `json:"metadata"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatal(err)
+			}
+			if body.Error.Code != tt.wantCode || body.Error.Message != tt.wantMessage {
+				t.Fatalf("error = %#v, want code %q message %q", body.Error, tt.wantCode, tt.wantMessage)
+			}
+			if body.Error.RequestID != "req-checkout-149" {
+				t.Fatalf("request_id = %q", body.Error.RequestID)
+			}
+			if body.Error.Metadata["decline_reason"] != tt.wantReason {
+				t.Fatalf("decline_reason = %#v, want %q", body.Error.Metadata["decline_reason"], tt.wantReason)
+			}
+			if strings.Contains(rec.Body.String(), "raw processor detail") {
+				t.Fatalf("response leaked processor text: %s", rec.Body.String())
+			}
+		})
+	}
+}
 
 func TestWriteCheckoutSessionErrorIncludesUSDCFundingMetadata(t *testing.T) {
 	rec := httptest.NewRecorder()

--- a/internal/http/handlers/payment_methods.go
+++ b/internal/http/handlers/payment_methods.go
@@ -229,18 +229,17 @@ func CreatePaymentMethod(r *httprequest.Request) {
 
 	pm, err := r.State.VaultService.CreateVault(ctx, user.ID, createReq)
 	if err != nil {
-		log.WithError(err).WithField("user_id", user.ID).Error("Failed to create payment method")
+		log.WithError(err).WithFields(log.Fields{
+			"request_id": r.RequestID(),
+			"user_id":    user.ID,
+		}).Error("Failed to create payment method")
 		if errors.Is(err, merchants.ErrSecretBackendUnavailable) {
 			r.ErrorJSON(http.StatusServiceUnavailable, "payment rail credentials are temporarily unavailable")
 			return
 		}
 		var vaultErr *paymentmethods.VaultError
 		if errors.As(err, &vaultErr) {
-			code := api.CodePaymentFailed
-			if strings.TrimSpace(vaultErr.LocalizationID) != "" {
-				code = vaultErr.LocalizationID
-			}
-			r.APIError(api.NewAPIError(http.StatusBadRequest, api.ErrorTypeCard, code, vaultErr.Error()))
+			writeVaultError(r, vaultErr)
 			return
 		}
 		r.ErrorJSON(http.StatusBadRequest, "failed to create payment method")

--- a/internal/http/request/request.go
+++ b/internal/http/request/request.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/go-playground/validator/v10"
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 
 	"github.com/jonboulle/clockwork"
@@ -62,6 +63,8 @@ type Request struct {
 	// UserContext stored only on a re-wrapped request context.
 	uc    billingauth.UserContext
 	ucSet bool
+
+	requestID string
 }
 
 // NewWithTransport builds a Request over an arbitrary Transport (test seam);
@@ -95,13 +98,35 @@ func (r *Request) ErrorJSON(code int, msg string) {
 }
 
 func (r *Request) APIError(err *api.APIError) {
+	requestID := r.RequestID()
+	err.WithRequestID(requestID)
 	logrus.WithFields(logrus.Fields{
-		"type":   err.Type,
-		"code":   err.Code,
-		"param":  err.Param,
-		"status": err.HTTPStatus,
+		"type":       err.Type,
+		"code":       err.Code,
+		"param":      err.Param,
+		"request_id": requestID,
+		"status":     err.HTTPStatus,
 	}).Error(err.Message)
 	r.t.WriteJSON(err.HTTPStatus, err.ToResponse())
+}
+
+const maxErrorRequestIDLength = 128
+
+// RequestID returns the request's correlation identifier, generating one when
+// the caller did not supply a usable value. The same value is propagated to
+// the request and response headers so handler logs and API errors correlate.
+func (r *Request) RequestID() string {
+	if r.requestID != "" {
+		return r.requestID
+	}
+	requestID := strings.TrimSpace(r.Request.Header.Get("X-Request-ID"))
+	if requestID == "" || len(requestID) > maxErrorRequestIDLength {
+		requestID = uuid.NewString()
+	}
+	r.requestID = requestID
+	r.Request.Header.Set("X-Request-ID", requestID)
+	r.SetHeader("X-Request-ID", requestID)
+	return requestID
 }
 
 func (r *Request) SuccessJSON(data any) {

--- a/internal/http/request/request_http_test.go
+++ b/internal/http/request/request_http_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/open-rails/openrails/pkg/api"
 	"github.com/open-rails/openrails/pkg/billingauth"
 )
 
@@ -106,6 +107,36 @@ func TestHTTPSuccessJSON(t *testing.T) {
 	var out map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil || out["ok"] != true {
 		t.Fatalf("body %s err %v", rec.Body.String(), err)
+	}
+}
+
+func TestHTTPAPIErrorIncludesRequestID(t *testing.T) {
+	tests := []struct {
+		name      string
+		requestID string
+	}{
+		{name: "preserves caller request id", requestID: "req-149"},
+		{name: "generates missing request id"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			httpReq := httptest.NewRequest(http.MethodPost, "/checkout", nil)
+			if tt.requestID != "" {
+				httpReq.Header.Set("X-Request-ID", tt.requestID)
+			}
+			req := NewHTTP(rec, httpReq, nil)
+			req.APIError(api.NewAPIError(http.StatusBadRequest, api.ErrorTypeCard, api.CodeCardDeclined, "Your card was declined."))
+
+			var body api.ErrorResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+			require.NotEmpty(t, body.Error.RequestID)
+			require.Equal(t, body.Error.RequestID, rec.Header().Get("X-Request-ID"))
+			if tt.requestID != "" {
+				require.Equal(t, tt.requestID, body.Error.RequestID)
+			}
+		})
 	}
 }
 

--- a/pkg/api/error.go
+++ b/pkg/api/error.go
@@ -57,12 +57,13 @@ const (
 
 // ErrorDetails contains the detailed error information (nested under "error" key)
 type ErrorDetails struct {
-	Type     string         `json:"type"`               // Error type category
-	Code     string         `json:"code"`               // Machine-readable error code
-	Message  string         `json:"message"`            // Human-readable message
-	Param    *string        `json:"param,omitempty"`    // Parameter that caused the error (if applicable)
-	DocURL   *string        `json:"doc_url,omitempty"`  // URL to documentation (optional)
-	Metadata map[string]any `json:"metadata,omitempty"` // Machine-readable context for actionable errors.
+	Type      string         `json:"type"`                 // Error type category
+	Code      string         `json:"code"`                 // Machine-readable error code
+	Message   string         `json:"message"`              // Human-readable message
+	RequestID string         `json:"request_id,omitempty"` // Correlates the response with server-side logs.
+	Param     *string        `json:"param,omitempty"`      // Parameter that caused the error (if applicable)
+	DocURL    *string        `json:"doc_url,omitempty"`    // URL to documentation (optional)
+	Metadata  map[string]any `json:"metadata,omitempty"`   // Machine-readable context for actionable errors.
 }
 
 // ErrorResponse is the top-level error response wrapper
@@ -76,6 +77,7 @@ type APIError struct {
 	Type       string
 	Code       string
 	Message    string
+	RequestID  string
 	Param      *string
 	Metadata   map[string]any
 }
@@ -92,11 +94,12 @@ func (e *APIError) Error() string {
 func (e *APIError) ToResponse() ErrorResponse {
 	return ErrorResponse{
 		Error: ErrorDetails{
-			Type:     e.Type,
-			Code:     e.Code,
-			Message:  e.Message,
-			Param:    e.Param,
-			Metadata: e.Metadata,
+			Type:      e.Type,
+			Code:      e.Code,
+			Message:   e.Message,
+			RequestID: e.RequestID,
+			Param:     e.Param,
+			Metadata:  e.Metadata,
 		},
 	}
 }
@@ -160,6 +163,12 @@ func (e *APIError) WithParam(param string) *APIError {
 // WithMetadata adds machine-readable context to the error response.
 func (e *APIError) WithMetadata(metadata map[string]any) *APIError {
 	e.Metadata = metadata
+	return e
+}
+
+// WithRequestID adds the request correlation identifier to the error response.
+func (e *APIError) WithRequestID(requestID string) *APIError {
+	e.RequestID = requestID
 	return e
 }
 


### PR DESCRIPTION
Summary:
- normalize public card decline responses and hide processor text
- include request IDs for support correlation

Verification:
- go test ./...
- go vet ./...