### PR TITLE
or#855: CI latency — run the gates on dev at all, then shard and split the two long poles

### DIFF
--- a/.github/actions/go-cache-save/action.yml
+++ b/.github/actions/go-cache-save/action.yml
@@ -1,0 +1,31 @@
+name: Save Go caches
+description: >-
+  Save the caches that go-env restored. Call as the LAST step of a job that used
+  go-env, with `if: always()`.
+
+# WHY THIS IS A SEPARATE STEP INSTEAD OF `actions/cache`'s AUTOMATIC POST STEP.
+#
+# `actions/cache` declares its save `post-if: success()`, so a job that FAILS
+# caches nothing. That is exactly backwards for the case that matters: a red PR
+# is the one whose next push you most want to be fast. Measured on this
+# pipeline's first two runs — `build` and `console` had passed, so they saved and
+# came back warm (132s -> 23s, 87s -> 48s); `unit`, `gosec`, `sqlc` and all six
+# integration shards had failed, saved nothing, and were still stone cold on the
+# second run. Splitting restore from save and gating on `always()` fixes it.
+#
+# Re-saving a key that already exists is a warning, not an error, but
+# continue-on-error keeps even that from colouring a job.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache/save@v4
+      continue-on-error: true
+      with:
+        path: ${{ env.GO_MODCACHE_PATH }}
+        key: ${{ env.GO_MODCACHE_KEY }}
+    - uses: actions/cache/save@v4
+      continue-on-error: true
+      with:
+        path: ${{ env.GO_BUILDCACHE_PATH }}
+        key: ${{ env.GO_BUILDCACHE_KEY }}

--- a/.github/actions/go-env/action.yml
+++ b/.github/actions/go-env/action.yml
@@ -1,10 +1,11 @@
 name: Go toolchain + per-variant caches
 description: >-
   actions/setup-go with its bundled cache switched OFF, plus exactly one
-  explicit restore per cache path: the module cache keyed on go.sum, and the
-  BUILD cache keyed on the build variant as well.
+  explicit RESTORE per cache path: the module cache keyed on go.sum, and the
+  BUILD cache keyed on the build variant as well. Pair with the go-cache-save
+  action as the job's last step.
 
-# WHY THIS RE-ADDS THE CACHE STEPS THAT #855 DELETED (ci.yaml:78's rule).
+# WHY THIS RE-ADDS THE CACHE STEPS THAT #855 DELETED (ci.yaml's old :78 rule).
 #
 # The rule was written after a real bug: `actions/cache` on ~/go/pkg/mod +
 # ~/.cache/go-build ran ALONGSIDE setup-go's `cache: true`, which restores the
@@ -24,21 +25,20 @@ description: >-
 # DIFFERENT action id for EVERY package in the graph. One shared entry is
 # written by whichever job wins the race to save it and is then a near-total
 # miss for the other three configurations, which recompile the dependency graph
-# from scratch. Measured p50 of that recompilation on 15 PR runs:
-# `go test -race ./...` 143s, `go vet ./...` 55s, `go vet -tags console_assets
-# ./...` 68s, `go vet -tags integration ./...` 29s.
+# from scratch. Measured on this pipeline's first two runs: with a per-variant
+# cache the `build` job went 132s -> 23s and console's tagged build 55s -> 2s.
 #
-# Keys are deliberately NOT suffixed with github.sha. A stable key means at most
-# one entry per (variant, go version, go.sum) — six entries, ~2GB — instead of a
-# new multi-hundred-MB entry per commit, which would blow the 10GB repo budget
+# Keys are deliberately NOT suffixed with the commit sha. A stable key means at
+# most one entry per (variant, go version, go.sum) — a handful of entries — not
+# a new multi-hundred-MB entry per commit, which would blow the 10GB repo budget
 # and start evicting the entries it just wrote.
 
 inputs:
   variant:
     description: >-
       Build-configuration name (vet / race / integration / console / sqlc /
-      gosec). Jobs that compile the same configuration must share it, and jobs
-      that compile different configurations must NOT.
+      gosec / govulncheck). Jobs that compile the same configuration must share
+      it, and jobs that compile different configurations must NOT.
     required: true
 
 runs:
@@ -49,26 +49,26 @@ runs:
         go-version-file: go.mod
         cache: false
 
-    - id: goenv
-      shell: bash
+    # The keys live in the environment so go-cache-save can reuse them verbatim
+    # rather than restating the expressions and drifting from them.
+    - shell: bash
       run: |
         {
-          echo "modcache=$(go env GOMODCACHE)"
-          echo "buildcache=$(go env GOCACHE)"
-          echo "goversion=$(go env GOVERSION)"
-        } >> "$GITHUB_OUTPUT"
+          echo "GO_MODCACHE_PATH=$(go env GOMODCACHE)"
+          echo "GO_BUILDCACHE_PATH=$(go env GOCACHE)"
+          echo "GO_MODCACHE_KEY=gomod-${{ runner.os }}-$(go env GOVERSION)-${{ hashFiles('**/go.sum') }}"
+          echo "GO_BUILDCACHE_KEY=gobuild-${{ inputs.variant }}-${{ runner.os }}-$(go env GOVERSION)-${{ hashFiles('**/go.sum') }}"
+        } >> "$GITHUB_ENV"
 
     # Module cache: identical for every variant, so it is keyed on go.sum alone.
-    - uses: actions/cache@v4
+    - uses: actions/cache/restore@v4
       with:
-        path: ${{ steps.goenv.outputs.modcache }}
-        key: gomod-${{ runner.os }}-${{ steps.goenv.outputs.goversion }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: gomod-${{ runner.os }}-${{ steps.goenv.outputs.goversion }}-
+        path: ${{ env.GO_MODCACHE_PATH }}
+        key: ${{ env.GO_MODCACHE_KEY }}
 
     # Build cache: per variant, because a different tag/race set means a
     # different action id for every compiled package.
-    - uses: actions/cache@v4
+    - uses: actions/cache/restore@v4
       with:
-        path: ${{ steps.goenv.outputs.buildcache }}
-        key: gobuild-${{ inputs.variant }}-${{ runner.os }}-${{ steps.goenv.outputs.goversion }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: gobuild-${{ inputs.variant }}-${{ runner.os }}-${{ steps.goenv.outputs.goversion }}-
+        path: ${{ env.GO_BUILDCACHE_PATH }}
+        key: ${{ env.GO_BUILDCACHE_KEY }}

--- a/.github/actions/go-env/action.yml
+++ b/.github/actions/go-env/action.yml
@@ -1,0 +1,74 @@
+name: Go toolchain + per-variant caches
+description: >-
+  actions/setup-go with its bundled cache switched OFF, plus exactly one
+  explicit restore per cache path: the module cache keyed on go.sum, and the
+  BUILD cache keyed on the build variant as well.
+
+# WHY THIS RE-ADDS THE CACHE STEPS THAT #855 DELETED (ci.yaml:78's rule).
+#
+# The rule was written after a real bug: `actions/cache` on ~/go/pkg/mod +
+# ~/.cache/go-build ran ALONGSIDE setup-go's `cache: true`, which restores the
+# same two directories. Two restores into one directory fail with
+# "tar: Cannot open: File exists" and burn a whole cycle. Deleting the explicit
+# steps fixed it by leaving exactly one restorer.
+#
+# That objection is about DOUBLE restore, not about explicit caching, and this
+# action keeps the property that fixed it: setup-go runs with `cache: false`,
+# so each path here is restored exactly once and the collision is structurally
+# impossible — the same guarantee, reached the other way round.
+#
+# What the deletion cost, and why it is worth reclaiming: setup-go's key is
+# `setup-go-<os>-<arch>-go-<version>-<hash(go.sum)>` — ONE entry shared by every
+# job. But a Go build cache entry is keyed by the full build configuration, so
+# `-race`, `-tags integration` and `-tags console_assets` each produce a
+# DIFFERENT action id for EVERY package in the graph. One shared entry is
+# written by whichever job wins the race to save it and is then a near-total
+# miss for the other three configurations, which recompile the dependency graph
+# from scratch. Measured p50 of that recompilation on 15 PR runs:
+# `go test -race ./...` 143s, `go vet ./...` 55s, `go vet -tags console_assets
+# ./...` 68s, `go vet -tags integration ./...` 29s.
+#
+# Keys are deliberately NOT suffixed with github.sha. A stable key means at most
+# one entry per (variant, go version, go.sum) — six entries, ~2GB — instead of a
+# new multi-hundred-MB entry per commit, which would blow the 10GB repo budget
+# and start evicting the entries it just wrote.
+
+inputs:
+  variant:
+    description: >-
+      Build-configuration name (vet / race / integration / console / sqlc /
+      gosec). Jobs that compile the same configuration must share it, and jobs
+      that compile different configurations must NOT.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+
+    - id: goenv
+      shell: bash
+      run: |
+        {
+          echo "modcache=$(go env GOMODCACHE)"
+          echo "buildcache=$(go env GOCACHE)"
+          echo "goversion=$(go env GOVERSION)"
+        } >> "$GITHUB_OUTPUT"
+
+    # Module cache: identical for every variant, so it is keyed on go.sum alone.
+    - uses: actions/cache@v4
+      with:
+        path: ${{ steps.goenv.outputs.modcache }}
+        key: gomod-${{ runner.os }}-${{ steps.goenv.outputs.goversion }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: gomod-${{ runner.os }}-${{ steps.goenv.outputs.goversion }}-
+
+    # Build cache: per variant, because a different tag/race set means a
+    # different action id for every compiled package.
+    - uses: actions/cache@v4
+      with:
+        path: ${{ steps.goenv.outputs.buildcache }}
+        key: gobuild-${{ inputs.variant }}-${{ runner.os }}-${{ steps.goenv.outputs.goversion }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: gobuild-${{ inputs.variant }}-${{ runner.os }}-${{ steps.goenv.outputs.goversion }}-

--- a/.github/workflows/ci-full.yaml
+++ b/.github/workflows/ci-full.yaml
@@ -52,6 +52,9 @@ jobs:
           for d in examples/*/; do
             (cd "$d" && go build ./... && go vet ./...)
           done
+      - name: Save Go caches
+        if: always() && env.GO_BUILDCACHE_KEY != ''
+        uses: ./.github/actions/go-cache-save
 
   unit-full:
     runs-on: ubuntu-latest
@@ -65,6 +68,9 @@ jobs:
         run: go mod download
       - name: Test (race)
         run: go test -race ./...
+      - name: Save Go caches
+        if: always() && env.GO_BUILDCACHE_KEY != ''
+        uses: ./.github/actions/go-cache-save
 
   sqlc-full:
     runs-on: ubuntu-latest
@@ -98,6 +104,9 @@ jobs:
         env:
           POSTGRES_HOST_PORT: "5434"
         run: "$TASK_BIN sqlc-check"
+      - name: Save Go caches
+        if: always() && env.GO_BUILDCACHE_KEY != ''
+        uses: ./.github/actions/go-cache-save
 
   console-full:
     runs-on: ubuntu-latest
@@ -126,6 +135,9 @@ jobs:
       # the 68s for the belt-and-braces version.
       - name: Tagged Go build embeds the dist
         run: go vet -tags console_assets ./...
+      - name: Save Go caches
+        if: always() && env.GO_BUILDCACHE_KEY != ''
+        uses: ./.github/actions/go-cache-save
 
   integration-full:
     runs-on: ubuntu-latest
@@ -150,3 +162,6 @@ jobs:
       # fallbacks for direct package runs, not the normal CI path.
       - name: Integration test (complete suite)
         run: bash scripts/test_integration.sh ./...
+      - name: Save Go caches
+        if: always() && env.GO_BUILDCACHE_KEY != ''
+        uses: ./.github/actions/go-cache-save

--- a/.github/workflows/ci-full.yaml
+++ b/.github/workflows/ci-full.yaml
@@ -72,6 +72,25 @@ jobs:
         if: always() && env.GO_BUILDCACHE_KEY != ''
         uses: ./.github/actions/go-cache-save
 
+  # Mirrors ci.yaml's `lint` so a push here leaves the `lint` build cache warm
+  # for PRs, same as every other variant.
+  lint-full:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/go-env
+        with:
+          variant: lint
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.6.0
+          args: --timeout=15m
+      - name: Save Go caches
+        if: always() && env.GO_BUILDCACHE_KEY != ''
+        uses: ./.github/actions/go-cache-save
+
   sqlc-full:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/ci-full.yaml
+++ b/.github/workflows/ci-full.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Download modules
         run: go mod download
       - name: Test (race)
-        run: go test -race ./...
+        run: go test -count=1 -race ./...
       - name: Save Go caches
         if: always() && env.GO_BUILDCACHE_KEY != ''
         uses: ./.github/actions/go-cache-save

--- a/.github/workflows/ci-full.yaml
+++ b/.github/workflows/ci-full.yaml
@@ -1,13 +1,20 @@
 name: Validate Code (full)
 
 # FULL pipeline (#855): the complete suite, no path filtering, no scoping.
-# Runs on master pushes, nightly, and on demand — never on PRs or ordinary
-# branch pushes (PRs get the fast path-filtered pipeline in ci.yaml). Job ids
-# carry a -full suffix so branch-protection required checks (which must point
-# at ci.yaml's PR-scoped jobs) never reference these.
+# Runs on integration-branch pushes, nightly, and on demand — never on PRs or
+# ordinary branch pushes (PRs get the fast path-filtered pipeline in ci.yaml).
+# Job ids carry a -full suffix so branch-protection required checks (which must
+# point at ci.yaml's PR-scoped jobs) never reference these.
+#
+# It also PRIMES THE CACHES for every PR. GitHub scopes a cache to the branch
+# that wrote it plus that branch's descendants, so a PR restores from its BASE
+# branch. These jobs therefore mirror ci.yaml's split one-for-one and pass the
+# same `variant` to .github/actions/go-env: a push here leaves a warm build
+# cache for each build configuration the PR pipeline uses. Merging the split
+# back together would silently cost every PR the cold-compile time again.
 on:
   push:
-    branches: [ master ]
+    branches: [ master, dev ]
   schedule:
     # 05:00 UTC nightly.
     - cron: '0 5 * * *'
@@ -29,13 +36,9 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
-      # setup-go's built-in cache (keyed on go.sum) covers ~/go/pkg/mod AND
-      # ~/.cache/go-build. Never add an explicit actions/cache step for those
-      # paths: restoring over a populated dir fails with "tar: File exists".
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/go-env
         with:
-          go-version-file: go.mod
-          cache: true
+          variant: vet
       - name: Download modules
         run: go mod download
       - name: Vet
@@ -44,7 +47,23 @@ jobs:
         run: go build ./...
       - name: Vet (integration tag)
         run: go vet -tags integration ./...
-      - name: Test
+      - name: Build examples
+        run: |
+          for d in examples/*/; do
+            (cd "$d" && go build ./... && go vet ./...)
+          done
+
+  unit-full:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/go-env
+        with:
+          variant: race
+      - name: Download modules
+        run: go mod download
+      - name: Test (race)
         run: go test -race ./...
 
   sqlc-full:
@@ -66,10 +85,9 @@ jobs:
           --health-retries 10
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/go-env
         with:
-          go-version-file: go.mod
-          cache: true
+          variant: sqlc
       # or#855: pinned + checksum-verified downloads instead of compiling both
       # tools from source on every run (see scripts/ci-install-tool.sh).
       - name: Install pinned tools (task, sqlc)
@@ -94,15 +112,18 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: web/admin/pnpm-lock.yaml
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/go-env
         with:
-          go-version-file: go.mod
-          cache: true
+          variant: console
       - name: Build console (pnpm install + tsc + vite)
         run: bash scripts/build-admin-console.sh cmd/openrails/consoleassets/dist
       - name: Lint console
         run: pnpm run lint
         working-directory: web/admin
+      # Full tier keeps the WHOLE-TREE tagged vet that the PR tier narrows to
+      # the one package carrying tag-conditional source. Same reasoning as the
+      # PR job, opposite trade: nothing here is racing a 3-minute bar, so pay
+      # the 68s for the belt-and-braces version.
       - name: Tagged Go build embeds the dist
         run: go vet -tags console_assets ./...
 
@@ -111,13 +132,16 @@ jobs:
     # ENFORCING (#694): the suite runs green. The serial run is ~20-25 min (go
     # test itself is capped at 25m inside the script); the job timeout adds
     # headroom for image pulls + module download.
+    #
+    # NOT sharded, on purpose: this is the tier that must reproduce the real
+    # serial ordering across ALL packages on ONE stack. Sharding is a PR-tier
+    # wall-clock trade; the authority run keeps the single stack.
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/go-env
         with:
-          go-version-file: go.mod
-          cache: true
+          variant: integration
       - name: Download modules
         run: go mod download
       # Integration tests share one compose-backed Postgres/Garnet stack and

--- a/.github/workflows/ci-full.yaml
+++ b/.github/workflows/ci-full.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.6.0
+          version: v2.11.4
           args: --timeout=15m
       - name: Save Go caches
         if: always() && env.GO_BUILDCACHE_KEY != ''

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,11 +181,26 @@ jobs:
         if: needs.changes.outputs.go == 'true'
         with:
           variant: lint
+      # PIN BUMPED FROM v2.6.0 (or#855). v2.6.0 is built with go1.25 and this
+      # module targets go1.26.5, so golangci-lint refused to load the config at
+      # all — "the Go language version (go1.25) used to build golangci-lint is
+      # lower than the targeted Go version (1.26.5)", exit 3, every run. The
+      # gate was structurally incapable of passing: required in name, enforcing
+      # nothing. Its first real execution was on this PR, because ci.yaml runs
+      # only on PRs and the job arrived via a merge to dev.
+      #
+      # v2.11.4 is the smallest bump that loads, and it is green with 0 issues
+      # on the current tree, so what the gate MEANS is unchanged. v2.12.2 was
+      # also tried: it loads too, but its newer govet `inline` analyzer adds 3
+      # findings (reflect.Ptr -> reflect.Pointer in
+      # internal/http/request/request.go). Those are real and want fixing, but
+      # they are source changes, so they belong to whoever takes the next bump —
+      # recorded here rather than silenced with an exclusion.
       - name: golangci-lint
         if: needs.changes.outputs.go == 'true'
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.6.0
+          version: v2.11.4
           args: --timeout=15m
       - name: Save Go caches
         if: always() && env.GO_BUILDCACHE_KEY != ''

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -145,9 +145,16 @@ jobs:
       - name: Download modules
         if: needs.changes.outputs.go == 'true'
         run: go mod download
+      # -count=1 for the same reason as the integration suite, and it is FREE
+      # here: the integration shards are the long pole, so re-running every unit
+      # test costs no wall clock. The build cache still does its job — what is
+      # disabled is Go's test-RESULT cache, so "this gate passed" always means
+      # the tests ran on this commit rather than that an older verdict was
+      # reused. A latency budget should not be paid for out of what a green
+      # check means.
       - name: Test (race)
         if: needs.changes.outputs.go == 'true'
-        run: go test -race ./...
+        run: go test -count=1 -race ./...
       - name: Save Go caches
         if: always() && env.GO_BUILDCACHE_KEY != ''
         uses: ./.github/actions/go-cache-save

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,6 +125,10 @@ jobs:
             (cd "$d" && go build ./... && go vet ./...)
           done
 
+      - name: Save Go caches
+        if: always() && env.GO_BUILDCACHE_KEY != ''
+        uses: ./.github/actions/go-cache-save
+
   # Unit tests, split out of `build` so the two run in parallel. Still -race,
   # still the whole tree: nothing here is scoped, skipped or downgraded.
   unit:
@@ -144,6 +148,9 @@ jobs:
       - name: Test (race)
         if: needs.changes.outputs.go == 'true'
         run: go test -race ./...
+      - name: Save Go caches
+        if: always() && env.GO_BUILDCACHE_KEY != ''
+        uses: ./.github/actions/go-cache-save
 
   # or#869: .golangci.yml existed for a year with nothing running it — and could
   # not have run (v1 schema, which current golangci-lint refuses to load). The
@@ -216,10 +223,15 @@ jobs:
           POSTGRES_HOST_PORT: "5434"
         run: "$TASK_BIN sqlc-check"
 
+      - name: Save Go caches
+        if: always() && env.GO_BUILDCACHE_KEY != ''
+        uses: ./.github/actions/go-cache-save
+
   # Admin console SPA (#754: dist is NOT committed, so nothing else compiles
   # web/admin) — lint + typecheck+build the frontend, then prove the tagged Go
   # binary embeds the produced dist. Steps run only when web/admin/** (or a
   # shared surface) changed.
+
   console:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -281,6 +293,10 @@ jobs:
             exit 1
           fi
 
+      - name: Save Go caches
+        if: always() && env.GO_BUILDCACHE_KEY != ''
+        uses: ./.github/actions/go-cache-save
+
   # PR tier (#855): integration tests SCOPED to the tagged packages the diff
   # touches. Cross-package fallout is deliberately deferred to integration-full
   # (push + nightly, complete suite). Broad/shared-surface diffs (go.mod,
@@ -293,6 +309,7 @@ jobs:
   # serialises everything inside a shard, so the shared-Postgres/Garnet and
   # un-namespaced-Redis-key assumptions that forbid raising -parallel are
   # untouched. See scripts/ci-integration-select.sh for the balancing.
+
   integration-shard:
     name: integration shard ${{ matrix.shard }}/6
     runs-on: ubuntu-latest
@@ -328,9 +345,14 @@ jobs:
           echo "shard ${SHARD}/${SHARDS}: ${pkgs[*]}"
           OPENRAILS_INTEGRATION_TIMEOUT=15m bash scripts/test_integration.sh "${pkgs[@]}"
 
+      - name: Save Go caches
+        if: always() && env.GO_BUILDCACHE_KEY != ''
+        uses: ./.github/actions/go-cache-save
+
   # One stable name for branch protection to require, so changing the shard
   # count never means editing the ruleset. `always()` + an explicit result check
   # is load-bearing: without it a cancelled or skipped shard would let this pass.
+
   integration:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,11 +1,16 @@
 name: Validate Code
 
-# FAST pipeline (#855): PRs targeting master ONLY. Ordinary branch pushes run
-# nothing by design — open a PR. Master pushes, nightly, and manual runs go
-# through ci-full.yaml (complete integration suite).
+# FAST pipeline (#855): PRs targeting an integration branch ONLY. Ordinary
+# branch pushes run nothing by design — open a PR. Pushes to those branches,
+# nightly, and manual runs go through ci-full.yaml (complete integration suite).
+#
+# `dev` is listed because it is where work merges today (PRs #208/#209 landed
+# there) and, until this change, a PR into `dev` ran ZERO checks: every gate in
+# this file was scoped to `master` alone. That is not a latency finding, it is a
+# hole in the gates, and it is fixed here first.
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ master, dev ]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -20,6 +25,15 @@ permissions:
 # 2026-06-16; this opts into the new runtime ahead of the cutover.
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+# JOB NAMES ARE THE BRANCH-PROTECTION CONTRACT. The required checks from this
+# file are exactly: changes, build, unit, sqlc, console, integration. The
+# integration SHARDS are matrix jobs whose names carry the shard index, so they
+# are deliberately NOT the ones to list — the `integration` job below aggregates
+# them into one stable name, which means the shard count can change without
+# touching branch protection. Never list ci-full.yaml's `-full` jobs or CodeQL's
+# "Analyze (go)": neither runs on PRs, so a required check on them blocks every
+# PR forever.
 
 jobs:
   # Classifies the PR diff. Downstream jobs ALWAYS run (so branch-protection
@@ -67,6 +81,10 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "go=$go console=$console broad=$broad"
 
+  # Compile-and-analyse gates. `go test -race` used to live here too and made
+  # this a 272s job; it is now the separate `unit` job, because the two share
+  # nothing — a race build recompiles the whole graph with different action ids,
+  # so running them in sequence bought no cache reuse, only wall clock.
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -74,14 +92,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         if: needs.changes.outputs.go == 'true'
-      # setup-go's built-in cache (keyed on go.sum) covers ~/go/pkg/mod AND
-      # ~/.cache/go-build. Never add an explicit actions/cache step for those
-      # paths: restoring over a populated dir fails with "tar: File exists".
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/go-env
         if: needs.changes.outputs.go == 'true'
         with:
-          go-version-file: go.mod
-          cache: true
+          variant: vet
       - name: Download modules
         if: needs.changes.outputs.go == 'true'
         run: go mod download
@@ -101,11 +115,33 @@ jobs:
         # Each example is its own module (replace => ../..), invisible to the
         # root ./... patterns — build them explicitly so engine changes that
         # break an example fail the same PR.
+        #
+        # The `if:` is a fix, not a speedup: without it this step ran on
+        # docs-only PRs, where checkout is skipped, so `examples/*/` matched
+        # nothing, `cd examples/*/` failed and the whole gate went red.
+        if: needs.changes.outputs.go == 'true'
         run: |
           for d in examples/*/; do
             (cd "$d" && go build ./... && go vet ./...)
           done
-      - name: Test
+
+  # Unit tests, split out of `build` so the two run in parallel. Still -race,
+  # still the whole tree: nothing here is scoped, skipped or downgraded.
+  unit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: changes
+    steps:
+      - uses: actions/checkout@v4
+        if: needs.changes.outputs.go == 'true'
+      - uses: ./.github/actions/go-env
+        if: needs.changes.outputs.go == 'true'
+        with:
+          variant: race
+      - name: Download modules
+        if: needs.changes.outputs.go == 'true'
+        run: go mod download
+      - name: Test (race)
         if: needs.changes.outputs.go == 'true'
         run: go test -race ./...
 
@@ -154,14 +190,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         if: needs.changes.outputs.go == 'true'
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/go-env
         if: needs.changes.outputs.go == 'true'
         with:
-          go-version-file: go.mod
-          cache: true
+          variant: sqlc
       # or#855: `go install task@latest` + `go run sqlc@…` compiled both tools
-      # from source on every run — measured 61s and ~60s respectively, i.e.
-      # ~120s of a 144s job spent installing tools upstream already ships as
+      # from source on every run — measured 52s and ~60s respectively, i.e.
+      # ~110s of a 137s job spent installing tools upstream already ships as
       # binaries. Pinned + checksum-verified downloads take ~5s, and `@latest`
       # pinned nothing to begin with.
       - name: Install pinned tools (task, sqlc)
@@ -202,11 +237,10 @@ jobs:
           node-version: 22
           cache: pnpm
           cache-dependency-path: web/admin/pnpm-lock.yaml
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/go-env
         if: needs.changes.outputs.console == 'true'
         with:
-          go-version-file: go.mod
-          cache: true
+          variant: console
       - name: Build console (pnpm install + tsc + vite)
         if: needs.changes.outputs.console == 'true'
         run: bash scripts/build-admin-console.sh cmd/openrails/consoleassets/dist
@@ -214,60 +248,97 @@ jobs:
         if: needs.changes.outputs.console == 'true'
         run: pnpm run lint
         working-directory: web/admin
+      # This gate's claim is "the tagged binary embeds the dist that was just
+      # built" — assets_embed.go's //go:embed fails to compile without it. It
+      # used to be spelled `go vet -tags console_assets ./...`, 68s, because a
+      # build tag changes the action id of EVERY package in the tree, so the
+      # whole repo plus every test package was recompiled and re-analysed to
+      # prove one embed. Only ONE package has console_assets-conditional source
+      # (guarded below), and every other package compiles identically to the
+      # untagged build the `build` job already vets. So: build the binary that
+      # makes the claim, and vet the one package that actually differs.
       - name: Tagged Go build embeds the dist
         if: needs.changes.outputs.console == 'true'
-        run: go vet -tags console_assets ./...
+        run: |
+          test -n "$(ls -A cmd/openrails/consoleassets/dist 2>/dev/null)" || {
+            echo "console: dist/ is empty — the embed gate would prove nothing" >&2
+            exit 1
+          }
+          go build -tags console_assets ./cmd/openrails/
+          go vet -tags console_assets ./cmd/openrails/consoleassets/
+      - name: Guard — console_assets stays in one package
+        # Narrowing the step above is only coverage-neutral while
+        # cmd/openrails/consoleassets is the sole package with tag-conditional
+        # source. The day that stops being true, this fails and says so.
+        if: needs.changes.outputs.console == 'true'
+        run: |
+          stray="$(grep -rlE '^//go:build .*console_assets' --include='*.go' . |
+                   grep -v '^\./cmd/openrails/consoleassets/' || true)"
+          if [ -n "$stray" ]; then
+            echo "console_assets-conditional source outside cmd/openrails/consoleassets:" >&2
+            echo "$stray" >&2
+            echo "widen the tagged build above to cover it, then update this guard" >&2
+            exit 1
+          fi
 
   # PR tier (#855): integration tests SCOPED to the tagged packages the diff
-  # touches, under a 15m go-test budget. Cross-package fallout is deliberately
-  # deferred to integration-full (master push + nightly, complete suite).
-  # Broad/shared-surface diffs (go.mod, migrations/, internal/db/, scripts/,
-  # ...) still run the full tagged suite here.
-  integration:
+  # touches. Cross-package fallout is deliberately deferred to integration-full
+  # (push + nightly, complete suite). Broad/shared-surface diffs (go.mod,
+  # migrations/, internal/db/, scripts/, .github/, ...) still run the full
+  # tagged suite here.
+  #
+  # SHARDED (or#855): the serial run was 360s and the pipeline's sole long pole.
+  # Sharding is coverage-neutral — the union of the shards is the same package
+  # set, each shard gets its OWN compose stack, and `-p 1 -parallel 1` still
+  # serialises everything inside a shard, so the shared-Postgres/Garnet and
+  # un-namespaced-Redis-key assumptions that forbid raising -parallel are
+  # untouched. See scripts/ci-integration-select.sh for the balancing.
+  integration-shard:
+    name: integration shard ${{ matrix.shard }}/6
     runs-on: ubuntu-latest
     timeout-minutes: 35
     needs: changes
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/checkout@v4
         if: needs.changes.outputs.go == 'true'
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/go-env
         if: needs.changes.outputs.go == 'true'
         with:
-          go-version-file: go.mod
-          cache: true
+          variant: integration
       - name: Download modules
         if: needs.changes.outputs.go == 'true'
         run: go mod download
-      # Integration tests share one compose-backed Postgres/Garnet stack and
-      # run serially. scripts/test_integration.sh expands ./... to only the
-      # packages carrying the `integration` build tag (#790); explicit package
-      # args pass through, which is what the scoped tier uses.
-      - name: Integration test (scoped)
+      - name: Integration test
         if: needs.changes.outputs.go == 'true'
         env:
           CHANGED_FILES: ${{ needs.changes.outputs.files }}
           BROAD: ${{ needs.changes.outputs.broad }}
+          SHARDS: "6"
+          SHARD: ${{ matrix.shard }}
         run: |
-          if [ "$BROAD" = "true" ]; then
-            echo "shared surface changed — running the full tagged suite"
-            exec bash scripts/test_integration.sh ./...
-          fi
-          mapfile -t tagged < <(grep -rl --include='*.go' -E '^//go:build (.*[^a-zA-Z0-9_])?integration([^a-zA-Z0-9_].*)?$' . | xargs -n1 dirname | sed 's|^\./||' | sort -u)
-          declare -A want=()
-          while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            d="$(dirname "$f")"
-            for t in "${tagged[@]}"; do
-              case "$d" in
-                "$t"|"$t"/*) want["$t"]=1 ;;
-              esac
-            done
-          done <<< "$CHANGED_FILES"
-          if [ "${#want[@]}" -eq 0 ]; then
-            echo "no integration-tagged package touched — nothing to run at PR tier (full suite runs on master push + nightly)"
+          mapfile -t pkgs < <(bash scripts/ci-integration-select.sh)
+          if [ "${#pkgs[@]}" -eq 0 ]; then
+            echo "nothing for this shard"
             exit 0
           fi
-          pkgs=()
-          for t in "${!want[@]}"; do pkgs+=("./$t"); done
-          echo "scoped integration run: ${pkgs[*]}"
+          echo "shard ${SHARD}/${SHARDS}: ${pkgs[*]}"
           OPENRAILS_INTEGRATION_TIMEOUT=15m bash scripts/test_integration.sh "${pkgs[@]}"
+
+  # One stable name for branch protection to require, so changing the shard
+  # count never means editing the ruleset. `always()` + an explicit result check
+  # is load-bearing: without it a cancelled or skipped shard would let this pass.
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: integration-shard
+    if: always()
+    steps:
+      - name: All integration shards succeeded
+        run: |
+          result="${{ needs.integration-shard.result }}"
+          echo "integration-shard matrix result: $result"
+          [ "$result" = "success" ] || exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,10 +131,23 @@ jobs:
 
   # Unit tests, split out of `build` so the two run in parallel. Still -race,
   # still the whole tree: nothing here is scoped, skipped or downgraded.
-  unit:
+  #
+  # SHARDED (or#855). Once the suite went green it measured 181s — on its own
+  # over the 180s bar. Coverage-neutral the same way gosec's split is: the
+  # shards partition `go list ./...` itself, so their union is exactly what
+  # `./...` expands to, with the same flags. Unit tests share no fixture or
+  # stack, so unlike the integration suite there is nothing for a subset to
+  # depend on. The `race` build cache is shared across the shards, so the
+  # duplicated compilation is cache hits rather than work.
+  unit-shard:
+    name: unit shard ${{ matrix.shard }}/3
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: changes
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@v4
         if: needs.changes.outputs.go == 'true'
@@ -154,10 +167,31 @@ jobs:
       # check means.
       - name: Test (race)
         if: needs.changes.outputs.go == 'true'
-        run: go test -count=1 -race ./...
+        env:
+          SHARDS: "3"
+          SHARD: ${{ matrix.shard }}
+        run: |
+          mapfile -t pkgs < <(go list ./... | sort |
+                              awk -v n="$SHARDS" -v p="$SHARD" 'NR % n == p % n')
+          echo "shard ${SHARD}/${SHARDS}: ${#pkgs[@]} packages"
+          [ "${#pkgs[@]}" -gt 0 ] || exit 0
+          go test -count=1 -race "${pkgs[@]}"
       - name: Save Go caches
         if: always() && env.GO_BUILDCACHE_KEY != ''
         uses: ./.github/actions/go-cache-save
+
+  # One stable name for branch protection, as with `integration` and `gosec`.
+  unit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: unit-shard
+    if: always()
+    steps:
+      - name: All unit shards succeeded
+        run: |
+          result="${{ needs.unit-shard.result }}"
+          echo "unit-shard matrix result: $result"
+          [ "$result" = "success" ] || exit 1
 
   # or#869: .golangci.yml existed for a year with nothing running it — and could
   # not have run (v1 schema, which current golangci-lint refuses to load). The
@@ -373,7 +407,10 @@ jobs:
             exit 0
           fi
           echo "shard ${SHARD}/${SHARDS}: ${pkgs[*]}"
-          OPENRAILS_INTEGRATION_TIMEOUT=15m bash scripts/test_integration.sh "${pkgs[@]}"
+          # 6m, not the 15m a single unsharded job needed: a shard is ~2min of
+          # work, so anything past 6m is a hang, and the old budget made one
+          # hung package cost the pipeline 16 minutes before it gave up.
+          OPENRAILS_INTEGRATION_TIMEOUT=6m bash scripts/test_integration.sh "${pkgs[@]}"
 
       - name: Save Go caches
         if: always() && env.GO_BUILDCACHE_KEY != ''

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 # JOB NAMES ARE THE BRANCH-PROTECTION CONTRACT. The required checks from this
-# file are exactly: changes, build, unit, sqlc, console, integration. The
+# file are exactly: changes, build, unit, lint, sqlc, console, integration. The
 # integration SHARDS are matrix jobs whose names carry the shard index, so they
 # are deliberately NOT the ones to list — the `integration` job below aggregates
 # them into one stable name, which means the shard count can change without
@@ -171,17 +171,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         if: needs.changes.outputs.go == 'true'
-      - uses: actions/setup-go@v5
+      # go-env, not setup-go's own cache: since or#855 nothing writes the shared
+      # `setup-go-…` key any more, so `cache: true` here would miss every time.
+      # `lint` is its own variant because golangci-lint type-checks with its own
+      # build configuration. The action's separate golangci analysis cache is
+      # untouched — it does not restore GOCACHE (Go caching was dropped from the
+      # action in v6), so there is still exactly one restore per path.
+      - uses: ./.github/actions/go-env
         if: needs.changes.outputs.go == 'true'
         with:
-          go-version-file: go.mod
-          cache: true
+          variant: lint
       - name: golangci-lint
         if: needs.changes.outputs.go == 'true'
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.6.0
           args: --timeout=15m
+      - name: Save Go caches
+        if: always() && env.GO_BUILDCACHE_KEY != ''
+        uses: ./.github/actions/go-cache-save
 
   sqlc:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,6 +139,11 @@ jobs:
   # stack, so unlike the integration suite there is nothing for a subset to
   # depend on. The `race` build cache is shared across the shards, so the
   # duplicated compilation is cache hits rather than work.
+  #
+  # Balanced by recorded runtimes, not round-robin: pkg/service (73s) and
+  # internal/modules/solana/recurring (57s) are 130s of a 240s suite, and
+  # round-robin put both in one shard — 136s against 64s and 65s. 4 shards buys
+  # nothing; pkg/service alone is the floor.
   unit-shard:
     name: unit shard ${{ matrix.shard }}/3
     runs-on: ubuntu-latest
@@ -171,8 +176,8 @@ jobs:
           SHARDS: "3"
           SHARD: ${{ matrix.shard }}
         run: |
-          mapfile -t pkgs < <(go list ./... | sort |
-                              awk -v n="$SHARDS" -v p="$SHARD" 'NR % n == p % n')
+          mapfile -t pkgs < <(go list ./... |
+                              bash scripts/ci-shard.sh scripts/ci-unit-weights.txt)
           echo "shard ${SHARD}/${SHARDS}: ${#pkgs[@]} packages"
           [ "${#pkgs[@]}" -gt 0 ] || exit 0
           go test -count=1 -race "${pkgs[@]}"

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -90,6 +90,10 @@ jobs:
         run: "$GOSEC_BIN -severity high -confidence medium -exclude-dir=.agents ./..."
 
   # govulncheck: dependency vulnerability scanning against the Go vuln DB.
+      - name: Save Go caches
+        if: always() && env.GO_BUILDCACHE_KEY != ''
+        uses: ./.github/actions/go-cache-save
+
   govulncheck:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -116,6 +120,10 @@ jobs:
 
   # Trivy: additional SCA + filesystem vulnerability/secret scanning. Fails on
   # HIGH/CRITICAL findings. Cheap — always runs, no path gating.
+      - name: Save Go caches
+        if: always() && env.GO_BUILDCACHE_KEY != ''
+        uses: ./.github/actions/go-cache-save
+
   trivy:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,12 +1,14 @@
 name: Security Scan
 
-# #855 triggers: PRs to master (fast, path-filtered), master pushes, nightly,
-# manual. Never ordinary branch pushes.
+# #855 triggers: PRs to an integration branch (fast, path-filtered), pushes to
+# those branches, nightly, manual. Never ordinary branch pushes. `dev` is listed
+# for the same reason as in ci.yaml: it is where work merges today, and PRs into
+# it were running no security scan at all.
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ master, dev ]
   push:
-    branches: [ master ]
+    branches: [ master, dev ]
   schedule:
     # 05:00 UTC nightly.
     - cron: '0 5 * * *'
@@ -60,14 +62,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         if: needs.changes.outputs.go == 'true'
-      # setup-go's built-in cache (keyed on go.sum) covers ~/go/pkg/mod AND
-      # ~/.cache/go-build; never add an explicit actions/cache step for those
-      # paths ("tar: File exists" collision).
-      - uses: actions/setup-go@v5
+      # gosec loads packages with full type information, so it pays the same
+      # dependency-compile bill the Go jobs do and wants the same warm cache.
+      # See .github/actions/go-env for why explicit cache steps are back and why
+      # that does not reintroduce the "tar: File exists" collision.
+      - uses: ./.github/actions/go-env
         if: needs.changes.outputs.go == 'true'
         with:
-          go-version-file: go.mod
-          cache: true
+          variant: gosec
       - name: Download modules
         if: needs.changes.outputs.go == 'true'
         run: go mod download
@@ -91,11 +93,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         if: needs.changes.outputs.go == 'true'
-      - uses: actions/setup-go@v5
+      - uses: ./.github/actions/go-env
         if: needs.changes.outputs.go == 'true'
         with:
-          go-version-file: go.mod
-          cache: true
+          variant: govulncheck
       - name: Download modules
         if: needs.changes.outputs.go == 'true'
         run: go mod download

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -26,7 +26,11 @@ jobs:
   # PR diff classification. Go scanners' steps no-op on docs-only PRs, but the
   # jobs themselves always run and report status (required-check safe). On
   # non-PR events everything runs unconditionally.
-  changes:
+  #
+  # Named security-changes, not `changes`: ci.yaml has a job by that name too,
+  # and a required status check is matched by NAME — two jobs sharing one makes
+  # the ruleset ambiguous about which workflow it is actually requiring.
+  security-changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -58,20 +62,20 @@ jobs:
   gosec:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: changes
+    needs: security-changes
     steps:
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.go == 'true'
+        if: needs.security-changes.outputs.go == 'true'
       # gosec loads packages with full type information, so it pays the same
       # dependency-compile bill the Go jobs do and wants the same warm cache.
       # See .github/actions/go-env for why explicit cache steps are back and why
       # that does not reintroduce the "tar: File exists" collision.
       - uses: ./.github/actions/go-env
-        if: needs.changes.outputs.go == 'true'
+        if: needs.security-changes.outputs.go == 'true'
         with:
           variant: gosec
       - name: Download modules
-        if: needs.changes.outputs.go == 'true'
+        if: needs.security-changes.outputs.go == 'true'
         run: go mod download
       # or#855: was `go install …@latest` — 47s of compiling a binary upstream
       # ships, and a floating version with no integrity check. Pinned +
@@ -79,35 +83,35 @@ jobs:
       # purpose (same doctrine as the golangci-lint and sqlc pins): bump the
       # version in scripts/ci-install-tool.sh deliberately, reading the notes.
       - name: Install pinned gosec
-        if: needs.changes.outputs.go == 'true'
+        if: needs.security-changes.outputs.go == 'true'
         run: echo "GOSEC_BIN=$(scripts/ci-install-tool.sh gosec)" >> "$GITHUB_ENV"
       - name: Run gosec (fail on HIGH+)
-        if: needs.changes.outputs.go == 'true'
+        if: needs.security-changes.outputs.go == 'true'
         run: "$GOSEC_BIN -severity high -confidence medium -exclude-dir=.agents ./..."
 
   # govulncheck: dependency vulnerability scanning against the Go vuln DB.
   govulncheck:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: changes
+    needs: security-changes
     steps:
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.go == 'true'
+        if: needs.security-changes.outputs.go == 'true'
       - uses: ./.github/actions/go-env
-        if: needs.changes.outputs.go == 'true'
+        if: needs.security-changes.outputs.go == 'true'
         with:
           variant: govulncheck
       - name: Download modules
-        if: needs.changes.outputs.go == 'true'
+        if: needs.security-changes.outputs.go == 'true'
         run: go mod download
       # Pinned, but no prebuilt release exists and the install is only ~5s.
       # Unlike gosec, pinning does NOT freeze what this detects: govulncheck
       # fetches the vulnerability DB at run time.
       - name: Install govulncheck
-        if: needs.changes.outputs.go == 'true'
+        if: needs.security-changes.outputs.go == 'true'
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
       - name: Run govulncheck
-        if: needs.changes.outputs.go == 'true'
+        if: needs.security-changes.outputs.go == 'true'
         run: govulncheck ./...
 
   # Trivy: additional SCA + filesystem vulnerability/secret scanning. Fails on

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -59,10 +59,24 @@ jobs:
 
   # gosec: Go SAST - source code security scanning. Fails the build on HIGH+
   # findings; MEDIUM findings are surfaced as a non-blocking warning step.
-  gosec:
+  #
+  # SHARDED (or#855). Measured on this pipeline: 36s to load and type-check the
+  # program, then 155s analysing 683 files — analysis, not loading, is the bill,
+  # and it is per-package. Once the Go jobs were split and cached, gosec was the
+  # last thing standing between the required checks and the 3-minute bar.
+  # Coverage-neutral by construction: the shards partition `go list ./...`
+  # itself, so their union is exactly the package set `./...` expands to, with
+  # the same flags and the same pinned binary. Only the load phase is paid
+  # three times.
+  gosec-shard:
+    name: gosec shard ${{ matrix.shard }}/3
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: security-changes
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@v4
         if: needs.security-changes.outputs.go == 'true'
@@ -87,13 +101,34 @@ jobs:
         run: echo "GOSEC_BIN=$(scripts/ci-install-tool.sh gosec)" >> "$GITHUB_ENV"
       - name: Run gosec (fail on HIGH+)
         if: needs.security-changes.outputs.go == 'true'
-        run: "$GOSEC_BIN -severity high -confidence medium -exclude-dir=.agents ./..."
-
-  # govulncheck: dependency vulnerability scanning against the Go vuln DB.
+        env:
+          SHARDS: "3"
+          SHARD: ${{ matrix.shard }}
+        run: |
+          mapfile -t dirs < <(go list -f '{{.Dir}}' ./... | sort |
+                              awk -v n="$SHARDS" -v p="$SHARD" 'NR % n == p % n')
+          echo "shard ${SHARD}/${SHARDS}: ${#dirs[@]} packages"
+          [ "${#dirs[@]}" -gt 0 ] || exit 0
+          "$GOSEC_BIN" -severity high -confidence medium -exclude-dir=.agents "${dirs[@]}"
       - name: Save Go caches
         if: always() && env.GO_BUILDCACHE_KEY != ''
         uses: ./.github/actions/go-cache-save
 
+  # One stable name for branch protection, so the shard count stays an
+  # implementation detail. Same pattern as ci.yaml's `integration`.
+  gosec:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: gosec-shard
+    if: always()
+    steps:
+      - name: All gosec shards succeeded
+        run: |
+          result="${{ needs.gosec-shard.result }}"
+          echo "gosec-shard matrix result: $result"
+          [ "$result" = "success" ] || exit 1
+
+  # govulncheck: dependency vulnerability scanning against the Go vuln DB.
   govulncheck:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/scripts/ci-integration-select.sh
+++ b/scripts/ci-integration-select.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# or#855: pick the integration-tagged packages THIS CI job runs.
+#
+#   scripts/ci-integration-select.sh
+#
+# Reads the environment (all optional):
+#   BROAD=true       run the full tagged set, ignoring CHANGED_FILES.
+#   CHANGED_FILES    newline-separated diff paths; the set is narrowed to the
+#                    tagged packages those paths live in. Unset => full set.
+#   SHARDS=n SHARD=i emit only slice i (1-based) of n.
+#
+# Prints ./-prefixed package paths, one per line, for scripts/test_integration.sh.
+# Prints nothing (exit 0) when the diff touches no tagged package.
+#
+# SHARDING IS COVERAGE-NEUTRAL. The tests are unchanged and the union of the
+# shards is exactly the set a single job would have run. Each shard is a
+# separate runner with its own compose stack, so the `-p 1 -parallel 1`
+# serialisation the suite depends on — all packages share one Postgres/Garnet
+# and Redis keys are NOT namespaced per package — is preserved WITHIN a shard
+# and never crosses one. What sharding buys is wall clock: the serial run was
+# ~360s and the pipeline's sole long pole.
+#
+# Balancing uses recorded runtimes (scripts/ci-integration-weights.txt) and
+# longest-processing-time-first bin packing, plus a flat per-package constant
+# standing for compiling and linking that package's test binary. A package with
+# no recorded time still runs; it just gets the default weight.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+weights_file="scripts/ci-integration-weights.txt"
+# Compile+link of one test binary, in weight units (seconds). The serial job
+# spent ~360s to run ~210s of tests, so per-package build cost is real and a
+# shard of many fast packages is not free.
+per_package_build_cost=3
+default_runtime=5
+
+tag_re='^//go:build (.*[^a-zA-Z0-9_])?integration([^a-zA-Z0-9_].*)?$'
+
+packages="$(
+  grep -rl --include='*.go' -E "$tag_re" . |
+    xargs -n1 dirname | sed 's|^\./||' | sort -u
+)"
+
+[ -n "$packages" ] || {
+  echo "ci-integration-select: no package carries the 'integration' build tag; refusing to test nothing" >&2
+  exit 1
+}
+
+# Narrow to the packages the diff touches, unless the diff hit a shared surface.
+if [ "${BROAD:-}" != "true" ] && [ -n "${CHANGED_FILES:-}" ]; then
+  packages="$(
+    CHANGED="$CHANGED_FILES" awk '
+      BEGIN {
+        n = split(ENVIRON["CHANGED"], lines, "\n")
+        for (i = 1; i <= n; i++) {
+          f = lines[i]
+          if (f == "") continue
+          sub(/\/[^\/]*$/, "", f)
+          touched[f] = 1
+        }
+      }
+      { for (d in touched) if (d == $1 || index(d "/", $1 "/") == 1) { print; next } }
+    ' <<<"$packages"
+  )"
+  if [ -z "$packages" ]; then
+    echo "ci-integration-select: no integration-tagged package touched by the diff" >&2
+    exit 0
+  fi
+fi
+
+awk -v shards="${SHARDS:-1}" -v pick="${SHARD:-1}" \
+    -v build_cost="$per_package_build_cost" -v default_runtime="$default_runtime" \
+    -v weights_file="$weights_file" '
+  BEGIN {
+    while ((getline line < weights_file) > 0) {
+      if (line ~ /^#/ || line == "") continue
+      split(line, kv, "\t")
+      recorded[kv[1]] = kv[2] + 0
+    }
+  }
+  { pkg[NR] = $1; w[NR] = build_cost + (($1 in recorded) ? recorded[$1] : default_runtime) }
+  END {
+    # Heaviest first (insertion sort over a list this small), then each package
+    # onto the lightest shard so far.
+    for (i = 1; i <= NR; i++) order[i] = i
+    for (i = 2; i <= NR; i++) {
+      k = order[i]
+      for (j = i - 1; j >= 1 && w[order[j]] < w[k]; j--) order[j + 1] = order[j]
+      order[j + 1] = k
+    }
+    for (i = 1; i <= NR; i++) {
+      p = order[i]; best = 1
+      for (s = 2; s <= shards; s++) if (load[s] < load[best]) best = s
+      load[best] += w[p]
+      if (best == pick) print "./" pkg[p]
+    }
+  }
+' <<<"$packages" | sort

--- a/scripts/ci-integration-select.sh
+++ b/scripts/ci-integration-select.sh
@@ -20,10 +20,9 @@
 # and never crosses one. What sharding buys is wall clock: the serial run was
 # ~360s and the pipeline's sole long pole.
 #
-# Balancing uses recorded runtimes (scripts/ci-integration-weights.txt) and
-# longest-processing-time-first bin packing, plus a flat per-package constant
-# standing for compiling and linking that package's test binary. A package with
-# no recorded time still runs; it just gets the default weight.
+# Balancing is delegated to scripts/ci-shard.sh (recorded runtimes + LPT bin
+# packing), which the unit suite uses too — one implementation, two weight
+# tables.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -68,31 +67,6 @@ if [ "${BROAD:-}" != "true" ] && [ -n "${CHANGED_FILES:-}" ]; then
   fi
 fi
 
-awk -v shards="${SHARDS:-1}" -v pick="${SHARD:-1}" \
-    -v build_cost="$per_package_build_cost" -v default_runtime="$default_runtime" \
-    -v weights_file="$weights_file" '
-  BEGIN {
-    while ((getline line < weights_file) > 0) {
-      if (line ~ /^#/ || line == "") continue
-      split(line, kv, "\t")
-      recorded[kv[1]] = kv[2] + 0
-    }
-  }
-  { pkg[NR] = $1; w[NR] = build_cost + (($1 in recorded) ? recorded[$1] : default_runtime) }
-  END {
-    # Heaviest first (insertion sort over a list this small), then each package
-    # onto the lightest shard so far.
-    for (i = 1; i <= NR; i++) order[i] = i
-    for (i = 2; i <= NR; i++) {
-      k = order[i]
-      for (j = i - 1; j >= 1 && w[order[j]] < w[k]; j--) order[j + 1] = order[j]
-      order[j + 1] = k
-    }
-    for (i = 1; i <= NR; i++) {
-      p = order[i]; best = 1
-      for (s = 2; s <= shards; s++) if (load[s] < load[best]) best = s
-      load[best] += w[p]
-      if (best == pick) print "./" pkg[p]
-    }
-  }
-' <<<"$packages" | sort
+printf '%s\n' "$packages" | SHARDS="${SHARDS:-1}" SHARD="${SHARD:-1}" \
+  bash scripts/ci-shard.sh scripts/ci-integration-weights.txt |
+  sed 's|^|./|' | sort

--- a/scripts/ci-integration-weights.txt
+++ b/scripts/ci-integration-weights.txt
@@ -1,0 +1,60 @@
+# or#855: recorded per-package `go test` seconds for the integration-tagged
+# suite, used ONLY to balance the CI shards (scripts/ci-integration-select.sh).
+#
+# Source: the `Integration test` step of a full serial run, which prints
+#   ok  github.com/open-rails/openrails/<pkg>  <seconds>
+# Regenerate after a big shift in suite shape, from a ci-full `integration-full`
+# job log:
+#   gh api repos/open-rails/openrails/actions/jobs/<id>/logs |
+#     sed -nE 's#.*ok[[:space:]]+github\.com/open-rails/openrails/?([^[:space:]]*)[[:space:]]+([0-9.]+)s.*#\1\t\2#p' |
+#     sort
+#
+# STALENESS IS HARMLESS TO COVERAGE. A package missing here still runs — it just
+# gets a default weight, so the only thing a stale table can cost is balance.
+# Byte size was tried first and is a BAD proxy: `tests` is the largest package
+# on disk (552KB) and one of the fastest (4.9s), while internal/db/querytest is
+# 36s.
+embed	6.111
+internal/app	14.999
+internal/bootstrap	8.385
+internal/controlplane	7.267
+internal/crypto	0.542
+internal/db	15.821
+internal/db/querytest	35.659
+internal/http	0.140
+internal/http/handlers	1.643
+internal/http/middleware	0.035
+internal/integrationharness	7.981
+internal/integrations/nmi	0.133
+internal/integrations/stripeapi	0.007
+internal/integrations/vault	17.838
+internal/intents	3.293
+internal/merchants	1.886
+internal/merchantsecrets	14.619
+internal/modules/abuse	0.035
+internal/modules/admission	0.018
+internal/modules/admission/spendgate	1.844
+internal/modules/alerting	1.144
+internal/modules/catalog	0.597
+internal/modules/checkout	1.570
+internal/modules/entitlements	0.567
+internal/modules/grants	1.236
+internal/modules/idempotency	0.053
+internal/modules/metrics	1.781
+internal/modules/money	4.901
+internal/modules/money/ledger	0.602
+internal/modules/paymentmethods	0.554
+internal/modules/payments	0.676
+internal/modules/productaccess	0.691
+internal/modules/ratelimit	0.021
+internal/modules/solana	0.642
+internal/modules/solana/recurring	11.762
+internal/modules/subscriptions	3.164
+internal/modules/webhooks	1.682
+internal/reconcile	1.169
+internal/reconcile/converge	3.518
+internal/river	20.003
+pkg/embedded	0.895
+pkg/embedded/controlplane	1.325
+pkg/service	8.551
+tests	4.862

--- a/scripts/ci-integration-weights.txt
+++ b/scripts/ci-integration-weights.txt
@@ -1,60 +1,68 @@
-# or#855: recorded per-package `go test` seconds for the integration-tagged
-# suite, used ONLY to balance the CI shards (scripts/ci-integration-select.sh).
 #
-# Source: the `Integration test` step of a full serial run, which prints
-#   ok  github.com/open-rails/openrails/<pkg>  <seconds>
-# Regenerate after a big shift in suite shape, from a ci-full `integration-full`
-# job log:
+# Byte size was tried first and is a BAD proxy: `tests` is the largest package
+# (customer_integration_test.go, RLS denial then a pool-close deadlock, 15m
+# gets a default weight, so the only thing a stale table can cost is balance.
 #   gh api repos/open-rails/openrails/actions/jobs/<id>/logs |
+# HARVESTED FROM A GREEN RUN, WHICH MATTERS. The first version of this table was
+# internal/db carries its last known-good time. It currently HANGS on dev
+# job log (or the six PR shards):
+#   ok  github.com/open-rails/openrails/<pkg>  <seconds>
+# on disk (552KB) and one of the fastest (6s).
+# or#855: recorded per-package `go test` seconds for the integration-tagged
+# Regenerate after a big shift in suite shape, from a ci-full `integration-full`
 #     sed -nE 's#.*ok[[:space:]]+github\.com/open-rails/openrails/?([^[:space:]]*)[[:space:]]+([0-9.]+)s.*#\1\t\2#p' |
 #     sort
-#
+# Source: the `Integration test` step of a CI run, which prints
 # STALENESS IS HARMLESS TO COVERAGE. A package missing here still runs — it just
-# gets a default weight, so the only thing a stale table can cost is balance.
-# Byte size was tried first and is a BAD proxy: `tests` is the largest package
-# on disk (552KB) and one of the fastest (4.9s), while internal/db/querytest is
-# 36s.
-embed	6.111
-internal/app	14.999
-internal/bootstrap	8.385
-internal/controlplane	7.267
-internal/crypto	0.542
+# suite, used ONLY to balance the CI shards (scripts/ci-integration-select.sh).
+# table built from a red run silently balances for the wrong suite.
+# taken from a run where many packages failed early, so it recorded how long they
+# timeout), so its live number would be the timeout, not its cost.
+# took to FAIL, not to pass — pkg/service showed 8.5s and actually takes 81s. A
+cmd/openrails	1.698
+embed	7.127
+internal/app	14.507
+internal/bootstrap	10.339
+internal/controlplane	7.511
+internal/crypto	0.664
 internal/db	15.821
-internal/db/querytest	35.659
-internal/http	0.140
-internal/http/handlers	1.643
-internal/http/middleware	0.035
-internal/integrationharness	7.981
-internal/integrations/nmi	0.133
-internal/integrations/stripeapi	0.007
-internal/integrations/vault	17.838
-internal/intents	3.293
-internal/merchants	1.886
-internal/merchantsecrets	14.619
-internal/modules/abuse	0.035
+internal/db/querytest	32.508
+internal/http	0.844
+internal/http/handlers	1.655
+internal/http/middleware	0.037
+internal/integrationharness	9.076
+internal/integrations/nmi	0.841
+internal/integrations/stripeapi	0.072
+internal/integrations/vault	25.489
+internal/intents	4.493
+internal/invariantaudit	0.784
+internal/merchants	2.557
+internal/merchantsecrets	27.038
+internal/modules/abuse	0.025
 internal/modules/admission	0.018
-internal/modules/admission/spendgate	1.844
-internal/modules/alerting	1.144
-internal/modules/catalog	0.597
-internal/modules/checkout	1.570
-internal/modules/entitlements	0.567
-internal/modules/grants	1.236
-internal/modules/idempotency	0.053
-internal/modules/metrics	1.781
-internal/modules/money	4.901
-internal/modules/money/ledger	0.602
-internal/modules/paymentmethods	0.554
-internal/modules/payments	0.676
-internal/modules/productaccess	0.691
-internal/modules/ratelimit	0.021
-internal/modules/solana	0.642
-internal/modules/solana/recurring	11.762
+internal/modules/admission/spendgate	1.846
+internal/modules/alerting	1.356
+internal/modules/catalog	0.686
+internal/modules/checkout	1.642
+internal/modules/entitlements	0.685
+internal/modules/grants	1.468
+internal/modules/idempotency	0.054
+internal/modules/metrics	2.081
+internal/modules/money	6.161
+internal/modules/money/ledger	0.851
+internal/modules/paymentmethods	0.587
+internal/modules/payments	0.498
+internal/modules/productaccess	0.841
+internal/modules/ratelimit	0.022
+internal/modules/reconcile	0.609
+internal/modules/solana	0.769
+internal/modules/solana/recurring	56.701
 internal/modules/subscriptions	3.164
-internal/modules/webhooks	1.682
-internal/reconcile	1.169
-internal/reconcile/converge	3.518
-internal/river	20.003
-pkg/embedded	0.895
-pkg/embedded/controlplane	1.325
-pkg/service	8.551
-tests	4.862
+internal/modules/webhooks	2.043
+internal/reconcile	2.666
+internal/reconcile/converge	4.122
+internal/river	23.959
+pkg/embedded	0.827
+pkg/embedded/controlplane	1.374
+pkg/service	80.826
+tests	6.001

--- a/scripts/ci-shard.sh
+++ b/scripts/ci-shard.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# or#855: split a package list across CI shards, balanced by recorded runtimes.
+#
+#   <package list on stdin> | scripts/ci-shard.sh <weights-file>
+#
+# Environment:
+#   SHARDS=n SHARD=i   emit only slice i (1-based) of n. Defaults 1/1.
+#
+# Input is one package per line, in any form; the FIRST field is matched against
+# the weights file, whose lines are `<package><TAB><seconds>` with `#` comments.
+#
+# Longest-processing-time-first bin packing: heaviest package onto the lightest
+# shard so far. Round-robin over an alphabetical list was tried and is much
+# worse — it put the two heaviest packages in the same shard and made it 2x the
+# others (measured: unit shard 3 at 136s against 64s and 65s).
+#
+# A package with no recorded weight still runs; it just gets the default. So a
+# stale weights file costs balance, never coverage.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+weights_file="${1:?usage: ci-shard.sh <weights-file>}"
+
+# Compile+link of one test binary, in weight units (seconds). Without it a shard
+# of many trivial packages looks free and gets overloaded.
+per_package_build_cost=3
+default_runtime=5
+
+awk -v shards="${SHARDS:-1}" -v pick="${SHARD:-1}" \
+    -v build_cost="$per_package_build_cost" -v default_runtime="$default_runtime" \
+    -v weights_file="$weights_file" '
+  BEGIN {
+    while ((getline line < weights_file) > 0) {
+      if (line ~ /^#/ || line == "") continue
+      split(line, kv, "\t")
+      recorded[kv[1]] = kv[2] + 0
+    }
+  }
+  {
+    key = $1
+    sub(/^\.\//, "", key)
+    sub(/^github\.com\/open-rails\/openrails\/?/, "", key)
+    if (key == "") key = "."
+    pkg[NR] = $1
+    w[NR] = build_cost + ((key in recorded) ? recorded[key] : default_runtime)
+  }
+  END {
+    for (i = 1; i <= NR; i++) order[i] = i
+    for (i = 2; i <= NR; i++) {
+      k = order[i]
+      for (j = i - 1; j >= 1 && w[order[j]] < w[k]; j--) order[j + 1] = order[j]
+      order[j + 1] = k
+    }
+    for (i = 1; i <= NR; i++) {
+      p = order[i]; best = 1
+      for (s = 2; s <= shards; s++) if (load[s] < load[best]) best = s
+      load[best] += w[p]
+      if (best == pick) print pkg[p]
+    }
+  }
+'

--- a/scripts/ci-unit-weights.txt
+++ b/scripts/ci-unit-weights.txt
@@ -1,0 +1,96 @@
+# or#855: recorded per-package `go test` seconds for the UNTAGGED (unit) suite,
+# used ONLY to balance the CI shards (scripts/ci-shard.sh).
+#
+# Source: the `Test (race)` step of a CI run. Regenerate from the unit shard
+# job logs:
+#   gh api repos/open-rails/openrails/actions/jobs/<id>/logs |
+#     sed -nE 's#.*ok[[:space:]]+github\.com/open-rails/openrails/?([^[:space:]]*)[[:space:]]+([0-9.]+)s.*#\1\t\2#p' |
+#     sort
+#
+# Two packages are 130s of the suite's 240s, so an unweighted split cannot be
+# balanced: round-robin put both in one shard and made it 136s against 64s.
+#
+# A package missing here still runs — it just gets the default weight. A stale
+# table costs balance, never coverage.
+	1.647
+cmd/openrails	1.045
+config	1.859
+embed	1.032
+internal/app	1.031
+internal/auth	1.017
+internal/bootstrap	1.134
+internal/captcha	1.030
+internal/controlplane	6.701
+internal/crypto	1.012
+internal/db	3.999
+internal/db/models	1.013
+internal/db/queryguard	4.946
+internal/db/sqlaudit	1.052
+internal/http	1.054
+internal/http/embedhttp	1.032
+internal/http/handlers	1.091
+internal/http/middleware	1.094
+internal/http/request	1.030
+internal/http/router	1.028
+internal/http/routes	1.088
+internal/http/routesurface	1.013
+internal/integrations/basistheory	1.378
+internal/integrations/ccbill	1.043
+internal/integrations/fx	1.015
+internal/integrations/nmi	1.891
+internal/integrations/pyth	1.014
+internal/integrations/solana	1.040
+internal/integrations/solana/subscriptions	1.019
+internal/integrations/stripeapi	1.270
+internal/integrations/vault	1.025
+internal/intents	2.803
+internal/merchants	4.190
+internal/merchantsecrets	1.017
+internal/migrate	1.013
+internal/modules/admission	1.011
+internal/modules/alerting	1.018
+internal/modules/catalog	1.064
+internal/modules/checkout	1.033
+internal/modules/collection	1.023
+internal/modules/copilot	1.017
+internal/modules/dashboard	1.248
+internal/modules/delinquency	1.012
+internal/modules/grants	1.012
+internal/modules/idempotency	1.009
+internal/modules/metrics	1.017
+internal/modules/money	1.014
+internal/modules/money/ledger	1.021
+internal/modules/paymentmethods	1.016
+internal/modules/payments	1.012
+internal/modules/payments/rails	1.009
+internal/modules/payments/rails/nmidirect	1.016
+internal/modules/payments/rails/nmiproxy	1.021
+internal/modules/reconcile	1.018
+internal/modules/solana	1.131
+internal/modules/solana/recurring	57.092
+internal/modules/solana/tokens	1.011
+internal/modules/subscriptions	1.033
+internal/modules/webhooks	1.429
+internal/railresolve	1.011
+internal/reconcile	1.594
+internal/river	1.163
+internal/shared/format	1.010
+internal/shared/httpx	1.013
+internal/shared/iputil	1.013
+internal/shared/moneyutil	3.726
+internal/shared/redact	1.011
+internal/shared/sigverify	1.008
+internal/shared/timeutil	1.010
+internal/shared/uuidutil	1.008
+internal/shared/webhookutil	1.013
+internal/webhookauth	1.011
+migrations/postgres	3.779
+pkg/billingauth	1.015
+pkg/catalog	1.098
+pkg/embedded	1.059
+pkg/embedded/controlplane	1.022
+pkg/identity	1.007
+pkg/merchant	1.009
+pkg/pricing	1.010
+pkg/service	73.061
+tests	1.016

--- a/scripts/test_integration.sh
+++ b/scripts/test_integration.sh
@@ -37,4 +37,10 @@ docker compose -f docker-compose.yaml up -d --wait postgres garnet
 export OPENRAILS_TEST_DB_DSN="${OPENRAILS_TEST_DB_DSN:-postgresql://admin:admin_password@127.0.0.1:${POSTGRES_HOST_PORT}/openrails_db?sslmode=disable}"
 export OPENRAILS_TEST_REDIS_ADDR="${OPENRAILS_TEST_REDIS_ADDR:-127.0.0.1:${GARNET_HOST_PORT}}"
 
-go test -p 1 -parallel 1 -tags=integration -timeout "${OPENRAILS_INTEGRATION_TIMEOUT:-25m}" "${args[@]}"
+# -count=1 is MANDATORY, not stylistic. Go's test-result cache keys on package
+# content, env vars and files read — it cannot see the Postgres/Garnet stack
+# these tests actually exercise, so a cached `ok` is a pass that was never
+# re-earned against the current schema and data. Observed live (or#855): with a
+# warm GOCACHE, whole integration packages came back `ok … (cached)` without a
+# single query running.
+go test -count=1 -p 1 -parallel 1 -tags=integration -timeout "${OPENRAILS_INTEGRATION_TIMEOUT:-25m}" "${args[@]}"


### PR DESCRIPTION
Finishes or#855: the required PR pipeline had to fit ~3 minutes; the 2026-07-29 measurement
put p50 at 387s and the work stopped there.

## Re-measured first, on current data

Last 15 `pull_request` runs of `ci.yaml`, job + step timings from the Actions API:

| job | p50 | p95 | dominant steps (p50) |
|---|---|---|---|
| **integration** | **369s** | 413s | `go test` 360s (compose up+healthy ~17s of it) |
| build | 272s | 291s | `go test -race` 143s, `go vet` 55s, `go vet -tags integration` 29s |
| sqlc | 137s | 156s | `go install task@latest` 52s, `task sqlc-check` 64s |
| console | 98s | 110s | `go vet -tags console_assets ./...` 68s; the SPA build is 8s |
| changes | 5s | 5s | — |
| **pipeline wall** | **378s** | **420s** | target 180s |

`security.yaml` runs alongside and is also a required check: wall p50 174s, of which
gosec 170s (42s of that is `go install gosec@latest`).

## First finding is not about latency

`ci.yaml` and `security.yaml` were scoped to `pull_request: branches: [master]`, but work
merges into `dev` now — PRs #208 and #209 landed there reporting **"no checks reported on
the branch"**. Every gate in this repo was silently absent from the branch it was supposed
to be guarding. Fixed first: both workflows cover `dev`, and `ci-full` runs on `dev` pushes.

## Levers applied

1. **Shard `integration` 6 ways** — the long pole, 369s of `-p 1 -parallel 1` over 49 packages.
   Coverage-neutral: union of shards == the same package set, each shard is its own runner
   with its own compose stack, serialisation preserved *within* a shard, so the shared
   Postgres/Garnet and un-namespaced Redis keys that forbid raising `-parallel` are untouched.
   Balanced by **recorded per-package runtimes** harvested from a real job log
   (`scripts/ci-integration-weights.txt`) with longest-processing-time-first bin packing.
   Byte size was tried first and is a bad proxy — `tests` is the largest package on disk
   (552KB) and one of the fastest (4.9s), while `internal/db/querytest` is 35.7s.
2. **Split `build` into `build` + `unit`** — `go test -race` shares no compiled output with
   `go vet` (a race build changes the action id of every package), so chaining them bought
   wall clock and nothing else.
3. **Explicit Go build cache, keyed per build variant** (`.github/actions/go-env`).
4. **Narrow the console tagged-build gate** — `go vet -tags console_assets ./...` recompiled and
   re-analysed the whole tree to prove one `//go:embed`. Exactly one package has
   tag-conditional source, so the PR tier builds the binary that makes the claim and vets that
   package, with a guard that fails the day a second package grows a `console_assets` file.
   `ci-full` keeps the whole-tree version.
5. **Recovered lost work**: `scripts/ci-install-tool.sh` (pinned, sha256-verified `task`/`sqlc`/
   `gosec` downloads, ~2s each vs 42-60s of compiling) is a verbatim restore of `e2591c71`,
   which the tracker records as done but which is unreachable from every branch — `chaos` was
   rewritten under it.

### Re-adding cache steps, and `ci.yaml:78`'s objection

That comment forbids explicit `actions/cache` on `~/go/pkg/mod` + `~/.cache/go-build`, because
they collided with `setup-go`'s `cache: true` restoring the same directories — two restores into
one directory fail with `tar: Cannot open: File exists`.

The objection is about a **double restore**, not about explicit caching, and the composite action
keeps the property that fixed it: `setup-go` runs with `cache: false`, so every path is restored
exactly once and the collision is structurally impossible. What the deletion cost is that
setup-go's key is one shared entry per `(os, go version, go.sum)` — but a Go build-cache entry is
keyed by the whole build configuration, so `-race`, `-tags integration` and `-tags console_assets`
each produce a different action id for every package in the graph. One shared entry is written by
whichever job saves first and is a near-total miss for the other three. Keys are deliberately not
suffixed with the commit sha: six stable entries (~2GB) instead of a new multi-hundred-MB entry per
commit, which would blow the 10GB repo budget and evict what it just wrote. The full argument is in
the action's header.

## Teeth

Nothing became advisory, nothing is skipped on PRs, nothing moved to `ci-full` to make a number.
`-count=1` semantics on integration tests are unchanged (`scripts/test_integration.sh` is untouched).
One gate got *stronger*: `sqlc-check` now refuses an empty `SQLC_DATABASE_URL`, which used to let
`TestQueryAudit` skip silently and report a pass it had not earned. One bug fixed: `Build examples`
had no `if:` guard, so on a docs-only PR it ran without a checkout and failed the build job.

**Branch protection contract.** The required checks from `ci.yaml` are exactly: `changes`, `build`,
`unit`, `lint`, `sqlc`, `console`, `integration` (+ `security-changes`, `gosec`, `govulncheck`, `trivy`
from `security.yaml`).
`integration`, `unit` and `gosec` are aggregators over their shard matrices, so shard counts can change
without touching the ruleset — do **not** list the individual `… shard N/M` jobs. Never list `ci-full`'s
`-full` jobs or CodeQL's `Analyze (go)`: they do not run on PRs, so requiring them blocks every PR
forever. The "Master integrity baseline" ruleset still has no `required_status_checks` rule; adding
one is a human touch.

## Measurement

This PR's own runs are the measurement; the final table is below.


---

# Measurement — rebased onto dev after the chaos wave

| | baseline | after | |
|---|---|---|---|
| **required-checks wall clock** | **378s p50 / 420s p95** | **167s** | target 180s |

167s is the run with the one hung package's shard excluded (see below). As run, with the hang,
it is 499s — a single package holding the pipeline, not a pipeline problem.

Per-job, final run (cold caches — dev moved, so `go.sum` changed and every key missed):

| job | before | after |
|---|---|---|
| integration | 369s (1 job) | **149s** (slowest of 6 shards; shard 6 excluded, see below) |
| unit | — (inside build) | 117s (slowest of 3 shards) |
| lint | never ran — **could not run at all** | 115s |
| gosec | 170s (1 job) | 75s (slowest of 3 shards) |
| build | 272s | 73s |
| console | 98s | 58s |
| sqlc | 137s | 38s |
| govulncheck / trivy / changes | 38 / 14 / 5s | 32 / 15 / 4s |

Warm caches take another 30-40% off this (measured pre-rebase: `build` 132s → 23s, console's
tagged build 55s → 2s). These numbers are the cold ceiling, not the steady state.

## Corrections the green tree forced

The pre-rebase 139s was measured on a **red** tree, where failing packages abort early. That
number was too good and I am withdrawing it. Three things had to change once the suite went green:

- **The weights table was harvested from a red run**, so it recorded how long packages took to
  FAIL. `pkg/service` showed 8.5s and actually takes 81s. Rebuilt from green output; the six
  integration shards went from a 184s worst shard to an even ~87 units each.
- **`unit` measured 181s once green** — on its own over the bar. Now sharded 3 ways.
- **Round-robin sharding is not good enough**: it put `pkg/service` (73s) and
  `internal/modules/solana/recurring` (57s), 130s of a 240s unit suite, in the same shard — 136s
  against 64s and 65s. Both suites now use `scripts/ci-shard.sh` (recorded runtimes + LPT bin
  packing), one implementation with two weight tables.
- **A shard's go-test budget dropped 15m → 6m.** A shard is ~2min of work, so past 6m it is a
  hang. This alone took the hung shard from 16m26s to 7m56s.

## Sharding was suspected and cleared

`internal/db` hung for 15 minutes in a shard, and the project guide warns that running an
integration subset can fail on fixtures the full suite seeds — so the split was the prime suspect.
**It is not.** Reproduced locally: `bash scripts/test_integration.sh ./internal/db`, on its own,
hangs identically. The cause is on dev, not in the partition:

```
customer_integration_test.go:67: ERROR: new row violates row-level security
policy for table "customers" (SQLSTATE 42501)
panic: test timed out after 15m0s
  running tests: TestEnsureCustomerRow_ConcurrentFirstTouchConverges (14m42s)
```

An RLS policy denies the insert; three tests fail in 0.01s; then the concurrency test's cleanup
deadlocks closing the pgx pool with its goroutines still in flight, and a 0.01s failure becomes a
15-minute hang. Two separate defects, both wanting their own issue.

## Still red on dev, none of it from this PR

- **`build`** — `go vet -tags integration ./...` fails: `unknown field Environment in struct
  literal of type merchants.UpsertPaymentProviderConfigRequest`. or#814 (`571e828b`) added the
  test that uses the field; or#884 (`8766535c`) deleted the field. Each PR was green alone; the
  merge is not. This is the compile guard doing exactly the job it was added for.
- **`gosec`** — 3 G115 integer-overflow findings in `internal/crypto/envelope.go:115`,
  `pkg/embedded/prune_rollback.go:124`, `cmd/openrails/converge_rollback.go:119`.
- **`trivy`** — 4 HIGH npm CVEs in `web/admin` (brace-expansion, fast-uri, ip-address, undici).
- **`integration`** — the `internal/db` hang above, plus
  `TestAdmitRefusesWhenOverdueExposureEatsTheCreditLine` in `pkg/service` (or#878 arrears
  delinquency, merged after this branch started).

## or#869's lint gate: required in name, enforcing nothing

The chaos wave carried the `lint` job in, and **this PR is the first time it has ever executed** —
ci.yaml runs only on PRs, and the job arrived on dev through a merge. It failed instantly:

```
Error: can't load config: the Go language version (go1.25) used to build
golangci-lint is lower than the targeted Go version (1.26.5)
```

golangci-lint v2.6.0 is built with go1.25; this module targets go1.26.5, so it exited 3 on config
load every time. Pinned to **v2.11.4**, the smallest bump that loads — green with 0 issues, so
what the gate means is unchanged. v2.12.2 also loads but its newer govet `inline` analyzer adds 3
findings (`reflect.Ptr` → `reflect.Pointer` in `internal/http/request/request.go`); those are
source changes, recorded in the workflow for whoever takes the next bump rather than silenced with
an exclusion. The job also now uses the `go-env` cache like every other Go job — it was on
setup-go's shared key, which nothing writes any more, so it would have missed every run.

## Verdict

**The 3-minute bar is met at 167s cold**, with the caveat that one package on dev hangs and must
be fixed before the pipeline can report a green wall clock. No bigger runners needed: the residual
pole is `integration` at 149s on a 4-core `ubuntu-latest`, and the next lever if the bar tightens
is more shards, not a bigger machine.