### PR TITLE
or#890 + or#888: harness PSP-key selector proof, and one RLS-posture door for the standalone CLI

### DIFF
--- a/cmd/openrails/dbopen.go
+++ b/cmd/openrails/dbopen.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/db"
+)
+
+// openCLIDB is the ONE door a standalone CLI command opens a merchant-scoped
+// database handle through. It opens the pool from config and runs the SAME
+// RLS-posture gate the server boot path runs (internal/app.buildRuntime), so an
+// operator command can never do merchant-scoped work on a role that skips every
+// merchant_isolation policy (or#888; same class as or#885 for embedded).
+//
+// DELIBERATE EXEMPTION: `openrails migrate` does NOT come through here. DDL
+// requires the privileged owner role by definition — it creates the very
+// policies and the unprivileged openrails_app role this gate demands. It opens
+// its own handle inside internal/migrate; see the note at its wiring in main.go.
+// Every OTHER command that touches merchant rows must use this door.
+func openCLIDB(ctx context.Context, cfg *config.Config) (*db.DB, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if cfg == nil || cfg.DB == nil {
+		return nil, fmt.Errorf("config not loaded")
+	}
+	database, err := db.NewDB(cfg.DB)
+	if err != nil {
+		return nil, fmt.Errorf("open postgres: %w", err)
+	}
+	if err := database.EnforceRLSPosture(ctx, cfg.RequiresRLS()); err != nil {
+		_ = database.Close()
+		return nil, err
+	}
+	return database, nil
+}

