### PR TITLE
feat: rate limit administrative operations

### DIFF
--- a/internal/controlplane/catalog.go
+++ b/internal/controlplane/catalog.go
@@ -168,12 +168,13 @@ const (
 	PermMerchantMembersManage          = permissions.MerchantMembersManage
 	PermMerchantCredentialsManage      = permissions.MerchantCredentialsManage
 
-	// --- Platform operator (root persona, #721): cross-merchant directory
-	// authority checked against the singleton root group, never a merchant
-	// group. `root:` is authkit's platform-operator namespace (#111 rename). ---
-	PermRootMerchantsRead    = permissions.RootMerchantsRead
-	PermRootMerchantsDelete  = permissions.RootMerchantsDelete
-	PermRootMerchantsRestore = permissions.RootMerchantsRestore
+	// --- Platform operator (root persona, #721): cross-merchant directory and
+	// operational override authority checked against the singleton root group,
+	// never a merchant group. `root:` is authkit's platform-operator namespace. ---
+	PermRootMerchantsRead         = permissions.RootMerchantsRead
+	PermRootMerchantsDelete       = permissions.RootMerchantsDelete
+	PermRootMerchantsRestore      = permissions.RootMerchantsRestore
+	PermRootAdminRateLimitsUnlock = permissions.RootAdminRateLimitsUnlock
 
 	// --- Customer treasury: a customer (any payer) acting on its OWN balance (NOT
 	// merchant-owner), scoped to /v1/customers/:customer_id/* (#567). Coarse: one

--- a/internal/http/embedhttp/embedhttp.go
+++ b/internal/http/embedhttp/embedhttp.go
@@ -75,6 +75,7 @@ type Assembler struct {
 	// RDB is the Redis/Garnet client backing the rate-limit counters + captcha
 	// challenge store. nil falls back to per-process in-memory rate-limit windows.
 	RDB           *redis.Client
+	AdminLimiter  *middleware.AdminOperationLimiter
 	Authenticator billingauth.Authenticator
 	Gate          billingauth.Gate
 	// DelegatedAuthenticator is the in-process host identity seam (#565). When set
@@ -147,6 +148,7 @@ func FromApp(a *app.App) *Assembler {
 		APIKeys:                   apiKeys,
 		CaptchaStore:              captcha.NewChallengeStore(a.RedisClient),
 		RDB:                       a.RedisClient,
+		AdminLimiter:              middleware.NewAdminOperationLimiter(a.RedisClient),
 		HostResolve:               hostResolve,
 	}
 	if checker != nil || resolver != nil {
@@ -216,8 +218,9 @@ func (s *Assembler) NewHTTPHandler(opts Options) http.Handler {
 	}
 	if routeSets[RouteSetMerchantAdmin] {
 		adminOpts := httproutes.Options{
-			Gate:    s.Gate,
-			APIKeys: s.APIKeys,
+			Gate:         s.Gate,
+			APIKeys:      s.APIKeys,
+			AdminLimiter: s.AdminLimiter,
 		}
 		// #528: per-user `/admin` retired; the delegated admin surface is mounted
 		// via embgin.SelfHandler (issuer→owner), not the base handler.

--- a/internal/http/middleware/admin_ratelimit.go
+++ b/internal/http/middleware/admin_ratelimit.go
@@ -1,0 +1,434 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	redis "github.com/redis/go-redis/v9"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/open-rails/openrails/internal/http/request"
+	"github.com/open-rails/openrails/internal/http/router"
+	"github.com/open-rails/openrails/pkg/api"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// AdminOperation identifies one security-sensitive merchant-console action.
+// Operations with the same policy still use separate counters unless they are
+// deliberately assigned the same identifier (the destructive actions below
+// share one aggregate blast-radius budget).
+type AdminOperation string
+
+const (
+	AdminOperationDestructive AdminOperation = "destructive"
+	AdminOperationExtend      AdminOperation = "extend"
+	AdminOperationOffChannel  AdminOperation = "off_channel"
+	AdminOperationGrant       AdminOperation = "grant"
+)
+
+const adminLockoutDuration = time.Hour
+
+type adminRateLimitWindow struct {
+	name     string
+	duration time.Duration
+	limit    int64
+}
+
+var adminRateLimitPolicies = map[AdminOperation][]adminRateLimitWindow{
+	AdminOperationDestructive: {
+		{name: "minute", duration: time.Minute, limit: 5},
+		{name: "hour", duration: time.Hour, limit: 10},
+		{name: "day", duration: 24 * time.Hour, limit: 50},
+	},
+	AdminOperationExtend: {
+		{name: "minute", duration: time.Minute, limit: 3},
+	},
+	AdminOperationOffChannel: {
+		{name: "minute", duration: time.Minute, limit: 10},
+	},
+	AdminOperationGrant: {
+		{name: "minute", duration: time.Minute, limit: 10},
+	},
+}
+
+// AdminRateLimitEvent is the structured audit/alert record emitted for every
+// protected request and explicit unlock. Threshold and lockout kinds are logged
+// at warning/error severity so production log alerting can page on them.
+type AdminRateLimitEvent struct {
+	Kind       string
+	UserID     string
+	ActorID    string
+	MerchantID string
+	Operation  AdminOperation
+	Counts     map[string]int64
+	RetryAfter time.Duration
+	RequestID  string
+}
+
+// AdminRateLimitEventSink receives audit/alert records synchronously and must
+// return quickly; external notification delivery belongs behind an async sink.
+type AdminRateLimitEventSink func(context.Context, AdminRateLimitEvent)
+
+type adminRateLimitDecision struct {
+	allowed    bool
+	wasLocked  bool
+	retryAfter time.Duration
+	counts     map[string]int64
+	thresholds []string
+}
+
+type adminMemoryCounter struct {
+	count int64
+	reset time.Time
+}
+
+type adminMemoryRateLimits struct {
+	mu       sync.Mutex
+	counters map[string]adminMemoryCounter
+	locks    map[string]time.Time
+}
+
+// AdminOperationLimiter enforces operation-specific, per-human-admin limits.
+// Redis is authoritative across replicas; the bounded in-process store keeps a
+// single-node deployment protected when Redis is absent or briefly unavailable.
+type AdminOperationLimiter struct {
+	rdb    *redis.Client
+	memory *adminMemoryRateLimits
+	now    func() time.Time
+	sink   AdminRateLimitEventSink
+}
+
+// NewAdminOperationLimiter builds the shared limiter used by both merchant
+// action middleware and the root-only unlock endpoint.
+func NewAdminOperationLimiter(rdb *redis.Client) *AdminOperationLimiter {
+	return &AdminOperationLimiter{
+		rdb: rdb,
+		memory: &adminMemoryRateLimits{
+			counters: make(map[string]adminMemoryCounter),
+			locks:    make(map[string]time.Time),
+		},
+		now:  time.Now,
+		sink: logAdminRateLimitEvent,
+	}
+}
+
+// AdminRateLimitMW applies one operation policy after the merchant permission
+// gate has pinned the effective principal. Non-human service credentials have
+// no UserID and retain their existing admission controls.
+func (l *AdminOperationLimiter) AdminRateLimitMW(operation AdminOperation) router.Middleware {
+	return func(next router.Handler) router.Handler {
+		return func(r *request.Request) {
+			if l == nil {
+				next(r)
+				return
+			}
+			user, ok := r.UserContext()
+			if !ok || strings.TrimSpace(user.UserID) == "" {
+				next(r)
+				return
+			}
+
+			userID, err := canonicalAdminUserID(user.UserID)
+			if err != nil {
+				r.AbortJSON(http.StatusInternalServerError, "administrative operation rate limit unavailable")
+				return
+			}
+			decision := l.evaluate(r.Request.Context(), userID, operation)
+			event := AdminRateLimitEvent{
+				UserID:     userID,
+				Operation:  operation,
+				Counts:     decision.counts,
+				RetryAfter: decision.retryAfter,
+				RequestID:  r.RequestID(),
+			}
+			if mid, found := merchant.FromContext(r.Request.Context()); found {
+				event.MerchantID = mid.String()
+			}
+
+			if !decision.allowed {
+				if decision.wasLocked {
+					event.Kind = "blocked"
+				} else {
+					event.Kind = "lockout"
+				}
+				l.emit(r.Request.Context(), event)
+				retrySeconds := int64(math.Ceil(decision.retryAfter.Seconds()))
+				if retrySeconds < 1 {
+					retrySeconds = 1
+				}
+				r.SetHeader("Retry-After", fmt.Sprintf("%d", retrySeconds))
+				r.APIError(&api.APIError{
+					HTTPStatus: http.StatusTooManyRequests,
+					Type:       api.ErrorTypeRateLimit,
+					Code:       api.CodeRateLimitExceeded,
+					Message:    "administrative operation rate limit exceeded",
+				})
+				return
+			}
+
+			event.Kind = "allowed"
+			l.emit(r.Request.Context(), event)
+			for _, window := range decision.thresholds {
+				thresholdEvent := event
+				thresholdEvent.Kind = "threshold"
+				thresholdEvent.Counts = map[string]int64{window: decision.counts[window]}
+				l.emit(r.Request.Context(), thresholdEvent)
+			}
+			next(r)
+		}
+	}
+}
+
+// Unlock clears the active lockout and current counters for userID. The actor
+// is recorded separately because root operators may unlock another admin.
+func (l *AdminOperationLimiter) Unlock(ctx context.Context, userID, actorID string) error {
+	if l == nil {
+		return nil
+	}
+	canonicalUserID, err := canonicalAdminUserID(userID)
+	if err != nil {
+		return fmt.Errorf("admin rate limit unlock: %w", err)
+	}
+	userID = canonicalUserID
+	now := l.now().UTC()
+	if l.rdb != nil {
+		if err := l.unlockRedis(ctx, userID, now); err != nil {
+			return fmt.Errorf("admin rate limit unlock: %w", err)
+		}
+	}
+	l.unlockMemory(userID)
+	l.emit(ctx, AdminRateLimitEvent{Kind: "unlocked", UserID: userID, ActorID: actorID})
+	return nil
+}
+
+func (l *AdminOperationLimiter) evaluate(ctx context.Context, userID string, operation AdminOperation) adminRateLimitDecision {
+	if canonicalUserID, err := canonicalAdminUserID(userID); err == nil {
+		userID = canonicalUserID
+	}
+	windows := adminRateLimitPolicies[operation]
+	if len(windows) == 0 {
+		return adminRateLimitDecision{allowed: true}
+	}
+	now := l.now().UTC()
+	if l.rdb != nil {
+		decision, err := l.evaluateRedis(ctx, userID, operation, windows, now)
+		if err == nil {
+			return decision
+		}
+		log.WithError(err).WithFields(log.Fields{
+			"admin_user_id": userID,
+			"operation":     operation,
+		}).Warn("admin rate limit redis error; falling back to in-memory limiter")
+	}
+	return l.evaluateMemory(userID, operation, windows, now)
+}
+
+func (l *AdminOperationLimiter) emit(ctx context.Context, event AdminRateLimitEvent) {
+	if l != nil && l.sink != nil {
+		l.sink(ctx, event)
+	}
+}
+
+func logAdminRateLimitEvent(ctx context.Context, event AdminRateLimitEvent) {
+	entry := log.WithContext(ctx).WithFields(log.Fields{
+		"audit_event":   "admin_rate_limit." + event.Kind,
+		"admin_user_id": event.UserID,
+		"actor_user_id": event.ActorID,
+		"merchant_id":   event.MerchantID,
+		"operation":     event.Operation,
+		"counts":        event.Counts,
+		"retry_after_s": int64(math.Ceil(event.RetryAfter.Seconds())),
+		"request_id":    event.RequestID,
+	})
+	switch event.Kind {
+	case "lockout":
+		entry.Error("admin operation lockout activated")
+	case "blocked", "threshold":
+		entry.Warn("admin operation rate limit alert")
+	default:
+		entry.Info("admin operation rate limit audit")
+	}
+}
+
+func (l *AdminOperationLimiter) evaluateMemory(userID string, operation AdminOperation, windows []adminRateLimitWindow, now time.Time) adminRateLimitDecision {
+	l.memory.mu.Lock()
+	defer l.memory.mu.Unlock()
+	l.memory.prune(now)
+
+	if until := l.memory.locks[userID]; until.After(now) {
+		return adminRateLimitDecision{allowed: false, wasLocked: true, retryAfter: until.Sub(now)}
+	}
+	delete(l.memory.locks, userID)
+
+	decision := adminRateLimitDecision{allowed: true, counts: make(map[string]int64, len(windows))}
+	breached := false
+	for _, window := range windows {
+		key := adminRateLimitCounterKey(userID, operation, window, now)
+		counter := l.memory.counters[key]
+		if !counter.reset.After(now) {
+			counter = adminMemoryCounter{reset: nextAdminRateLimitWindow(now, window.duration)}
+		}
+		counter.count++
+		l.memory.counters[key] = counter
+		decision.counts[window.name] = counter.count
+		if counter.count == adminRateLimitAlertThreshold(window.limit) {
+			decision.thresholds = append(decision.thresholds, window.name)
+		}
+		if counter.count > window.limit {
+			breached = true
+		}
+	}
+	if breached {
+		until := now.Add(adminLockoutDuration)
+		l.memory.locks[userID] = until
+		decision.allowed = false
+		decision.retryAfter = adminLockoutDuration
+	}
+	return decision
+}
+
+func (m *adminMemoryRateLimits) prune(now time.Time) {
+	for userID, until := range m.locks {
+		if !until.After(now) {
+			delete(m.locks, userID)
+		}
+	}
+	for key, counter := range m.counters {
+		if !counter.reset.After(now) {
+			delete(m.counters, key)
+		}
+	}
+	for len(m.counters) >= maxInMemoryRateLimitCounters {
+		var oldestKey string
+		var oldestReset time.Time
+		for key, counter := range m.counters {
+			if oldestKey == "" || counter.reset.Before(oldestReset) {
+				oldestKey = key
+				oldestReset = counter.reset
+			}
+		}
+		if oldestKey == "" {
+			return
+		}
+		delete(m.counters, oldestKey)
+	}
+}
+
+func (l *AdminOperationLimiter) unlockMemory(userID string) {
+	l.memory.mu.Lock()
+	defer l.memory.mu.Unlock()
+	delete(l.memory.locks, userID)
+	prefix := "admin-rl:{" + userID + "}:"
+	for key := range l.memory.counters {
+		if strings.HasPrefix(key, prefix) {
+			delete(l.memory.counters, key)
+		}
+	}
+}
+
+func adminRateLimitAlertThreshold(limit int64) int64 {
+	return int64(math.Ceil(float64(limit) * 0.8))
+}
+
+func nextAdminRateLimitWindow(now time.Time, duration time.Duration) time.Time {
+	seconds := int64(duration / time.Second)
+	return time.Unix(((now.Unix()/seconds)+1)*seconds, 0).UTC()
+}
+
+func adminRateLimitCounterKey(userID string, operation AdminOperation, window adminRateLimitWindow, now time.Time) string {
+	start := now.Unix() / int64(window.duration/time.Second)
+	return fmt.Sprintf("admin-rl:{%s}:%s:%s:%d", userID, operation, window.name, start)
+}
+
+func adminRateLimitLockKey(userID string) string {
+	return fmt.Sprintf("admin-rl:{%s}:lock", userID)
+}
+
+func canonicalAdminUserID(userID string) (string, error) {
+	id, err := uuid.Parse(strings.TrimSpace(userID))
+	if err != nil {
+		return "", fmt.Errorf("invalid user id")
+	}
+	return id.String(), nil
+}
+
+var adminRateLimitScript = redis.NewScript(`
+local lock_ttl = redis.call("TTL", KEYS[1])
+if lock_ttl > 0 then
+  local locked = {0, lock_ttl, 1}
+  for i = 2, #KEYS do table.insert(locked, 0) end
+  return locked
+end
+
+local counts = {}
+local breached = 0
+for i = 2, #KEYS do
+  local arg = ((i - 2) * 2) + 2
+  local count = redis.call("INCR", KEYS[i])
+  if count == 1 then redis.call("EXPIRE", KEYS[i], ARGV[arg]) end
+  table.insert(counts, count)
+  if count > tonumber(ARGV[arg + 1]) then breached = 1 end
+end
+
+if breached == 1 then
+  redis.call("SET", KEYS[1], "1", "EX", ARGV[1])
+end
+
+local result = {1, 0, 0}
+if breached == 1 then result = {0, tonumber(ARGV[1]), 0} end
+for _, count in ipairs(counts) do table.insert(result, count) end
+return result
+`)
+
+func (l *AdminOperationLimiter) evaluateRedis(ctx context.Context, userID string, operation AdminOperation, windows []adminRateLimitWindow, now time.Time) (adminRateLimitDecision, error) {
+	keys := make([]string, 1, len(windows)+1)
+	keys[0] = adminRateLimitLockKey(userID)
+	args := make([]any, 1, (len(windows)*2)+1)
+	args[0] = int64(adminLockoutDuration / time.Second)
+	for _, window := range windows {
+		keys = append(keys, adminRateLimitCounterKey(userID, operation, window, now))
+		ttl := int64(math.Ceil(nextAdminRateLimitWindow(now, window.duration).Sub(now).Seconds()))
+		if ttl < 1 {
+			ttl = 1
+		}
+		args = append(args, ttl, window.limit)
+	}
+
+	values, err := adminRateLimitScript.Run(ctx, l.rdb, keys, args...).Int64Slice()
+	if err != nil {
+		return adminRateLimitDecision{}, err
+	}
+	if len(values) != len(windows)+3 {
+		return adminRateLimitDecision{}, fmt.Errorf("unexpected redis result length %d", len(values))
+	}
+	decision := adminRateLimitDecision{
+		allowed:    values[0] == 1,
+		wasLocked:  values[2] == 1,
+		retryAfter: time.Duration(values[1]) * time.Second,
+		counts:     make(map[string]int64, len(windows)),
+	}
+	for i, window := range windows {
+		count := values[i+3]
+		decision.counts[window.name] = count
+		if count == adminRateLimitAlertThreshold(window.limit) {
+			decision.thresholds = append(decision.thresholds, window.name)
+		}
+	}
+	return decision, nil
+}
+
+func (l *AdminOperationLimiter) unlockRedis(ctx context.Context, userID string, now time.Time) error {
+	keys := []string{adminRateLimitLockKey(userID)}
+	for operation, windows := range adminRateLimitPolicies {
+		for _, window := range windows {
+			keys = append(keys, adminRateLimitCounterKey(userID, operation, window, now))
+		}
+	}
+	return l.rdb.Del(ctx, keys...).Err()
+}

--- a/internal/http/middleware/admin_ratelimit_integration_test.go
+++ b/internal/http/middleware/admin_ratelimit_integration_test.go
@@ -1,0 +1,33 @@
+//go:build integration
+
+package middleware
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/dbtest"
+)
+
+func TestAdminOperationLimiterRedisSharesLockoutAcrossInstances(t *testing.T) {
+	rdb, ctx := dbtest.SharedRedisClient(t)
+	now := time.Date(2026, time.August, 1, 12, 0, 0, 0, time.UTC)
+	first := NewAdminOperationLimiter(rdb)
+	first.now = func() time.Time { return now }
+	second := NewAdminOperationLimiter(rdb)
+	second.now = func() time.Time { return now }
+
+	for i := 0; i < 5; i++ {
+		require.True(t, first.evaluate(ctx, adminRateLimitTestUser, AdminOperationDestructive).allowed)
+	}
+	require.False(t, first.evaluate(ctx, adminRateLimitTestUser, AdminOperationDestructive).allowed)
+	blocked := second.evaluate(ctx, adminRateLimitTestUser, AdminOperationGrant)
+	require.False(t, blocked.allowed)
+	require.True(t, blocked.wasLocked)
+
+	require.NoError(t, second.Unlock(context.Background(), adminRateLimitTestUser, "root-operator"))
+	require.True(t, first.evaluate(ctx, adminRateLimitTestUser, AdminOperationDestructive).allowed)
+}

--- a/internal/http/middleware/admin_ratelimit_test.go
+++ b/internal/http/middleware/admin_ratelimit_test.go
@@ -1,0 +1,188 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/http/request"
+	"github.com/open-rails/openrails/internal/http/router"
+	"github.com/open-rails/openrails/pkg/billingauth"
+)
+
+const adminRateLimitTestUser = "11111111-1111-1111-1111-111111111111"
+
+func newTestAdminLimiter(now *time.Time) (*AdminOperationLimiter, *[]AdminRateLimitEvent) {
+	limiter := NewAdminOperationLimiter(nil)
+	limiter.now = func() time.Time { return *now }
+	events := make([]AdminRateLimitEvent, 0)
+	limiter.sink = func(_ context.Context, event AdminRateLimitEvent) {
+		events = append(events, event)
+	}
+	return limiter, &events
+}
+
+func TestAdminOperationLimiterDestructiveMinuteLimitAndLockout(t *testing.T) {
+	now := time.Date(2026, time.August, 1, 12, 0, 0, 0, time.UTC)
+	limiter, _ := newTestAdminLimiter(&now)
+
+	for i := 1; i <= 5; i++ {
+		decision := limiter.evaluate(context.Background(), adminRateLimitTestUser, AdminOperationDestructive)
+		require.True(t, decision.allowed, "request %d", i)
+		require.Equal(t, int64(i), decision.counts["minute"])
+	}
+
+	decision := limiter.evaluate(context.Background(), adminRateLimitTestUser, AdminOperationDestructive)
+	require.False(t, decision.allowed)
+	require.False(t, decision.wasLocked)
+	require.Equal(t, adminLockoutDuration, decision.retryAfter)
+
+	decision = limiter.evaluate(context.Background(), adminRateLimitTestUser, AdminOperationGrant)
+	require.False(t, decision.allowed, "lockout applies across protected operations")
+	require.True(t, decision.wasLocked)
+
+}
+
+func TestAdminOperationLimiterCanonicalizesUserID(t *testing.T) {
+	now := time.Date(2026, time.August, 1, 12, 0, 0, 0, time.UTC)
+	limiter, _ := newTestAdminLimiter(&now)
+	uppercase := "ABCDEFAB-CDEF-4ABC-8DEF-ABCDEFABCDEF"
+	lowercase := "abcdefab-cdef-4abc-8def-abcdefabcdef"
+
+	first := limiter.evaluate(context.Background(), uppercase, AdminOperationDestructive)
+	second := limiter.evaluate(context.Background(), lowercase, AdminOperationDestructive)
+
+	require.Equal(t, int64(1), first.counts["minute"])
+	require.Equal(t, int64(2), second.counts["minute"])
+}
+
+func TestAdminOperationLimiterHourlyAndDailyWindows(t *testing.T) {
+	t.Run("hour", func(t *testing.T) {
+		now := time.Date(2026, time.August, 1, 12, 1, 0, 0, time.UTC)
+		limiter, _ := newTestAdminLimiter(&now)
+		for i := 0; i < 10; i++ {
+			decision := limiter.evaluate(context.Background(), adminRateLimitTestUser, AdminOperationDestructive)
+			require.True(t, decision.allowed, "request %d", i+1)
+			now = now.Add(2 * time.Minute)
+		}
+		decision := limiter.evaluate(context.Background(), adminRateLimitTestUser, AdminOperationDestructive)
+		require.False(t, decision.allowed)
+		require.Equal(t, int64(11), decision.counts["hour"])
+	})
+
+	t.Run("day", func(t *testing.T) {
+		now := time.Date(2026, time.August, 1, 0, 1, 0, 0, time.UTC)
+		limiter, _ := newTestAdminLimiter(&now)
+		for hour := 0; hour < 10; hour++ {
+			for requestNumber := 0; requestNumber < 5; requestNumber++ {
+				decision := limiter.evaluate(context.Background(), adminRateLimitTestUser, AdminOperationDestructive)
+				require.True(t, decision.allowed, "hour %d request %d", hour, requestNumber+1)
+			}
+			now = now.Add(time.Hour)
+		}
+		decision := limiter.evaluate(context.Background(), adminRateLimitTestUser, AdminOperationDestructive)
+		require.False(t, decision.allowed)
+		require.Equal(t, int64(51), decision.counts["day"])
+	})
+}
+
+func TestAdminOperationLimiterExpensiveOperationPolicies(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation AdminOperation
+		limit     int
+	}{
+		{name: "extend", operation: AdminOperationExtend, limit: 3},
+		{name: "off channel", operation: AdminOperationOffChannel, limit: 10},
+		{name: "admin grant", operation: AdminOperationGrant, limit: 10},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			now := time.Date(2026, time.August, 1, 12, 0, 0, 0, time.UTC)
+			limiter, _ := newTestAdminLimiter(&now)
+			for i := 0; i < tc.limit; i++ {
+				require.True(t, limiter.evaluate(context.Background(), adminRateLimitTestUser, tc.operation).allowed)
+			}
+			require.False(t, limiter.evaluate(context.Background(), adminRateLimitTestUser, tc.operation).allowed)
+		})
+	}
+}
+
+func TestAdminOperationLimiterThresholdAuditAndHTTPResponse(t *testing.T) {
+	now := time.Date(2026, time.August, 1, 12, 0, 0, 0, time.UTC)
+	limiter, events := newTestAdminLimiter(&now)
+	handled := 0
+	handler := router.Chain(func(_ *request.Request) { handled++ }, []router.Middleware{
+		func(next router.Handler) router.Handler {
+			return func(r *request.Request) {
+				r.SetUserContext(billingauth.UserContext{UserID: adminRateLimitTestUser})
+				next(r)
+			}
+		},
+		limiter.AdminRateLimitMW(AdminOperationDestructive),
+	})
+
+	for i := 0; i < 6; i++ {
+		recorder := httptest.NewRecorder()
+		httpRequest := httptest.NewRequest(http.MethodPost, "/v1/merchant/subscriptions/sub_1/cancel", nil)
+		handler(request.NewHTTP(recorder, httpRequest, nil))
+		if i < 5 {
+			require.Equal(t, http.StatusOK, recorder.Code)
+			continue
+		}
+		require.Equal(t, http.StatusTooManyRequests, recorder.Code)
+		require.Equal(t, "3600", recorder.Header().Get("Retry-After"))
+		require.Contains(t, recorder.Body.String(), `"code":"rate_limit_exceeded"`)
+	}
+	require.Equal(t, 5, handled)
+
+	var thresholdEvents, lockoutEvents int
+	for _, event := range *events {
+		switch event.Kind {
+		case "threshold":
+			thresholdEvents++
+			require.Equal(t, map[string]int64{"minute": 4}, event.Counts)
+		case "lockout":
+			lockoutEvents++
+		}
+	}
+	require.Equal(t, 1, thresholdEvents, "80%% alert fires once on the crossing")
+	require.Equal(t, 1, lockoutEvents)
+}
+
+func TestAdminOperationLimiterUnlockClearsLockAndCounters(t *testing.T) {
+	now := time.Date(2026, time.August, 1, 12, 0, 0, 0, time.UTC)
+	limiter, events := newTestAdminLimiter(&now)
+	for i := 0; i < 6; i++ {
+		_ = limiter.evaluate(context.Background(), adminRateLimitTestUser, AdminOperationDestructive)
+	}
+
+	actorID := "22222222-2222-2222-2222-222222222222"
+	require.NoError(t, limiter.Unlock(context.Background(), adminRateLimitTestUser, actorID))
+	decision := limiter.evaluate(context.Background(), adminRateLimitTestUser, AdminOperationDestructive)
+	require.True(t, decision.allowed)
+	require.Equal(t, int64(1), decision.counts["minute"])
+	require.Equal(t, AdminRateLimitEvent{
+		Kind:    "unlocked",
+		UserID:  adminRateLimitTestUser,
+		ActorID: actorID,
+	}, (*events)[len(*events)-1])
+}
+
+func TestAdminOperationLimiterServicePrincipalIsNotUserBucketed(t *testing.T) {
+	now := time.Date(2026, time.August, 1, 12, 0, 0, 0, time.UTC)
+	limiter, _ := newTestAdminLimiter(&now)
+	handled := 0
+	handler := limiter.AdminRateLimitMW(AdminOperationDestructive)(func(_ *request.Request) { handled++ })
+
+	for i := 0; i < 20; i++ {
+		recorder := httptest.NewRecorder()
+		handler(request.NewHTTP(recorder, httptest.NewRequest(http.MethodPost, "/operation", nil), nil))
+		require.Equal(t, http.StatusOK, recorder.Code)
+	}
+	require.Equal(t, 20, handled)
+}

