### PR TITLE
Complete provider configuration validation

### DIFF
--- a/internal/db/gen/psps.sql.go
+++ b/internal/db/gen/psps.sql.go
@@ -262,7 +262,7 @@ INSERT INTO openrails.psps (
     $6,
     COALESCE($7::boolean, false),
     $8,
-    COALESCE($9::timestamptz, now())
+    $9::timestamptz
 )
 ON CONFLICT (rail, environment, account_id) DO UPDATE SET
     key = COALESCE(EXCLUDED.key, openrails.psps.key),
@@ -272,7 +272,7 @@ ON CONFLICT (rail, environment, account_id) DO UPDATE SET
         ELSE NULL
     END,
     evidence = COALESCE(EXCLUDED.evidence, openrails.psps.evidence),
-    last_verified_at = EXCLUDED.last_verified_at,
+    last_verified_at = COALESCE(EXCLUDED.last_verified_at, openrails.psps.last_verified_at),
     updated_at = now()
 WHERE openrails.psps.merchant_id = EXCLUDED.merchant_id
 RETURNING id, merchant_id, rail, environment, account_id, key, evidence, first_seen_at, last_verified_at, replaced_at, created_at, updated_at, archived

--- a/internal/db/queries/psps.sql
+++ b/internal/db/queries/psps.sql
@@ -20,7 +20,7 @@ INSERT INTO openrails.psps (
     sqlc.narg(key),
     COALESCE(sqlc.narg(archived)::boolean, false),
     sqlc.narg(evidence),
-    COALESCE(sqlc.narg(last_verified_at)::timestamptz, now())
+    sqlc.narg(last_verified_at)::timestamptz
 )
 ON CONFLICT (rail, environment, account_id) DO UPDATE SET
     key = COALESCE(EXCLUDED.key, openrails.psps.key),
@@ -30,7 +30,7 @@ ON CONFLICT (rail, environment, account_id) DO UPDATE SET
         ELSE NULL
     END,
     evidence = COALESCE(EXCLUDED.evidence, openrails.psps.evidence),
-    last_verified_at = EXCLUDED.last_verified_at,
+    last_verified_at = COALESCE(EXCLUDED.last_verified_at, openrails.psps.last_verified_at),
     updated_at = now()
 WHERE openrails.psps.merchant_id = EXCLUDED.merchant_id
 RETURNING *;

--- a/internal/db/querytest/contracts_test.go
+++ b/internal/db/querytest/contracts_test.go
@@ -402,6 +402,37 @@ func TestRailMerchantAccountIdentityIsGlobal(t *testing.T) {
 	require.Equal(t, dbtest.TestMerchantID.UUID(), byIdentity.MerchantID)
 }
 
+func TestUpsertPSPOnlyRecordsExplicitValidation(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.SharedPGXPool(t)
+	dbtest.EnsureTestMerchant(ctx, t, pool)
+	q := gen.New(pool)
+	accountID := "validation-" + uuid.NewString()
+	params := gen.UpsertPSPParams{
+		MerchantID:  dbtest.TestMerchantID.UUID(),
+		Rail:        "nmi",
+		Environment: strptr("test"),
+		AccountID:   accountID,
+	}
+
+	unvalidated, err := q.UpsertPSP(ctx, params)
+	require.NoError(t, err)
+	require.Nil(t, unvalidated.LastVerifiedAt)
+
+	validatedAt := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	params.LastVerifiedAt = &validatedAt
+	validated, err := q.UpsertPSP(ctx, params)
+	require.NoError(t, err)
+	require.NotNil(t, validated.LastVerifiedAt)
+	require.True(t, validatedAt.Equal(*validated.LastVerifiedAt))
+
+	params.LastVerifiedAt = nil
+	preserved, err := q.UpsertPSP(ctx, params)
+	require.NoError(t, err)
+	require.NotNil(t, preserved.LastVerifiedAt)
+	require.True(t, validatedAt.Equal(*preserved.LastVerifiedAt))
+}
+
 func strptr(s string) *string { return &s }
 
 func int32ptr(i int32) *int32 { return &i }

--- a/internal/http/handlers/merchant_payment_providers.go
+++ b/internal/http/handlers/merchant_payment_providers.go
@@ -28,7 +28,10 @@ func MerchantListPaymentProviders(r *httprequest.Request) {
 		writeMerchantProviderError(r, err)
 		return
 	}
-	r.JSON(http.StatusOK, map[string]any{"data": items})
+	r.JSON(http.StatusOK, map[string]any{
+		"data":                 items,
+		"provider_definitions": merchants.PaymentProviderDefinitions(),
+	})
 }
 
 // MerchantGetPaymentProvider handles GET /v1/merchant/payment-providers/:provider.

--- a/internal/integrations/ccbill/credential_probe.go
+++ b/internal/integrations/ccbill/credential_probe.go
@@ -1,0 +1,20 @@
+package ccbill
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// ProbeCredentials verifies the DataLink account through a bounded, read-only
+// export window. It never creates or changes provider state.
+func (c *DataLinkClient) ProbeCredentials(ctx context.Context) error {
+	if err := c.ValidateConfig(); err != nil {
+		return err
+	}
+	end := time.Now().UTC()
+	if _, err := c.FetchTransactionExport(ctx, end.Add(-time.Second), end, []DataLinkTxnType{DataLinkTxnRebill}); err != nil {
+		return fmt.Errorf("ccbill credential probe: %w", err)
+	}
+	return nil
+}

