### PR TITLE
or#895: River is a REQUIRED dependency, and its progress detector no longer lives inside River

### DIFF
--- a/cmd/openrails/main.go
+++ b/cmd/openrails/main.go
@@ -133,7 +133,13 @@ func runServer(cmd *cobra.Command, args []string) error {
 
 	// ConsoleAssets is nil unless this binary was built with
 	// `-tags console_assets` (#754: `task build-console-binary` / Dockerfile).
-	embeddedApp, err := embedded.New(embedded.Options{Config: cfg, ConsoleAssets: consoleassets.FS()})
+	embeddedApp, err := embedded.New(embedded.Options{
+		Config:        cfg,
+		ConsoleAssets: consoleassets.FS(),
+		// Standalone keeps self-provisioning (#895): OpenRails builds and runs
+		// its own River client in RunWorkers. The declaration is now explicit.
+		River: embedded.RiverManagedByOpenRails(),
+	})
 	if err != nil {
 		return fmt.Errorf("bootstrap application: %w", err)
 	}

--- a/embed/ccbill_webhook_integration_test.go
+++ b/embed/ccbill_webhook_integration_test.go
@@ -200,7 +200,7 @@ func TestManifestMode_CCBillWebhookNewSaleSuccessEndToEnd(t *testing.T) {
 	ccbillAccount := fmt.Sprintf("94%04d-0001", nano%10_000)
 
 	cfg := sandboxModeConfig(dsn, config.MerchantSourceManifest)
-	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg}})
+	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg, River: embedded.RiverManagedByOpenRails()}})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })
 	id, err := rt.UpsertMerchantConfig(ctx, slug, embed.MerchantConfig{
@@ -276,7 +276,7 @@ func TestAPIMode_CCBillWebhookNewSaleSuccessEndToEnd(t *testing.T) {
 	ccbillAccount := fmt.Sprintf("95%04d-0002", nano%10_000)
 
 	cfg := sandboxModeConfig(dsn, config.MerchantSourceAPI)
-	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg}})
+	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg, River: embedded.RiverManagedByOpenRails()}})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })
 	// API mode: bare identity bind; rail truth arrives over the HTTP API.
@@ -361,7 +361,7 @@ func TestCCBillWebhookUnarmedRailFailsClosed(t *testing.T) {
 	slug := fmt.Sprintf("mwhoff%d", nano)
 
 	cfg := sandboxModeConfig(dsn, config.MerchantSourceManifest)
-	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg}})
+	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg, River: embedded.RiverManagedByOpenRails()}})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })
 	// Merchant exists but declares NO rail accounts at all.

--- a/embed/client_timeout_integration_test.go
+++ b/embed/client_timeout_integration_test.go
@@ -37,7 +37,7 @@ func TestInProcessClientHasNoHiddenTimeout(t *testing.T) {
 	dbtest.EnsureTestMerchant(ctx, t, pool)
 
 	cfg := &config.Config{Env: "dev", TestMode: config.CredentialPostureLive, DB: &config.DBConfig{URL: dsn}}
-	rt, err := New(ctx, Options{Options: embedded.Options{Config: cfg}})
+	rt, err := New(ctx, Options{Options: embedded.Options{Config: cfg, River: embedded.RiverManagedByOpenRails()}})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })
 	rt.emb.App().Runtime.SetConfiguredMerchant(dbtest.TestMerchantID)

--- a/embed/inprocess_transport_integration_test.go
+++ b/embed/inprocess_transport_integration_test.go
@@ -35,7 +35,7 @@ func TestInProcessTransportAuthTraversal(t *testing.T) {
 	dbtest.EnsureTestMerchant(ctx, t, pool)
 
 	cfg := &config.Config{Env: "dev", TestMode: config.CredentialPostureLive, DB: &config.DBConfig{URL: dsn}}
-	rt, err := New(ctx, Options{Options: embedded.Options{Config: cfg}})
+	rt, err := New(ctx, Options{Options: embedded.Options{Config: cfg, River: embedded.RiverManagedByOpenRails()}})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })
 	rt.emb.App().Runtime.SetConfiguredMerchant(dbtest.TestMerchantID)

--- a/embed/localclient_admit_integration_test.go
+++ b/embed/localclient_admit_integration_test.go
@@ -49,7 +49,7 @@ func TestLocalClientAdmit(t *testing.T) {
 		rdb, _ := dbtest.SharedRedisClient(t)
 
 		slug := fmt.Sprintf("embed-localclient-admit-%d", time.Now().UnixNano())
-		rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg, Redis: rdb}})
+		rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg, Redis: rdb, River: embedded.RiverManagedByOpenRails()}})
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = rt.Close(context.Background()) })
 
@@ -94,7 +94,7 @@ func TestLocalClientAdmit(t *testing.T) {
 	})
 
 	t.Run("no merchant bound: 500 message names the real cause", func(t *testing.T) {
-		rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg}})
+		rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg, River: embedded.RiverManagedByOpenRails()}})
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = rt.Close(context.Background()) })
 		// Deliberately no UpsertMerchantConfig: merchantCtx has nothing to pin, so
@@ -142,7 +142,7 @@ func TestMerchantPinMismatch(t *testing.T) {
 	t.Cleanup(pool.Close)
 
 	slug := fmt.Sprintf("embed-merchant-pin-mismatch-%d", time.Now().UnixNano())
-	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg}})
+	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg, River: embedded.RiverManagedByOpenRails()}})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })
 

--- a/embed/manifest_mode_integration_test.go
+++ b/embed/manifest_mode_integration_test.go
@@ -88,7 +88,7 @@ func bootManifestRuntime(t *testing.T, ctx context.Context, dsn, slug, nmiV5Base
 	cfg := manifestModeConfig(dsn)
 	manifest, err := embed.LoadMerchantConfigManifest(manifestRaw)
 	require.NoError(t, err)
-	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg}})
+	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg, River: embedded.RiverManagedByOpenRails()}})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })
 	id, err := rt.UpsertMerchantConfig(ctx, slug, manifest.Merchants[slug])
@@ -310,7 +310,7 @@ func TestManifestMode_MutationRoutesRejected405(t *testing.T) {
 	nano := time.Now().UnixNano()
 	slug := fmt.Sprintf("m405%d", nano)
 	cfg := manifestModeConfig(dsn)
-	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg}})
+	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg, River: embedded.RiverManagedByOpenRails()}})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })
 	id, err := rt.UpsertMerchantConfig(ctx, slug, embed.MerchantConfig{DisplayName: slug})
@@ -382,7 +382,7 @@ func TestAPIMode_MutationRoutesWork(t *testing.T) {
 		ProviderWriteMode: config.ProviderWriteModeFull,
 		DB:                &config.DBConfig{URL: dsn},
 	}
-	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg}})
+	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg, River: embedded.RiverManagedByOpenRails()}})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })
 	// API mode still allows the bare identity bind.
@@ -435,7 +435,7 @@ func TestManifestMode_APIModeRefusesManifestTruth(t *testing.T) {
 		MerchantSource: config.MerchantSourceAPI,
 		DB:             &config.DBConfig{URL: dsn},
 	}
-	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg}})
+	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg, River: embedded.RiverManagedByOpenRails()}})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })
 
@@ -473,7 +473,7 @@ func TestManifestMode_MissingSecretFailsClosed(t *testing.T) {
 
 	manifest, err := embed.LoadMerchantConfigManifest(manifestModeManifestYAML(slug, gatewayID))
 	require.NoError(t, err)
-	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg}})
+	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg, River: embedded.RiverManagedByOpenRails()}})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })
 
@@ -518,7 +518,7 @@ func TestManifestMode_ReadSideBindKeepsWorking(t *testing.T) {
 
 	// Writer host (doujins shape) declares the merchant.
 	writerCfg := manifestModeConfig(dsn)
-	writer, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: writerCfg}})
+	writer, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: writerCfg, River: embedded.RiverManagedByOpenRails()}})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = writer.Close(context.Background()) })
 	id, err := writer.UpsertMerchantConfig(ctx, slug, embed.MerchantConfig{DisplayName: slug})
@@ -529,7 +529,7 @@ func TestManifestMode_ReadSideBindKeepsWorking(t *testing.T) {
 
 	// Reader host (hentai0 shape): empty MerchantConfig — pure bind.
 	readerCfg := manifestModeConfig(dsn)
-	reader, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: readerCfg}})
+	reader, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: readerCfg, River: embedded.RiverManagedByOpenRails()}})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = reader.Close(context.Background()) })
 	boundID, err := reader.UpsertMerchantConfig(ctx, slug, embed.MerchantConfig{})
@@ -548,7 +548,7 @@ func bootManifestRuntimeWithRailAccounts(t *testing.T, ctx context.Context, dsn,
 	t.Helper()
 	appDB := dbtest.OpenAppDB(t, dsn)
 	cfg := manifestModeConfig(dsn)
-	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg}})
+	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg, River: embedded.RiverManagedByOpenRails()}})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })
 	id, err := rt.UpsertMerchantConfig(ctx, slug, embed.MerchantConfig{

--- a/embed/mount_order_integration_test.go
+++ b/embed/mount_order_integration_test.go
@@ -34,7 +34,7 @@ func TestMountedHandlerResolvesMerchantBoundAfterMount(t *testing.T) {
 
 	slug := fmt.Sprintf("mount-order-%d", time.Now().UnixNano())
 	cfg := &config.Config{Env: "dev", TestMode: config.CredentialPostureSandbox, DB: &config.DBConfig{URL: dsn}}
-	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg}})
+	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg, River: embedded.RiverManagedByOpenRails()}})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })
 

--- a/embed/provision_integration_test.go
+++ b/embed/provision_integration_test.go
@@ -30,7 +30,7 @@ func TestUpsertMerchantConfig_SeedsRailMerchantAccounts(t *testing.T) {
 	slug := fmt.Sprintf("embed-provision-%d", time.Now().UnixNano())
 	cfg := &config.Config{Env: "dev", TestMode: config.CredentialPostureLive, DB: &config.DBConfig{URL: dsn}}
 	rt, err := embed.New(ctx, embed.Options{
-		Options: embedded.Options{Config: cfg},
+		Options: embedded.Options{Config: cfg, River: embedded.RiverManagedByOpenRails()},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })

--- a/embed/pull_arming_integration_test.go
+++ b/embed/pull_arming_integration_test.go
@@ -44,7 +44,7 @@ func TestEmbeddedPullArming_ManifestSecretsNoPaymentProviders(t *testing.T) {
 
 	cfg := &config.Config{Env: "dev", TestMode: config.CredentialPostureLive, DB: &config.DBConfig{URL: dsn}}
 	rt, err := embed.New(ctx, embed.Options{
-		Options: embedded.Options{Config: cfg}, // deliberately NO PaymentProviders
+		Options: embedded.Options{Config: cfg, River: embedded.RiverManagedByOpenRails()}, // deliberately NO PaymentProviders
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })
@@ -176,7 +176,7 @@ func pullCLIManifestMerchant(t *testing.T, ctx context.Context, dsn, slug string
 	t.Helper()
 	appDB := dbtest.OpenAppDB(t, dsn)
 	cfg := &config.Config{Env: "dev", TestMode: config.CredentialPostureLive, DB: &config.DBConfig{URL: dsn}}
-	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg}})
+	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg, River: embedded.RiverManagedByOpenRails()}})
 	require.NoError(t, err)
 	id, err := rt.UpsertMerchantConfig(ctx, slug, m)
 	require.NoError(t, err)

--- a/embed/river_fold_integration_test.go
+++ b/embed/river_fold_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 	riverpgxv5 "github.com/riverqueue/river/riverdriver/riverpgxv5"
@@ -19,10 +20,9 @@ import (
 	"github.com/open-rails/openrails/pkg/embedded"
 )
 
-// noopWorker is a trivial host worker folded into the SAME registry as
-// billing's workers, proving FoldIntoRiver's contract: workers must be fixed
-// BEFORE river.NewClient, so both the host's own worker and billing's workers
-// must already be in the same *river.Workers by the time the client is built.
+// noopWorker is a trivial host worker added to the SAME registry as billing's
+// workers, proving the #895 binder contract: River fixes Workers at NewClient
+// time, so the binder is the one moment host and billing workers can be merged.
 type noopJobArgs struct{}
 
 func (noopJobArgs) Kind() string { return "embed_test_noop" }
