### PR TITLE
fix(catalog): canonicalize credit grant declarations

### DIFF
--- a/pkg/catalog/load.go
+++ b/pkg/catalog/load.go
@@ -356,18 +356,11 @@ func validateCredits(productKey string, credits []CreditGrant, balances map[stri
 		if !ok {
 			return fmt.Errorf("product %q credit %q references unknown credit balance", productKey, credit.Key)
 		}
-		if strings.TrimSpace(credit.Unit) == "" && strings.TrimSpace(credit.Currency) != "" {
-			credit.Unit = credit.Currency
-		}
-		if strings.TrimSpace(credit.Unit) == "" {
-			credit.Unit = balance.Unit
-		}
-		if unit := strings.ToLower(strings.TrimSpace(credit.Unit)); unit != "" && !validCreditUnit(unit) {
-			return fmt.Errorf("product %q credit %q has invalid unit %q", productKey, credit.Key, credit.Unit)
-		}
+		credit.Unit = balance.Unit
 		if credit.Amount != nil && *credit.Amount <= 0 {
 			return fmt.Errorf("product %q credit %q amount must be positive", productKey, credit.Key)
 		}
+		credit.ExpiryHours = nil
 		expires := strings.TrimSpace(credit.Expires)
 		if expires == "" {
 			expires = strings.TrimSpace(balance.ExpiresDefault)

--- a/pkg/catalog/load_test.go
+++ b/pkg/catalog/load_test.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -162,6 +163,76 @@ credit_balances:
 	_, err := Load(writeManifest(t, body))
 	if err == nil || !strings.Contains(err.Error(), "providers/provider_links were renamed to psps/psp_links") {
 		t.Fatalf("want retired provider-key error, got %v", err)
+	}
+}
+
+func TestLoad_RejectsNoncanonicalCreditGrantFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		field     string
+		yamlValue string
+		jsonValue string
+	}{
+		{name: "unit", field: "unit", yamlValue: "other-credit", jsonValue: `"other-credit"`},
+		{name: "currency", field: "currency", yamlValue: "usd", jsonValue: `"usd"`},
+		{name: "expiry hours", field: "expiry_hours", yamlValue: "24", jsonValue: "24"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := `
+version: 1
+credit_balances:
+  - {key: credits, unit: credit}
+products:
+  - key: product
+    display_name: Product
+    credits:
+      - key: credits
+        amount: 10
+        ` + tt.field + `: ` + tt.yamlValue + `
+`
+			_, err := Parse([]byte(body))
+			if err == nil || !strings.Contains(err.Error(), "unknown field") {
+				t.Fatalf("want noncanonical %s rejection, got %v", tt.field, err)
+			}
+
+			var grant CreditGrant
+			err = json.Unmarshal([]byte(`{"key":"credits","`+tt.field+`":`+tt.jsonValue+`}`), &grant)
+			if err == nil || !strings.Contains(err.Error(), "unknown field") {
+				t.Fatalf("want noncanonical JSON %s rejection, got %v", tt.field, err)
+			}
+		})
+	}
+}
+
+func TestValidate_CreditGrantPreservesInternalCurrency(t *testing.T) {
+	amount := int64(10)
+	m := &Manifest{
+		Version: SupportedVersion,
+		CreditBalances: []CreditBalance{
+			{Key: "credits", Unit: "credit"},
+		},
+		Products: []Product{
+			{
+				Key:         "product",
+				DisplayName: "Product",
+				Credits: []CreditGrant{
+					{Key: "credits", Currency: "usd", Amount: &amount},
+				},
+			},
+		},
+	}
+
+	if err := m.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	grant := m.TierGroups[0].Products[0].Credits[0]
+	if grant.Unit != "credit" {
+		t.Fatalf("credit did not derive balance unit: %q", grant.Unit)
+	}
+	if grant.Currency != "usd" {
+		t.Fatalf("validation discarded internal currency: %q", grant.Currency)
 	}
 }
 
@@ -501,12 +572,10 @@ products:
     usage_limits: [starter-spend]
     credits:
       - key: monthly-usd
-        currency: usd
         amount: 25_000_000
         expires: 30d
         cadence: per_renewal
       - key: ai-images
-        unit: local-stack/ai-image-credit
         amount: 100
     prices:
       - currency: usd
@@ -526,10 +595,13 @@ products:
 		t.Fatalf("product benefits not normalized: %+v", p)
 	}
 	if got := p.Credits[0].Unit; got != "usd" {
-		t.Fatalf("credit currency alias did not populate unit: %q", got)
+		t.Fatalf("credit did not derive balance unit: %q", got)
+	}
+	if got := p.Credits[0].ExpiryHours; got == nil || *got != 30*24 {
+		t.Fatalf("credit expires did not populate expiry hours: %v", got)
 	}
 	if got := p.Credits[1].Unit; got != "local-stack/ai-image-credit" {
-		t.Fatalf("qualified custom credit unit not preserved: %q", got)
+		t.Fatalf("credit did not derive qualified balance unit: %q", got)
 	}
 	// #707: the metered: sugar translates into a rate card; the pure-usage
 	// (unit_amount 0) price row disappears.

