### PR TITLE
or#863: one Solana amount formatter, wire-pinned

### DIFF
--- a/internal/modules/solana/fiat_conversion_test.go
+++ b/internal/modules/solana/fiat_conversion_test.go
@@ -116,22 +116,3 @@ func TestPegConversionExhaustiveWholeCents(t *testing.T) {
 		}
 	}
 }
-
-func TestFormatBaseUnits(t *testing.T) {
-	cases := []struct {
-		units    uint64
-		decimals int
-		want     string
-	}{
-		{10_000_000, 6, "10.000000"},
-		{19_990_000, 6, "19.990000"},
-		{1, 6, "0.000001"},
-		{10_000_000_000, 9, "10.000000000"},
-		{0, 6, "0.000000"},
-	}
-	for _, c := range cases {
-		if got := FormatBaseUnits(c.units, c.decimals); got != c.want {
-			t.Fatalf("FormatBaseUnits(%d, %d) = %q, want %q", c.units, c.decimals, got, c.want)
-		}
-	}
-}

--- a/internal/modules/solana/format_base_units_test.go
+++ b/internal/modules/solana/format_base_units_test.go
@@ -1,0 +1,118 @@
+package solana
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/shared/moneyutil"
+)
+
+// TestFormatBaseUnitsWirePins is the wire pin for the ONE Solana amount
+// formatter (#863: pay.go's untested `formatTokenAmount` twin was deleted in
+// favour of this one). Known base units + decimals => the exact string that
+// goes out as Solana Pay's `amount=`. Fixed precision, no trailing-zero
+// trimming, no rounding — the split is exact integer QuoRem.
+func TestFormatBaseUnitsWirePins(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		units    uint64
+		decimals int
+		want     string
+	}{
+		// 6 decimals — USDC/USDT, what every live merchant sends today.
+		{"usdc one", 1_000_000, 6, "1.000000"},
+		{"usdc ten", 10_000_000, 6, "10.000000"},
+		{"usdc nineteen ninety nine", 19_990_000, 6, "19.990000"},
+		{"usdc five", 5_000_000, 6, "5.000000"},
+		{"usdc one base unit", 1, 6, "0.000001"},
+		{"usdc zero", 0, 6, "0.000000"},
+		// Whole/fraction boundary: one base unit below and at the unit.
+		{"usdc just under one", 999_999, 6, "0.999999"},
+		{"usdc just over one", 1_000_001, 6, "1.000001"},
+		// A fraction whose digits are shorter than `decimals` must be
+		// left-zero-padded, not left-shifted (0.000005, never 0.5).
+		{"usdc leading-zero fraction", 1_000_005, 6, "1.000005"},
+
+		// 8 decimals — the wBTC-class scale.
+		{"8dp one", 100_000_000, 8, "1.00000000"},
+		{"8dp one base unit", 1, 8, "0.00000001"},
+		{"8dp mixed", 123_456_789, 8, "1.23456789"},
+
+		// 9 decimals — SOL and the #817 1000x-vs-6dp mint class.
+		{"9dp ten", 10_000_000_000, 9, "10.000000000"},
+		{"9dp one base unit", 1, 9, "0.000000001"},
+		{"9dp nineteen ninety nine", 19_990_000_000, 9, "19.990000000"},
+
+		// Extremes: the registry's declared bounds and uint64 saturation.
+		{"min decimals", 15, config.MinTokenDecimals, "1.5"},
+		{"max decimals", 1, config.MaxTokenDecimals, "0.000000000000000001"},
+		{"max uint64 at 9dp", 18_446_744_073_709_551_615, 9, "18446744073.709551615"},
+
+		// Defensive: ValidateTokenDecimals rejects <1 upstream, but the
+		// formatter must never emit a bare "." if it ever sees one.
+		{"zero decimals", 1_000_000, 0, "1000000"},
+	}
+
+	for _, c := range cases {
+		got := FormatBaseUnits(c.units, c.decimals)
+		if got != c.want {
+			t.Fatalf("%s: FormatBaseUnits(%d, %d) = %q, want %q", c.name, c.units, c.decimals, got, c.want)
+		}
+		if c.decimals > 0 {
+			if _, frac, ok := strings.Cut(got, "."); !ok || len(frac) != c.decimals {
+				t.Fatalf("%s: %q must carry exactly %d fractional digits", c.name, got, c.decimals)
+			}
+		}
+	}
+}
+
+// TestSolanaPayAmountWirePin walks the whole live chain — fiat micros in, the
+// `amount=` query param out — for the decimals a merchant actually runs. The
+// point of the chain (rather than the formatter alone) is that a 10^n slip
+// anywhere between micros and the wallet shows up here as a wrong dollar value.
+func TestSolanaPayAmountWirePin(t *testing.T) {
+	t.Parallel()
+
+	const (
+		recipient = "DzGLHdTfgHCYh8v3qNGJHn85CyX7aeFmqoUdVRBYkWMh"
+		mint      = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"
+		reference = "11111111111111111111111111111112"
+	)
+	s := &SolanaPayService{}
+
+	cases := []struct {
+		name     string
+		micros   moneyutil.Micros
+		decimals int
+		want     string
+	}{
+		{"$1 on a 6-decimal mint", 1_000_000, 6, "1.000000"},
+		{"$19.99 on a 6-decimal mint", 19_990_000, 6, "19.990000"},
+		{"$0.01 on a 6-decimal mint", 10_000, 6, "0.010000"},
+		// Same dollars, 9-decimal mint => 1000x the base units and three
+		// more digits, but the SAME dollar amount on the wire (#817).
+		{"$1 on a 9-decimal mint", 1_000_000, 9, "1.000000000"},
+		{"$19.99 on a 9-decimal mint", 19_990_000, 9, "19.990000000"},
+		{"$19.99 on an 8-decimal mint", 19_990_000, 8, "19.99000000"},
+	}
+
+	for _, c := range cases {
+		units, err := FiatMicrosToBaseUnitsAtPeg(c.micros, "USDC", c.decimals)
+		if err != nil {
+			t.Fatalf("%s: %v", c.name, err)
+		}
+		url := s.buildTransferRequestURL(context.Background(), recipient, units, c.decimals, mint, "USDC", reference, "")
+		wantURL := "solana:" + recipient +
+			"?amount=" + c.want +
+			"&spl-token=" + mint +
+			"&reference=" + reference +
+			"&label=Purchase"
+		if url != wantURL {
+			t.Fatalf("%s: got %q, want %q", c.name, url, wantURL)
+		}
+	}
+}