--- a/internal/integrations/ccbill/credential_probe_test.go
+++ b/internal/integrations/ccbill/credential_probe_test.go
@@ -1,0 +1,59 @@
+package ccbill
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProbeCredentials(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		status    int
+		response  string
+		wantError bool
+	}{
+		{name: "valid credentials", status: http.StatusOK},
+		{name: "rejected credentials", status: http.StatusUnauthorized, wantError: true},
+		{name: "error payload", status: http.StatusOK, response: "Error: authentication failed", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.NoError(t, r.ParseForm())
+				assert.Equal(t, "REBILL", r.Form.Get("transactionTypes"))
+				assert.Equal(t, "900000", r.Form.Get("clientAccnum"))
+				assert.Equal(t, "0000", r.Form.Get("clientSubacc"))
+				assert.Equal(t, "user", r.Form.Get("username"))
+				assert.Equal(t, "pass", r.Form.Get("password"))
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			t.Cleanup(server.Close)
+
+			client := NewDataLinkClient(&config.CCBillConfig{
+				ClientAccNum:     "900000",
+				ClientSubAcc:     "0000",
+				DataLinkUsername: "user",
+				DataLinkPassword: "pass",
+			})
+			client.BaseURL = server.URL
+			client.HTTPClient = server.Client()
+
+			err := client.ProbeCredentials(t.Context())
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/integrations/nmi/client.go
+++ b/internal/integrations/nmi/client.go
@@ -1,6 +1,7 @@
 package nmi
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -368,7 +369,16 @@ func (c *NMIClient) sendDirectRequest(data url.Values) (_ string, err error) {
 }
 
 func (c *NMIClient) sendQueryRequest(data url.Values) (_ string, err error) {
-	resp, err := c.client().PostForm(c.QueryURL, data)
+	return c.sendQueryRequestWithContext(context.TODO(), data)
+}
+
+func (c *NMIClient) sendQueryRequestWithContext(ctx context.Context, data url.Values) (_ string, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.QueryURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("failed to build query request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := c.client().Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to send query request: %w", err)
 	}

--- a/internal/integrations/nmi/credential_probe.go
+++ b/internal/integrations/nmi/credential_probe.go
@@ -1,0 +1,37 @@
+package nmi
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// ProbeCredentials verifies the security key through a bounded, read-only
+// transaction query. It never creates or changes provider state.
+func (c *NMIClient) ProbeCredentials(ctx context.Context) error {
+	if err := c.checkConfiguration(); err != nil {
+		return err
+	}
+	raw, err := c.sendQueryRequestWithContext(ctx, url.Values{
+		"report_type":  {"transaction"},
+		"result_limit": {"1"},
+		"security_key": {c.SecurityKey},
+	})
+	if err != nil {
+		return fmt.Errorf("nmi credential probe: %w", err)
+	}
+	var response struct {
+		XMLName       xml.Name `xml:"nm_response"`
+		ErrorResponse string   `xml:"error_response"`
+	}
+	if err := xml.Unmarshal([]byte(raw), &response); err != nil {
+		return fmt.Errorf("nmi credential probe: parse response: %w", err)
+	}
+	if strings.TrimSpace(response.ErrorResponse) != "" {
+		return errors.New("nmi credential probe: provider rejected credentials")
+	}
+	return nil
+}

--- a/internal/integrations/nmi/credential_probe_test.go
+++ b/internal/integrations/nmi/credential_probe_test.go
@@ -1,0 +1,51 @@
+package nmi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProbeCredentials(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		response  string
+		wantError bool
+	}{
+		{name: "valid credentials", response: `<?xml version="1.0"?><nm_response></nm_response>`},
+		{name: "rejected credentials", response: `<?xml version="1.0"?><nm_response><error_response>Invalid security key</error_response></nm_response>`, wantError: true},
+		{name: "unexpected xml response", response: `<html></html>`, wantError: true},
+		{name: "invalid response", response: `not xml`, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.NoError(t, r.ParseForm())
+				assert.Equal(t, "transaction", r.Form.Get("report_type"))
+				assert.Equal(t, "1", r.Form.Get("result_limit"))
+				assert.Equal(t, "security-key", r.Form.Get("security_key"))
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			t.Cleanup(server.Close)
+
+			client, err := NewClient("nmi", &config.NMIProviderSettings{SecurityKey: "security-key"}, true)
+			require.NoError(t, err)
+			client.QueryURL = server.URL
+
+			err = client.ProbeCredentials(t.Context())
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/merchants/lifecycle.go
+++ b/internal/merchants/lifecycle.go
@@ -65,6 +65,10 @@ type Service struct {
 	// point it at a fake gateway instead of the real NMI API. Empty in
 	// production — the probe uses nmi.NewClient's documented default.
 	nmiProbeV5BaseURL string
+	// Credential-probe endpoint overrides are test-only seams for the
+	// read-only NMI Query API and CCBill DataLink checks.
+	nmiCredentialProbeQueryURL   string
+	ccbillCredentialProbeBaseURL string
 }
 
 // NewService builds the lifecycle service. pool is required (it owns the merchant

--- a/internal/merchants/nmi_probe_arm_integration_test.go
+++ b/internal/merchants/nmi_probe_arm_integration_test.go
@@ -22,6 +22,10 @@ func nmiProbeArmTestServer(t *testing.T, authCode string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/":
+			require.NoError(t, r.ParseForm())
+			require.NotEmpty(t, r.Form.Get("security_key"))
+			_, _ = w.Write([]byte(`<?xml version="1.0"?><nm_response></nm_response>`))
 		case r.Method == http.MethodPost && r.URL.Path == "/payments/auth":
 			var req struct {
 				PaymentDetails struct {
@@ -59,6 +63,7 @@ func TestUpsertPaymentProviderConfigRefusesLiveNMIUnderTestMode(t *testing.T) {
 	server := nmiProbeArmTestServer(t, "2") // declined -> LIVE account
 	defer server.Close()
 	svc.nmiProbeV5BaseURL = server.URL
+	svc.nmiCredentialProbeQueryURL = server.URL
 
 	ctx := context.Background()
 	tn, _, err := svc.Provision(ctx, ProvisionRequest{Slug: "probe-live-348", PermissionGroupID: "group-probe-live-348"})
@@ -86,6 +91,7 @@ func TestUpsertPaymentProviderConfigArmsSimulatedNMIUnderTestMode(t *testing.T) 
 	server := nmiProbeArmTestServer(t, "1") // approved -> simulating
 	defer server.Close()
 	svc.nmiProbeV5BaseURL = server.URL
+	svc.nmiCredentialProbeQueryURL = server.URL
 
 	ctx := context.Background()
 	tn, _, err := svc.Provision(ctx, ProvisionRequest{Slug: "probe-sim-348", PermissionGroupID: "group-probe-sim-348"})
@@ -111,6 +117,7 @@ func TestUpsertPaymentProviderConfigProbeIndeterminateNeverRefuses(t *testing.T)
 	server := nmiProbeArmTestServer(t, "3") // gateway-level error -> indeterminate
 	defer server.Close()
 	svc.nmiProbeV5BaseURL = server.URL
+	svc.nmiCredentialProbeQueryURL = server.URL
 
 	ctx := context.Background()
 	tn, _, err := svc.Provision(ctx, ProvisionRequest{Slug: "probe-indeterminate-348", PermissionGroupID: "group-probe-indeterminate-348"})
@@ -156,17 +163,21 @@ func TestUpsertPaymentProviderConfigCooldownRespected(t *testing.T) {
 	require.Contains(t, err.Error(), "cached probe verdict")
 }
 
-// TestUpsertPaymentProviderConfigSkipsProbeOutsideTestMode proves production
-// deployments (providerEnvironment == "live") never probe-charge on arm.
-func TestUpsertPaymentProviderConfigSkipsProbeOutsideTestMode(t *testing.T) {
+// TestUpsertPaymentProviderConfigSkipsTestModeProbeOutsideTestMode proves
+// production deployments never run the v5 test-card arm probe. The read-only
+// credential-validation query still runs.
+func TestUpsertPaymentProviderConfigSkipsTestModeProbeOutsideTestMode(t *testing.T) {
 	pool := newTestPool(t)
 	svc, err := NewService(db.WrapPool(pool, ""), NewMemorySecretStore(), "live")
 	require.NoError(t, err)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		t.Errorf("production (providerEnvironment=live) must never probe an NMI account on arm, got %s %s", r.Method, r.URL.Path)
+		require.Equal(t, "/", r.URL.Path, "production must skip the v5 test-mode probe")
+		require.NoError(t, r.ParseForm())
+		_, _ = w.Write([]byte(`<?xml version="1.0"?><nm_response></nm_response>`))
 	}))
 	defer server.Close()
 	svc.nmiProbeV5BaseURL = server.URL
+	svc.nmiCredentialProbeQueryURL = server.URL
 
 	ctx := context.Background()
 	tn, _, err := svc.Provision(ctx, ProvisionRequest{Slug: "probe-prod-348", PermissionGroupID: "group-probe-prod-348"})
@@ -193,6 +204,7 @@ func TestUpsertPaymentProviderConfigRefusesUsingExistingStoredKey(t *testing.T) 
 	require.NoError(t, err)
 	simServer := nmiProbeArmTestServer(t, "1") // first arm: simulating
 	svc.nmiProbeV5BaseURL = simServer.URL
+	svc.nmiCredentialProbeQueryURL = simServer.URL
 
 	ctx := context.Background()
 	tn, _, err := svc.Provision(ctx, ProvisionRequest{Slug: "probe-existing-348", PermissionGroupID: "group-probe-existing-348"})

--- a/internal/merchants/payment_provider_config.go
+++ b/internal/merchants/payment_provider_config.go
@@ -64,7 +64,8 @@ type UpsertPaymentProviderConfigRequest struct {
 }
 
 type railMerchantAccountEvidence struct {
-	PublicConfig map[string]string `json:"public_config,omitempty"`
+	PublicConfig         map[string]string `json:"public_config,omitempty"`
+	CredentialsValidated bool              `json:"credentials_validated,omitempty"`
 }
 
 // PaymentProviderDefinitions returns every merchant-configurable provider in
@@ -192,7 +193,13 @@ func (s *Service) UpsertPaymentProviderConfig(ctx context.Context, id merchant.I
 	}
 
 	secretNames := make(map[string]string, len(req.Credentials))
+	probeCredentials := make(map[string]string, len(req.Credentials))
+	credentialsValidated := false
 	for key, value := range req.Credentials {
+		normalizedKey, err := NormalizePSPSecretKey(rail, key)
+		if err != nil {
+			return PaymentProviderConfig{}, err
+		}
 		name, err := PSPSecretName(rail, environment, accountID, key)
 		if err != nil {
 			return PaymentProviderConfig{}, err
@@ -200,10 +207,24 @@ func (s *Service) UpsertPaymentProviderConfig(ctx context.Context, id merchant.I
 		if err := s.ValidateCredential(ctx, id, name, value, nil); err != nil {
 			return PaymentProviderConfig{}, err
 		}
+		if rail == "stripe" && normalizedKey == "secret_key" {
+			credentialsValidated = true
+		}
 		secretNames[name] = value
+		probeCredentials[normalizedKey] = value
+	}
+	probed, err := s.probePaymentProviderCredentials(ctx, id, rail, environment, accountID, probeCredentials)
+	if err != nil {
+		return PaymentProviderConfig{}, err
+	}
+	credentialsValidated = credentialsValidated || probed
+	var lastVerifiedAt *time.Time
+	if credentialsValidated {
+		now := time.Now().UTC()
+		lastVerifiedAt = &now
 	}
 
-	row, err := s.upsertRailMerchantAccount(ctx, id, rail, environment, accountID, enabled, req.PublicConfig)
+	row, err := s.upsertRailMerchantAccount(ctx, id, rail, environment, accountID, enabled, req.PublicConfig, credentialsValidated, lastVerifiedAt)
 	if err != nil {
 		return PaymentProviderConfig{}, err
 	}
@@ -252,14 +273,11 @@ func (s *Service) DeletePaymentProviderConfig(ctx context.Context, id merchant.I
 	return cfg, nil
 }
 
-func (s *Service) upsertRailMerchantAccount(ctx context.Context, id merchant.ID, rail, environment, accountID string, enabled bool, publicConfig map[string]string) (gen.OpenrailsPsp, error) {
-	evidence, err := marshalProviderEvidence(publicConfig)
-	if err != nil {
-		return gen.OpenrailsPsp{}, err
-	}
+func (s *Service) upsertRailMerchantAccount(ctx context.Context, id merchant.ID, rail, environment, accountID string, enabled bool, publicConfig map[string]string, credentialsValidated bool, lastVerifiedAt *time.Time) (gen.OpenrailsPsp, error) {
 	// #650: reject a cross-merchant claim with a clear error before the upsert
 	// (which would otherwise fail with an opaque unique-violation under RLS).
-	if err := AssertPSPUnowned(ctx, gen.New(s.pool), id.UUID(), rail, environment, accountID); err != nil {
+	queries := gen.New(s.pool)
+	if err := AssertPSPUnowned(ctx, queries, id.UUID(), rail, environment, accountID); err != nil {
 		return gen.OpenrailsPsp{}, err
 	}
 	archived := !enabled
@@ -267,17 +285,42 @@ func (s *Service) upsertRailMerchantAccount(ctx context.Context, id merchant.ID,
 	// normalized (rail, environment, account_id) the id is hashed from, so the
 	// id corresponds 1:1 to the unique index.
 	railAcctID, nRail, nEnv, nAccount := PSPNaturalKey(rail, environment, accountID)
+	if len(publicConfig) == 0 || !credentialsValidated {
+		existing, err := queries.GetPSPByRailIdentity(ctx, gen.GetPSPByRailIdentityParams{
+			Rail:        nRail,
+			Environment: &nEnv,
+			AccountID:   nAccount,
+		})
+		switch {
+		case err == nil:
+			existingEvidence := unmarshalProviderEvidence(existing.Evidence)
+			if len(publicConfig) == 0 {
+				publicConfig = existingEvidence.PublicConfig
+			}
+			if !credentialsValidated && existingEvidence.CredentialsValidated {
+				credentialsValidated = true
+				lastVerifiedAt = existing.LastVerifiedAt
+			}
+		case !errors.Is(err, pgx.ErrNoRows):
+			return gen.OpenrailsPsp{}, fmt.Errorf("merchants: load existing provider config: %w", err)
+		}
+	}
+	evidence, err := marshalProviderEvidence(publicConfig, credentialsValidated)
+	if err != nil {
+		return gen.OpenrailsPsp{}, err
+	}
 	var row gen.OpenrailsPsp
 	err = s.pool.MerchantTx(ctx, id, func(ctx context.Context, tx pgx.Tx) error {
 		var err error
 		row, err = gen.New(tx).UpsertPSP(ctx, gen.UpsertPSPParams{
-			ID:          railAcctID,
-			MerchantID:  id.UUID(),
-			Rail:        nRail,
-			Environment: &nEnv,
-			AccountID:   nAccount,
-			Archived:    &archived,
-			Evidence:    evidence,
+			ID:             railAcctID,
+			MerchantID:     id.UUID(),
+			Rail:           nRail,
+			Environment:    &nEnv,
+			AccountID:      nAccount,
+			Archived:       &archived,
+			Evidence:       evidence,
+			LastVerifiedAt: lastVerifiedAt,
 		})
 		return err
 	})
@@ -367,11 +410,16 @@ func isUndefinedTable(err error) bool {
 }
 
 func paymentProviderConfigFromRow(row gen.OpenrailsPsp, statuses []MerchantSecretStatus) PaymentProviderConfig {
+	evidence := unmarshalProviderEvidence(row.Evidence)
 	configured := map[string]struct{}{}
 	for _, st := range statuses {
 		if st.Configured {
 			configured[cleanSecretName(st.Name)] = struct{}{}
 		}
+	}
+	lastVerifiedAt := row.LastVerifiedAt
+	if !evidence.CredentialsValidated || !providerValidationCredentialsConfigured(row, configured) {
+		lastVerifiedAt = nil
 	}
 	credentials := make(map[string]PaymentProviderCredentialStatus)
 	for _, key := range paymentProviderCredentialKeys(row.Rail) {
@@ -380,9 +428,13 @@ func paymentProviderConfigFromRow(row gen.OpenrailsPsp, statuses []MerchantSecre
 			continue
 		}
 		_, ok := configured[name]
+		var validatedAt *time.Time
+		if ok {
+			validatedAt = credentialValidatedAt(row.Rail, key, lastVerifiedAt)
+		}
 		credentials[key] = PaymentProviderCredentialStatus{
 			Configured:      ok,
-			LastValidatedAt: row.LastVerifiedAt,
+			LastValidatedAt: validatedAt,
 		}
 	}
 	return PaymentProviderConfig{
@@ -391,14 +443,38 @@ func paymentProviderConfigFromRow(row gen.OpenrailsPsp, statuses []MerchantSecre
 		Environment:    row.Environment,
 		AccountID:      row.AccountID,
 		Archived:       row.Archived,
-		PublicConfig:   unmarshalProviderEvidence(row.Evidence).PublicConfig,
+		PublicConfig:   evidence.PublicConfig,
 		Credentials:    credentials,
 		FirstSeenAt:    row.FirstSeenAt,
-		LastVerifiedAt: row.LastVerifiedAt,
+		LastVerifiedAt: lastVerifiedAt,
 		ReplacedAt:     row.ReplacedAt,
 		CreatedAt:      row.CreatedAt,
 		UpdatedAt:      row.UpdatedAt,
 	}
+}
+
+func providerValidationCredentialsConfigured(row gen.OpenrailsPsp, configured map[string]struct{}) bool {
+	requiredKeys := []string{}
+	switch row.Rail {
+	case "stripe":
+		requiredKeys = []string{"secret_key"}
+	case "nmi":
+		requiredKeys = []string{"security_key"}
+	case "ccbill":
+		requiredKeys = []string{"datalink_username", "datalink_password"}
+	default:
+		return false
+	}
+	for _, key := range requiredKeys {
+		name, err := PSPSecretName(row.Rail, row.Environment, row.AccountID, key)
+		if err != nil {
+			return false
+		}
+		if _, ok := configured[name]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func pspLifecycleMatches(archived bool, status string) bool {
@@ -425,11 +501,35 @@ func paymentProviderCredentialKeys(provider string) []string {
 	return rails.MerchantCredentialKeyNames(models.Rail(provider))
 }
 
-func marshalProviderEvidence(publicConfig map[string]string) ([]byte, error) {
-	if len(publicConfig) == 0 {
+func credentialValidatedAt(rail, key string, validatedAt *time.Time) *time.Time {
+	if validatedAt == nil {
+		return nil
+	}
+	switch rail {
+	case "stripe":
+		if key == "secret_key" {
+			return validatedAt
+		}
+	case "nmi":
+		if key == "security_key" {
+			return validatedAt
+		}
+	case "ccbill":
+		if key == "datalink_username" || key == "datalink_password" {
+			return validatedAt
+		}
+	}
+	return nil
+}
+
+func marshalProviderEvidence(publicConfig map[string]string, credentialsValidated bool) ([]byte, error) {
+	if len(publicConfig) == 0 && !credentialsValidated {
 		return nil, nil
 	}
-	b, err := json.Marshal(railMerchantAccountEvidence{PublicConfig: publicConfig})
+	b, err := json.Marshal(railMerchantAccountEvidence{
+		PublicConfig:         publicConfig,
+		CredentialsValidated: credentialsValidated,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal provider config evidence: %w", err)
 	}

--- a/internal/merchants/payment_provider_config.go
+++ b/internal/merchants/payment_provider_config.go
@@ -46,6 +46,14 @@ type PaymentProviderConfig struct {
 	UpdatedAt       time.Time                                  `json:"updated_at"`
 }
 
+// PaymentProviderDefinition describes one merchant-configurable provider from
+// the rail registry. CredentialKeys contains only merchant-writable secrets.
+type PaymentProviderDefinition struct {
+	Rail           string   `json:"rail"`
+	DisplayName    string   `json:"display_name"`
+	CredentialKeys []string `json:"credential_keys"`
+}
+
 // UpsertPaymentProviderConfigRequest creates or replaces one provider account.
 type UpsertPaymentProviderConfigRequest struct {
 	Environment  string            `json:"environment"`
@@ -57,6 +65,28 @@ type UpsertPaymentProviderConfigRequest struct {
 
 type railMerchantAccountEvidence struct {
 	PublicConfig map[string]string `json:"public_config,omitempty"`
+}
+
+// PaymentProviderDefinitions returns every merchant-configurable provider in
+// registry order.
+func PaymentProviderDefinitions() []PaymentProviderDefinition {
+	descriptors := rails.All()
+	definitions := make([]PaymentProviderDefinition, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		if !descriptor.HasRailMerchantAccounts {
+			continue
+		}
+		credentialKeys := rails.MerchantCredentialKeyNames(descriptor.Rail)
+		if credentialKeys == nil {
+			credentialKeys = []string{}
+		}
+		definitions = append(definitions, PaymentProviderDefinition{
+			Rail:           string(descriptor.Rail),
+			DisplayName:    descriptor.DisplayName,
+			CredentialKeys: credentialKeys,
+		})
+	}
+	return definitions
 }
 
 // ListPaymentProviderConfigs returns provider-account configs for a merchant.

--- a/internal/merchants/payment_provider_config_test.go
+++ b/internal/merchants/payment_provider_config_test.go
@@ -40,7 +40,7 @@ func TestPaymentProviderConfigFromRowRedactsCredentials(t *testing.T) {
 		Environment:    "live",
 		AccountID:      "acct_123",
 		Archived:       false,
-		Evidence:       []byte(`{"public_config":{"publishable_key":"pk_live_123"}}`),
+		Evidence:       []byte(`{"public_config":{"publishable_key":"pk_live_123"},"credentials_validated":true}`),
 		FirstSeenAt:    now,
 		LastVerifiedAt: &now,
 		CreatedAt:      now,
@@ -59,8 +59,60 @@ func TestPaymentProviderConfigFromRowRedactsCredentials(t *testing.T) {
 	if got.Credentials["secret_key"].LastValidatedAt == nil {
 		t.Fatal("secret_key should carry last validation metadata")
 	}
+	if got.Credentials["webhook_signing_secret"].LastValidatedAt != nil {
+		t.Fatal("format-only webhook secret must not carry live validation metadata")
+	}
 	if _, leaked := any(got.Credentials["secret_key"]).(string); leaked {
 		t.Fatal("credential status leaked plaintext")
+	}
+}
+
+func TestPaymentProviderConfigFromRowHidesUnprovenTimestamp(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	secretName, err := PSPSecretName("nmi", "live", "gateway", "security_key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := paymentProviderConfigFromRow(gen.OpenrailsPsp{
+		Rail:           "nmi",
+		Environment:    "live",
+		AccountID:      "gateway",
+		LastVerifiedAt: &now,
+	}, []MerchantSecretStatus{{
+		SecretDefinition: SecretDefinition{Name: secretName},
+		Configured:       true,
+	}})
+
+	if got.LastVerifiedAt != nil || got.Credentials["security_key"].LastValidatedAt != nil {
+		t.Fatal("an auto-stamped timestamp without probe evidence must stay hidden")
+	}
+}
+
+func TestCredentialValidatedAtOnlyMarksLiveProbedCredentials(t *testing.T) {
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		rail string
+		key  string
+		want bool
+	}{
+		{name: "stripe secret key", rail: "stripe", key: "secret_key", want: true},
+		{name: "stripe webhook secret", rail: "stripe", key: "webhook_signing_secret"},
+		{name: "nmi security key", rail: "nmi", key: "security_key", want: true},
+		{name: "nmi webhook secret", rail: "nmi", key: "webhook_signing_secret"},
+		{name: "ccbill datalink username", rail: "ccbill", key: "datalink_username", want: true},
+		{name: "ccbill datalink password", rail: "ccbill", key: "datalink_password", want: true},
+		{name: "ccbill salt", rail: "ccbill", key: "salt"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := credentialValidatedAt(tt.rail, tt.key, &now)
+			if (got != nil) != tt.want {
+				t.Fatalf("credentialValidatedAt(%q, %q) validated = %t, want %t", tt.rail, tt.key, got != nil, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/merchants/payment_provider_config_test.go
+++ b/internal/merchants/payment_provider_config_test.go
@@ -2,6 +2,7 @@ package merchants
 
 import (
 	"context"
+	"reflect"
 	"testing"
 	"time"
 
@@ -10,6 +11,20 @@ import (
 	"github.com/open-rails/openrails/internal/db/gen"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
+
+func TestPaymentProviderDefinitions(t *testing.T) {
+	expected := []PaymentProviderDefinition{
+		{Rail: "nmi", DisplayName: "Credit Card", CredentialKeys: []string{"security_key", "webhook_signing_secret"}},
+		{Rail: "ccbill", DisplayName: "Credit Card", CredentialKeys: []string{"salt", "datalink_username", "datalink_password"}},
+		{Rail: "stripe", DisplayName: "Stripe", CredentialKeys: []string{"secret_key", "webhook_signing_secret", "webhook_signing_secret_thin"}},
+		{Rail: "solana", DisplayName: "Solana", CredentialKeys: []string{}},
+		{Rail: "vaulted_card", DisplayName: "Credit Card", CredentialKeys: []string{"api_key"}},
+	}
+
+	if got := PaymentProviderDefinitions(); !reflect.DeepEqual(got, expected) {
+		t.Fatalf("PaymentProviderDefinitions() = %#v, want %#v", got, expected)
+	}
+}
 
 func TestPaymentProviderConfigFromRowRedactsCredentials(t *testing.T) {
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)

--- a/internal/merchants/payment_provider_validation.go
+++ b/internal/merchants/payment_provider_validation.go
@@ -1,0 +1,95 @@
+package merchants
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/integrations/ccbill"
+	"github.com/open-rails/openrails/internal/integrations/nmi"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+const providerCredentialProbeTimeout = 15 * time.Second
+
+func (s *Service) probePaymentProviderCredentials(ctx context.Context, id merchant.ID, rail, environment, accountID string, supplied map[string]string) (bool, error) {
+	switch rail {
+	case "nmi":
+		securityKey, ok, err := s.effectiveProviderCredential(ctx, id, rail, environment, accountID, supplied, "security_key")
+		if err != nil || !ok {
+			return false, err
+		}
+		client, err := nmi.NewClient(accountID, &config.NMIProviderSettings{SecurityKey: securityKey}, environment == "test")
+		if err != nil {
+			return false, fmt.Errorf("merchants: build nmi credential probe: %w", err)
+		}
+		if s.nmiCredentialProbeQueryURL != "" {
+			client.QueryURL = s.nmiCredentialProbeQueryURL
+		}
+		probeCtx, cancel := context.WithTimeout(ctx, providerCredentialProbeTimeout)
+		defer cancel()
+		if err := client.ProbeCredentials(probeCtx); err != nil {
+			return false, fmt.Errorf("merchants: validate nmi credentials: %w", err)
+		}
+		return true, nil
+
+	case "ccbill":
+		username, hasUsername, err := s.effectiveProviderCredential(ctx, id, rail, environment, accountID, supplied, "datalink_username")
+		if err != nil {
+			return false, err
+		}
+		password, hasPassword, err := s.effectiveProviderCredential(ctx, id, rail, environment, accountID, supplied, "datalink_password")
+		if err != nil {
+			return false, err
+		}
+		if !hasUsername && !hasPassword {
+			return false, nil
+		}
+		if !hasUsername || !hasPassword {
+			return false, errors.New("merchants: ccbill datalink_username and datalink_password are required together")
+		}
+		clientAccNum, clientSubAcc, err := config.SplitCCBillAccountID(accountID)
+		if err != nil {
+			return false, fmt.Errorf("merchants: validate ccbill account id: %w", err)
+		}
+		client := ccbill.NewDataLinkClient(&config.CCBillConfig{
+			ClientAccNum:     clientAccNum,
+			ClientSubAcc:     clientSubAcc,
+			DataLinkUsername: username,
+			DataLinkPassword: password,
+			TestMode:         environment == "test",
+		})
+		if s.ccbillCredentialProbeBaseURL != "" {
+			client.BaseURL = s.ccbillCredentialProbeBaseURL
+		}
+		probeCtx, cancel := context.WithTimeout(ctx, providerCredentialProbeTimeout)
+		defer cancel()
+		if err := client.ProbeCredentials(probeCtx); err != nil {
+			return false, fmt.Errorf("merchants: validate ccbill credentials: %w", err)
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func (s *Service) effectiveProviderCredential(ctx context.Context, id merchant.ID, rail, environment, accountID string, supplied map[string]string, key string) (string, bool, error) {
+	if value := strings.TrimSpace(supplied[key]); value != "" {
+		return value, true, nil
+	}
+	name, err := PSPSecretName(rail, environment, accountID, key)
+	if err != nil {
+		return "", false, err
+	}
+	secret, err := s.secrets.Get(ctx, id, name)
+	if errors.Is(err, ErrSecretNotFound) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("merchants: load provider credential %q: %w", key, err)
+	}
+	value := strings.TrimSpace(secret.Value)
+	return value, value != "", nil
+}

--- a/internal/merchants/payment_provider_validation_integration.go
+++ b/internal/merchants/payment_provider_validation_integration.go
@@ -1,0 +1,17 @@
+//go:build integration
+
+package merchants
+
+// SetCredentialProbeEndpointsForIntegration points live credential probes at
+// integration-test provider servers. It is excluded from production builds.
+func (s *Service) SetCredentialProbeEndpointsForIntegration(nmiQueryURL, ccbillDataLinkBaseURL string) {
+	if s == nil {
+		return
+	}
+	if nmiQueryURL != "" {
+		s.nmiCredentialProbeQueryURL = nmiQueryURL
+	}
+	if ccbillDataLinkBaseURL != "" {
+		s.ccbillCredentialProbeBaseURL = ccbillDataLinkBaseURL
+	}
+}

--- a/internal/merchants/payment_provider_validation_test.go
+++ b/internal/merchants/payment_provider_validation_test.go
@@ -1,0 +1,73 @@
+package merchants
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/open-rails/openrails/pkg/merchant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProbePaymentProviderCredentialsNMI(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.NoError(t, r.ParseForm())
+		assert.Equal(t, "security-key", r.Form.Get("security_key"))
+		_, _ = w.Write([]byte(`<?xml version="1.0"?><nm_response></nm_response>`))
+	}))
+	t.Cleanup(server.Close)
+
+	svc := &Service{
+		secrets:                    NewMemorySecretStore(),
+		nmiCredentialProbeQueryURL: server.URL,
+	}
+	validated, err := svc.probePaymentProviderCredentials(
+		t.Context(), merchant.ID(uuid.New()), "nmi", "test", "gateway", map[string]string{"security_key": "security-key"},
+	)
+	require.NoError(t, err)
+	assert.True(t, validated)
+}
+
+func TestProbePaymentProviderCredentialsCCBillUsesEffectivePair(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.NoError(t, r.ParseForm())
+		assert.Equal(t, "new-user", r.Form.Get("username"))
+		assert.Equal(t, "stored-pass", r.Form.Get("password"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	id := merchant.ID(uuid.New())
+	store := NewMemorySecretStore()
+	passwordName, err := PSPSecretName("ccbill", "live", "900000-0000", "datalink_password")
+	require.NoError(t, err)
+	_, err = store.Put(t.Context(), id, passwordName, "stored-pass")
+	require.NoError(t, err)
+
+	svc := &Service{
+		secrets:                      store,
+		ccbillCredentialProbeBaseURL: server.URL,
+	}
+	validated, err := svc.probePaymentProviderCredentials(
+		t.Context(), id, "ccbill", "live", "900000-0000", map[string]string{"datalink_username": "new-user"},
+	)
+	require.NoError(t, err)
+	assert.True(t, validated)
+}
+
+func TestProbePaymentProviderCredentialsCCBillRequiresCompletePair(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{secrets: NewMemorySecretStore()}
+	validated, err := svc.probePaymentProviderCredentials(
+		t.Context(), merchant.ID(uuid.New()), "ccbill", "live", "900000-0000", map[string]string{"datalink_username": "user"},
+	)
+	require.ErrorContains(t, err, "required together")
+	assert.False(t, validated)
+}

--- a/internal/merchantsecrets/vault_scenarios_integration_test.go
+++ b/internal/merchantsecrets/vault_scenarios_integration_test.go
@@ -10,6 +10,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"path"
 	"strings"
 	"testing"
@@ -167,6 +169,11 @@ func TestVaultFullStack_PaymentProviderConfigRotationAndIsolation(t *testing.T) 
 
 	svc, err := merchants.NewService(pool, store.Secrets, "live")
 	require.NoError(t, err)
+	probeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`<?xml version="1.0"?><nm_response></nm_response>`))
+	}))
+	t.Cleanup(probeServer.Close)
+	svc.SetCredentialProbeEndpointsForIntegration(probeServer.URL, "")
 
 	midA, slugA := registerMerchant(t, ctx, pool, "vfs-a")
 	midB, slugB := registerMerchant(t, ctx, pool, "vfs-b")

--- a/internal/reconcile/merchant_wiring_integration_test.go
+++ b/internal/reconcile/merchant_wiring_integration_test.go
@@ -4,6 +4,8 @@ package reconcile
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -42,6 +44,11 @@ func newWiringService(t *testing.T, dbi *db.DB) *merchants.Service {
 	t.Helper()
 	svc, err := merchants.NewService(dbi.DataPool(), merchants.NewMemorySecretStore(), "live")
 	require.NoError(t, err)
+	probeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`<?xml version="1.0"?><nm_response></nm_response>`))
+	}))
+	t.Cleanup(probeServer.Close)
+	svc.SetCredentialProbeEndpointsForIntegration(probeServer.URL, "")
 	return svc
 }
 

--- a/internal/river/jobs_provider_refresh_pull_integration_test.go
+++ b/internal/river/jobs_provider_refresh_pull_integration_test.go
@@ -195,6 +195,13 @@ func pullTestMerchantsService(t *testing.T, dbi *db.DB) *merchants.Service {
 	t.Helper()
 	svc, err := merchants.NewService(dbi.DataPool(), merchants.NewMemorySecretStore(), "live")
 	require.NoError(t, err)
+	nmiProbeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`<?xml version="1.0"?><nm_response></nm_response>`))
+	}))
+	t.Cleanup(nmiProbeServer.Close)
+	ccbillProbeServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	t.Cleanup(ccbillProbeServer.Close)
+	svc.SetCredentialProbeEndpointsForIntegration(nmiProbeServer.URL, ccbillProbeServer.URL)
 	return svc
 }
 

--- a/web/admin/src/lib/api/endpoints.ts
+++ b/web/admin/src/lib/api/endpoints.ts
@@ -25,6 +25,7 @@ import type {
   PaymentMethodResponse,
   PaymentObject,
   PaymentProviderConfig,
+  PaymentProviderDefinition,
   PriceKeyHistoryEntry,
   RawEntitlement,
   RepairAlert,
@@ -311,7 +312,10 @@ export const putMerchantSettings = (body: MerchantSettings) =>
   api<{ message: string }>("/merchant/settings", { method: "PUT", body })
 
 export const listPaymentProviders = () =>
-  api<{ data: PaymentProviderConfig[] }>("/merchant/payment-providers")
+  api<{
+    data: PaymentProviderConfig[]
+    provider_definitions: PaymentProviderDefinition[]
+  }>("/merchant/payment-providers")
 
 export interface UpsertProviderRequest {
   environment?: string

--- a/web/admin/src/lib/api/types.ts
+++ b/web/admin/src/lib/api/types.ts
@@ -411,6 +411,12 @@ export interface PaymentProviderConfig {
   updated_at: string
 }
 
+export interface PaymentProviderDefinition {
+  rail: Rail
+  display_name: string
+  credential_keys: string[]
+}
+
 // --- API keys (#757) ---
 
 export interface MerchantAPIKey {

--- a/web/admin/src/pages/settings/index.tsx
+++ b/web/admin/src/pages/settings/index.tsx
@@ -30,7 +30,6 @@ import {
   TableRow,
 } from "@/components/ui/table"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { Textarea } from "@/components/ui/textarea"
 import { useApiData } from "@/hooks/use-api-data"
 import {
   deletePaymentProvider,
@@ -42,7 +41,10 @@ import {
   putPaymentProvider,
   setCreditLimit,
 } from "@/lib/api/endpoints"
-import type { PaymentProviderConfig } from "@/lib/api/types"
+import type {
+  PaymentProviderConfig,
+  PaymentProviderDefinition,
+} from "@/lib/api/types"
 import { formatDate, formatMicros, microsFromInput } from "@/lib/format"
 import { toastApiError } from "@/lib/toast"
 import { AlertsTab } from "./alerts"
@@ -210,8 +212,6 @@ function RepriceNoticeWindowForm({ initial }: { initial?: number }) {
   )
 }
 
-const PROVIDER_RAILS = ["nmi", "ccbill", "stripe", "solana"]
-
 function ProvidersTab() {
   const { data, loading, error, reload } = useApiData(() => listPaymentProviders(), [])
   React.useEffect(() => {
@@ -223,7 +223,10 @@ function ProvidersTab() {
   return (
     <div className="flex flex-col gap-3">
       <div className="flex justify-end">
-        <ProviderDialog onDone={reload} />
+        <ProviderDialog
+          providerDefinitions={data?.provider_definitions ?? []}
+          onDone={reload}
+        />
       </div>
       {!data?.data?.length ? (
         <p className="text-sm text-muted-foreground">No payment providers configured.</p>
@@ -313,13 +316,24 @@ function ProviderRow({ provider, onDone }: { provider: PaymentProviderConfig; on
   )
 }
 
-function ProviderDialog({ onDone }: { onDone: () => void }) {
+function ProviderDialog({
+  providerDefinitions,
+  onDone,
+}: {
+  providerDefinitions: PaymentProviderDefinition[]
+  onDone: () => void
+}) {
   const [open, setOpen] = React.useState(false)
   const [rail, setRail] = React.useState("")
   const [accountID, setAccountID] = React.useState("")
   const [environment, setEnvironment] = React.useState("")
-  const [credentials, setCredentials] = React.useState("")
+  const [credentials, setCredentials] = React.useState<Record<string, string>>(
+    {}
+  )
   const [busy, setBusy] = React.useState(false)
+  const selectedProvider = providerDefinitions.find(
+    (provider) => provider.rail === rail
+  )
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
@@ -329,9 +343,9 @@ function ProviderDialog({ onDone }: { onDone: () => void }) {
         <DialogHeader>
           <DialogTitle>Configure payment provider</DialogTitle>
           <DialogDescription>
-            account_id is operator-declared per rail (NMI gateway id, Stripe acct_…, CCBill
-            clientAccnum-clientSubacc, Solana wallet). Credentials are name=value lines and
-            are stored in the secret backend.
+            account_id is operator-declared per rail (NMI gateway id, Stripe
+            acct_…, CCBill clientAccnum-clientSubacc, Solana wallet).
+            Credentials are stored in the secret backend.
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-3">
@@ -340,12 +354,15 @@ function ProviderDialog({ onDone }: { onDone: () => void }) {
               id="pv-rail"
               className="h-9 rounded-md border bg-transparent px-3 text-sm"
               value={rail}
-              onChange={(e) => setRail(e.target.value)}
+              onChange={(e) => {
+                setRail(e.target.value)
+                setCredentials({})
+              }}
             >
               <option value="">Pick a rail…</option>
-              {PROVIDER_RAILS.map((r) => (
-                <option key={r} value={r}>
-                  {r}
+              {providerDefinitions.map((provider) => (
+                <option key={provider.rail} value={provider.rail}>
+                  {provider.rail} — {provider.display_name}
                 </option>
               ))}
             </select>
@@ -356,25 +373,30 @@ function ProviderDialog({ onDone }: { onDone: () => void }) {
           <Field label="Environment (live | test, empty = deployment default)" id="pv-env">
             <Input id="pv-env" value={environment} onChange={(e) => setEnvironment(e.target.value)} />
           </Field>
-          <Field label="Credentials (name=value per line)" id="pv-creds">
-            <Textarea
-              id="pv-creds"
-              className="font-mono text-xs"
-              placeholder={"security_key=...\n"}
-              value={credentials}
-              onChange={(e) => setCredentials(e.target.value)}
-            />
-          </Field>
+          {selectedProvider?.credential_keys.map((name) => (
+            <Field key={name} label={name} id={`pv-credential-${name}`}>
+              <Input
+                id={`pv-credential-${name}`}
+                type="password"
+                autoComplete="new-password"
+                value={credentials[name] ?? ""}
+                onChange={(e) =>
+                  setCredentials((current) => ({
+                    ...current,
+                    [name]: e.target.value,
+                  }))
+                }
+              />
+            </Field>
+          ))}
         </div>
         <DialogFooter>
           <Button
             disabled={busy || !rail || !accountID.trim()}
             onClick={async () => {
-              const creds: Record<string, string> = {}
-              for (const line of credentials.split("\n")) {
-                const idx = line.indexOf("=")
-                if (idx > 0) creds[line.slice(0, idx).trim()] = line.slice(idx + 1).trim()
-              }
+              const creds = Object.fromEntries(
+                Object.entries(credentials).filter(([, value]) => value !== "")
+              )
               setBusy(true)
               try {
                 await putPaymentProvider(rail, {
@@ -382,6 +404,7 @@ function ProviderDialog({ onDone }: { onDone: () => void }) {
                   ...(environment ? { environment } : {}),
                   ...(Object.keys(creds).length ? { credentials: creds } : {}),
                 })
+                setCredentials({})
                 toast.success("Provider saved")
                 setOpen(false)
                 onDone()


### PR DESCRIPTION
## Summary

- make the provider configuration UI registry-driven, including vaulted card
- clear submitted plaintext credentials after successful updates
- validate NMI and CCBill credentials with bounded read-only probes
- report live validation metadata only for credentials actually probed

## Verification

- `go build ./...`
- `go vet ./...`
- `go vet -tags=integration ./...`
- `go test -race ./...`
- `sqlc generate` and `sqlc vet`
- SQL query audit and lint
- `go test -tags=integration ./internal/db/querytest -count=1`