--- a/internal/http/routes/platform.go
+++ b/internal/http/routes/platform.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/google/uuid"
+
 	"github.com/open-rails/openrails/internal/app"
 	"github.com/open-rails/openrails/internal/controlplane"
 	httphandlers "github.com/open-rails/openrails/internal/http/handlers"
@@ -26,6 +28,13 @@ type RootPermissionChecker interface {
 type PlatformOptions struct {
 	Authenticator billingauth.Authenticator
 	Root          RootPermissionChecker
+	AdminLimiter  AdminRateLimitUnlocker
+}
+
+// AdminRateLimitUnlocker is the explicit root-operator override seam for an
+// active administrative-operation lockout.
+type AdminRateLimitUnlocker interface {
+	Unlock(ctx context.Context, userID, actorID string) error
 }
 
 // RegisterPlatformRoutes mounts the cross-merchant platform operator directory
@@ -38,12 +47,37 @@ func RegisterPlatformRoutes(rr router.Router, rt *app.Runtime, opts PlatformOpti
 	read := opts.platformPermissionMW(controlplane.PermRootMerchantsRead)
 	del := opts.platformPermissionMW(controlplane.PermRootMerchantsDelete)
 	restore := opts.platformPermissionMW(controlplane.PermRootMerchantsRestore)
+	unlock := opts.platformPermissionMW(controlplane.PermRootAdminRateLimitsUnlock)
 
 	merchants := rr.Group("/merchants")
 	merchants.Handle(http.MethodGet, "", h(httphandlers.PlatformListMerchants), read)
 	merchants.Handle(http.MethodGet, "/:id", h(httphandlers.PlatformGetMerchant), read)
 	merchants.Handle(http.MethodDelete, "/:id", h(httphandlers.PlatformSoftDeleteMerchant), del)
 	merchants.Handle(http.MethodPost, "/:id/restore", h(httphandlers.PlatformRestoreMerchant), restore)
+
+	// Root-owner-only manual override. Bounded merchant-directory roles do not
+	// hold this distinct permission.
+	rr.Handle(http.MethodDelete, "/admin-rate-limit-lockouts/:user_id", h(func(r *httprequest.Request) {
+		if opts.AdminLimiter == nil {
+			r.AbortJSON(http.StatusServiceUnavailable, "admin rate limit unlock unavailable")
+			return
+		}
+		target := r.Param("user_id")
+		if _, err := uuid.Parse(target); err != nil {
+			r.AbortJSON(http.StatusBadRequest, "invalid user_id")
+			return
+		}
+		actor, ok := r.UserContext()
+		if !ok || actor.UserID == "" {
+			r.AbortJSON(http.StatusUnauthorized, "authentication required")
+			return
+		}
+		if err := opts.AdminLimiter.Unlock(r.Request.Context(), target, actor.UserID); err != nil {
+			r.AbortJSON(http.StatusServiceUnavailable, "admin rate limit unlock unavailable")
+			return
+		}
+		r.SuccessJSONMessage("admin rate limit lockout cleared")
+	}), unlock)
 }
 
 // platformPermissionMW authenticates the user session and requires perm in the

--- a/internal/http/routes/platform_rate_limit_unlock_test.go
+++ b/internal/http/routes/platform_rate_limit_unlock_test.go
@@ -1,0 +1,84 @@
+package routes
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/controlplane"
+	"github.com/open-rails/openrails/internal/http/router"
+	"github.com/open-rails/openrails/pkg/billingauth"
+)
+
+type platformUnlockAuthenticator struct{}
+
+func (platformUnlockAuthenticator) Authenticate(context.Context, *http.Request) (billingauth.UserContext, error) {
+	return billingauth.UserContext{UserID: "22222222-2222-2222-2222-222222222222"}, nil
+}
+
+type platformUnlockRootChecker struct {
+	permission string
+}
+
+func (c *platformUnlockRootChecker) HasRootPermission(_ context.Context, _ string, permission string) (bool, error) {
+	c.permission = permission
+	return true, nil
+}
+
+type platformUnlockRecorder struct {
+	userID  string
+	actorID string
+}
+
+func (r *platformUnlockRecorder) Unlock(_ context.Context, userID, actorID string) error {
+	r.userID = userID
+	r.actorID = actorID
+	return nil
+}
+
+func TestPlatformAdminRateLimitUnlock(t *testing.T) {
+	mux := http.NewServeMux()
+	root := &platformUnlockRootChecker{}
+	unlocker := &platformUnlockRecorder{}
+	RegisterPlatformRoutes(router.NewMux(mux, "/v1/platform", nil), nil, PlatformOptions{
+		Authenticator: platformUnlockAuthenticator{},
+		Root:          root,
+		AdminLimiter:  unlocker,
+	})
+
+	target := "11111111-1111-1111-1111-111111111111"
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, httptest.NewRequest(
+		http.MethodDelete,
+		"/v1/platform/admin-rate-limit-lockouts/"+target,
+		nil,
+	))
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.Equal(t, controlplane.PermRootAdminRateLimitsUnlock, root.permission)
+	require.Equal(t, target, unlocker.userID)
+	require.Equal(t, "22222222-2222-2222-2222-222222222222", unlocker.actorID)
+}
+
+func TestPlatformAdminRateLimitUnlockRejectsInvalidTarget(t *testing.T) {
+	mux := http.NewServeMux()
+	unlocker := &platformUnlockRecorder{}
+	RegisterPlatformRoutes(router.NewMux(mux, "/v1/platform", nil), nil, PlatformOptions{
+		Authenticator: platformUnlockAuthenticator{},
+		Root:          &platformUnlockRootChecker{},
+		AdminLimiter:  unlocker,
+	})
+
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, httptest.NewRequest(
+		http.MethodDelete,
+		"/v1/platform/admin-rate-limit-lockouts/not-a-uuid",
+		nil,
+	))
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+	require.Empty(t, unlocker.userID)
+}