@@ -33,16 +33,22 @@ type noopWorker struct {
 
 func (noopWorker) Work(context.Context, *river.Job[noopJobArgs]) error { return nil }
 
-// TestFoldIntoRiver_HostSharedClientDrainsBillingJobs proves the #546 recipe
-// end-to-end: fold billing's workers/periodic jobs into a host-owned
-// river.Workers/river.Client (the exact shape doujins/hentai0 hand-wrote as
-// Service.RegisterRiverWorkers/RegisterRiverClient), then confirm the
-// resulting SHARED client (a) is the one the embedded engine now reports via
-// HasExternalRiverClient, (b) actually drains a billing job enqueued through
-// it, and (c) surfaces billing's periodic jobs for the host to register.
-func TestFoldIntoRiver_HostSharedClientDrainsBillingJobs(t *testing.T) {
+// TestRiverFromHost_SharedClientDrainsBillingJobs proves state (1) of #895 —
+// correct wiring — end to end on the real path: a host declares ownership via
+// Options.River, builds the shared client inside the binder, and the resulting
+// client (a) is the one the engine reports as external, (b) actually drains a
+// billing job, and (c) carries billing's periodic jobs, which OpenRails
+// registered itself rather than trusting the host to.
+func TestRiverFromHost_SharedClientDrainsBillingJobs(t *testing.T) {
 	ctx := context.Background()
 	dsn := dbtest.SharedPostgresDSN(t)
+
+	pool, err := pgxpool.New(ctx, dsn)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	var client *river.Client[pgx.Tx]
+	var sawBillingWorkers bool
 
 	rt, err := embed.New(ctx, embed.Options{
 		Options: embedded.Options{
@@ -51,45 +57,44 @@ func TestFoldIntoRiver_HostSharedClientDrainsBillingJobs(t *testing.T) {
 				TestMode: config.CredentialPostureSandbox,
 				DB:       &config.DBConfig{URL: dsn},
 			},
+			River: embedded.RiverFromHost(func(ctx context.Context, fleet *embedded.RiverFleet) (*river.Client[pgx.Tx], error) {
+				// Billing's workers are ALREADY in the registry, with their
+				// health bookkeeping attached — the host adds its own on top.
+				require.NotNil(t, fleet.Workers)
+				require.Equal(t, riverjobs.QueueBilling, fleet.QueueBilling)
+				sawBillingWorkers = true
+				require.NoError(t, river.AddWorkerSafely(fleet.Workers, &noopWorker{}))
+
+				c, err := river.NewClient(riverpgxv5.New(pool), &river.Config{
+					Queues: map[string]river.QueueConfig{
+						river.QueueDefault:     {MaxWorkers: 2},
+						fleet.QueueBilling:     {MaxWorkers: 2},
+						riverjobs.QueueBilling: {MaxWorkers: 2},
+					},
+					Workers: fleet.Workers,
+				})
+				if err != nil {
+					return nil, err
+				}
+				client = c
+				return c, nil
+			}),
 		},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })
 
+	require.True(t, sawBillingWorkers, "binder must be invoked during New")
 	emb := rt.Embedded()
-	require.False(t, emb.HasExternalRiverClient(), "no client injected yet")
-
-	// Host builds its own worker registry with its own worker already added —
-	// FoldIntoRiver must be callable on top of that, not require an empty one.
-	workers := river.NewWorkers()
-	river.AddWorkerSafely(workers, &noopWorker{})
-
-	periodic, register, err := embedded.FoldIntoRiver(ctx, emb, workers)
-	require.NoError(t, err)
-	require.NotEmpty(t, periodic, "billing has at least one periodic job to fold in")
-
-	pool, err := pgxpool.New(ctx, dsn)
-	require.NoError(t, err)
-	t.Cleanup(pool.Close)
-
-	client, err := river.NewClient(riverpgxv5.New(pool), &river.Config{
-		Queues: map[string]river.QueueConfig{
-			river.QueueDefault:     {MaxWorkers: 2},
-			riverjobs.QueueBilling: {MaxWorkers: 2},
-		},
-		Workers: workers,
-	})
-	require.NoError(t, err)
-
-	require.NoError(t, register(client))
-	require.True(t, emb.HasExternalRiverClient(), "register must inject the client (SetRiverClient)")
+	require.True(t, emb.HasExternalRiverClient(), "the binder's client must be injected by New")
+	require.NotNil(t, client)
 
 	require.NoError(t, client.Start(ctx))
 	t.Cleanup(func() { _ = client.Stop(context.Background()) })
 
-	// A billing job enqueued through the SHARED client is drained by the
-	// billing worker FoldIntoRiver added to `workers` — proving AddWorkersTo
-	// actually wired the worker, not just that the call didn't error.
+	// A billing job enqueued through the SHARED client is drained by the billing
+	// worker the binder received — proving the registry was actually wired, not
+	// just that the call didn't error.
 	res, err := client.Insert(ctx, riverjobs.CleanupExpiredDataArgs{}, &river.InsertOpts{Queue: riverjobs.QueueBilling})
 	require.NoError(t, err)
 
@@ -97,12 +102,64 @@ func TestFoldIntoRiver_HostSharedClientDrainsBillingJobs(t *testing.T) {
 		var state string
 		row := pool.QueryRow(ctx, `SELECT state FROM river_job WHERE id = $1`, res.Job.ID)
 		return row.Scan(&state) == nil && state == "completed"
-	}, 5*time.Second, 100*time.Millisecond, "billing job must complete on the host's shared client")
+	}, 30*time.Second, 100*time.Millisecond, "billing job must complete on the host's shared client")
+
+	// #895 state 2, structurally fixed: the host installed NO client-level
+	// middleware, yet the worked job still recorded a success — the bookkeeping
+	// rides on the worker itself, so a host cannot omit it.
+	dbi := dbtest.OpenAppDB(t, dsn)
+	var lastSuccess *time.Time
+	require.NoError(t, dbi.Qx(ctx).QueryRow(ctx,
+		`SELECT last_success_at FROM openrails.worker_health WHERE worker_kind = $1`,
+		riverjobs.CleanupExpiredDataArgs{}.Kind()).Scan(&lastSuccess))
+	require.NotNil(t, lastSuccess, "health bookkeeping must be installed without host cooperation (#895)")
+
+	// The fleet is progressing, and OpenRails can say so without running a job.
+	report, err := emb.CheckJobProgress(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, report.Kinds, "periodic kinds are registered")
+	require.NoError(t, report.Err())
 }
 
-// TestFoldIntoRiver_NilEmbeddedErrors pins the not-initialized guard: calling
-// FoldIntoRiver before the engine exists must error, not panic.
-func TestFoldIntoRiver_NilEmbeddedErrors(t *testing.T) {
-	_, _, err := embedded.FoldIntoRiver(context.Background(), nil, river.NewWorkers())
-	require.ErrorIs(t, err, embedded.ErrNotInitialized)
+// TestRiverRequired_ConstructionRefuses is the #895 headline: an embedded host
+// that never declares River ownership must NOT get a usable engine. Before this
+// change the same Options silently produced a working-looking engine whose
+// money-moving periodic jobs would never run.
+func TestRiverRequired_ConstructionRefuses(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+
+	_, err := embed.New(ctx, embed.Options{
+		Options: embedded.Options{
+			Config: &config.Config{
+				Env:      "dev",
+				TestMode: config.CredentialPostureSandbox,
+				DB:       &config.DBConfig{URL: dsn},
+			},
+			// River deliberately omitted.
+		},
+	})
+	require.ErrorIs(t, err, embedded.ErrRiverRequired)
+}
+
+// TestRiverFromHost_NilClientRefuses closes the other half of the handoff: a
+// host may not declare ownership and then hand back nothing.
+func TestRiverFromHost_NilClientRefuses(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+
+	_, err := embed.New(ctx, embed.Options{
+		Options: embedded.Options{
+			Config: &config.Config{
+				Env:      "dev",
+				TestMode: config.CredentialPostureSandbox,
+				DB:       &config.DBConfig{URL: dsn},
+			},
+			River: embedded.RiverFromHost(func(context.Context, *embedded.RiverFleet) (*river.Client[pgx.Tx], error) {
+				return nil, nil
+			}),
+		},
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "nil client")
 }

--- a/embed/spend_delegations_integration_test.go
+++ b/embed/spend_delegations_integration_test.go
@@ -30,7 +30,7 @@ func TestEmbeddedClientSetCustomerSpendDelegations(t *testing.T) {
 	customerID := dbtest.EnsureCustomerIDPgx(ctx, t, pool, "b6b6b6b6-0000-4000-8000-000000000042")
 
 	cfg := &config.Config{Env: "dev", TestMode: config.CredentialPostureLive, DB: &config.DBConfig{URL: dsn}}
-	rt, err := New(ctx, Options{Options: embedded.Options{Config: cfg}})
+	rt, err := New(ctx, Options{Options: embedded.Options{Config: cfg, River: embedded.RiverManagedByOpenRails()}})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })
 	rt.emb.App().Runtime.SetConfiguredMerchant(dbtest.TestMerchantID)

--- a/internal/app/river_progress.go
+++ b/internal/app/river_progress.go
@@ -1,0 +1,109 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/open-rails/openrails/config"
+	riverjobs "github.com/open-rails/openrails/internal/river"
+)
+
+// #895: OpenRails' own liveness answer for "is the cron system progressing?".
+//
+// The detector must not require the monitored subsystem to be alive, so it is
+// NOT a River job: StartRiverProgressMonitor runs an ordinary goroutine that
+// reads River's own river_job watermarks. It keeps reporting — and alerting —
+// when River was never started, was started without OpenRails' workers, or is
+// wedged.
+
+// riverProgressMonitor lazily builds the monitor. It is safe to call before or
+// after a River client exists; the monitor reads tables, not clients.
+func (r *Runtime) riverProgressMonitor() *riverjobs.ProgressMonitor {
+	r.progressOnce.Do(func() {
+		clock := r.Clock
+		if clock == nil {
+			clock = clockwork.NewRealClock()
+		}
+		pool := r.riverStatsPool()
+		r.progress = &riverjobs.ProgressMonitor{
+			DB:                  r.DB,
+			Pool:                pool,
+			RiverSchema:         config.RiverSchema,
+			Clock:               clock,
+			Registrations:       r.workerHealthRegistrations(),
+			NotificationService: r.NotificationService,
+		}
+	})
+	return r.progress
+}
+
+// riverStatsPool returns the pool used to read River's own tables. River lives
+// in `public` in the SAME database as the billing schema (#545), so the app
+// pool reads it directly; a dedicated River pool is used when one exists.
+func (r *Runtime) riverStatsPool() *pgxpool.Pool {
+	if r.riverPool != nil {
+		return r.riverPool
+	}
+	if r.DB != nil {
+		return r.DB.Pool()
+	}
+	return nil
+}
+
+// StartRiverProgressMonitor starts the out-of-River progress detector, once.
+// The returned stop function is idempotent; Runtime.Close calls it.
+func (r *Runtime) StartRiverProgressMonitor(ctx context.Context) {
+	if r == nil || r.DB == nil {
+		return
+	}
+	r.progressStartOnce.Do(func() {
+		monitorCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+		r.progressCancel = cancel
+		r.progressDone = make(chan struct{})
+		monitor := r.riverProgressMonitor()
+		go func() {
+			defer close(r.progressDone)
+			monitor.Run(monitorCtx)
+		}()
+	})
+}
+
+// stopRiverProgressMonitor cancels the monitor goroutine and waits for it.
+func (r *Runtime) stopRiverProgressMonitor() {
+	if r == nil {
+		return
+	}
+	r.progressStopOnce.Do(func() {
+		if r.progressCancel != nil {
+			r.progressCancel()
+		}
+		if r.progressDone != nil {
+			<-r.progressDone
+		}
+	})
+}
+
+// RiverProgress evaluates the periodic fleet RIGHT NOW and returns the report.
+// It is a pure read — no job runs, nothing is enqueued — so a host may call it
+// from its own health endpoint and get a truthful answer while River is down.
+func (r *Runtime) RiverProgress(ctx context.Context) (riverjobs.ProgressReport, error) {
+	if r == nil || r.DB == nil {
+		return riverjobs.ProgressReport{}, fmt.Errorf("river progress: runtime not initialized")
+	}
+	return r.riverProgressMonitor().Check(ctx)
+}
+
+// progressLifecycle groups the monitor's once-guards so Runtime's struct stays
+// readable; embedded into Runtime.
+type progressLifecycle struct {
+	progress          *riverjobs.ProgressMonitor
+	progressOnce      sync.Once
+	progressStartOnce sync.Once
+	progressStopOnce  sync.Once
+	progressCancel    context.CancelFunc
+	progressDone      chan struct{}
+}

--- a/internal/app/river_register.go
+++ b/internal/app/river_register.go
@@ -294,17 +294,11 @@ func (r *Runtime) addBillingWorkersToRegistry(ctx context.Context, workers *rive
 	}); err != nil {
 		return fmt.Errorf("add findings digest worker: %w", err)
 	}
-	// Worker health checker (#689): evaluates per-kind health rows written by the
-	// WorkerHealthMiddleware and raises repair alerts for never-succeeded /
-	// failing / stale kinds. Registered last so every kind above is already noted.
-	if err := addTrackedWorker(r, workers, &riverjobs.WorkerHealthCheckWorker{
-		DB:                  r.DB,
-		Clock:               clock,
-		Registrations:       r.workerHealthRegistrations(),
-		NotificationService: r.NotificationService,
-	}); err != nil {
-		return fmt.Errorf("add worker health check worker: %w", err)
-	}
+	// #895: there is deliberately NO worker-health-check WORKER here any more.
+	// The detector used to be a River periodic job, so a stalled River stalled
+	// its own detector and could only report health where health was never in
+	// doubt. It now lives outside River entirely, as riverjobs.ProgressMonitor —
+	// a plain goroutine started by Runtime.StartRiverProgressMonitor.
 	return nil
 }
 
@@ -753,18 +747,10 @@ func (r *Runtime) buildRiverPeriodicJobs(ctx context.Context) ([]*river.Periodic
 		&river.PeriodicJobOpts{RunOnStart: false},
 	))
 