--- a/internal/modules/solana/pay.go
+++ b/internal/modules/solana/pay.go
@@ -268,14 +268,14 @@ func (s *SolanaPayService) GeneratePayment(ctx context.Context, userID string, p
 	// checkout session id on the wallet-built tx: per the Solana Pay spec the
 	// wallet includes it as an SPL Memo instruction BEFORE the transfer.
 	// Discovery hint, never money truth.
-	url := s.buildTransferRequestURL(ctx, recipient, tokenUnits, tokenMint, tokenSymbol, reference, solanarpc.PurchaseMemo(*sessionID))
+	url := s.buildTransferRequestURL(ctx, recipient, tokenUnits, tokenCfg.Decimals, tokenMint, tokenSymbol, reference, solanarpc.PurchaseMemo(*sessionID))
 
 	return &PayResult{
 		URL:            url,
 		Reference:      reference,
 		Amount:         price.Amount,
 		Currency:       price.Currency,
-		TokenAmount:    formatTokenAmount(tokenUnits, tokenCfg.Decimals),
+		TokenAmount:    FormatBaseUnits(tokenUnits, tokenCfg.Decimals),
 		TokenUnits:     tokenUnits,
 		TokenMint:      tokenMint,
 		Recipient:      recipient,
@@ -289,26 +289,16 @@ func (s *SolanaPayService) GeneratePayment(ctx context.Context, userID string, p
 	}, nil
 }
 
-// buildTransferRequestURL constructs the solana: URL per the Solana Pay spec
-func (s *SolanaPayService) buildTransferRequestURL(ctx context.Context, recipient string, amount uint64, tokenMint, tokenSymbol, reference, memo string) string {
+// buildTransferRequestURL constructs the solana: URL per the Solana Pay spec.
+// `decimals` is the caller's already-resolved token precision — re-reading it
+// here from a map without an ok-check turned an unknown symbol into decimals=0,
+// i.e. the raw base-unit count on the wire (a 10^d overcharge).
+func (s *SolanaPayService) buildTransferRequestURL(ctx context.Context, recipient string, amount uint64, decimals int, tokenMint, tokenSymbol, reference, memo string) string {
 	// Base URL: solana:<recipient>
 	baseURL := fmt.Sprintf("solana:%s", recipient)
 
-	// Get token config for decimals
-	solanaProc, err := RequireSolanaRailConfig(ctx, s.rails)
-	if err != nil {
-		return baseURL // fallback without params if not configured
-	}
-	if solanaProc.Solana == nil {
-		return baseURL
-	}
-	tokenCfg := solanaProc.Solana.Tokens[tokenSymbol]
-
-	// Format amount with proper decimals
-	formattedAmount := formatTokenAmount(amount, tokenCfg.Decimals)
-
 	// Add query params
-	params := fmt.Sprintf("?amount=%s", formattedAmount)
+	params := fmt.Sprintf("?amount=%s", FormatBaseUnits(amount, decimals))
 
 	// Add spl-token param if not native SOL
 	if tokenMint != "" && tokenSymbol != "SOL" {
@@ -601,26 +591,4 @@ func (s *SolanaPayService) getPaymentByReference(ctx context.Context, reference 
 	// Once a payment is confirmed, it's identified by its transaction signature.
 	// Return not found - callers should check Redis for pending status.
 	return nil, fmt.Errorf("payment not found for reference")
-}
-
-// formatTokenAmount formats a token amount with the appropriate decimal places
-func formatTokenAmount(amount uint64, decimals int) string {
-	if decimals <= 0 {
-		return fmt.Sprintf("%d", amount)
-	}
-	// Convert to string with decimal point
-	divisor := uint64(1)
-	for i := 0; i < decimals; i++ {
-		divisor *= 10
-	}
-	whole := amount / divisor
-	frac := amount % divisor
-	if frac == 0 {
-		return fmt.Sprintf("%d", whole)
-	}
-	// Format fractional part with leading zeros
-	fracStr := fmt.Sprintf("%0*d", decimals, frac)
-	// Trim trailing zeros
-	fracStr = strings.TrimRight(fracStr, "0")
-	return fmt.Sprintf("%d.%s", whole, fracStr)
 }

--- a/internal/modules/solana/pay_memo_test.go
+++ b/internal/modules/solana/pay_memo_test.go
@@ -2,12 +2,9 @@ package solana
 
 import (
 	"context"
-	"github.com/open-rails/openrails/internal/railresolve"
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/open-rails/openrails/config"
-	"github.com/open-rails/openrails/internal/db/models"
 	solanarpc "github.com/open-rails/openrails/internal/integrations/solana"
 	"github.com/stretchr/testify/require"
 )
@@ -25,22 +22,12 @@ func TestTransferRequestURLIncludesPurchaseMemo(t *testing.T) {
 	)
 	sessionID := uuid.MustParse("0dae1b8f-4c6e-4f6a-9b2d-7e5c3a1f8d42")
 
-	s := &SolanaPayService{rails: railresolve.FixedSet{
-		"solana": {
-			Rail:      models.RailSolana,
-			AccountID: recipient,
-			Solana: &config.SolanaRailConfig{
-				Tokens: map[string]config.TokenConfig{
-					"USDC": {Mint: usdcMint, Decimals: 6},
-				},
-			},
-		},
-	}}
+	s := &SolanaPayService{}
 
-	got := s.buildTransferRequestURL(context.Background(), recipient, 5_000_000, usdcMint, "USDC", reference, solanarpc.PurchaseMemo(sessionID))
+	got := s.buildTransferRequestURL(context.Background(), recipient, 5_000_000, 6, usdcMint, "USDC", reference, solanarpc.PurchaseMemo(sessionID))
 	require.Equal(t,
 		"solana:"+recipient+
-			"?amount=5"+
+			"?amount=5.000000"+
 			"&spl-token="+usdcMint+
 			"&reference="+reference+
 			"&memo=openrails%3A1%3A0dae1b8f-4c6e-4f6a-9b2d-7e5c3a1f8d42"+
@@ -48,6 +35,6 @@ func TestTransferRequestURLIncludesPurchaseMemo(t *testing.T) {
 		got)
 
 	// No memo (defensive: e.g. an empty stamp) omits the param entirely.
-	got = s.buildTransferRequestURL(context.Background(), recipient, 5_000_000, usdcMint, "USDC", reference, "")
+	got = s.buildTransferRequestURL(context.Background(), recipient, 5_000_000, 6, usdcMint, "USDC", reference, "")
 	require.NotContains(t, got, "memo=")
 }

--- a/internal/modules/solana/support.go
+++ b/internal/modules/solana/support.go
@@ -162,7 +162,12 @@ func FiatMicrosToStablecoinBaseUnits(ctx context.Context, micros moneyutil.Micro
 }
 
 // FormatBaseUnits renders base units as a fixed-point decimal string with
-// `decimals` fractional digits. Display only — pure integer, no float rounding.
+// `decimals` fractional digits. Pure integer, no float rounding. This is the
+// ONLY Solana amount formatter (#863 collapsed pay.go's trailing-zero-trimming
+// twin into it): it reaches the Solana Pay `amount=` wire as well as display.
+// Fixed precision is deliberate — it states the scale on the wire, so a wrong
+// `decimals` makes the wallet reject the URL (decimal places > mint decimals)
+// instead of silently transferring a 10^n-wrong amount.
 func FormatBaseUnits(units uint64, decimals int) string {
 	if decimals <= 0 {
 		return strconv.FormatUint(units, 10)


### PR DESCRIPTION
Closes finding 3 (GAP-15) of or#863. The CCBill refund-scale item is untouched — it needs live-money verification.

## The defect
Two near-duplicate Solana amount formatters, and only the untested one reached the wire:
- `solana/pay.go formatTokenAmount` — live on the Solana Pay `amount=` param, **no test**
- `solana/support.go FormatBaseUnits` — tested, not on the wire

## Did they diverge? Yes
`formatTokenAmount` trimmed trailing zeros and dropped the point entirely when the fraction was zero (`5000000, 6` -> `"5"`); `FormatBaseUnits` emits fixed precision (`"5.000000"`). Both are valid per the Solana Pay spec, so the wire does not *require* either — but fixed precision is strictly safer:

- It states the scale on the wire. If `decimals` is wrong (the #817 class), the wallet rejects the URL because decimal places exceed the mint's decimals. The trimming version hides the mismatch and silently transfers a 10^n-wrong amount.
- It already matches what `CalculateTokenQuote` reports for the same purchase, so the quote surface and the URL no longer disagree.

`FormatBaseUnits` survives; `formatTokenAmount` is deleted (no alias). `PayResult.TokenAmount` is a display string — reconciliation compares integer base units, so nothing parses the old trimmed form.

## Second bug found in the same path
`buildTransferRequestURL` re-resolved the token config itself with an **unchecked** map lookup: an unknown symbol yielded the zero `TokenConfig`, `decimals=0`, and the raw base-unit count as the wire amount (a 10^d overcharge). A config-read error dropped `amount=` from the URL entirely. It now takes the caller's already-resolved `decimals`.

## What the pins assert
- `TestFormatBaseUnitsWirePins` — base units + decimals => exact string: 6 (USDC/USDT), 8 (wBTC-class) and 9 (SOL) decimals; the registry's `MinTokenDecimals`/`MaxTokenDecimals`; zero; one base unit; the whole/fraction boundary (999_999 / 1_000_001); a leading-zero fraction (`1.000005`, never `1.5`); uint64 saturation. Every case also asserts the fractional digit count equals `decimals`.
- `TestSolanaPayAmountWirePin` — the full live chain, fiat micros -> `FiatMicrosToBaseUnitsAtPeg` -> `buildTransferRequestURL`, so a 10^n slip anywhere between micros and the wallet surfaces as a wrong dollar figure. Same dollars on 6/8/9-decimal mints produce the same dollar value with different scale.
- Decimals is a parameter throughout — no config lookup in the tests.

Verified the pins bite: reintroducing trailing-zero trimming fails both the new URL pin and the existing `TestCalculateTokenQuote_MicrosWirePin`.

## Tests
- `go build ./...` clean, `go vet ./...` clean
- `go test ./internal/modules/solana/...` — all green