--- a/internal/http/routes/routes.go
+++ b/internal/http/routes/routes.go
@@ -44,6 +44,11 @@ type Options struct {
 	// *controlplane.ControlPlane. Nil (an embedded host without a control plane)
 	// keeps the /team routes mounted but answering 501.
 	Team httphandlers.MerchantTeamManager
+
+	// AdminLimiter is the #111 per-human-admin operation limiter. It runs after
+	// Gate has resolved the effective principal, so counters key the authorized
+	// user rather than an untrusted token claim or source IP.
+	AdminLimiter *middleware.AdminOperationLimiter
 }
 
 type GateOptions struct {
@@ -253,6 +258,9 @@ func RegisterServiceRoutes(rr router.Router, rt *app.Runtime, opts Options) {
 }
 
 func RegisterMerchantActionRoutes(rr router.Router, rt *app.Runtime, opts Options) {
+	if opts.AdminLimiter == nil && rt != nil {
+		opts.AdminLimiter = middleware.NewAdminOperationLimiter(rt.RedisClient)
+	}
 	var dbMW []router.Middleware
 	if rt != nil && rt.DB != nil {
 		dbMW = append(dbMW, middleware.MerchantDBConnMW(rt.DB))
@@ -679,11 +687,14 @@ func registerPaymentProviderActionRoutes(providers router.Router, rt *app.Runtim
 
 func registerMerchantSupportRoutes(rr router.Router, opts Options, dbMW ...router.Middleware) {
 	customerRead := append([]router.Middleware{opts.merchantActionPermissionMW(controlplane.PermMerchantCustomerSettingsRead)}, dbMW...)
-	customerWrite := append([]router.Middleware{opts.merchantActionPermissionMW(controlplane.PermMerchantCustomerSettingsUpdate)}, dbMW...)
+	offChannelWrite := opts.merchantAdminOperationMW(controlplane.PermMerchantCustomerSettingsUpdate, middleware.AdminOperationOffChannel, dbMW...)
+	grantWrite := opts.merchantAdminOperationMW(controlplane.PermMerchantCustomerSettingsUpdate, middleware.AdminOperationGrant, dbMW...)
+	revokeWrite := opts.merchantAdminOperationMW(controlplane.PermMerchantCustomerSettingsUpdate, middleware.AdminOperationDestructive, dbMW...)
 	payRead := append([]router.Middleware{opts.merchantActionPermissionMW(controlplane.PermMerchantPaymentsRead)}, dbMW...)
-	payRefund := append([]router.Middleware{opts.merchantActionPermissionMW(controlplane.PermMerchantPaymentsRefund)}, dbMW...)
+	payRefund := opts.merchantAdminOperationMW(controlplane.PermMerchantPaymentsRefund, middleware.AdminOperationDestructive, dbMW...)
 	subRead := append([]router.Middleware{opts.merchantActionPermissionMW(controlplane.PermMerchantSubscriptionsRead)}, dbMW...)
 	subWrite := append([]router.Middleware{opts.merchantActionPermissionMW(controlplane.PermMerchantSubscriptionsUpdate)}, dbMW...)
+	subCancel := opts.merchantAdminOperationMW(controlplane.PermMerchantSubscriptionsUpdate, middleware.AdminOperationDestructive, dbMW...)
 	repairRead := append([]router.Middleware{opts.merchantActionPermissionMW(controlplane.PermMerchantRepairAlertsRead)}, dbMW...)
 
 	// #740: merchant customer list/search for the admin console.
@@ -693,11 +704,11 @@ func registerMerchantSupportRoutes(rr router.Router, opts Options, dbMW ...route
 	customers.Handle(http.MethodGet, "", h(httphandlers.GetAdminUserBillingProfile), customerRead...)
 	customers.Handle(http.MethodGet, "/payment-methods", h(httphandlers.GetAdminUserPaymentMethods), customerRead...)
 	customers.Handle(http.MethodGet, "/payments", h(httphandlers.GetAdminUserPayments), payRead...)
-	customers.Handle(http.MethodPost, "/payments/off-channel", h(httphandlers.AdminCreateOffChannelPayment), customerWrite...)
-	customers.Handle(http.MethodPost, "/entitlements", h(httphandlers.GrantAdminEntitlement), customerWrite...)
-	customers.Handle(http.MethodDelete, "/entitlements/:id", h(httphandlers.RevokeAdminEntitlement), customerWrite...)
-	customers.Handle(http.MethodPost, "/product-access", h(httphandlers.GrantAdminProductAccess), customerWrite...)
-	customers.Handle(http.MethodDelete, "/product-access/:id", h(httphandlers.RevokeAdminProductAccess), customerWrite...)
+	customers.Handle(http.MethodPost, "/payments/off-channel", h(httphandlers.AdminCreateOffChannelPayment), offChannelWrite...)
+	customers.Handle(http.MethodPost, "/entitlements", h(httphandlers.GrantAdminEntitlement), grantWrite...)
+	customers.Handle(http.MethodDelete, "/entitlements/:id", h(httphandlers.RevokeAdminEntitlement), revokeWrite...)
+	customers.Handle(http.MethodPost, "/product-access", h(httphandlers.GrantAdminProductAccess), grantWrite...)
+	customers.Handle(http.MethodDelete, "/product-access/:id", h(httphandlers.RevokeAdminProductAccess), revokeWrite...)
 
 	payments := rr.Group("/payments")
 	payments.Handle(http.MethodGet, "", h(httphandlers.GetAdminPayments), payRead...)
@@ -707,7 +718,7 @@ func registerMerchantSupportRoutes(rr router.Router, opts Options, dbMW ...route
 	subs := rr.Group("/subscriptions")
 	subs.Handle(http.MethodGet, "", h(httphandlers.GetAdminSubscriptions), subRead...)
 	subs.Handle(http.MethodGet, "/:id", h(httphandlers.GetAdminSubscription), subRead...)
-	subs.Handle(http.MethodPost, "/:id/cancel", h(httphandlers.AdminCancelSubscription), subWrite...)
+	subs.Handle(http.MethodPost, "/:id/cancel", h(httphandlers.AdminCancelSubscription), subCancel...)
 	subs.Handle(http.MethodPost, "/:id/resume", h(httphandlers.AdminResumeSubscription), subWrite...)
 	subs.Handle(http.MethodPut, "/:id/payment-method", h(httphandlers.AdminUpdateSubscriptionPaymentMethod), subWrite...)
 	// #773 reprice: schedule a single subscription's price move at its next
@@ -823,6 +834,16 @@ func registerMerchantSupportRoutes(rr router.Router, opts Options, dbMW ...route
 	findings.Handle(http.MethodGet, "", h(httphandlers.AdminListFindings), repairRead...)
 	findings.Handle(http.MethodGet, "/:id", h(httphandlers.AdminGetFinding), repairRead...)
 	findings.Handle(http.MethodPost, "/:id/resolve", h(httphandlers.AdminResolveFinding), findingsResolve...)
+}
+
+// merchantAdminOperationMW keeps the authorization gate outermost, then applies
+// the user-keyed operation limiter before any merchant DB connection is pinned.
+func (opts Options) merchantAdminOperationMW(perm string, operation middleware.AdminOperation, trailing ...router.Middleware) []router.Middleware {
+	mw := []router.Middleware{opts.merchantActionPermissionMW(perm)}
+	if opts.AdminLimiter != nil && operation != "" {
+		mw = append(mw, opts.AdminLimiter.AdminRateLimitMW(operation))
+	}
+	return append(mw, trailing...)
 }
 
 // RegisterWebhookRoutes mounts the CANONICAL standalone webhook surface (#650):

--- a/internal/http/routes_admin.go
+++ b/internal/http/routes_admin.go
@@ -20,7 +20,8 @@ func (s *Server) registerMerchantActionRoutesAt(mux *http.ServeMux, apiPrefix st
 		// #757 self-serve API keys (mint/list/revoke via AuthKit core).
 		APIKeys: s.controlPlane,
 		// #760 team management (roster/invites/role/remove via AuthKit membership).
-		Team: s.controlPlane,
+		Team:         s.controlPlane,
+		AdminLimiter: s.adminLimiter,
 	}
 	// #555 HARD CUT: the merchant API surface is `/v1/merchant/*`. Standalone
 	// mounts every merchant route set here: human admin/support, settings/catalog,

--- a/internal/http/routes_platform.go
+++ b/internal/http/routes_platform.go
@@ -16,6 +16,7 @@ func (s *Server) registerPlatformRoutes(mux *http.ServeMux) {
 	opts := httproutes.PlatformOptions{
 		Authenticator: s.authenticator,
 		Root:          s.controlPlane,
+		AdminLimiter:  s.adminLimiter,
 	}
 	httproutes.RegisterPlatformRoutes(
 		router.NewMuxRecorded(mux, StandaloneV1Prefix+"/platform", s.runtime, s.recordRoute),

--- a/internal/http/server.go
+++ b/internal/http/server.go
@@ -64,6 +64,7 @@ type Server struct {
 	controlPlane           *controlplane.ControlPlane
 	delegatedResolver      middleware.DelegatedResolver
 	captchaStore           *captcha.ChallengeStore
+	adminLimiter           *middleware.AdminOperationLimiter
 	// consoleAssets is the host/binary-supplied admin console build (#754).
 	consoleAssets fs.FS
 
@@ -208,6 +209,7 @@ func New(deps Dependencies) (*Server, error) {
 		delegatedAuthenticator: deps.DelegatedAuthenticator,
 		controlPlane:           deps.ControlPlane,
 		captchaStore:           captcha.NewChallengeStore(deps.Redis),
+		adminLimiter:           middleware.NewAdminOperationLimiter(deps.Redis),
 		consoleAssets:          deps.ConsoleAssets,
 		browserTierRoutes:      middleware.NewBrowserTierRoutes(),
 	}

--- a/internal/integrationharness/testdata/standalone_route_surface.txt
+++ b/internal/integrationharness/testdata/standalone_route_surface.txt
@@ -8,6 +8,7 @@ DELETE /v1/merchant/payment-providers/{provider}
 DELETE /v1/merchant/team/invites/{id}
 DELETE /v1/merchant/team/{user_id}
 DELETE /v1/merchant/webhooks/{id}
+DELETE /v1/platform/admin-rate-limit-lockouts/{user_id}
 DELETE /v1/platform/merchants/{id}
 GET /health/live
 GET /health/ready

--- a/permissions/permissions.go
+++ b/permissions/permissions.go
@@ -62,12 +62,13 @@ const (
 // Platform-operator (root) permissions (#721). AuthKit's #111 rename made
 // `root:` the platform-operator namespace (was `platform:`); namespace purity
 // means root-persona roles may only hold `root:` perms, so openrails-saas #16's
-// platform:merchants:* map 1:1 onto these. They gate the cross-merchant
-// /v1/platform/merchants directory (standalone only).
+// platform:merchants:* map 1:1 onto these. They gate the standalone
+// cross-merchant directory and root-only operational overrides.
 const (
-	RootMerchantsRead    = "root:merchants:read"
-	RootMerchantsDelete  = "root:merchants:delete"
-	RootMerchantsRestore = "root:merchants:restore"
+	RootMerchantsRead         = "root:merchants:read"
+	RootMerchantsDelete       = "root:merchants:delete"
+	RootMerchantsRestore      = "root:merchants:restore"
+	RootAdminRateLimitsUnlock = "root:admin-rate-limits:unlock"
 )
 
 // Customer (buyer/treasury) permissions.

--- a/tests/admin_payments_test.go
+++ b/tests/admin_payments_test.go
@@ -41,7 +41,7 @@ func adminPaymentsReader(t *testing.T, suite *TestContainerSuite) http.Handler {
 // adminPaymentsWriter mounts the delegated merchant surface with refund access
 // and payments:read, which a refund operator naturally also holds.
 func adminPaymentsWriter(t *testing.T, suite *TestContainerSuite) http.Handler {
-	return newHostSeamAdminRouter(t, suite, "bc000000-0000-4000-8000-000000000002",
+	return newHostSeamAdminRouter(t, suite, uuid.NewString(),
 		[]string{controlplane.PermMerchantPaymentsRead, controlplane.PermMerchantPaymentsRefund})
 }
 
@@ -477,7 +477,6 @@ func TestAdminRefund_RequiresPaymentsWrite(t *testing.T) {
 // TestAdminRefundPayment tests POST /v1/merchant/payments/:id/refunds
 func TestAdminRefundPayment(t *testing.T) {
 	suite := getSharedTestSuite(t)
-	admin := adminPaymentsWriter(t, suite)
 
 	// Seed test data
 	products := suite.SeedProducts()
@@ -485,6 +484,7 @@ func TestAdminRefundPayment(t *testing.T) {
 	userID := uuid.New().String()
 
 	t.Run("returns 404 for non-existent payment", func(t *testing.T) {
+		admin := adminPaymentsWriter(t, suite)
 		nonExistentID := uuid.New()
 
 		w := httptest.NewRecorder()
@@ -499,6 +499,7 @@ func TestAdminRefundPayment(t *testing.T) {
 	})
 
 	t.Run("returns 400 for invalid payment ID", func(t *testing.T) {
+		admin := adminPaymentsWriter(t, suite)
 		w := httptest.NewRecorder()
 		body := `{"amount": 500}`
 		req, _ := http.NewRequest("POST", "/v1/merchant/payments/not-a-uuid/refunds", strings.NewReader(body))
@@ -510,6 +511,7 @@ func TestAdminRefundPayment(t *testing.T) {
 	})
 
 	t.Run("returns 400 for missing amount", func(t *testing.T) {
+		admin := adminPaymentsWriter(t, suite)
 		payment := suite.CreateTestPaymentWithOptions(PaymentOptions{
 			UserID:  userID,
 			PriceID: priceID,
@@ -529,6 +531,7 @@ func TestAdminRefundPayment(t *testing.T) {
 	})
 
 	t.Run("returns 400 for zero amount", func(t *testing.T) {
+		admin := adminPaymentsWriter(t, suite)
 		payment := suite.CreateTestPaymentWithOptions(PaymentOptions{
 			UserID:  userID,
 			PriceID: priceID,
@@ -548,6 +551,7 @@ func TestAdminRefundPayment(t *testing.T) {
 	})
 
 	t.Run("returns 400 for sub-cent refund micros", func(t *testing.T) {
+		admin := adminPaymentsWriter(t, suite)
 		// #671: RefundPayload.AmountCents is true cents; a refund amount with a
 		// sub-cent micros remainder is rejected, never rounded.
 		payment := suite.CreateTestPaymentWithOptions(PaymentOptions{
@@ -575,6 +579,7 @@ func TestAdminRefundPayment(t *testing.T) {
 	})
 
 	t.Run("returns actionable 400 for stripe historical non-refundable id", func(t *testing.T) {
+		admin := adminPaymentsWriter(t, suite)
 		payment := suite.CreateTestPaymentWithOptions(PaymentOptions{
 			UserID:        userID,
 			PriceID:       priceID,
@@ -603,6 +608,7 @@ func TestAdminRefundPayment(t *testing.T) {
 	})
 
 	t.Run("returns 400 for CCBill payments without a linked subscription", func(t *testing.T) {
+		admin := adminPaymentsWriter(t, suite)
 		// #696: CCBill refunds ride the DataLink intent path keyed off the linked
 		// subscription's CCBill subscription id. Without that link the API path
 		// can't resolve its refund coordinates — the 400 must say why and direct


### PR DESCRIPTION
## Summary

- add Redis-backed per-admin limits for destructive and expensive merchant operations
- emit structured threshold, lockout, and unlock audit events
- add a root-owner-only manual lockout override

## Verification

- `go test ./...`
- `go test -race ./internal/http/middleware ./internal/http/routes ./internal/http ./internal/http/embedhttp`
- `go test -tags=integration ./internal/http/middleware -run TestAdminOperationLimiterRedisSharesLockoutAcrossInstances -count=1`
- `go vet ./...`
- `git diff --check`