-	// Every 5 minutes: worker health check (#689). RunOnStart=true so health rows
-	// are seeded (and lingering incidents re-evaluated) right after boot.
-	jobs = append(jobs, r.healthPeriodic(
-		5*time.Minute,
-		func() (river.JobArgs, *river.InsertOpts) {
-			return riverjobs.WorkerHealthCheckArgs{}, &river.InsertOpts{
-				Queue:      riverjobs.QueueBilling,
-				UniqueOpts: river.UniqueOpts{ByQueue: true, ByPeriod: 5 * time.Minute},
-			}
-		},
-		&river.PeriodicJobOpts{RunOnStart: true},
-	))
+	// #895: the worker-health check is NOT scheduled here any more. Scheduling
+	// the detector as a periodic job is what made "River is not running"
+	// undetectable — the detector could not run either. riverjobs.ProgressMonitor
+	// replaces it, outside River.
 
 	return jobs, nil
 }

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	redis "github.com/redis/go-redis/v9"
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/rivertype"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/jonboulle/clockwork"
@@ -222,6 +221,11 @@ type Runtime struct {
 	riverStarted        bool
 	externalRiverClient bool // true if River client was provided externally
 
+	// progressLifecycle owns the #895 out-of-River progress detector: a plain
+	// goroutine that answers "is the periodic fleet progressing?" without
+	// needing a job to run to find out.
+	progressLifecycle
+
 	// workerHealthRegs captures every registered worker kind + periodic cadence
 	// for the #689 health checker; lazily built (see workerHealthRegistrations).
 	workerHealthRegs     *riverjobs.WorkerRegistrations
@@ -277,6 +281,10 @@ func (r *Runtime) Close(ctx context.Context) error {
 		return nil
 	}
 	var errs []error
+
+	// #895: stop the out-of-River progress detector first — it outlives the
+	// River client on purpose, so nothing else will cancel it.
+	r.stopRiverProgressMonitor()
 
 	// Stop Solana Pay poller
 	if r.SolanaPayPoller != nil {
@@ -346,8 +354,9 @@ func (r *Runtime) InitRiver(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("build river workers: %w", err)
 	}
-	// #689: one middleware covers every registered worker's health bookkeeping.
-	client, pool, err := buildRiverClient(r.Config, workers, []rivertype.Middleware{r.WorkerHealthMiddleware()})
+	// #895: health bookkeeping rides on each worker (addTrackedWorker), not on
+	// the client, so it cannot be omitted by whoever builds the client.
+	client, pool, err := buildRiverClient(r.Config, workers, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/app/worker_health.go
+++ b/internal/app/worker_health.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"time"
 
 	"github.com/riverqueue/river"
@@ -12,6 +13,16 @@ import (
 // #689 worker health wiring: kinds are noted as workers register and periodic
 // cadences as schedules are declared, so the health checker knows every kind
 // and what "on time" means with zero per-worker code.
+//
+// #895: the bookkeeping middleware is installed PER WORKER, at registration,
+// not on the client. It used to be a client-level river.Config.Middleware
+// entry, which meant an embedded host could adopt the fleet via AddWorkersTo
+// and simply omit it — measured on two hosts, where every periodic kind then
+// reported never_succeeded forever (19/25 on cozy-art, 20/24 on tensorhub:
+// 100% false alarms, which trains operators to ignore the real signal). River
+// honours Worker.Middleware(job) per work unit (internal/jobexecutor), so
+// attaching it here makes the omission unrepresentable: registering an
+// OpenRails worker registers its bookkeeping, with no host cooperation.
 
 // workerHealthRegistrations lazily builds the runtime's registration set.
 func (r *Runtime) workerHealthRegistrations() *riverjobs.WorkerRegistrations {
@@ -21,11 +32,41 @@ func (r *Runtime) workerHealthRegistrations() *riverjobs.WorkerRegistrations {
 	return r.workerHealthRegs
 }
 
-// addTrackedWorker registers a worker and notes its kind for health seeding.
+// healthTrackedWorker wraps an OpenRails worker so its health bookkeeping
+// travels with the worker itself rather than with whoever built the client.
+type healthTrackedWorker[T river.JobArgs] struct {
+	inner  river.Worker[T]
+	health rivertype.WorkerMiddleware
+}
+
+func (w *healthTrackedWorker[T]) Middleware(job *rivertype.JobRow) []rivertype.WorkerMiddleware {
+	inner := w.inner.Middleware(job)
+	out := make([]rivertype.WorkerMiddleware, 0, len(inner)+1)
+	out = append(out, w.health)
+	return append(out, inner...)
+}
+
+func (w *healthTrackedWorker[T]) NextRetry(job *river.Job[T]) time.Time {
+	return w.inner.NextRetry(job)
+}
+
+func (w *healthTrackedWorker[T]) Timeout(job *river.Job[T]) time.Duration {
+	return w.inner.Timeout(job)
+}
+
+func (w *healthTrackedWorker[T]) Work(ctx context.Context, job *river.Job[T]) error {
+	return w.inner.Work(ctx, job)
+}
+
+// addTrackedWorker registers a worker, notes its kind for health seeding, and
+// attaches the health bookkeeping middleware to the worker itself (#895).
 func addTrackedWorker[T river.JobArgs](r *Runtime, workers *river.Workers, worker river.Worker[T]) error {
 	var args T
 	r.workerHealthRegistrations().NoteKind(args.Kind())
-	return river.AddWorkerSafely(workers, worker)
+	return river.AddWorkerSafely[T](workers, &healthTrackedWorker[T]{
+		inner:  worker,
+		health: riverjobs.NewWorkerHealthMiddleware(r.DB),
+	})
 }
 
 // healthPeriodic wraps river.NewPeriodicJob with a fixed interval, recording
@@ -35,12 +76,4 @@ func (r *Runtime) healthPeriodic(interval time.Duration, ctor river.PeriodicJobC
 		r.workerHealthRegistrations().NotePeriod(args.Kind(), interval)
 	}
 	return river.NewPeriodicJob(river.PeriodicInterval(interval), ctor, opts)
-}
-
-// WorkerHealthMiddleware returns the per-job health bookkeeping middleware.
-// The standalone client installs it automatically (InitRiver); embedded hosts
-// running an external River client should add it to their client's
-// river.Config.Middleware so their billing workers are covered too.
-func (r *Runtime) WorkerHealthMiddleware() rivertype.Middleware {
-	return riverjobs.NewWorkerHealthMiddleware(r.DB)
 }

--- a/internal/db/queries/EXEMPTIONS.md
+++ b/internal/db/queries/EXEMPTIONS.md
@@ -118,6 +118,13 @@ dynamically from operator definitions (metrics, fleet analytics, dump/restore
 over a dynamic table list), and privileged access that runs before merchant
 context exists (DEK bootstrap, merchant secret stores).
 
+`internal/river/progress.go` is PERMANENT for a different reason: it reads
+**River's own** `river_job` table, which is not part of OpenRails' schema, is
+created by River's migrator rather than `migrations/`, and lives in a schema
+named at runtime (`config.RiverSchema`). sqlc has no type information for it and
+could not express the schema-qualified name anyway. Only the schema is
+interpolated, after an identifier check; the kind list is a bound parameter.
+
 **DEBT** is ordinary queries not yet ported to `internal/db/queries/*.sql`.
 Nothing about them requires raw SQL.
 

--- a/internal/db/queries/LINT_ALLOWLIST.txt
+++ b/internal/db/queries/LINT_ALLOWLIST.txt
@@ -22,6 +22,7 @@ PERMANENT internal/controlplane/fleet_timeseries.go # cross-merchant time series
 PERMANENT internal/bootstrap/merchant_dump.go       # dump/restore over a dynamic table list
 PERMANENT internal/bootstrap/merchant_manifest.go   # dump/restore over a dynamic table list
 PERMANENT pkg/embedded/catalog_dump.go              # dump/restore over a dynamic table list
+PERMANENT internal/river/progress.go                # reads River's OWN river_job table (not OpenRails' schema)
 
 # --- PERMANENT: privileged, runs before merchant context/RLS exists ---------
 PERMANENT internal/crypto/dek_store_db.go      # DEK bootstrap on the privileged pool

--- a/internal/integrationharness/embedded_mount_handler_integration_test.go
+++ b/internal/integrationharness/embedded_mount_handler_integration_test.go
@@ -50,6 +50,7 @@ func TestEmbeddedMountHandlerEndToEnd(t *testing.T) {
 				DB:       &config.DBConfig{URL: h.DSN},
 			},
 			Redis: h.Redis,
+			River: embedded.RiverManagedByOpenRails(),
 		},
 	})
 	require.NoError(t, err)

--- a/internal/integrationharness/harness.go
+++ b/internal/integrationharness/harness.go
@@ -245,7 +245,7 @@ func (h *Harness) StartEmbeddedHost(currency string) *Surface {
 
 	cfg := &config.Config{Env: "dev", TestMode: config.CredentialPostureSandbox, DB: &config.DBConfig{URL: h.DSN}}
 	rt, err := embed.New(h.ctx, embed.Options{
-		Options: embedded.Options{Config: cfg, Redis: h.Redis},
+		Options: embedded.Options{Config: cfg, Redis: h.Redis, River: embedded.RiverManagedByOpenRails()},
 	})
 	require.NoError(h.t, err, "embed.New")
 	h.cleanup(func() { _ = rt.Close(context.Background()) })

--- a/internal/integrationharness/host_webhook_mount_test.go
+++ b/internal/integrationharness/host_webhook_mount_test.go
@@ -43,7 +43,7 @@ func TestHostRoutedWebhookMountHTTP(t *testing.T) {
 		Auth:     &config.AuthConfig{Issuer: "https://host-webhook-controlplane.test"},
 	}
 
-	e, err := embedded.New(embedded.Options{Config: cfg, Redis: h.Redis})
+	e, err := embedded.New(embedded.Options{Config: cfg, Redis: h.Redis, River: embedded.RiverManagedByOpenRails()})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = e.Close(context.Background()) })
 

--- a/internal/integrationharness/mount_route_selection_integration_test.go
+++ b/internal/integrationharness/mount_route_selection_integration_test.go
@@ -56,6 +56,7 @@ func TestMountHandlerRouteSelection(t *testing.T) {
 				DB:       &config.DBConfig{URL: h.DSN},
 			},
 			Redis: h.Redis,
+			River: embedded.RiverManagedByOpenRails(),
 		},
 	})
 	require.NoError(t, err)