--- a/cmd/openrails/intents.go
+++ b/cmd/openrails/intents.go
@@ -378,13 +378,9 @@ func runIntentsMutationLog(cmd *cobra.Command, provider, intentID, providerAccou
 
 func withIntentsListDB(cmd *cobra.Command, merchantSlug string, fn func(ctx context.Context, database *db.DB) error) error {
 	cfg, _ := cmd.Context().Value(config.ConfigContextKey).(*config.Config)
-	if cfg == nil || cfg.DB == nil {
-		return fmt.Errorf("config not loaded")
-	}
-
-	database, err := db.NewDB(cfg.DB)
+	database, err := openCLIDB(cmd.Context(), cfg)
 	if err != nil {
-		return fmt.Errorf("open postgres: %w", err)
+		return err
 	}
 	defer func() {
 		_ = database.Close()

--- a/cmd/openrails/ledger_audit.go
+++ b/cmd/openrails/ledger_audit.go
@@ -51,12 +51,9 @@ type ledgerAuditResult struct {
 
 func runLedgerAudit(cmd *cobra.Command, merchantSlug, format string) error {
 	cfg, _ := cmd.Context().Value(config.ConfigContextKey).(*config.Config)
-	if cfg == nil || cfg.DB == nil {
-		return fmt.Errorf("config not loaded")
-	}
-	database, err := db.NewDB(cfg.DB)
+	database, err := openCLIDB(cmd.Context(), cfg)
 	if err != nil {
-		return fmt.Errorf("open postgres: %w", err)
+		return err
 	}
 	defer func() { _ = database.Close() }()
 

--- a/cmd/openrails/main.go
+++ b/cmd/openrails/main.go
@@ -94,6 +94,11 @@ func newRootCmd() *cobra.Command {
 		Short: "Start OpenRails background workers",
 	}
 
+	// migrate is the ONE deliberately RLS-posture-EXEMPT command (or#888): DDL
+	// requires the privileged owner role — it creates the merchant_isolation
+	// policies and the unprivileged openrails_app role the gate demands, so it
+	// cannot run behind that gate. It opens its own handle in internal/migrate;
+	// every other command that touches merchant rows goes through openCLIDB.
 	migrateCmd := &cobra.Command{
 		Use:   "migrate",
 		Short: "Manage all database tables",

--- a/cmd/openrails/rls_posture_integration_test.go
+++ b/cmd/openrails/rls_posture_integration_test.go
@@ -1,0 +1,106 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/dbtest"
+)
+
+// or#888: `openrails intents` / `intents-log` / `ledger-audit` opened a pool
+// straight from cfg.DB and checked nothing, so an operator running them against
+// the owner/admin role got every merchant_isolation policy skipped on commands
+// that read and write merchant-scoped state. They now share openCLIDB, the same
+// posture-checked door or#885 gave the embedded entry points. These tests drive
+// the real cobra commands, not openCLIDB directly, so a future command that
+// re-opens its own pool is caught here.
+
+func cliCmdContext(dsn, env string) context.Context {
+	cfg := &config.Config{
+		Env:               env,
+		TestMode:          config.CredentialPostureSandbox,
+		ProviderWriteMode: config.ProviderWriteModeReadOnly,
+		DB:                &config.DBConfig{URL: dsn},
+	}
+	return context.WithValue(context.Background(), config.ConfigContextKey, cfg)
+}
+
+func runCLI(t *testing.T, cmd *cobra.Command, ctx context.Context, args ...string) error {
+	t.Helper()
+	cmd.SetArgs(args)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SilenceErrors = true
+	return cmd.ExecuteContext(ctx)
+}
+
+// TestCLICommandsRefuseBypassRLSRoleOutsideDev: every merchant-scoped operator
+// command must refuse a superuser/BYPASSRLS connection outside development.
+func TestCLICommandsRefuseBypassRLSRoleOutsideDev(t *testing.T) {
+	superDSN, _ := dbtest.SharedRLSPostgres(t)
+	ctx := cliCmdContext(superDSN, "staging")
+
+	for name, build := range map[string]func() *cobra.Command{
+		"intents":      newIntentsCmd,
+		"intents-log":  newIntentsLogCmd,
+		"ledger-audit": newLedgerAuditCmd,
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := runCLI(t, build(), ctx, "--merchant="+dbtest.TestMerchantSlug)
+			require.Error(t, err, "%s must refuse a BYPASSRLS role outside development", name)
+			require.ErrorContains(t, err, "bypasses RLS")
+			require.ErrorContains(t, err, "openrails_app")
+		})
+	}
+}
+
+// TestCLICommandsAcceptAppRole: the same commands get past the gate on the
+// unprivileged openrails_app role. They may still fail for ordinary reasons
+// (RLS hides rows the CLI has no merchant GUC for) — what must never appear is
+// the posture rejection.
+func TestCLICommandsAcceptAppRole(t *testing.T) {
+	_, appDSN := dbtest.SharedRLSPostgres(t)
+	ctx := cliCmdContext(appDSN, "staging")
+
+	for name, build := range map[string]func() *cobra.Command{
+		"intents":      newIntentsCmd,
+		"intents-log":  newIntentsLogCmd,
+		"ledger-audit": newLedgerAuditCmd,
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := runCLI(t, build(), ctx, "--merchant="+dbtest.TestMerchantSlug)
+			if err != nil {
+				require.NotContains(t, err.Error(), "bypasses RLS", "%s must pass the posture gate on openrails_app", name)
+			}
+		})
+	}
+}
+
+// TestCLIDevelopmentWarnsOnBypassRLSRole mirrors the server/embedded gate:
+// development only warns, so a local privileged DSN stays usable.
+func TestCLIDevelopmentWarnsOnBypassRLSRole(t *testing.T) {
+	superDSN, _ := dbtest.SharedRLSPostgres(t)
+	cfg := &config.Config{
+		Env:      "development",
+		TestMode: config.CredentialPostureSandbox,
+		DB:       &config.DBConfig{URL: superDSN},
+	}
+	database, err := openCLIDB(context.Background(), cfg)
+	require.NoError(t, err, "development must only warn, never fail, on a bypass-RLS role")
+	require.NoError(t, database.Close())
+}
+
+// TestOpenCLIDBRequiresConfig: no config, no door.
+func TestOpenCLIDBRequiresConfig(t *testing.T) {
+	_, err := openCLIDB(context.Background(), nil)
+	require.ErrorContains(t, err, "config not loaded")
+	_, err = openCLIDB(context.Background(), &config.Config{Env: "staging"})
+	require.ErrorContains(t, err, "config not loaded")
+}

--- a/internal/integrationharness/rail_seeding.go
+++ b/internal/integrationharness/rail_seeding.go
@@ -57,6 +57,9 @@ func SeedRailMerchantAccounts(ctx context.Context, t *testing.T, rt *app.Runtime
 		mctx := merchant.WithID(ctx, mid)
 		archived := proc.Archived
 		require.NoError(t, rt.DB.RunInMerchantConn(mctx, func(cctx context.Context) error {
+			// Key is the declared manifest key, not decoration: the #848 wire
+			// selector names a PSP by it, so a NULL key makes a merchant's
+			// second armed PSP unreachable (or#890).
 			_, err := rt.DB.Gen(cctx).UpsertPSP(cctx, gen.UpsertPSPParams{
 				ID:          id,
 				MerchantID:  mid.UUID(),

--- a/internal/integrationharness/rail_seeding_psp_key_test.go
+++ b/internal/integrationharness/rail_seeding_psp_key_test.go
@@ -1,0 +1,95 @@
+//go:build integration
+
+package integrationharness
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/merchants"
+	"github.com/open-rails/openrails/internal/modules/checkout"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// or#890: SeedRailMerchantAccounts used to carry only the natural key
+// (rail/environment/account_id), so psps.key stayed NULL on every seeded
+// account and the #848 wire selector — "declared PSP key wins, unambiguous
+// rail-kind fallback" — could never name one. A merchant's SECOND armed PSP
+// then made every checkout ambiguous with no way to disambiguate, and tests
+// papered over it by re-stamping the key themselves.
+//
+// This drives the real seeder into a real standalone runtime and asserts both
+// halves of the selector against two armed NMI PSPs: each declared key picks
+// ITS account, and the bare rail kind refuses with both keys named.
+func TestSeedRailMerchantAccountsStampsPSPKeyForWireSelection(t *testing.T) {
+	ctx := context.Background()
+	h := New(t, ctx)
+	surface := h.StartStandalone("usd")
+	rt := surface.App().Runtime
+	require.NotNil(t, rt.CheckoutService)
+
+	// A dedicated merchant: two armed NMI PSPs on the shared test merchant
+	// would make bare-"nmi" resolution ambiguous for every other test here.
+	nano := time.Now().UnixNano()
+	mid := merchant.ID(uuid.New())
+	pool := h.Pool()
+	_, err := pool.Exec(ctx,
+		`INSERT INTO openrails.merchants (id, slug, status) VALUES ($1, $2, 'active')`,
+		mid.UUID(), fmt.Sprintf("psp890-%d", nano))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM openrails.psps WHERE merchant_id = $1`, mid.UUID())
+		_, _ = pool.Exec(ctx, `DELETE FROM openrails.merchant_secrets WHERE merchant_id = $1`, mid.UUID())
+		_, _ = pool.Exec(ctx, `DELETE FROM openrails.merchants WHERE id = $1`, mid.UUID())
+	})
+
+	keyA := fmt.Sprintf("mobius-a-%d", nano)
+	keyB := fmt.Sprintf("mobius-b-%d", nano)
+	accountA := fmt.Sprintf("gw-a-%d", nano)
+	accountB := fmt.Sprintf("gw-b-%d", nano)
+
+	SeedRailMerchantAccounts(ctx, t, rt, mid, config.PSPSet{
+		keyA: {Rail: models.RailNMI, AccountID: accountA, NMI: &config.NMIRailConfig{SecurityKey: "sk-" + accountA}},
+		keyB: {Rail: models.RailNMI, AccountID: accountB, NMI: &config.NMIRailConfig{SecurityKey: "sk-" + accountB}},
+	})
+
+	// 1. The seeder stamps the declared manifest key on the row.
+	rows, err := pool.Query(ctx,
+		`SELECT key, account_id FROM openrails.psps WHERE merchant_id = $1`, mid.UUID())
+	require.NoError(t, err)
+	defer rows.Close()
+	seeded := map[string]string{}
+	for rows.Next() {
+		var key *string
+		var account string
+		require.NoError(t, rows.Scan(&key, &account))
+		require.NotNil(t, key, "psps.key must be stamped for account %s", account)
+		seeded[*key] = account
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, map[string]string{keyA: accountA, keyB: accountB}, seeded)
+
+	// 2. Each declared key selects ITS account on the checkout wire.
+	env := config.ExpectedProviderEnvironment(rt.Config.IsTestMode())
+	mctx := merchant.WithID(ctx, mid)
+	for key, account := range map[string]string{keyA: accountA, keyB: accountB} {
+		require.NoError(t, rt.CheckoutService.CheckoutRailUsable(mctx, key), "PSP key %q must be usable", key)
+		got := rt.CheckoutService.ResolvePSPID(mctx, key)
+		require.NotNil(t, got, "PSP key %q must resolve to an armed account", key)
+		require.Equal(t, merchants.PspID(string(models.RailNMI), env, account), *got)
+	}
+
+	// 3. The bare rail kind stays ambiguous — and names both keys, which is only
+	// possible because the keys are stamped.
+	err = rt.CheckoutService.CheckoutRailUsable(mctx, string(models.RailNMI))
+	var ambiguous *checkout.AmbiguousRailError
+	require.ErrorAs(t, err, &ambiguous)
+	require.ElementsMatch(t, []string{keyA, keyB}, ambiguous.Keys)
+}


### PR DESCRIPTION
Two small adjacent fixes.

## or#890 — the harness's `psps.key` stamp
The #848 wire selector is "declared PSP key wins, unambiguous rail-kind fallback", so a NULL `psps.key` makes a merchant's SECOND armed PSP unreachable — every checkout ambiguous with no way to disambiguate.

On `dev` the harness seeder already stamps the key (it landed incidentally in `4dd0c6ba`) and the `tests/SeedNMIProviderAccount` workaround the issue names does **not** exist here — it is on `chaos`, along with an unstamped seeder. So what this branch adds is the thing that was missing: a test that holds the stamp there. It drives the real `SeedRailMerchantAccounts` into a real standalone runtime with two armed NMI PSPs and asserts both halves of the selector — each declared key resolves to ITS account (`ResolvePSPID` vs the deterministic natural-key id), and the bare rail kind refuses with both keys named. Verified to fail when the `Key` field is removed from the seeder.

**`chaos` still needs the workaround removed** once its seeder stamps the key; that is a separate change on that branch.

## or#888 — posture-checked CLI pool
`intents`, `intents-log` and `ledger-audit` opened a pool straight from `cfg.DB` and checked nothing: an operator running them as the owner/admin role skipped every `merchant_isolation` policy on commands that read and write merchant state.

`cmd/openrails/dbopen.go`'s `openCLIDB` is now the one door — open from config, then `EnforceRLSPosture` before any work — mirroring the server boot gate and or#885's `openEmbeddedDB`. The rest of `cmd/` was audited: every other command reaches the DB through `pkg/embedded` / `internal/bootstrap`, so these three were the only direct openers.

`migrate` stays exempt **deliberately**, stated at both the door and its wiring in `main.go`: DDL needs the privileged owner role because it creates the policies and the `openrails_app` role the gate demands.

New integration test drives the real cobra commands (not `openCLIDB` directly) and proves: refused on a BYPASSRLS pool outside dev, past the gate on `openrails_app`, warn-only in development.

## Tests
```
go build ./... && go vet ./... && go vet -tags integration ./...          # clean
go test -tags integration -p 1 ./internal/integrationharness/ ./cmd/openrails/   # ok
go test -tags integration -p 1 ./internal/modules/checkout/                      # ok
go test -tags integration -run TestCheckoutSupportsConfiguredSecondaryNMIProvider ./tests/  # ok
```