### PR TITLE
Bound idempotent card saves

### DIFF
--- a/docs/frontend-integration.md
+++ b/docs/frontend-integration.md
@@ -191,6 +191,12 @@ card. Checkout with a fresh `payment_token` also persists a payment method
 automatically. `payment_method_id`s can only be used by their owner — using someone
 else's is a 403.
 
+Send `Idempotency-Key` on the create request and retain the key, payment token, and
+exact JSON body for an exact-request retry. A different token is a new attempt and
+must use a new key. If create returns `provider_outcome_unknown`, refresh the payment
+method list before starting another attempt because the provider mutation may have
+completed.
+
 ### Shared-customer treasury: `/v1/customers/:customer_id/*`
 
 `/v1/me/*` needs no grants. Acting on a *shared* customer balance (an org/team wallet

--- a/internal/http/handlers/payment_methods.go
+++ b/internal/http/handlers/payment_methods.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/open-rails/openrails/internal/db/models"
 	httprequest "github.com/open-rails/openrails/internal/http/request"
+	"github.com/open-rails/openrails/internal/integrations/nmi"
 	"github.com/open-rails/openrails/internal/intents"
 	"github.com/open-rails/openrails/internal/merchants"
 	"github.com/open-rails/openrails/internal/modules/paymentmethods"
@@ -20,6 +21,11 @@ import (
 	sharedformat "github.com/open-rails/openrails/internal/shared/format"
 	"github.com/open-rails/openrails/pkg/api"
 	log "github.com/sirupsen/logrus"
+)
+
+const (
+	createPaymentMethodTimeout              = 28 * time.Second
+	codePaymentMethodProviderOutcomeUnknown = "provider_outcome_unknown"
 )
 
 type listPaymentMethodsQuery struct {
@@ -214,7 +220,9 @@ func CreatePaymentMethod(r *httprequest.Request) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(r.Request.Context(), 10*time.Second)
+	// The NMI transport has a 25-second ceiling. Leave enough time for the
+	// local write while still completing before the browser's 30-second cap.
+	ctx, cancel := context.WithTimeout(r.Request.Context(), createPaymentMethodTimeout)
 	defer cancel()
 
 	email := strings.TrimSpace(req.Email)
@@ -237,6 +245,10 @@ func CreatePaymentMethod(r *httprequest.Request) {
 			r.ErrorJSON(http.StatusServiceUnavailable, "payment rail credentials are temporarily unavailable")
 			return
 		}
+		if providerErr := createPaymentMethodProviderError(err); providerErr != nil {
+			r.APIError(providerErr)
+			return
+		}
 		var vaultErr *paymentmethods.VaultError
 		if errors.As(err, &vaultErr) {
 			writeVaultError(r, vaultErr)
@@ -247,6 +259,18 @@ func CreatePaymentMethod(r *httprequest.Request) {
 	}
 
 	r.SuccessJSON(paymentMethodToAPI(pm, nil))
+}
+
+func createPaymentMethodProviderError(err error) *api.APIError {
+	if !nmi.IsTransportAmbiguous(err) {
+		return nil
+	}
+	return api.NewAPIError(
+		http.StatusConflict,
+		api.ErrorTypeAPI,
+		codePaymentMethodProviderOutcomeUnknown,
+		"The payment provider did not confirm whether the card was saved. Refresh your payment methods before trying again.",
+	)
 }
 
 func createVaultRequestFromPaymentMethodRequest(req *createPaymentMethodRequest, email string) *paymentmethods.CreateVaultRequest {

--- a/internal/http/handlers/payment_methods_test.go
+++ b/internal/http/handlers/payment_methods_test.go
@@ -2,13 +2,31 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/integrations/nmi"
 	"github.com/open-rails/openrails/internal/modules/paymentmethods"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCreatePaymentMethodProviderError(t *testing.T) {
+	ambiguous := fmt.Errorf("create vault: %w", &nmi.TransportAmbiguousError{
+		Err: errors.New("request timed out after send"),
+	})
+
+	got := createPaymentMethodProviderError(ambiguous)
+	require.NotNil(t, got)
+	require.Equal(t, http.StatusConflict, got.HTTPStatus)
+	require.Equal(t, codePaymentMethodProviderOutcomeUnknown, got.Code)
+	require.Contains(t, got.Message, "Refresh your payment methods")
+
+	require.Nil(t, createPaymentMethodProviderError(errors.New("declined")))
+}
 
 // #589: derived payment-method health is computed at query time, so the pure
 // derivation logic is unit-tested without a DB.

--- a/internal/http/middleware/idempotency_neutral.go
+++ b/internal/http/middleware/idempotency_neutral.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -9,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -26,6 +28,7 @@ import (
 const (
 	idempotencyHeaderCanonical = "Idempotency-Key"
 	maxCapturedResponseBytes   = 1 << 20 // 1 MiB — matches DefaultMaxBodyBytes
+	idempotencyFinalizeTimeout = 5 * time.Second
 )
 
 // IdempotencyKeyFromRequest returns the client-supplied idempotency key from the
@@ -155,7 +158,9 @@ func IdempotencyHTTP(svc *idempotency.IdempotencyService) HTTPMiddleware {
 			resolved := false
 			defer func() {
 				if !resolved {
-					_ = svc.Fail(ctx, operation, storeKey, fmt.Errorf("handler did not complete"))
+					_ = finalizeIdempotency(ctx, func(finalizeCtx context.Context) error {
+						return svc.Fail(finalizeCtx, operation, storeKey, fmt.Errorf("handler did not complete"))
+					})
 				}
 			}()
 
@@ -167,7 +172,9 @@ func IdempotencyHTTP(svc *idempotency.IdempotencyService) HTTPMiddleware {
 			}
 			if status >= 500 || cw.over {
 				// Do not cache server errors or oversized bodies; a retry re-runs.
-				_ = svc.Fail(ctx, operation, storeKey, fmt.Errorf("status %d not cached", status))
+				_ = finalizeIdempotency(ctx, func(finalizeCtx context.Context) error {
+					return svc.Fail(finalizeCtx, operation, storeKey, fmt.Errorf("status %d not cached", status))
+				})
 				resolved = true
 				return
 			}
@@ -178,17 +185,29 @@ func IdempotencyHTTP(svc *idempotency.IdempotencyService) HTTPMiddleware {
 				Body:        cw.buf.Bytes(),
 			})
 			if mErr != nil {
-				_ = svc.Fail(ctx, operation, storeKey, mErr)
+				_ = finalizeIdempotency(ctx, func(finalizeCtx context.Context) error {
+					return svc.Fail(finalizeCtx, operation, storeKey, mErr)
+				})
 				resolved = true
 				return
 			}
-			if cErr := svc.Complete(ctx, operation, storeKey, payload); cErr != nil {
+			if cErr := finalizeIdempotency(ctx, func(finalizeCtx context.Context) error {
+				return svc.Complete(finalizeCtx, operation, storeKey, payload)
+			}); cErr != nil {
 				log.WithError(cErr).Warn("idempotency: Complete failed; response was still returned (#579)")
 			} else {
 				resolved = true
 			}
 		})
 	}
+}
+
+func finalizeIdempotency(requestCtx context.Context, fn func(context.Context) error) error {
+	// Recording the terminal replay state must survive a client disconnect;
+	// otherwise a timed-out caller can leave its key pending for the full TTL.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(requestCtx), idempotencyFinalizeTimeout)
+	defer cancel()
+	return fn(ctx)
 }
 
 func hashIdempotencyKey(key string) string {

--- a/internal/http/middleware/idempotency_neutral_test.go
+++ b/internal/http/middleware/idempotency_neutral_test.go
@@ -1,11 +1,13 @@
 package middleware
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -28,6 +30,23 @@ func idempotencyTestHandler(counter *atomic.Int64, status int, body string) http
 }
 
 func TestIdempotencyHTTP(t *testing.T) {
+	t.Run("finalization survives request cancellation", func(t *testing.T) {
+		requestCtx, cancelRequest := context.WithCancel(context.Background())
+		cancelRequest()
+
+		var finalizeErr error
+		err := finalizeIdempotency(requestCtx, func(ctx context.Context) error {
+			finalizeErr = ctx.Err()
+			deadline, ok := ctx.Deadline()
+			require.True(t, ok)
+			require.WithinDuration(t, time.Now().Add(idempotencyFinalizeTimeout), deadline, time.Second)
+			return nil
+		})
+
+		require.NoError(t, err)
+		require.NoError(t, finalizeErr)
+	})
+
 	t.Run("replay: same key same body twice returns the same response, handler runs once", func(t *testing.T) {
 		svc := idempotency.NewIdempotencyService(nil)
 		t.Cleanup(svc.Close)

--- a/internal/integrations/nmi/ambiguity_test.go
+++ b/internal/integrations/nmi/ambiguity_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/open-rails/openrails/config"
 )
@@ -94,6 +95,25 @@ func TestTransportAmbiguity_ConnectionRefused(t *testing.T) {
 	_, err = client.AddRecurringSubscription(RecurringPaymentData{PlanID: "p", CustomerVaultID: "v1", Currency: "USD"})
 	if !IsTransportAmbiguous(err) {
 		t.Fatalf("direct-post connection failure should be transport-ambiguous, got %v", err)
+	}
+}
+
+func TestCreateCustomerVaultTimeoutIsBoundedAndAmbiguous(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	client := testClient(t, srv.URL)
+	client.httpClient.Timeout = 20 * time.Millisecond
+	started := time.Now()
+	_, err := client.CreateCustomerVault(CreateCustomerVaultData{PaymentToken: "tok_test"})
+
+	if !IsTransportAmbiguous(err) {
+		t.Fatalf("timed-out vault create should be transport-ambiguous, got %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("vault create timeout took %s", elapsed)
 	}
 }
 


### PR DESCRIPTION
Summary:
- align card-save deadlines and classify ambiguous provider outcomes safely
- finalize idempotency records after client disconnects

Verification:
- go test ./...
- go vet ./...