--- a/pkg/catalog/manifest.go
+++ b/pkg/catalog/manifest.go
@@ -18,6 +18,11 @@
 // so apply can fan out explicitly across Stripe, NMI, CCBill and Solana.
 package catalog
 
+import (
+	"bytes"
+	"encoding/json"
+)
+
 // Manifest is the root of a catalog-as-code document.
 //
 // Every price declares its own `currency` and `psps` explicitly — there
@@ -97,13 +102,30 @@ type CreditBalance struct {
 }
 
 type CreditGrant struct {
-	Key         string `json:"key" yaml:"key"`
-	Unit        string `json:"unit,omitempty" yaml:"unit,omitempty"`
-	Currency    string `json:"currency,omitempty" yaml:"currency,omitempty"`
-	Amount      *int64 `json:"amount,omitempty" yaml:"amount,omitempty"`
-	ExpiryHours *int   `json:"expiry_hours,omitempty" yaml:"expiry_hours,omitempty"`
+	Key string `json:"key" yaml:"key"`
+	// Unit is resolved from the referenced CreditBalance during validation.
+	Unit string `json:"-" yaml:"-"`
+	// Currency is internal state; catalog v1 does not declare it on grants.
+	Currency string `json:"-" yaml:"-"`
+	Amount   *int64 `json:"amount,omitempty" yaml:"amount,omitempty"`
+	// ExpiryHours is resolved from Expires or the balance default.
+	ExpiryHours *int   `json:"-" yaml:"-"`
 	Expires     string `json:"expires,omitempty" yaml:"expires,omitempty"`
 	Cadence     string `json:"cadence,omitempty" yaml:"cadence,omitempty"`
+}
+
+// UnmarshalJSON keeps the HTTP catalog manifest as strict as the YAML parser.
+func (g *CreditGrant) UnmarshalJSON(raw []byte) error {
+	type manifestCreditGrant CreditGrant
+
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var declared manifestCreditGrant
+	if err := decoder.Decode(&declared); err != nil {
+		return err
+	}
+	*g = CreditGrant(declared)
+	return nil
 }
 
 func (p Product) tierRank() int {

--- a/pkg/embedded/catalog_dump.go
+++ b/pkg/embedded/catalog_dump.go
@@ -447,7 +447,18 @@ func creditGrants(raw []byte) []catalog.CreditGrant {
 	for _, k := range keys {
 		v := m[k]
 		amount := v.Amount
-		out = append(out, catalog.CreditGrant{Key: k, Unit: v.Unit, Amount: &amount, ExpiryHours: v.ExpiryHours, Cadence: v.Cadence})
+		expires := ""
+		if v.ExpiryHours != nil {
+			expires = hoursSpec(*v.ExpiryHours)
+		}
+		out = append(out, catalog.CreditGrant{
+			Key:         k,
+			Unit:        v.Unit,
+			Amount:      &amount,
+			ExpiryHours: v.ExpiryHours,
+			Expires:     expires,
+			Cadence:     v.Cadence,
+		})
 	}
 	return out
 }

--- a/pkg/embedded/catalog_dump_integration_test.go
+++ b/pkg/embedded/catalog_dump_integration_test.go
@@ -85,6 +85,8 @@ catalogs:
 	require.NoError(t, DumpMerchantCatalog(ctx, CatalogDumpOptions{
 		Config: cfg, PGXPool: pool, Merchant: merchantSlug, Out: &firstDump,
 	}))
+	require.Contains(t, firstDump.String(), "expires: 30d")
+	require.NotContains(t, firstDump.String(), "expiry_hours")
 	targets, err := loadCatalogPushTargets(CatalogPushOptions{Manifest: firstDump.Bytes()})
 	require.NoError(t, err, "dump should parse as push-catalog YAML")
 	require.Len(t, targets, 1)


### PR DESCRIPTION
## Summary

- derive each credit grant's unit from its referenced credit balance
- accept `expires` as the sole expiry declaration and emit it from catalog dumps
- reject noncanonical grant-level `unit`, `currency`, and `expiry_hours` fields in YAML and JSON manifests
- preserve internal `Currency` state while keeping it outside the catalog v1 wire contract

## Why

A grant could previously declare a unit that disagreed with the balance it named, causing credit deposits to target a different unit. Dumps also emitted the computed `expiry_hours` field instead of the canonical `expires` declaration.

## Validation

- `go test ./...`
- `go vet ./...`
- `DOCKER_HOST=unix:///Users/abdulrahmanyusuf/.colima/default/docker.sock TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock go test -tags=integration ./pkg/embedded -run '^TestCatalogPushDumpRoundTrip$' -count=1`
- `git diff --check`

Tracker: OpenRails #883