--- a/internal/river/progress.go
+++ b/internal/river/progress.go
@@ -1,0 +1,579 @@
+package riverjobs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jonboulle/clockwork"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/open-rails/openrails/internal/db"
+	"github.com/open-rails/openrails/internal/db/gen"
+	"github.com/open-rails/openrails/internal/modules/subscriptions"
+	"github.com/open-rails/openrails/internal/modules/webhooks"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// #895: the progress detector must NOT be a River job.
+//
+// It used to be — WorkerHealthCheckWorker was itself a River periodic job, so a
+// stalled River stalled its own detector and could only report health in the
+// cases where health was never in doubt. ProgressMonitor is a plain goroutine
+// owned by OpenRails: it reads River's OWN `river_job` table plus the
+// openrails.worker_health rows and decides whether the periodic fleet is
+// progressing, without needing a job to run to find out.
+//
+// river_job is the primary signal deliberately. worker_health.last_success_at
+// is written by WorkerHealthMiddleware, so a fleet running without that
+// middleware reports never_succeeded for every kind forever (100% false alarms,
+// measured 19/25 on cozy-art, 20/24 on tensorhub). river_job is written by
+// River itself, so it stays truthful regardless of how the host wired things.
+
+// Progress verdicts. Empty string means healthy.
+const (
+	// ProgressNotScheduling: River is not inserting OpenRails' periodic jobs at
+	// all — the client was never started, the periodic jobs were never
+	// registered, or the whole process is gone. This is the failure that used to
+	// be invisible by construction.
+	ProgressNotScheduling = "river_not_scheduling"
+	// ProgressNotCompleting: rows ARE being inserted but nothing finalizes —
+	// workers unregistered, the billing queue not configured on the host's
+	// client, or every worker wedged.
+	ProgressNotCompleting = "river_not_completing"
+	// ProgressBacklog: work is queued past its due time and piling up.
+	ProgressBacklog = "river_backlog"
+
+	// Per-kind verdicts (evaluated against worker_health, secondary detail).
+	ProgressConsecutiveFailures = "consecutive_failures"
+	ProgressNeverSucceeded      = "never_succeeded"
+	ProgressStale               = "stale"
+)
+
+// riverJobStat is one kind's watermark row from River's own table.
+type riverJobStat struct {
+	Kind            string
+	LastEnqueuedAt  *time.Time
+	LastCompletedAt *time.Time
+	Overdue         int64
+}
+
+// KindProgress is one worker kind's verdict.
+type KindProgress struct {
+	Kind string
+	// ExpectedPeriod is the declared cadence; 0 = on-demand (never stale).
+	ExpectedPeriod time.Duration
+	// LastEnqueuedAt/LastCompletedAt come from river_job (River's own writes).
+	LastEnqueuedAt  *time.Time
+	LastCompletedAt *time.Time
+	// LastSuccessAt comes from openrails.worker_health (middleware bookkeeping).
+	LastSuccessAt *time.Time
+	Overdue       int64
+	// Reason is "" when healthy.
+	Reason string
+}
+
+// ProgressReport is one evaluation of the periodic fleet.
+type ProgressReport struct {
+	CheckedAt time.Time
+	// Progressing is the headline: false means the cron fleet is not moving.
+	Progressing bool
+	// Reason is the fleet-level verdict ("" when progressing).
+	Reason string
+	// ShortestPeriod is the tightest declared cadence across registered kinds.
+	ShortestPeriod time.Duration
+	// FleetLastEnqueuedAt/FleetLastCompletedAt are the newest watermarks across
+	// every OpenRails kind, read from river_job.
+	FleetLastEnqueuedAt  *time.Time
+	FleetLastCompletedAt *time.Time
+	// Kinds carries per-kind detail, sorted by kind.
+	Kinds []KindProgress
+	// Unhealthy counts kinds with a non-empty Reason.
+	Unhealthy int
+}
+
+// Err renders the report as an error when the fleet is not progressing, so a
+// host health endpoint can `if err := e.CheckJobProgress(ctx); err != nil`.
+func (r ProgressReport) Err() error {
+	if r.Progressing {
+		return nil
+	}
+	detail := "no completions observed"
+	if r.FleetLastCompletedAt != nil {
+		detail = "last completion " + r.FleetLastCompletedAt.UTC().Format(time.RFC3339)
+	}
+	return fmt.Errorf("river periodic fleet is not progressing (%s): %s", r.Reason, detail)
+}
+
+// ProgressMonitor evaluates whether the River periodic fleet is progressing.
+// It is NOT a River worker and never enqueues anything (#895): Check is a pure
+// read, and Run is an ordinary ticker goroutine owned by the OpenRails runtime,
+// so it keeps reporting while River itself is dead.
+type ProgressMonitor struct {
+	DB *db.DB
+	// Pool reads River's own tables. River's schema is configurable and its
+	// tables are not part of OpenRails' sqlc schema, so this is a raw read (see
+	// internal/db/queries/EXEMPTIONS.md). Nil disables the river_job signal and
+	// the monitor falls back to worker_health only.
+	Pool        *pgxpool.Pool
+	RiverSchema string
+	Clock       clockwork.Clock
+	// Registrations is the kind -> declared cadence set built at worker
+	// registration; it is what "expected" means.
+	Registrations       *WorkerRegistrations
+	NotificationService *subscriptions.NotificationService
+
+	// Tunables; zero values take the defaults below.
+	FailureThreshold int           // consecutive failures before alerting (default 3)
+	StaleMultiplier  int           // k in "no progress within k x expected period" (default 3)
+	MinStale         time.Duration // floor for the staleness threshold (default 30m)
+	ReAlertEvery     time.Duration // re-alert pacing while a kind stays unhealthy (default 24h)
+	Interval         time.Duration // Run's tick (default 1m)
+
+	// startedAt anchors the boot grace period: a freshly booted process has no
+	// river_job rows yet and must not alarm before the fleet has had a chance to
+	// schedule anything. Set on the first Check.
+	startedAt time.Time
+}
+
+func (m *ProgressMonitor) now() time.Time {
+	if m.Clock != nil {
+		return m.Clock.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (m *ProgressMonitor) failureThreshold() int {
+	if m.FailureThreshold > 0 {
+		return m.FailureThreshold
+	}
+	return 3
+}
+
+func (m *ProgressMonitor) staleMultiplier() int {
+	if m.StaleMultiplier > 0 {
+		return m.StaleMultiplier
+	}
+	return 3
+}
+
+func (m *ProgressMonitor) minStale() time.Duration {
+	if m.MinStale > 0 {
+		return m.MinStale
+	}
+	return 30 * time.Minute
+}
+
+func (m *ProgressMonitor) reAlertEvery() time.Duration {
+	if m.ReAlertEvery > 0 {
+		return m.ReAlertEvery
+	}
+	return 24 * time.Hour
+}
+
+func (m *ProgressMonitor) interval() time.Duration {
+	if m.Interval > 0 {
+		return m.Interval
+	}
+	return time.Minute
+}
+
+// Run ticks Check + Alert until ctx is done. It is a plain goroutine on
+// purpose: nothing about it goes through River, so River being wedged, never
+// started, or never wired at all cannot suppress it.
+func (m *ProgressMonitor) Run(ctx context.Context) {
+	if m == nil || m.DB == nil {
+		return
+	}
+	var ticker clockwork.Ticker
+	if m.Clock != nil {
+		ticker = m.Clock.NewTicker(m.interval())
+	} else {
+		ticker = clockwork.NewRealClock().NewTicker(m.interval())
+	}
+	defer ticker.Stop()
+	log.WithField("interval", m.interval()).Info("river progress monitor started (#895: out-of-River detector)")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.Chan():
+			report, err := m.Check(ctx)
+			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				log.WithError(err).Warn("river progress monitor: check failed")
+				continue
+			}
+			if err := m.RaiseAlerts(ctx, report); err != nil && ctx.Err() == nil {
+				log.WithError(err).Warn("river progress monitor: alerting failed")
+			}
+		}
+	}
+}
+
+// Check evaluates the fleet. It seeds a health row per registered kind first,
+// so a kind that has never run once is a visible row rather than an absence,
+// then reads River's own river_job watermarks and the worker_health rows.
+func (m *ProgressMonitor) Check(ctx context.Context) (ProgressReport, error) {
+	if m == nil || m.DB == nil {
+		return ProgressReport{}, fmt.Errorf("river progress: DB is required")
+	}
+	now := m.now()
+	if m.startedAt.IsZero() {
+		m.startedAt = now
+	}
+	q := m.DB.Gen(ctx)
+
+	registered := m.Registrations.Snapshot()
+	for kind, period := range registered {
+		var secs *int64
+		if period > 0 {
+			s := int64(period / time.Second)
+			secs = &s
+		}
+		if err := q.SeedWorkerHealth(ctx, gen.SeedWorkerHealthParams{WorkerKind: kind, ExpectedPeriodSeconds: secs}); err != nil {
+			return ProgressReport{}, fmt.Errorf("river progress: seed %s: %w", kind, err)
+		}
+	}
+
+	rows, err := q.ListWorkerHealth(ctx)
+	if err != nil {
+		return ProgressReport{}, fmt.Errorf("river progress: list worker health: %w", err)
+	}
+
+	kinds := make([]string, 0, len(registered))
+	shortest := time.Duration(0)
+	for kind, period := range registered {
+		kinds = append(kinds, kind)
+		if period > 0 && (shortest == 0 || period < shortest) {
+			shortest = period
+		}
+	}
+	sort.Strings(kinds)
+
+	stats, err := m.readRiverJobStats(ctx, kinds)
+	if err != nil {
+		return ProgressReport{}, err
+	}
+
+	report := ProgressReport{CheckedAt: now, ShortestPeriod: shortest}
+	byKind := make(map[string]gen.OpenrailsWorkerHealth, len(rows))
+	for _, row := range rows {
+		byKind[row.WorkerKind] = row
+	}
+	for _, kind := range kinds {
+		stat := stats[kind]
+		kp := KindProgress{
+			Kind:            kind,
+			ExpectedPeriod:  registered[kind],
+			LastEnqueuedAt:  stat.LastEnqueuedAt,
+			LastCompletedAt: stat.LastCompletedAt,
+			Overdue:         stat.Overdue,
+		}
+		if row, ok := byKind[kind]; ok {
+			kp.LastSuccessAt = row.LastSuccessAt
+			kp.Reason = evaluateKindProgress(row, kp, now, m.failureThreshold(), m.staleMultiplier(), m.minStale())
+		}
+		if kp.Reason != "" {
+			report.Unhealthy++
+		}
+		report.Kinds = append(report.Kinds, kp)
+		report.FleetLastEnqueuedAt = laterOf(report.FleetLastEnqueuedAt, stat.LastEnqueuedAt)
+		report.FleetLastCompletedAt = laterOf(report.FleetLastCompletedAt, stat.LastCompletedAt)
+	}
+
+	report.Reason = m.fleetVerdict(report, now)
+	report.Progressing = report.Reason == ""
+	return report, nil
+}
+
+// fleetVerdict answers Paul's question directly — "is the cron system
+// progressing?" — from river_job watermarks alone, with a boot grace period so
+// a process that just started does not alarm before its first tick could fire.
+func (m *ProgressMonitor) fleetVerdict(report ProgressReport, now time.Time) string {
+	if report.ShortestPeriod <= 0 {
+		return "" // no periodic kinds registered: nothing to be late against
+	}
+	if m.Pool == nil {
+		return "" // river_job unreadable by configuration; per-kind detail still applies
+	}
+	threshold := report.ShortestPeriod * time.Duration(m.staleMultiplier())
+	if threshold < m.minStale() {
+		threshold = m.minStale()
+	}
+	// Boot grace: never alarm on a window the process was not alive for.
+	if now.Sub(m.startedAt) < threshold {
+		return ""
+	}
+	if report.FleetLastEnqueuedAt == nil || now.Sub(*report.FleetLastEnqueuedAt) > threshold {
+		return ProgressNotScheduling
+	}
+	if report.FleetLastCompletedAt == nil || now.Sub(*report.FleetLastCompletedAt) > threshold {
+		return ProgressNotCompleting
+	}
+	for _, kp := range report.Kinds {
+		if kp.Overdue > 0 {
+			return ProgressBacklog
+		}
+	}
+	return ""
+}
+
+// readRiverJobStats reads River's OWN table. The kind list is bound as a
+// parameter; only the schema is interpolated, and it is validated as a plain
+// identifier first so it can never carry SQL.
+func (m *ProgressMonitor) readRiverJobStats(ctx context.Context, kinds []string) (map[string]riverJobStat, error) {
+	out := make(map[string]riverJobStat, len(kinds))
+	if m.Pool == nil || len(kinds) == 0 {
+		return out, nil
+	}
+	schema := strings.TrimSpace(m.RiverSchema)
+	if schema == "" {
+		schema = "public"
+	}
+	if !isPlainIdentifier(schema) {
+		return nil, fmt.Errorf("river progress: refusing unsafe river schema %q", schema)
+	}
+	// Overdue = due in the past by more than one shortest-cadence beat and still
+	// not finalized. now() is the DB clock deliberately: a skewed app clock must
+	// not manufacture a backlog.
+	sql := fmt.Sprintf(`
+SELECT kind,
+       max(created_at)                                      AS last_enqueued_at,
+       max(finalized_at) FILTER (WHERE state = 'completed') AS last_completed_at,
+       count(*) FILTER (WHERE state IN ('available', 'retryable')
+                          AND scheduled_at < now() - $2::interval) AS overdue
+FROM %s.river_job
+WHERE kind = ANY($1::text[])
+GROUP BY kind`, schema)
+
+	overdueAfter := m.minStale()
+	rows, err := m.Pool.Query(ctx, sql, kinds, overdueAfter.String())
+	if err != nil {
+		return nil, fmt.Errorf("river progress: read %s.river_job: %w", schema, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var s riverJobStat
+		if err := rows.Scan(&s.Kind, &s.LastEnqueuedAt, &s.LastCompletedAt, &s.Overdue); err != nil {
+			return nil, fmt.Errorf("river progress: scan river_job: %w", err)
+		}
+		out[s.Kind] = s
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("river progress: read %s.river_job: %w", schema, err)
+	}
+	return out, nil
+}
+
+func isPlainIdentifier(s string) bool {
+	if s == "" || len(s) > 63 {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r == '_':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9' && i > 0:
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func laterOf(a, b *time.Time) *time.Time {
+	if b == nil {
+		return a
+	}
+	if a == nil || b.After(*a) {
+		return b
+	}
+	return a
+}
+
+// evaluateKindProgress returns "" when the kind is healthy, else the reason.
+// Progress evidence is taken from river_job FIRST (River's own writes) and only
+// then from worker_health.last_success_at, so a deployment whose middleware is
+// missing reports the truth instead of never_succeeded for everything.
+func evaluateKindProgress(row gen.OpenrailsWorkerHealth, kp KindProgress, now time.Time, failureThreshold, staleMultiplier int, minStale time.Duration) string {
+	if int(row.ConsecutiveFailures) >= failureThreshold {
+		return ProgressConsecutiveFailures
+	}
+	if kp.ExpectedPeriod <= 0 && (row.ExpectedPeriodSeconds == nil || *row.ExpectedPeriodSeconds <= 0) {
+		return "" // on-demand kind: no cadence to be late against
+	}
+	period := kp.ExpectedPeriod
+	if period <= 0 {
+		period = time.Duration(*row.ExpectedPeriodSeconds) * time.Second
+	}
+	threshold := period * time.Duration(staleMultiplier)
+	if threshold < minStale {
+		threshold = minStale
+	}
+	progress := laterOf(kp.LastCompletedAt, row.LastSuccessAt)
+	if progress == nil {
+		if now.Sub(row.RegisteredAt) > threshold {
+			return ProgressNeverSucceeded
+		}
+		return ""
+	}
+	if now.Sub(*progress) > threshold {
+		return ProgressStale
+	}
+	return ""
+}
+
+// workerAlertDue dedupes: alert on first trip, on a fresh incident (progress
+// happened since the last alert), or on the re-alert pacing while it persists.
+func workerAlertDue(row gen.OpenrailsWorkerHealth, now time.Time, reAlertEvery time.Duration) bool {
+	if row.LastAlertedAt == nil {
+		return true
+	}
+	if row.LastSuccessAt != nil && row.LastSuccessAt.After(*row.LastAlertedAt) {
+		return true
+	}
+	return now.Sub(*row.LastAlertedAt) >= reAlertEvery
+}
+
+// RaiseAlerts routes every unhealthy kind — and the fleet-level stall itself —
+// to the durable repair-alert channel (notification_queue system alerts, the
+// same admin surface the ledger reconcilers use).
+func (m *ProgressMonitor) RaiseAlerts(ctx context.Context, report ProgressReport) error {
+	if m == nil || m.DB == nil {
+		return fmt.Errorf("river progress: DB is required")
+	}
+	q := m.DB.Gen(ctx)
+	rows, err := q.ListWorkerHealth(ctx)
+	if err != nil {
+		return fmt.Errorf("river progress: list worker health: %w", err)
+	}
+	byKind := make(map[string]gen.OpenrailsWorkerHealth, len(rows))
+	for _, row := range rows {
+		byKind[row.WorkerKind] = row
+	}
+
+	var alerted, failedAlerts int
+	// The fleet-level stall is the #895 signal: it fires even when every
+	// per-kind row still looks fine (nothing has been late long enough yet),
+	// and it is the ONLY one that can fire while River is completely dead.
+	if !report.Progressing {
+		fleetRow := byKind[fleetHealthKind]
+		fleetRow.WorkerKind = fleetHealthKind
+		if workerAlertDue(fleetRow, report.CheckedAt, m.reAlertEvery()) {
+			if err := m.raiseAlert(ctx, fleetRow, report.Reason, report.CheckedAt, report); err != nil {
+				failedAlerts++
+				log.WithContext(ctx).WithError(err).Error("river progress: failed to raise fleet repair alert")
+			} else {
+				alerted++
+				if err := q.SeedWorkerHealth(ctx, gen.SeedWorkerHealthParams{WorkerKind: fleetHealthKind}); err != nil {
+					log.WithContext(ctx).WithError(err).Warn("river progress: failed to seed fleet health row")
+				}
+				if err := q.MarkWorkerHealthAlerted(ctx, gen.MarkWorkerHealthAlertedParams{WorkerKind: fleetHealthKind, Now: report.CheckedAt}); err != nil {
+					log.WithContext(ctx).WithError(err).Warn("river progress: failed to mark fleet alerted")
+				}
+			}
+		}
+	}
+
+	for _, kp := range report.Kinds {
+		if kp.Reason == "" {
+			continue
+		}
+		row, ok := byKind[kp.Kind]
+		if !ok {
+			row = gen.OpenrailsWorkerHealth{WorkerKind: kp.Kind}
+		}
+		if !workerAlertDue(row, report.CheckedAt, m.reAlertEvery()) {
+			continue
+		}
+		if err := m.raiseAlert(ctx, row, kp.Reason, report.CheckedAt, report); err != nil {
+			failedAlerts++
+			log.WithContext(ctx).WithError(err).WithField("worker_kind", kp.Kind).
+				Error("river progress: failed to raise repair alert")
+			continue
+		}
+		alerted++
+		if err := q.MarkWorkerHealthAlerted(ctx, gen.MarkWorkerHealthAlertedParams{WorkerKind: kp.Kind, Now: report.CheckedAt}); err != nil {
+			log.WithContext(ctx).WithError(err).WithField("worker_kind", kp.Kind).
+				Warn("river progress: failed to mark alerted")
+		}
+	}
+	if alerted > 0 || failedAlerts > 0 {
+		log.WithContext(ctx).WithFields(log.Fields{"alerted": alerted, "failed": failedAlerts, "reason": report.Reason}).
+			Warn("river progress: unhealthy periodic fleet")
+	}
+	if failedAlerts > 0 {
+		return fmt.Errorf("river progress: %d repair alerts failed to record", failedAlerts)
+	}
+	return nil
+}
+
+// fleetHealthKind is the pseudo-kind the fleet-level verdict alerts and dedupes
+// under. It is NOT a River job kind — nothing enqueues it — it exists so the
+// fleet stall gets the same durable, deduped alert row every other kind gets.
+const fleetHealthKind = "openrails.river_fleet"
+
+func (m *ProgressMonitor) raiseAlert(ctx context.Context, row gen.OpenrailsWorkerHealth, reason string, now time.Time, report ProgressReport) error {
+	merchantIDs, err := m.DB.Gen(ctx).ListActiveMerchantIDs(ctx)
+	if err != nil {
+		return fmt.Errorf("list merchants: %w", err)
+	}
+	if len(merchantIDs) == 0 {
+		return fmt.Errorf("no active merchants to receive the alert")
+	}
+	metadata := map[string]any{
+		"worker_kind":          row.WorkerKind,
+		"reason":               reason,
+		"consecutive_failures": row.ConsecutiveFailures,
+		"detector":             "river_progress_monitor",
+	}
+	if row.ExpectedPeriodSeconds != nil {
+		metadata["expected_period_seconds"] = *row.ExpectedPeriodSeconds
+	}
+	if row.LastSuccessAt != nil {
+		metadata["last_success_at"] = row.LastSuccessAt.UTC().Format(time.RFC3339)
+	}
+	if row.LastErrorAt != nil {
+		metadata["last_error_at"] = row.LastErrorAt.UTC().Format(time.RFC3339)
+	}
+	if report.FleetLastEnqueuedAt != nil {
+		metadata["fleet_last_enqueued_at"] = report.FleetLastEnqueuedAt.UTC().Format(time.RFC3339)
+	}
+	if report.FleetLastCompletedAt != nil {
+		metadata["fleet_last_completed_at"] = report.FleetLastCompletedAt.UTC().Format(time.RFC3339)
+	}
+	alertErr := fmt.Errorf("worker %s unhealthy: %s", row.WorkerKind, reason)
+	if row.WorkerKind == fleetHealthKind {
+		alertErr = fmt.Errorf("river periodic fleet is not progressing: %s", reason)
+	}
+	if row.LastError != nil && *row.LastError != "" {
+		alertErr = fmt.Errorf("worker %s unhealthy (%s): %s", row.WorkerKind, reason, *row.LastError)
+	}
+	alertErrors := make([]error, 0)
+	idempotencyKey := workerHealthAlertIdempotencyKey(row, reason)
+	for _, mid := range merchantIDs {
+		mctx := merchant.WithID(ctx, merchant.ID(mid))
+		if err := m.DB.RunInMerchantConn(mctx, func(ctx context.Context) error {
+			return webhooks.RecordLedgerRepairAlert(ctx, m.NotificationService, m.DB, now, webhooks.LedgerRepairAlert{
+				Provider:       "openrails",
+				Operation:      "river_progress",
+				IdempotencyKey: idempotencyKey,
+				Err:            alertErr,
+				Metadata:       metadata,
+			})
+		}); err != nil {
+			alertErrors = append(alertErrors, fmt.Errorf("merchant %s: %w", mid, err))
+		}
+	}
+	if err := errors.Join(alertErrors...); err != nil {
+		return fmt.Errorf("record repair alerts: %w", err)
+	}
+	return nil
+}

--- a/internal/river/progress_integration_test.go
+++ b/internal/river/progress_integration_test.go
@@ -1,0 +1,208 @@
+//go:build integration
+
+package riverjobs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	riverpgxv5 "github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/db"
+	"github.com/open-rails/openrails/internal/dbtest"
+)
+
+// #895 deliverable (B): a live progress detector that does NOT live in River.
+//
+// These tests exercise the case the retired WorkerHealthCheckWorker could not
+// reach by construction — River genuinely not progressing — against a REAL
+// Postgres, a REAL river.Client and REAL river_job rows. The detector is the
+// same object internal/app runs; only its thresholds are shrunk so the test
+// does not take half an hour.
+
+type progArgs struct{}
+
+func (progArgs) Kind() string { return progKind }
+
+const progKind = "test.progress_periodic"
+
+type progWorker struct {
+	river.WorkerDefaults[progArgs]
+}
+
+func (progWorker) Work(context.Context, *river.Job[progArgs]) error { return nil }
+
+func newProgressMonitor(t *testing.T, dbi *db.DB, regs *WorkerRegistrations) *ProgressMonitor {
+	t.Helper()
+	return &ProgressMonitor{
+		DB:               dbi,
+		Pool:             dbtest.SharedPGXPool(t),
+		RiverSchema:      "public",
+		Registrations:    regs,
+		FailureThreshold: 99, // keep the streak rule out of these tests
+		StaleMultiplier:  1,
+		MinStale:         time.Second,
+		ReAlertEvery:     time.Hour,
+	}
+}
+
+// countRiverJobs reports how many rows exist for the test kind in a given state.
+func countRiverJobs(t *testing.T, state string) int {
+	t.Helper()
+	ctx := context.Background()
+	var n int
+	require.NoError(t, dbtest.SharedPGXPool(t).QueryRow(ctx,
+		`SELECT count(*) FROM public.river_job WHERE kind = $1 AND state::text = $2`, progKind, state).Scan(&n))
+	return n
+}
+
+func clearRiverJobs(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := dbtest.SharedPGXPool(t).Exec(ctx, `DELETE FROM public.river_job WHERE kind = $1`, progKind)
+	require.NoError(t, err)
+}
+
+// TestProgressMonitor_DetectsFleetNeverStarted is the headline #895 proof: a
+// host wires the fleet (workers registered, periodic jobs scheduled, client
+// constructed) and never starts it. Nothing is enqueued, nothing completes —
+// and the detector still fires, because it is not a job.
+func TestProgressMonitor_DetectsFleetNeverStarted(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+	dbi := dbtest.OpenAppDB(t, dsn)
+	dbtest.EnsureTestMerchant(dbtest.WithTestMerchant(ctx), t, dbi.Pool())
+	cleanupWorkerHealth(t, dbi, progKind, "openrails.river_fleet")
+	clearRiverJobs(t)
+	t.Cleanup(func() { clearRiverJobs(t) })
+
+	regs := NewWorkerRegistrations()
+	regs.NoteKind(progKind)
+	regs.NotePeriod(progKind, time.Second)
+	monitor := newProgressMonitor(t, dbi, regs)
+
+	// A REAL client, fully wired — and deliberately never started. This is
+	// exactly the state that used to be invisible: the in-River detector could
+	// not run either, so "nothing is running" looked identical to "healthy".
+	workers := river.NewWorkers()
+	require.NoError(t, river.AddWorkerSafely(workers, &progWorker{}))
+	client, err := river.NewClient(riverpgxv5.New(dbtest.SharedPGXPool(t)), &river.Config{
+		Queues:            map[string]river.QueueConfig{river.QueueDefault: {MaxWorkers: 2}},
+		Workers:           workers,
+		FetchCooldown:     10 * time.Millisecond,
+		FetchPollInterval: 50 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	client.PeriodicJobs().Add(river.NewPeriodicJob(
+		river.PeriodicInterval(time.Second),
+		func() (river.JobArgs, *river.InsertOpts) { return progArgs{}, nil },
+		&river.PeriodicJobOpts{RunOnStart: true},
+	))
+
+	// First Check anchors the boot grace window; wait past it, then evaluate.
+	first, err := monitor.Check(ctx)
+	require.NoError(t, err)
+	require.True(t, first.Progressing, "inside the boot grace window nothing is late yet")
+
+	time.Sleep(2 * time.Second)
+	stalled, err := monitor.Check(ctx)
+	require.NoError(t, err)
+
+	// NEGATIVE CONTROL, in-test: at the instant the detector fires, ZERO jobs
+	// have run. Any detector implemented as a River job had exactly zero
+	// opportunities to produce this signal.
+	require.Equal(t, 0, countRiverJobs(t, "completed"), "no job has completed")
+	require.Equal(t, 0, countRiverJobs(t, "available"), "nothing was even enqueued")
+
+	require.False(t, stalled.Progressing, "a fleet that never started is not progressing")
+	require.Equal(t, ProgressNotScheduling, stalled.Reason)
+	require.Nil(t, stalled.FleetLastEnqueuedAt)
+
+	// The stall reaches the operator through the durable repair-alert channel.
+	require.NoError(t, monitor.RaiseAlerts(ctx, stalled))
+	require.Equal(t, 1, countWorkerHealthAlerts(t, dbi, "openrails.river_fleet"))
+	require.Equal(t, ProgressNotScheduling, alertReason(t, dbi, "openrails.river_fleet"))
+
+	// Now start the SAME client. River schedules and works the periodic job, and
+	// the detector flips back on its own — no job ran to tell it so.
+	require.NoError(t, client.Start(ctx))
+	t.Cleanup(func() { _ = client.Stop(context.Background()) })
+
+	require.Eventually(t, func() bool {
+		report, err := monitor.Check(ctx)
+		return err == nil && report.Progressing
+	}, 30*time.Second, 250*time.Millisecond, "detector must clear once River actually progresses")
+}
+
+// TestProgressMonitor_DetectsQueueNotDraining covers the other half of "wired
+// but not progressing": River IS running and inserting, but the queue the jobs
+// land on is not configured on the client, so nothing is ever worked. Every
+// read API stays correct while the money stops.
+func TestProgressMonitor_DetectsQueueNotDraining(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+	dbi := dbtest.OpenAppDB(t, dsn)
+	dbtest.EnsureTestMerchant(dbtest.WithTestMerchant(ctx), t, dbi.Pool())
+	cleanupWorkerHealth(t, dbi, progKind, "openrails.river_fleet")
+	clearRiverJobs(t)
+	t.Cleanup(func() { clearRiverJobs(t) })
+
+	regs := NewWorkerRegistrations()
+	regs.NoteKind(progKind)
+	regs.NotePeriod(progKind, time.Second)
+	monitor := newProgressMonitor(t, dbi, regs)
+
+	unservedQueue := "test_unserved_" + uuid.NewString()[:8]
+	workers := river.NewWorkers()
+	require.NoError(t, river.AddWorkerSafely(workers, &progWorker{}))
+	client, err := river.NewClient(riverpgxv5.New(dbtest.SharedPGXPool(t)), &river.Config{
+		// Only the default queue is served; the periodic job lands elsewhere.
+		Queues:            map[string]river.QueueConfig{river.QueueDefault: {MaxWorkers: 2}},
+		Workers:           workers,
+		FetchCooldown:     10 * time.Millisecond,
+		FetchPollInterval: 50 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	client.PeriodicJobs().Add(river.NewPeriodicJob(
+		river.PeriodicInterval(time.Second),
+		func() (river.JobArgs, *river.InsertOpts) {
+			return progArgs{}, &river.InsertOpts{Queue: unservedQueue}
+		},
+		&river.PeriodicJobOpts{RunOnStart: true},
+	))
+
+	_, err = monitor.Check(ctx) // anchor the grace window
+	require.NoError(t, err)
+
+	require.NoError(t, client.Start(ctx))
+	t.Cleanup(func() { _ = client.Stop(context.Background()) })
+
+	require.Eventually(t, func() bool {
+		return countRiverJobs(t, "available") > 0
+	}, 30*time.Second, 100*time.Millisecond, "River must be inserting the periodic job")
+
+	time.Sleep(2 * time.Second)
+	report, err := monitor.Check(ctx)
+	require.NoError(t, err)
+
+	require.Positive(t, countRiverJobs(t, "available"), "work is queued")
+	require.Equal(t, 0, countRiverJobs(t, "completed"), "and none of it is being worked")
+
+	require.False(t, report.Progressing, "inserting without completing is not progress")
+	require.Equal(t, ProgressNotCompleting, report.Reason)
+	require.NotNil(t, report.FleetLastEnqueuedAt, "River IS alive — it is the workers that are not")
+	require.Error(t, report.Err(), "the report renders as a host-facing error")
+}
+
+// TestProgressReport_ErrRendersStall pins the host-facing rendering used by
+// health endpoints.
+func TestProgressReport_ErrRendersStall(t *testing.T) {
+	require.NoError(t, ProgressReport{Progressing: true}.Err())
+	err := ProgressReport{Reason: ProgressNotScheduling}.Err()
+	require.Error(t, err)
+	require.ErrorContains(t, err, ProgressNotScheduling)
+}

--- a/internal/river/worker_health.go
+++ b/internal/river/worker_health.go
@@ -3,7 +3,6 @@ package riverjobs
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -14,26 +13,17 @@ import (
 
 	"github.com/open-rails/openrails/internal/db"
 	"github.com/open-rails/openrails/internal/db/gen"
-	"github.com/open-rails/openrails/internal/modules/subscriptions"
-	"github.com/open-rails/openrails/internal/modules/webhooks"
 	"github.com/open-rails/openrails/internal/shared/uuidutil"
-	"github.com/open-rails/openrails/pkg/merchant"
 )
 
-// #689: per-worker health bookkeeping. One middleware wraps EVERY registered
-// worker (zero per-worker code) and upserts openrails.worker_health per job
-// completion; a periodic checker raises durable repair alerts when a kind has
-// never succeeded, keeps failing, or went stale past its declared cadence.
-
-const KindWorkerHealthCheck = "openrails.worker_health_check"
+// #689/#895: per-worker health bookkeeping. The middleware is attached to every
+// OpenRails worker at registration (internal/app.addTrackedWorker) and upserts
+// openrails.worker_health per job completion. The ALERT EVALUATOR that reads
+// these rows lives in progress.go and is deliberately NOT a River job (#895).
 
 // maxWorkerHealthErrorLen bounds last_error (runes, so truncation never splits
 // a UTF-8 sequence — Postgres rejects invalid text).
 const maxWorkerHealthErrorLen = 2000
-
-type WorkerHealthCheckArgs struct{}
-
-func (WorkerHealthCheckArgs) Kind() string { return KindWorkerHealthCheck }
 
 // WorkerRegistrations captures every registered worker kind and, for periodic
 // kinds, the expected cadence — recorded at registration time so the checker
@@ -143,167 +133,6 @@ func truncateRunes(s string, n int) string {
 	return string(runes[:n])
 }
 
-// WorkerHealthCheckWorker is the periodic alert evaluator: it seeds a health
-// row for every registered kind (so never-run workers are visible from day
-// one), evaluates the alert rules and routes trips to the existing repair-alert
-// channel (notification_queue system alerts, per active merchant — the same
-// admin surface the ledger reconcilers use). Its own runs heartbeat through the
-// same table, so a wedged checker is at least visible as a stale row.
-type WorkerHealthCheckWorker struct {
-	river.WorkerDefaults[WorkerHealthCheckArgs]
-	DB                  *db.DB
-	Clock               clockwork.Clock
-	Registrations       *WorkerRegistrations
-	NotificationService *subscriptions.NotificationService
-
-	// Tunables; zero values take the defaults below.
-	FailureThreshold int           // consecutive failures before alerting (default 3)
-	StaleMultiplier  int           // k in "no success within k x expected period" (default 3)
-	MinStale         time.Duration // floor for the staleness threshold (default 30m)
-	ReAlertEvery     time.Duration // re-alert pacing while a kind stays unhealthy (default 24h)
-}
-
-func (WorkerHealthCheckWorker) Kind() string { return KindWorkerHealthCheck }
-
-func (w *WorkerHealthCheckWorker) now() time.Time {
-	if w.Clock != nil {
-		return w.Clock.Now().UTC()
-	}
-	return time.Now().UTC()
-}
-
-func (w *WorkerHealthCheckWorker) failureThreshold() int {
-	if w.FailureThreshold > 0 {
-		return w.FailureThreshold
-	}
-	return 3
-}
-
-func (w *WorkerHealthCheckWorker) staleMultiplier() int {
-	if w.StaleMultiplier > 0 {
-		return w.StaleMultiplier
-	}
-	return 3
-}
-
-func (w *WorkerHealthCheckWorker) minStale() time.Duration {
-	if w.MinStale > 0 {
-		return w.MinStale
-	}
-	return 30 * time.Minute
-}
-
-func (w *WorkerHealthCheckWorker) reAlertEvery() time.Duration {
-	if w.ReAlertEvery > 0 {
-		return w.ReAlertEvery
-	}
-	return 24 * time.Hour
-}
-
-func (w *WorkerHealthCheckWorker) Work(ctx context.Context, _ *river.Job[WorkerHealthCheckArgs]) error {
-	if w.DB == nil {
-		return fmt.Errorf("worker health check: DB is required")
-	}
-	now := w.now()
-	q := w.DB.Gen(ctx)
-
-	// Seed a row per registered kind so "expected N runs, got 0" is a visible
-	// row, not an absence. Idempotent; refreshes the declared cadence.
-	registered := w.Registrations.Snapshot()
-	for kind, period := range registered {
-		var secs *int64
-		if period > 0 {
-			s := int64(period / time.Second)
-			secs = &s
-		}
-		if err := q.SeedWorkerHealth(ctx, gen.SeedWorkerHealthParams{WorkerKind: kind, ExpectedPeriodSeconds: secs}); err != nil {
-			return fmt.Errorf("worker health check: seed %s: %w", kind, err)
-		}
-	}
-
-	rows, err := q.ListWorkerHealth(ctx)
-	if err != nil {
-		return fmt.Errorf("worker health check: list: %w", err)
-	}
-
-	var alerted, failedAlerts int
-	for _, row := range rows {
-		// Rows for kinds not registered in THIS deploy (retired workers) stay
-		// visible on the admin surface but never alert. A nil registration set
-		// (manual/test invocation) evaluates everything.
-		if registered != nil {
-			if _, ok := registered[row.WorkerKind]; !ok {
-				continue
-			}
-		}
-		reason := evaluateWorkerHealth(row, now, w.failureThreshold(), w.staleMultiplier(), w.minStale())
-		if reason == "" || !workerAlertDue(row, now, w.reAlertEvery()) {
-			continue
-		}
-		if err := w.raiseAlert(ctx, row, reason, now); err != nil {
-			failedAlerts++
-			log.WithContext(ctx).WithError(err).WithField("worker_kind", row.WorkerKind).
-				Error("worker health check: failed to raise repair alert")
-			continue
-		}
-		alerted++
-		if err := q.MarkWorkerHealthAlerted(ctx, gen.MarkWorkerHealthAlertedParams{WorkerKind: row.WorkerKind, Now: now}); err != nil {
-			log.WithContext(ctx).WithError(err).WithField("worker_kind", row.WorkerKind).
-				Warn("worker health check: failed to mark alerted")
-		}
-	}
-	if alerted > 0 || failedAlerts > 0 {
-		log.WithContext(ctx).WithFields(log.Fields{"alerted": alerted, "failed": failedAlerts}).
-			Warn("worker health check: unhealthy workers")
-	}
-
-	// Explicit heartbeat: even without the middleware attached (external River
-	// wiring), a completed evaluation is recorded.
-	if err := q.RecordWorkerSuccess(ctx, gen.RecordWorkerSuccessParams{WorkerKind: KindWorkerHealthCheck, Now: now}); err != nil {
-		log.WithContext(ctx).WithError(err).Warn("worker health check: heartbeat failed")
-	}
-	if failedAlerts > 0 {
-		return fmt.Errorf("worker health check: %d repair alerts failed to record", failedAlerts)
-	}
-	return nil
-}
-
-// evaluateWorkerHealth returns "" when healthy, else the alert reason.
-func evaluateWorkerHealth(row gen.OpenrailsWorkerHealth, now time.Time, failureThreshold, staleMultiplier int, minStale time.Duration) string {
-	if int(row.ConsecutiveFailures) >= failureThreshold {
-		return "consecutive_failures"
-	}
-	if row.ExpectedPeriodSeconds == nil || *row.ExpectedPeriodSeconds <= 0 {
-		return "" // on-demand kind: no cadence to be late against
-	}
-	threshold := time.Duration(*row.ExpectedPeriodSeconds) * time.Second * time.Duration(staleMultiplier)
-	if threshold < minStale {
-		threshold = minStale
-	}
-	if row.LastSuccessAt == nil {
-		if now.Sub(row.RegisteredAt) > threshold {
-			return "never_succeeded"
-		}
-		return ""
-	}
-	if now.Sub(*row.LastSuccessAt) > threshold {
-		return "stale"
-	}
-	return ""
-}
-
-// workerAlertDue dedupes: alert on first trip, on a fresh incident (a success
-// happened since the last alert), or on the re-alert pacing while it persists.
-func workerAlertDue(row gen.OpenrailsWorkerHealth, now time.Time, reAlertEvery time.Duration) bool {
-	if row.LastAlertedAt == nil {
-		return true
-	}
-	if row.LastSuccessAt != nil && row.LastSuccessAt.After(*row.LastAlertedAt) {
-		return true
-	}
-	return now.Sub(*row.LastAlertedAt) >= reAlertEvery
-}
-
 // workerHealthAlertIdempotencyKey identifies one alerting incident. Retry-
 // volatile health details are deliberately excluded so a partial merchant
 // fan-out retries only the deliveries that did not already persist.
@@ -327,54 +156,3 @@ func workerHealthAlertIdempotencyKey(row gen.OpenrailsWorkerHealth, reason strin
 	).String()
 }
 
-// raiseAlert routes one unhealthy kind to the existing repair-alert channel.
-// Worker health is operator-global but the channel is merchant-scoped, so the
-// alert fans out to every active merchant (embedded deployments have exactly
-// one) — a wedged worker stalls billing for all of them.
-func (w *WorkerHealthCheckWorker) raiseAlert(ctx context.Context, row gen.OpenrailsWorkerHealth, reason string, now time.Time) error {
-	merchantIDs, err := w.DB.Gen(ctx).ListActiveMerchantIDs(ctx)
-	if err != nil {
-		return fmt.Errorf("list merchants: %w", err)
-	}
-	if len(merchantIDs) == 0 {
-		return fmt.Errorf("no active merchants to receive the alert")
-	}
-	metadata := map[string]any{
-		"worker_kind":          row.WorkerKind,
-		"reason":               reason,
-		"consecutive_failures": row.ConsecutiveFailures,
-	}
-	if row.ExpectedPeriodSeconds != nil {
-		metadata["expected_period_seconds"] = *row.ExpectedPeriodSeconds
-	}
-	if row.LastSuccessAt != nil {
-		metadata["last_success_at"] = row.LastSuccessAt.UTC().Format(time.RFC3339)
-	}
-	if row.LastErrorAt != nil {
-		metadata["last_error_at"] = row.LastErrorAt.UTC().Format(time.RFC3339)
-	}
-	alertErr := fmt.Errorf("worker %s unhealthy: %s", row.WorkerKind, reason)
-	if row.LastError != nil && *row.LastError != "" {
-		alertErr = fmt.Errorf("worker %s unhealthy (%s): %s", row.WorkerKind, reason, *row.LastError)
-	}
-	alertErrors := make([]error, 0)
-	idempotencyKey := workerHealthAlertIdempotencyKey(row, reason)
-	for _, mid := range merchantIDs {
-		mctx := merchant.WithID(ctx, merchant.ID(mid))
-		if err := w.DB.RunInMerchantConn(mctx, func(ctx context.Context) error {
-			return webhooks.RecordLedgerRepairAlert(ctx, w.NotificationService, w.DB, now, webhooks.LedgerRepairAlert{
-				Provider:       "openrails",
-				Operation:      "worker_health",
-				IdempotencyKey: idempotencyKey,
-				Err:            alertErr,
-				Metadata:       metadata,
-			})
-		}); err != nil {
-			alertErrors = append(alertErrors, fmt.Errorf("merchant %s: %w", mid, err))
-		}
-	}
-	if err := errors.Join(alertErrors...); err != nil {
-		return fmt.Errorf("record repair alerts: %w", err)
-	}
-	return nil
-}

--- a/internal/river/worker_health_integration_test.go
+++ b/internal/river/worker_health_integration_test.go
@@ -20,11 +20,13 @@ import (
 	"github.com/open-rails/openrails/pkg/merchant"
 )
 
-// #689 end-to-end through a REAL River client: the one middleware records every
-// worked job's outcome in openrails.worker_health, and the checker routes
-// unhealthy kinds to the existing repair-alert channel (notification_queue
-// system alerts) — the failure mode of #673 (a worker failing 100% of its runs
-// since birth) becomes a durable alert instead of log wallpaper.
+// #689/#895 end-to-end through a REAL River client: the middleware records every
+// worked job's outcome in openrails.worker_health, and ProgressMonitor — which
+// is NOT a River job (#895) — routes unhealthy kinds to the existing
+// repair-alert channel (notification_queue system alerts). The failure mode of
+// #673 (a worker failing 100% of its runs since birth) becomes a durable alert
+// instead of log wallpaper, and unlike the retired WorkerHealthCheckWorker the
+// evaluation runs even when River itself never worked a job.
 
 const (
 	whFailingKind = "test.wh_always_failing"
@@ -88,7 +90,7 @@ func cleanupWorkerHealth(t *testing.T, dbi *db.DB, kinds ...string) {
 		}
 		mctx := dbtest.WithTestMerchant(ctx)
 		_ = dbi.RunInMerchantConn(mctx, func(ctx context.Context) error {
-			_, _ = dbi.Qx(ctx).Exec(ctx, `DELETE FROM openrails.notification_queue WHERE event_type = 'system_alert' AND data->>'operation' = 'worker_health'`)
+			_, _ = dbi.Qx(ctx).Exec(ctx, `DELETE FROM openrails.notification_queue WHERE event_type = 'system_alert' AND data->>'operation' = 'river_progress'`)
 			if !systemCustomerExisted {
 				_, _ = dbi.Qx(ctx).Exec(ctx,
 					`DELETE FROM openrails.customers c
@@ -179,7 +181,7 @@ func countWorkerHealthAlertsForMerchant(t *testing.T, dbi *db.DB, merchantID mer
 		return dbi.Qx(ctx).QueryRow(ctx,
 			`SELECT count(*) FROM openrails.notification_queue
 			 WHERE merchant_id = $1 AND event_type = 'system_alert'
-			   AND data->>'operation' = 'worker_health' AND data->>'worker_kind' = $2`,
+			   AND data->>'operation' = 'river_progress' AND data->>'worker_kind' = $2`,
 			merchantID.UUID(), kind).Scan(&n)
 	}))
 	return n
@@ -193,7 +195,7 @@ func alertReason(t *testing.T, dbi *db.DB, kind string) string {
 		return dbi.Qx(ctx).QueryRow(ctx,
 			`SELECT data->>'reason' FROM openrails.notification_queue
 			 WHERE merchant_id = $1 AND event_type = 'system_alert'
-			   AND data->>'operation' = 'worker_health' AND data->>'worker_kind' = $2
+			   AND data->>'operation' = 'river_progress' AND data->>'worker_kind' = $2
 			 ORDER BY created_at DESC LIMIT 1`,
 			dbtest.TestMerchantID.UUID(), kind).Scan(&reason)
 	}))
@@ -205,14 +207,15 @@ func TestWorkerHealth_MiddlewareRecordsAndCheckerAlerts(t *testing.T) {
 	dbi := dbtest.OpenAppDB(t, dsn)
 	pool := dbtest.SharedPGXPool(t)
 	dbtest.EnsureTestMerchant(dbtest.WithTestMerchant(context.Background()), t, dbi.Pool())
-	cleanupWorkerHealth(t, dbi, whFailingKind, whHealthyKind, KindWorkerHealthCheck)
+	cleanupWorkerHealth(t, dbi, whFailingKind, whHealthyKind)
 
 	regs := NewWorkerRegistrations()
 	regs.NoteKind(whFailingKind)
 	regs.NoteKind(whHealthyKind)
-	regs.NoteKind(KindWorkerHealthCheck)
 
-	checker := &WorkerHealthCheckWorker{
+	// #895: the detector is a plain object, not a worker. It is never registered
+	// with River and never enqueued — it is simply called.
+	monitor := &ProgressMonitor{
 		DB:               dbi,
 		Registrations:    regs,
 		FailureThreshold: 3,
@@ -222,7 +225,6 @@ func TestWorkerHealth_MiddlewareRecordsAndCheckerAlerts(t *testing.T) {
 	workers := river.NewWorkers()
 	require.NoError(t, river.AddWorkerSafely(workers, &whFailingWorker{}))
 	require.NoError(t, river.AddWorkerSafely(workers, &whHealthyWorker{}))
-	require.NoError(t, river.AddWorkerSafely(workers, checker))
 
 	client, err := river.NewClient(riverpgxv5.New(pool), &river.Config{
 		Queues:            map[string]river.QueueConfig{river.QueueDefault: {MaxWorkers: 4}},
@@ -267,25 +269,21 @@ func TestWorkerHealth_MiddlewareRecordsAndCheckerAlerts(t *testing.T) {
 	require.NotNil(t, okSuccess, "healthy worker recorded a success")
 	require.EqualValues(t, 0, okStreak)
 
-	// The checker (run through the client like any worker) trips the streak rule
-	// for the failing kind and stays quiet for the healthy one.
-	_, err = client.Insert(ctx, WorkerHealthCheckArgs{}, &river.InsertOpts{MaxAttempts: 1})
+	// The monitor trips the streak rule for the failing kind and stays quiet for
+	// the healthy one — evaluated OUT of band, with nothing enqueued.
+	report, err := monitor.Check(ctx)
 	require.NoError(t, err)
-	awaitJobs(t, events, 1)
+	require.NoError(t, monitor.RaiseAlerts(ctx, report))
 
 	require.Equal(t, 1, countWorkerHealthAlerts(t, dbi, whFailingKind), "failing kind alerts within threshold")
 	require.Equal(t, "consecutive_failures", alertReason(t, dbi, whFailingKind))
 	require.Equal(t, 0, countWorkerHealthAlerts(t, dbi, whHealthyKind), "healthy kind never alerts")
 
-	// Re-running the checker within the re-alert window does NOT duplicate.
-	_, err = client.Insert(ctx, WorkerHealthCheckArgs{}, &river.InsertOpts{MaxAttempts: 1})
+	// Re-running the monitor within the re-alert window does NOT duplicate.
+	report, err = monitor.Check(ctx)
 	require.NoError(t, err)
-	awaitJobs(t, events, 1)
+	require.NoError(t, monitor.RaiseAlerts(ctx, report))
 	require.Equal(t, 1, countWorkerHealthAlerts(t, dbi, whFailingKind), "alert deduped while incident persists")
-
-	// The checker heartbeats through the same table (visible if IT wedges).
-	chkSuccess, _, _, _ := workerHealthRow(t, dbi, KindWorkerHealthCheck)
-	require.NotNil(t, chkSuccess, "checker recorded its own heartbeat")
 }
 
 // TestWorkerHealth_NeverSucceededMerchantRequire reproduces #673: a periodic
@@ -296,14 +294,13 @@ func TestWorkerHealth_NeverSucceededMerchantRequire(t *testing.T) {
 	dbi := dbtest.OpenAppDB(t, dsn)
 	pool := dbtest.SharedPGXPool(t)
 	dbtest.EnsureTestMerchant(dbtest.WithTestMerchant(context.Background()), t, dbi.Pool())
-	cleanupWorkerHealth(t, dbi, whNoMerchKind, KindWorkerHealthCheck)
+	cleanupWorkerHealth(t, dbi, whNoMerchKind)
 
 	regs := NewWorkerRegistrations()
 	regs.NoteKind(whNoMerchKind)
 	regs.NotePeriod(whNoMerchKind, time.Second) // "hourly" in miniature
-	regs.NoteKind(KindWorkerHealthCheck)
 
-	checker := &WorkerHealthCheckWorker{
+	monitor := &ProgressMonitor{
 		DB:               dbi,
 		Registrations:    regs,
 		FailureThreshold: 99, // force the never-succeeded rule to be what trips
@@ -313,7 +310,6 @@ func TestWorkerHealth_NeverSucceededMerchantRequire(t *testing.T) {
 
 	workers := river.NewWorkers()
 	require.NoError(t, river.AddWorkerSafely(workers, &whNoMerchWorker{}))
-	require.NoError(t, river.AddWorkerSafely(workers, checker))
 
 	client, err := river.NewClient(riverpgxv5.New(pool), &river.Config{
 		Queues:            map[string]river.QueueConfig{river.QueueDefault: {MaxWorkers: 2}},
@@ -346,18 +342,18 @@ func TestWorkerHealth_NeverSucceededMerchantRequire(t *testing.T) {
 	require.Contains(t, *errMsg, "merchant")
 	require.EqualValues(t, 1, streak)
 
-	// First checker pass seeds the row; backdate registration past the grace
-	// window (in production the row simply ages), then re-run the checker.
-	_, err = client.Insert(ctx, WorkerHealthCheckArgs{}, &river.InsertOpts{MaxAttempts: 1})
+	// First monitor pass seeds the row; backdate registration past the grace
+	// window (in production the row simply ages), then re-run the monitor.
+	report, err := monitor.Check(ctx)
 	require.NoError(t, err)
-	awaitJobs(t, events, 1)
+	require.NoError(t, monitor.RaiseAlerts(ctx, report))
 	_, execErr := dbi.Qx(ctx).Exec(ctx,
 		`UPDATE openrails.worker_health SET registered_at = now() - interval '1 hour' WHERE worker_kind = $1`, whNoMerchKind)
 	require.NoError(t, execErr)
 
-	_, err = client.Insert(ctx, WorkerHealthCheckArgs{}, &river.InsertOpts{MaxAttempts: 1})
+	report, err = monitor.Check(ctx)
 	require.NoError(t, err)
-	awaitJobs(t, events, 1)
+	require.NoError(t, monitor.RaiseAlerts(ctx, report))
 
 	require.Equal(t, 1, countWorkerHealthAlerts(t, dbi, whNoMerchKind))
 	require.Equal(t, "never_succeeded", alertReason(t, dbi, whNoMerchKind))
@@ -401,8 +397,8 @@ func TestWorkerHealth_AlertFanoutReachesEveryMerchantUnderRLS(t *testing.T) {
 	}
 	cleanupNewFanoutSystemCustomers(t, super, kind)
 
-	checker := &WorkerHealthCheckWorker{DB: appDB}
-	err = checker.raiseAlert(ctx, gen.OpenrailsWorkerHealth{WorkerKind: kind}, "stale", time.Now().UTC())
+	monitor := &ProgressMonitor{DB: appDB}
+	err = monitor.raiseAlert(ctx, gen.OpenrailsWorkerHealth{WorkerKind: kind}, "stale", time.Now().UTC(), ProgressReport{})
 	require.NoError(t, err)
 
 	for _, merchantID := range []merchant.ID{merchantA, merchantB} {
@@ -468,10 +464,10 @@ func TestWorkerHealth_AlertFanoutReportsPartialFailure(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	checker := &WorkerHealthCheckWorker{DB: appDB}
+	monitor := &ProgressMonitor{DB: appDB}
 	row := gen.OpenrailsWorkerHealth{WorkerKind: kind, RegisteredAt: time.Now().Add(-time.Hour).UTC()}
 	now := time.Now().UTC()
-	err = checker.raiseAlert(ctx, row, "stale", now)
+	err = monitor.raiseAlert(ctx, row, "stale", now, ProgressReport{})
 	require.Error(t, err)
 	require.ErrorContains(t, err, merchantB.String())
 	require.Equal(t, 1, countWorkerHealthAlertsForMerchant(t, appDB, merchantA, kind),
@@ -479,9 +475,9 @@ func TestWorkerHealth_AlertFanoutReportsPartialFailure(t *testing.T) {
 	require.Equal(t, 0, countWorkerHealthAlertsForMerchant(t, appDB, merchantB, kind),
 		"failed merchant delivery must not be reported as successful")
 
-	// River retries the entire checker job after a partial fan-out failure. The
-	// successful merchant must not receive another copy of the same incident.
-	err = checker.raiseAlert(ctx, row, "stale", now.Add(time.Minute))
+	// The monitor re-evaluates on its next tick after a partial fan-out failure.
+	// The successful merchant must not receive another copy of the same incident.
+	err = monitor.raiseAlert(ctx, row, "stale", now.Add(time.Minute), ProgressReport{})
 	require.Error(t, err)
 	require.ErrorContains(t, err, merchantB.String())
 	require.Equal(t, 1, countWorkerHealthAlertsForMerchant(t, appDB, merchantA, kind),

--- a/internal/river/worker_health_test.go
+++ b/internal/river/worker_health_test.go
@@ -16,6 +16,13 @@ func agoAt(d time.Duration) *time.Time {
 	return &t
 }
 
+// evalRow keeps these cases on the worker_health-only evidence path (no
+// river_job watermark), which is exactly the shape the old River-job checker
+// evaluated — so the ported rules are compared like for like.
+func evalRow(row gen.OpenrailsWorkerHealth, now time.Time, failureThreshold, staleMultiplier int, minStale time.Duration) string {
+	return evaluateKindProgress(row, KindProgress{}, now, failureThreshold, staleMultiplier, minStale)
+}
+
 func TestEvaluateWorkerHealth(t *testing.T) {
 	now := healthNow()
 	const threshold, mult = 3, 3
@@ -39,7 +46,7 @@ func TestEvaluateWorkerHealth(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, evaluateWorkerHealth(tc.row, now, threshold, mult, minStale))
+			require.Equal(t, tc.want, evalRow(tc.row, now, threshold, mult, minStale))
 		})
 	}
 }

--- a/pkg/embedded/controlplane/provision_integration_test.go
+++ b/pkg/embedded/controlplane/provision_integration_test.go
@@ -85,7 +85,7 @@ func hostedTestConfig(dsn, issuer string) *config.Config {
 
 func newHostApp(t *testing.T, cfg *config.Config) *embedded.Embedded {
 	t.Helper()
-	e, err := embedded.New(embedded.Options{Config: cfg})
+	e, err := embedded.New(embedded.Options{Config: cfg, River: embedded.RiverManagedByOpenRails()})
 	require.NoError(t, err, "embedded.New")
 	t.Cleanup(func() { _ = e.Close(context.Background()) })
 	return e

--- a/pkg/embedded/embedded.go
+++ b/pkg/embedded/embedded.go
@@ -58,6 +58,13 @@ type Options struct {
 	// admin_console.enabled without assets refuses to build the standalone
 	// surface. Hosts using embed.New pass embed.WithAdminConsole instead.
 	ConsoleAssets fs.FS
+	// River declares who owns the River job fleet. REQUIRED (#895): OpenRails'
+	// periodic fleet is where the money moves, so construction refuses rather
+	// than returning an engine whose money jobs silently never run. Use
+	// RiverFromHost(bind) when the host owns River (the embedded posture), or
+	// RiverManagedByOpenRails() to have OpenRails construct and run its own
+	// (standalone). The zero value is the rejected "nobody" state.
+	River RiverOwnership
 }
 
 type Embedded struct {
@@ -73,6 +80,13 @@ type Embedded struct {
 func New(opts Options) (*Embedded, error) {
 	if opts.Config == nil {
 		return nil, fmt.Errorf("config is required")
+	}
+	// #895: refuse BEFORE building the application graph — an engine with no
+	// declared River owner is not a usable engine, and returning one is what
+	// made "the host forgot River entirely" indistinguishable from a healthy
+	// boot.
+	if !opts.River.declared() {
+		return nil, ErrRiverRequired
 	}
 	if err := applyEmbeddedDefaults(opts.Config); err != nil {
 		return nil, err
@@ -92,7 +106,17 @@ func New(opts Options) (*Embedded, error) {
 		return nil, fmt.Errorf("bootstrap application: %w", err)
 	}
 
-	return &Embedded{app: application, consoleAssets: opts.ConsoleAssets}, nil
+	e := &Embedded{app: application, consoleAssets: opts.ConsoleAssets}
+	ctx := context.Background()
+	if err := e.bindRiver(ctx, opts.River); err != nil {
+		_ = application.Close(ctx)
+		return nil, err
+	}
+	// #895: start the out-of-River progress detector. It is deliberately started
+	// at CONSTRUCTION, not in RunWorkers — a host that never calls RunWorkers is
+	// exactly the case that used to be undetectable.
+	application.Runtime.StartRiverProgressMonitor(ctx)
+	return e, nil
 }
 
 // applyEmbeddedDefaults enforces the posture embedded construction must

--- a/pkg/embedded/embedded_test.go
+++ b/pkg/embedded/embedded_test.go
@@ -80,10 +80,24 @@ func TestNewRejectsMissingConfig(t *testing.T) {
 
 func TestNewRejectsUnsetPostureBeforeTouchingTheDatabase(t *testing.T) {
 	cfg := &config.Config{} // no Env, no TestMode, no DB
-	_, err := New(Options{Config: cfg})
+	_, err := New(Options{Config: cfg, River: RiverManagedByOpenRails()})
 	require.ErrorContains(t, err, "config.Env is required")
 
 	cfg = &config.Config{Env: "development"}
-	_, err = New(Options{Config: cfg})
+	_, err = New(Options{Config: cfg, River: RiverManagedByOpenRails()})
 	require.ErrorContains(t, err, "config.TestMode is required")
+}
+
+// #895: an undeclared River owner is refused BEFORE the posture checks and
+// before any DB work — a host that forgot the fleet entirely must never get an
+// engine back, because every read API would keep working while the money stops.
+func TestNewRequiresRiverOwnership(t *testing.T) {
+	cfg := &config.Config{Env: "development", TestMode: config.CredentialPostureSandbox}
+	_, err := New(Options{Config: cfg})
+	require.ErrorIs(t, err, ErrRiverRequired)
+
+	// And the declaration is the ONLY thing that changes: with it, construction
+	// proceeds far enough to reach the ordinary DB-dependent failure.
+	_, err = New(Options{Config: cfg, River: RiverManagedByOpenRails()})
+	require.NotErrorIs(t, err, ErrRiverRequired)
 }

--- a/pkg/embedded/merchant_conn_integration_test.go
+++ b/pkg/embedded/merchant_conn_integration_test.go
@@ -47,7 +47,7 @@ func TestEmbedded_RunInMerchantConn(t *testing.T) {
 		DB:                &config.DBConfig{URL: appDSN},
 		Auth:              &config.AuthConfig{Issuer: "https://merchant-conn-" + sfx + ".openrails.test"},
 	}
-	e, err := New(Options{Config: cfg, PGXPool: pool})
+	e, err := New(Options{Config: cfg, PGXPool: pool, River: RiverManagedByOpenRails()})
 	require.NoError(t, err, "boot as the openrails_app role")
 	t.Cleanup(func() { _ = e.Close(context.Background()) })
 

--- a/pkg/embedded/redis_ownership_integration_test.go
+++ b/pkg/embedded/redis_ownership_integration_test.go
@@ -30,7 +30,7 @@ func TestClose_DoesNotCloseInjectedRedisClient(t *testing.T) {
 		TestMode: config.CredentialPostureSandbox,
 		DB:       &config.DBConfig{URL: superDSN},
 	}
-	e, err := New(Options{Config: cfg, PGXPool: pool, Redis: rdb})
+	e, err := New(Options{Config: cfg, PGXPool: pool, Redis: rdb, River: RiverManagedByOpenRails()})
 	require.NoError(t, err)
 	require.NoError(t, e.Close(context.Background()))
 

--- a/pkg/embedded/river.go
+++ b/pkg/embedded/river.go
@@ -1,5 +1,26 @@
 // Package embedded exposes OpenRails billing as an in-process library.
 //
+// # River is a REQUIRED dependency (#895)
+//
+// OpenRails' River periodic fleet is not auxiliary — it is where the money
+// moves: subscription_converge, credit_expiry, auto_topup, invoice,
+// credit_reconcile, stripe_webhook_reconcile, provider_intent_execute,
+// ledger_integrity, the Solana cranks. With River absent every read API keeps
+// answering correctly and the money silently stops: subscriptions never renew,
+// credits never expire, invoices are never cut, webhooks are never reconciled.
+// There is no degraded mode worth having, so River is not optional.
+//
+// Options.River is therefore MANDATORY and has exactly two values — there is no
+// third state that silently means "nobody owns the fleet":
+//
+//   - RiverFromHost(bind): the HOST owns River. bind is called during New with
+//     OpenRails' workers already registered; it must return a live, unstarted
+//     *river.Client. Returning nil, or an error, fails construction. This is the
+//     embedded posture, and the only way to declare host ownership: a host can
+//     no longer claim the fleet and then never deliver it.
+//   - RiverManagedByOpenRails(): OpenRails constructs and runs its own client
+//     (the standalone posture). The caller must run RunWorkers.
+//
 // # Schema contract (issues #165, #545)
 //
 // OpenRails owns a single configurable Postgres schema, set via config `db.schema`
@@ -7,25 +28,22 @@
 // the portable billing data, and ONLY that.
 //
 // River job-queue tables (river_*) are runtime/infra state, NEVER portable billing
-// data, so they NEVER live in the OpenRails billing schema. They follow these
-// rules (#545):
-//
-//   - River tables ALWAYS live in `public` (config.RiverSchema) — River's own
-//     documented default, alongside `public.migrations` and `pgcrypto`. This keeps
-//     the OpenRails billing schema 100% portable for the embedded↔standalone data
-//     move (#544).
-//
-//   - Standalone: OpenRails constructs its own River client in `public`.
-//
-//   - Embedded/library (this package): the HOST owns River. If the host runs River,
-//     inject your unified client via SetRiverClient — OpenRails then enqueues
-//     through it and NEVER constructs a River client (host + OpenRails share one
-//     `public.river_*` set). If no client is injected, OpenRails constructs its own
-//     River client in `public`.
+// data, so they NEVER live in the OpenRails billing schema. River tables ALWAYS
+// live in `public` (config.RiverSchema) — River's own documented default,
+// alongside `public.migrations` and `pgcrypto`. This keeps the OpenRails billing
+// schema 100% portable for the embedded<->standalone data move (#544). A
+// host-supplied client whose Schema() is not `public` is rejected by New.
 //
 // Migration safety: River does not auto-migrate its tables across schemas. Hosts
 // or deployments still on an alternate River schema must drain and decommission
 // the old `<schema>.river_*` objects when cutting over to `public`.
+//
+// # Liveness
+//
+// Construction refusing only covers "not wired at all". "Wired but not
+// progressing" is a live property, so OpenRails runs its own out-of-River
+// detector (see CheckJobProgress) that reads River's `river_job` watermarks from
+// a plain goroutine — it keeps reporting while River is wedged or never started.
 package embedded
 
 import (
@@ -35,108 +53,123 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/rivertype"
 
+	"github.com/open-rails/openrails/config"
 	riverjobs "github.com/open-rails/openrails/internal/river"
 )
 
 // ErrNotInitialized is returned when operations are attempted on an uninitialized Embedded instance.
 var ErrNotInitialized = errors.New("embedded billing: not initialized")
 
-// QueueBilling is the River queue name used by billing workers.
-// Host applications should configure this queue when creating their River client.
+// ErrRiverRequired is returned by New when Options.River is unset (#895).
+var ErrRiverRequired = errors.New("embedded billing: Options.River is required (#895) — declare RiverFromHost(bind) to inject your River client, or RiverManagedByOpenRails() to let OpenRails construct and run its own; OpenRails cannot function without River, so there is no third state")
+
+// QueueBilling is the River queue name used by billing workers. A host-owned
+// client MUST configure it, or billing jobs are inserted and never worked.
 //
 // Example:
 //
-//	client, _ := river.NewClient(driver, river.Config{
-//	    Workers: workers,
+//	river.NewClient(driver, &river.Config{
 //	    Queues: map[string]river.QueueConfig{
-//	        river.QueueDefault: {MaxWorkers: 10},
+//	        river.QueueDefault:    {MaxWorkers: 10},
 //	        embedded.QueueBilling: {MaxWorkers: 5},
 //	    },
 //	})
 const QueueBilling = riverjobs.QueueBilling
 
-// AddWorkersTo adds billing's River workers to the provided worker registry.
-// Call this after creating your worker registry and adding your own workers.
-//
-// Example:
-//
-//	openrails, _ := embedded.New(opts)
-//
-//	workers := river.NewWorkers()
-//	river.AddWorkerSafely(workers, &MyAppWorker{})
-//	// Add billing workers
-//	if err := openrails.AddWorkersTo(ctx, workers); err != nil {
-//	    return err
-//	}
-//
-//	client, _ := river.NewClient(driver, river.Config{Workers: workers})
-func (e *Embedded) AddWorkersTo(ctx context.Context, workers *river.Workers) error {
-	if e == nil || e.app == nil || e.app.Runtime == nil {
-		return ErrNotInitialized
-	}
-	return e.app.Runtime.AddBillingWorkersTo(ctx, workers)
+// RiverFleet is handed to a RiverBinder during New. Workers already holds every
+// OpenRails billing worker, each with its health bookkeeping attached (#895), so
+// there is nothing for the host to remember to install. Add your own workers to
+// it, then build your client from it.
+type RiverFleet struct {
+	// Workers is the SHARED registry. River fixes Workers at NewClient time, so
+	// this is the one moment host and billing workers can be merged.
+	Workers *river.Workers
+	// QueueBilling is the queue OpenRails' jobs are inserted on; configure it on
+	// the client you return.
+	QueueBilling string
+	// Schema is the schema OpenRails expects River's tables in; your client's
+	// river.Config.Schema must match (empty means River's default, `public`).
+	Schema string
 }
 
-// GetPeriodicJobs returns billing's periodic jobs that should be added to your River client.
-// Call this after creating your River client but before starting it.
-//
-// Example:
-//
-//	client, _ := river.NewClient(...)
-//	periodicJobs, _ := openrails.GetPeriodicJobs(ctx)
-//	for _, job := range periodicJobs {
-//	    client.PeriodicJobs().Add(job)
-//	}
-//	client.Start(ctx)
-func (e *Embedded) GetPeriodicJobs(ctx context.Context) ([]*river.PeriodicJob, error) {
-	if e == nil || e.app == nil || e.app.Runtime == nil {
-		return nil, ErrNotInitialized
-	}
-	return e.app.Runtime.GetBillingPeriodicJobs(ctx)
+// RiverBinder builds the host's River client from the shared fleet. It must
+// return a constructed but NOT-yet-started client: OpenRails registers its own
+// periodic jobs on it before the host starts it, so the host cannot omit them.
+type RiverBinder func(ctx context.Context, fleet *RiverFleet) (*river.Client[pgx.Tx], error)
+
+// RiverOwnership declares who owns the River fleet. Build it with
+// RiverFromHost or RiverManagedByOpenRails; the zero value is the rejected
+// "nobody" state.
+type RiverOwnership struct {
+	managed bool
+	bind    RiverBinder
 }
 
-// WorkerMiddleware returns the #689 worker-health bookkeeping middleware. Add
-// it to your River client's river.Config.Middleware so billing workers get
-// per-kind health rows (and the health checker can alert on wedged workers):
-//
-//	client, _ := river.NewClient(driver, &river.Config{
-//	    Workers:    workers,
-//	    Middleware: []rivertype.Middleware{openrails.WorkerMiddleware()},
-//	})
-func (e *Embedded) WorkerMiddleware() rivertype.Middleware {
-	if e == nil || e.app == nil || e.app.Runtime == nil {
+func (o RiverOwnership) declared() bool { return o.managed || o.bind != nil }
+
+// RiverFromHost declares that the HOST owns River and hands OpenRails the
+// client. bind is invoked during New; if it returns an error or a nil client,
+// construction fails.
+func RiverFromHost(bind RiverBinder) RiverOwnership {
+	return RiverOwnership{bind: bind}
+}
+
+// RiverManagedByOpenRails declares that OpenRails constructs and runs its own
+// River client — the standalone posture. The caller MUST run RunWorkers, or the
+// fleet never starts (and the progress monitor will say so).
+func RiverManagedByOpenRails() RiverOwnership {
+	return RiverOwnership{managed: true}
+}
+
+// bindRiver runs the host's binder and folds the result into the engine. Called
+// once, from New, after the application graph exists.
+func (e *Embedded) bindRiver(ctx context.Context, own RiverOwnership) error {
+	rt := e.app.Runtime
+	if own.managed {
+		// Populate the health registrations (kind -> declared cadence) NOW, even
+		// though standalone builds its client later in RunWorkers: the progress
+		// monitor needs to know what "expected" means before the fleet starts, or
+		// "declared managed and then never ran RunWorkers" is invisible too.
+		if _, err := rt.GetBillingPeriodicJobs(ctx); err != nil {
+			return fmt.Errorf("build billing periodic jobs: %w", err)
+		}
 		return nil
 	}
-	return e.app.Runtime.WorkerHealthMiddleware()
-}
-
-// SetRiverClient injects an external River client for billing to use for job enqueueing.
-// Call this after creating your unified River client but before starting it.
-//
-// When an external client is provided:
-//   - Billing will use it for enqueueing jobs (e.g., dunning, cleanup)
-//   - Billing will NOT create its own River client
-//   - RunWorkers() becomes a no-op (you're responsible for starting the client)
-//   - The host client OWNS the River schema. River tables must live in `public`
-//     (#545) so host and OpenRails share one `public.river_*` set; configure this
-//     client accordingly. If you do NOT inject a client, OpenRails builds its own
-//     in `public`.
-//
-// Example:
-//
-//	client, _ := river.NewClient(...)
-//	openrails.SetRiverClient(client)
-//	client.Start(ctx)
-func (e *Embedded) SetRiverClient(client *river.Client[pgx.Tx]) {
-	if e == nil || e.app == nil || e.app.Runtime == nil {
-		return
+	workers := river.NewWorkers()
+	if err := rt.AddBillingWorkersTo(ctx, workers); err != nil {
+		return fmt.Errorf("register billing workers: %w", err)
 	}
-	e.app.Runtime.SetExternalRiverClient(client)
+	periodic, err := rt.GetBillingPeriodicJobs(ctx)
+	if err != nil {
+		return fmt.Errorf("build billing periodic jobs: %w", err)
+	}
+	client, err := own.bind(ctx, &RiverFleet{
+		Workers:      workers,
+		QueueBilling: QueueBilling,
+		Schema:       config.RiverSchema,
+	})
+	if err != nil {
+		return fmt.Errorf("embedded billing: River binder failed (#895): %w", err)
+	}
+	if client == nil {
+		return fmt.Errorf("embedded billing: River binder returned a nil client (#895) — OpenRails cannot run its periodic fleet, and every money-moving job would silently never run")
+	}
+	if schema := client.Schema(); schema != "" && schema != config.RiverSchema {
+		return fmt.Errorf("embedded billing: host River client uses schema %q, OpenRails requires %q (#545) — host and billing must share one river_* set", schema, config.RiverSchema)
+	}
+	// OpenRails registers its OWN periodic jobs on the host's client. This is
+	// deliberately not the host's job: a host that registered workers but not
+	// schedules would have a fleet that can work but is never asked to.
+	for _, job := range periodic {
+		client.PeriodicJobs().Add(job)
+	}
+	rt.SetExternalRiverClient(client)
+	return nil
 }
 
-// HasExternalRiverClient returns true if an external River client was provided via SetRiverClient.
+// HasExternalRiverClient reports whether the host owns the River client
+// (RiverFromHost) rather than OpenRails (RiverManagedByOpenRails).
 func (e *Embedded) HasExternalRiverClient() bool {
 	if e == nil || e.app == nil || e.app.Runtime == nil {
 		return false
@@ -144,53 +177,25 @@ func (e *Embedded) HasExternalRiverClient() bool {
 	return e.app.Runtime.HasExternalRiverClient()
 }
 
-// FoldIntoRiver folds billing's River workers and periodic jobs into a host's
-// SHARED river.Workers/river.Client (#546), in the one order River's own API
-// allows: Workers is fixed at river.NewClient, and periodic jobs must be
-// registered before Client.Start. It replaces the AddWorkersTo/GetPeriodicJobs/
-// SetRiverClient three-call dance (each host previously hand-wrote this as
-// Service.RegisterRiverWorkers/RegisterRiverClient, ~40 near-identical lines).
+// JobProgress is one evaluation of the periodic fleet.
+type JobProgress = riverjobs.ProgressReport
+
+// CheckJobProgress answers "are OpenRails' cron jobs actually progressing?"
+// RIGHT NOW, from a path that does not require a job to run (#895): it reads
+// River's own `river_job` watermarks plus the per-kind health rows. Safe to call
+// from a host health endpoint.
 //
-// Call FoldIntoRiver once, with your own workers already added to workers,
-// BEFORE building your river.Client:
+// A host is not REQUIRED to call it — OpenRails runs the same check on its own
+// goroutine and raises durable repair alerts — but a host that wants the verdict
+// on its own /healthz can have it:
 //
-//	workers := river.NewWorkers()
-//	river.AddWorkerSafely(workers, &MyAppWorker{})
-//	periodic, register, err := embedded.FoldIntoRiver(ctx, openrails, workers)
-//	// err != nil: engine not initialized.
-//
-//	client, err := river.NewClient(driver, &river.Config{Workers: workers})
-//	// periodic is billing's periodic jobs, exposed for logging/inspection —
-//	// register (below) is what actually adds them to the client.
-//	_ = periodic
-//	if err := register(client); err != nil {
-//	    // err != nil: client is nil.
+//	report, err := openrails.CheckJobProgress(ctx)
+//	if err == nil {
+//	    err = report.Err() // non-nil when the fleet is stalled
 //	}
-//	client.Start(ctx)
-//
-// register (called AFTER NewClient, BEFORE Start) adds periodic to the client
-// and calls SetRiverClient, injecting it so billing enqueues through it and
-// never builds its own.
-func FoldIntoRiver(ctx context.Context, e *Embedded, workers *river.Workers) (periodic []*river.PeriodicJob, register func(*river.Client[pgx.Tx]) error, err error) {
+func (e *Embedded) CheckJobProgress(ctx context.Context) (JobProgress, error) {
 	if e == nil || e.app == nil || e.app.Runtime == nil {
-		return nil, nil, ErrNotInitialized
+		return JobProgress{}, ErrNotInitialized
 	}
-	if err := e.AddWorkersTo(ctx, workers); err != nil {
-		return nil, nil, err
-	}
-	jobs, err := e.GetPeriodicJobs(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	register = func(client *river.Client[pgx.Tx]) error {
-		if client == nil {
-			return fmt.Errorf("embedded billing: river client required")
-		}
-		for _, job := range jobs {
-			_ = client.PeriodicJobs().Add(job)
-		}
-		e.SetRiverClient(client)
-		return nil
-	}
-	return jobs, register, nil
+	return e.app.Runtime.RiverProgress(ctx)
 }

--- a/pkg/embedded/rls_posture_integration_test.go
+++ b/pkg/embedded/rls_posture_integration_test.go
@@ -37,7 +37,7 @@ func TestNew_EmbeddedBootRefusesBypassRLSRoleOutsideDev(t *testing.T) {
 		ProviderWriteMode: config.ProviderWriteModeReadOnly,
 		DB:                &config.DBConfig{URL: superDSN},
 	}
-	_, err = New(Options{Config: cfg, PGXPool: pool})
+	_, err = New(Options{Config: cfg, PGXPool: pool, River: RiverManagedByOpenRails()})
 	require.Error(t, err, "an embedded host connected as a BYPASSRLS role must refuse to boot outside development")
 	require.ErrorContains(t, err, "bypasses RLS")
 	require.ErrorContains(t, err, "openrails_app")
@@ -56,7 +56,7 @@ func TestNew_EmbeddedBootWarnsOnBypassRLSRoleInDev(t *testing.T) {
 		TestMode: config.CredentialPostureSandbox,
 		DB:       &config.DBConfig{URL: superDSN},
 	}
-	e, err := New(Options{Config: cfg, PGXPool: pool})
+	e, err := New(Options{Config: cfg, PGXPool: pool, River: RiverManagedByOpenRails()})
 	require.NoError(t, err, "development must only warn, never fail, on a bypass-RLS role")
 	t.Cleanup(func() { _ = e.Close(context.Background()) })
 }
@@ -75,7 +75,7 @@ func TestNew_EmbeddedBootSucceedsAsAppRoleOutsideDev(t *testing.T) {
 		ProviderWriteMode: config.ProviderWriteModeReadOnly,
 		DB:                &config.DBConfig{URL: appDSN},
 	}
-	e, err := New(Options{Config: cfg, PGXPool: pool})
+	e, err := New(Options{Config: cfg, PGXPool: pool, River: RiverManagedByOpenRails()})
 	require.NoError(t, err, "an RLS-enforcing role must boot outside development")
 	t.Cleanup(func() { _ = e.Close(context.Background()) })
 }


### PR DESCRIPTION
Implements Paul's 2026-08-04 ruling on or#895 (P0, ARCHITECTURE):

> "when we construct an openrails client in embedded mode, we should require a river client be passed in, and we should throw an error otherwise. Also the health-checker of openrails should ensure that the river client / cron job system is progressing as expected, and it should be able to detect when that's not working."

Two independent deliverables; neither substitutes for the other.

## (A) Construction refuses

`pkg/embedded.Options` gains a **mandatory** `River RiverOwnership` field with exactly two values and no third state:

- `RiverFromHost(bind)` — the host owns River. The binder is invoked **during `New`** with OpenRails' workers already registered; it must return a live, unstarted `*river.Client`. A nil client or an error fails construction. A schema mismatch against `config.RiverSchema` fails construction too (#545).
- `RiverManagedByOpenRails()` — the standalone posture, which **keeps self-provisioning** exactly as before.

The zero value returns `ErrRiverRequired`, refused before the application graph is built.

This deletes the `AddWorkersTo` / `GetPeriodicJobs` / `SetRiverClient` / `FoldIntoRiver` post-construction dance. That shape is precisely what made "host takes ownership and then never delivers" representable — `runtime.go` stepped aside for an external client on the host's unverified word. Inverting the handoff into a constructor callback makes the claim and the delivery the same call. OpenRails also now registers **its own** periodic jobs onto the host's client rather than asking the host to remember.

Package doc rewritten: it previously described River ownership as a free deployment choice and promised a silent self-provisioning fallback.

## (B) A live progress detector that is not a River job

`WorkerHealthCheckWorker` **was** a River periodic job, so a stalled River stalled its own detector. It is deleted and replaced by `riverjobs.ProgressMonitor`:

- a plain goroutine, started at **construction** (not in `RunWorkers` — a host that never calls `RunWorkers` is exactly the case that used to be invisible), stopped by `Close`;
- reads River's **own** `river_job` watermarks, so it needs no job to run and no middleware to have been installed;
- verdicts: `river_not_scheduling` (nothing being inserted → client never started / periodic jobs never registered), `river_not_completing` (inserted, nothing finalizing → workers unregistered or the billing queue unconfigured), `river_backlog`;
- alerts through the existing durable repair-alert channel under the pseudo-kind `openrails.river_fleet`;
- exposed to hosts as `Embedded.CheckJobProgress(ctx)` for their own health endpoints — offered, not required.

`river_job` is the **primary** signal deliberately: `worker_health.last_success_at` is written only by the bookkeeping middleware, so a fleet running without it reports `never_succeeded` for everything. River writes `river_job` itself, so it stays truthful regardless of host wiring.

## The middle state, fixed structurally

A host could adopt the fleet and omit the health middleware — measured as 19/25 kinds `never_succeeded` on cozy-art and 20/24 on tensorhub, 100% false alarms. Rather than make `AddWorkersTo` refuse (unverifiable — nothing can inspect a `river.Client`'s middleware), the bookkeeping now rides **on each worker**: River honours `Worker.Middleware(job)` per work unit (`internal/jobexecutor/job_executor.go:241`), so `addTrackedWorker` attaches it at registration. Registering an OpenRails worker registers its bookkeeping. The client-level middleware is removed from the standalone client to avoid double-counting.

## Proof

Integration tests on real Postgres, a real `river.Client`, and real `river_job` rows — no mocks:

- `TestProgressMonitor_DetectsFleetNeverStarted` — a fully wired client that is never started. The detector fires; the test asserts **zero** completed and **zero** enqueued jobs at that instant, so any job-based detector had zero opportunities to produce the signal. Starting the same client clears the verdict on its own.
- `TestProgressMonitor_DetectsQueueNotDraining` — River alive and inserting onto a queue the client does not serve. `river_not_completing`.
- `TestRiverFromHost_SharedClientDrainsBillingJobs` — correct wiring drains a billing job **and** records `last_success_at` with no host-installed middleware.
- `TestRiverRequired_ConstructionRefuses` / `TestRiverFromHost_NilClientRefuses`.

**Negative control:** stubbing out `fleetVerdict`'s two `river_job` checks fails both progress tests at the `require.False(t, report.Progressing)` assertions (`progress_integration_test.go:121` and `:196`). Restored and re-run green.

`task sqlc-check` — all six steps green on the final commit (generate, vet, gen diff, query audit, sql-lint, migration-lint). No migration added. One reviewed `sql-lint` exemption added for `internal/river/progress.go` with rationale in `EXEMPTIONS.md`: it reads River's own table, which is not in OpenRails' sqlc schema and lives in a runtime-named schema.

## Breaking change for hosts

cozy-art and tensorhub must switch from `FoldIntoRiver` to `Options.River = RiverFromHost(...)`, and may delete their host-side boot-fatal middleware guards (th#1441, ca#261) — the library now enforces that posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)