### PR TITLE
or#889: refuse cross-merchant customer claims instead of silently taking them

### DIFF
--- a/internal/controlplane/customer.go
+++ b/internal/controlplane/customer.go
@@ -3,9 +3,11 @@ package controlplane
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/open-rails/openrails/internal/db"
 	"github.com/open-rails/openrails/internal/db/gen"
@@ -53,6 +55,13 @@ func (c *ControlPlane) TouchCustomer(ctx context.Context, merchantID merchant.ID
 		Issuer:     issuerPtr,
 		Subject:    &subjectID,
 	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		// The guarded upsert matches no row when the subject is already a
+		// customer of a DIFFERENT merchant (#889). One AuthKit instance can
+		// serve several merchants, so refuse instead of handing back an id the
+		// merchant does not own.
+		return uuid.Nil, fmt.Errorf("%w: subject %s under merchant %s", db.ErrCustomerOwnedByAnotherMerchant, subjectID, merchantID)
+	}
 	if err != nil {
 		return uuid.Nil, err
 	}

--- a/internal/db/customer.go
+++ b/internal/db/customer.go
@@ -2,10 +2,12 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/open-rails/openrails/internal/db/gen"
 	"github.com/open-rails/openrails/internal/shared/uuidutil"
@@ -24,6 +26,14 @@ var systemCustomerNamespace = uuid.MustParse("00000000-0000-0000-0000-0000000000
 func SystemCustomerID(merchantID uuid.UUID) uuid.UUID {
 	return uuidutil.DeterministicID(systemCustomerNamespace, merchantID.String())
 }
+
+// ErrCustomerOwnedByAnotherMerchant signals that a customer id already belongs
+// to a DIFFERENT merchant. customers.id is globally unique while customer rows
+// are merchant-isolated (#889), so a foreign id must be refused loudly: silently
+// re-pointing it (privileged upsert) or silently no-op'ing (ON CONFLICT DO
+// NOTHING, which then lets the caller's row FK into another merchant's customer,
+// because FK checks bypass RLS) is cross-merchant corruption that logs success.
+var ErrCustomerOwnedByAnotherMerchant = errors.New("customer id is already owned by another merchant")
 
 // errNonUUIDSubject builds the rejection for non-UUID payable identities.
 // OpenRails is UUID-only (#364): there is no legacy issuer, no generated row
@@ -60,11 +70,25 @@ func EnsureCustomerID(ctx context.Context, qx gen.DBTX, tenantID uuid.UUID, user
 		}
 		tenantID = tid.UUID()
 	}
-	return gen.New(qx).EnsureCustomer(ctx, gen.EnsureCustomerParams{
+	id, err := gen.New(qx).EnsureCustomer(ctx, gen.EnsureCustomerParams{
 		ID:         uid,
 		MerchantID: tenantID,
 		Subject:    &userID,
 	})
+	if err != nil {
+		return uuid.Nil, customerOwnershipError(err, uid, tenantID)
+	}
+	return id, nil
+}
+
+// customerOwnershipError names the cross-merchant claim behind an empty upsert
+// result: the guarded ON CONFLICT matches no row exactly when the id belongs to
+// another merchant (#889).
+func customerOwnershipError(err error, id, merchantID uuid.UUID) error {
+	if errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("%w: customer %s under merchant %s", ErrCustomerOwnedByAnotherMerchant, id, merchantID)
+	}
+	return err
 }
 
 // ResolveCustomerID derives the payable merchant subject id for a userID
@@ -91,6 +115,12 @@ func ResolveCustomerID(userID string) (uuid.UUID, error) {
 // repeat a no-op. A zero id is a no-op (the caller must set model.CustomerID
 // before Create).
 func EnsureCustomerRow(ctx context.Context, qx gen.DBTX, tenantID uuid.UUID, tsid uuid.UUID) error {
+	return EnsureCustomerRowQ(ctx, gen.New(qx), tenantID, tsid)
+}
+
+// EnsureCustomerRowQ is EnsureCustomerRow for callers already holding a
+// *gen.Queries bound to their transaction.
+func EnsureCustomerRowQ(ctx context.Context, q *gen.Queries, tenantID uuid.UUID, tsid uuid.UUID) error {
 	if tsid == uuid.Nil {
 		return nil
 	}
@@ -102,9 +132,23 @@ func EnsureCustomerRow(ctx context.Context, qx gen.DBTX, tenantID uuid.UUID, tsi
 		tenantID = tid.UUID()
 	}
 	subject := tsid.String()
-	return gen.New(qx).EnsureCustomerRow(ctx, gen.EnsureCustomerRowParams{
+	_, err := q.EnsureCustomerRow(ctx, gen.EnsureCustomerRowParams{
 		ID:         tsid,
 		MerchantID: tenantID,
 		Subject:    &subject,
 	})
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return err
+	}
+	// No row back means either a foreign owner or a race: ON CONFLICT DO NOTHING
+	// returns nothing for a row this statement's snapshot cannot see, including
+	// one a concurrent first-touch committed after the snapshot was taken. A
+	// locking re-read settles it — it waits out the other writer and sees the
+	// committed row (#889).
+	if _, lerr := q.LockCustomerForMerchant(ctx, gen.LockCustomerForMerchantParams{
+		ID: tsid, MerchantID: tenantID,
+	}); lerr != nil {
+		return customerOwnershipError(lerr, tsid, tenantID)
+	}
+	return nil
 }

--- a/internal/db/customer_integration_test.go
+++ b/internal/db/customer_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-rails/openrails/internal/db"
+	"github.com/open-rails/openrails/internal/db/gen"
 	"github.com/open-rails/openrails/internal/dbtest"
 )
 
@@ -48,6 +49,125 @@ func TestEnsureCustomerID_UUIDReusesExistingPayableID(t *testing.T) {
 		`SELECT last_seen_at FROM openrails.customers WHERE id = $1`, userID,
 	).Scan(&lastSeenAt))
 	require.True(t, lastSeenAt.After(createdAt))
+}
+
+// seedForeignCustomer creates a second merchant plus a customer row owned by it,
+// returning that merchant's id and the customer id.
+func seedForeignCustomer(ctx context.Context, t *testing.T, pool gen.DBTX) (uuid.UUID, uuid.UUID) {
+	t.Helper()
+	otherMerchantID := uuid.New()
+	customerID := uuid.New()
+	_, err := pool.Exec(ctx,
+		`INSERT INTO openrails.merchants (id, slug, status) VALUES ($1, $2, 'active')`,
+		otherMerchantID, "cross-merchant-"+otherMerchantID.String()[:8])
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx,
+		`INSERT INTO openrails.customers (id, merchant_id, subject) VALUES ($1, $2, $3)`,
+		customerID, otherMerchantID, customerID.String())
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM openrails.customers WHERE id = $1`, customerID)
+		_, _ = pool.Exec(ctx, `DELETE FROM openrails.merchants WHERE id = $1`, otherMerchantID)
+	})
+	return otherMerchantID, customerID
+}
+
+// #889 family: customers.id is globally unique but customer rows are merchant
+// isolated, so an id already owned by another merchant must be REFUSED, never
+// re-pointed. On a privileged (RLS-bypassing) handle — bootstrap, import, the
+// dev owner connection — the upsert used to rewrite the other merchant's row
+// and hand the caller an id it does not own.
+func TestEnsureCustomerID_RefusesCrossMerchantClaim(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.SharedPGXPool(t)
+
+	dbtest.EnsureTestMerchant(ctx, t, pool)
+	otherMerchantID, customerID := seedForeignCustomer(ctx, t, pool)
+
+	_, err := db.EnsureCustomerID(ctx, pool, dbtest.TestMerchantID.UUID(), customerID.String())
+	require.ErrorIs(t, err, db.ErrCustomerOwnedByAnotherMerchant)
+
+	var ownerID uuid.UUID
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT merchant_id FROM openrails.customers WHERE id = $1`, customerID,
+	).Scan(&ownerID))
+	require.Equal(t, otherMerchantID, ownerID, "the owning merchant must not change")
+}
+
+// EnsureCustomerRow is the FK-target materializer every commerce Create calls.
+// Its ON CONFLICT DO NOTHING used to make a cross-merchant id a SILENT success,
+// so the caller's row landed pointing at another merchant's customer (FK checks
+// bypass RLS).
+func TestEnsureCustomerRow_RefusesCrossMerchantClaim(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.SharedPGXPool(t)
+
+	dbtest.EnsureTestMerchant(ctx, t, pool)
+	otherMerchantID, customerID := seedForeignCustomer(ctx, t, pool)
+
+	err := db.EnsureCustomerRow(ctx, pool, dbtest.TestMerchantID.UUID(), customerID)
+	require.ErrorIs(t, err, db.ErrCustomerOwnedByAnotherMerchant)
+
+	var ownerID uuid.UUID
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT merchant_id FROM openrails.customers WHERE id = $1`, customerID,
+	).Scan(&ownerID))
+	require.Equal(t, otherMerchantID, ownerID)
+}
+
+// The same id under the SAME merchant stays a plain idempotent no-op.
+func TestEnsureCustomerRow_RepeatIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.SharedPGXPool(t)
+
+	dbtest.EnsureTestMerchant(ctx, t, pool)
+	tenantID := dbtest.TestMerchantID.UUID()
+	customerID := uuid.New()
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM openrails.customers WHERE id = $1`, customerID)
+	})
+
+	require.NoError(t, db.EnsureCustomerRow(ctx, pool, tenantID, customerID))
+	require.NoError(t, db.EnsureCustomerRow(ctx, pool, tenantID, customerID))
+
+	var count int
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT count(*) FROM openrails.customers WHERE id = $1 AND merchant_id = $2`,
+		customerID, tenantID,
+	).Scan(&count))
+	require.Equal(t, 1, count)
+}
+
+// A concurrent first-touch of the SAME customer under the same merchant must
+// converge, not be mistaken for a foreign owner: the insert sees nothing (the
+// other writer is uncommitted at snapshot time) and the locking re-read settles
+// it once that writer commits (#889).
+func TestEnsureCustomerRow_ConcurrentFirstTouchConverges(t *testing.T) {
+	ctx := context.Background()
+	pool := dbtest.SharedPGXPool(t)
+
+	dbtest.EnsureTestMerchant(ctx, t, pool)
+	tenantID := dbtest.TestMerchantID.UUID()
+	customerID := uuid.New()
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM openrails.customers WHERE id = $1`, customerID)
+	})
+
+	tx, err := pool.Begin(ctx)
+	require.NoError(t, err)
+	_, err = tx.Exec(ctx,
+		`INSERT INTO openrails.customers (id, merchant_id, subject) VALUES ($1, $2, $3)`,
+		customerID, tenantID, customerID.String())
+	require.NoError(t, err)
+
+	committed := make(chan error, 1)
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		committed <- tx.Commit(ctx)
+	}()
+
+	require.NoError(t, db.EnsureCustomerRow(ctx, pool, tenantID, customerID))
+	require.NoError(t, <-committed)
 }
 
 // Payable identities are UUID-only (#364): non-UUID subjects are rejected, the

--- a/internal/db/gen/customers.sql.go
+++ b/internal/db/gen/customers.sql.go
@@ -44,6 +44,7 @@ VALUES ($1, $2, $3)
 ON CONFLICT (id) DO UPDATE SET
   subject = EXCLUDED.subject,
   last_seen_at = now()
+WHERE openrails.customers.merchant_id = EXCLUDED.merchant_id
 RETURNING id
 `
 
@@ -57,7 +58,10 @@ type EnsureCustomerParams struct {
 // balance keyed by its UUID id (#364); the caller/merchant supplies the id.
 // Materialize (or refresh) the customers row for a payable UUID id under a
 // merchant. The caller supplies id (the payable UUID). ON CONFLICT refreshes
-// last_seen_at so concurrent first-touch is safe.
+// last_seen_at so concurrent first-touch is safe. The merchant_id guard makes a
+// foreign id return NO ROW instead of re-pointing another merchant's customer
+// (#889) — RLS already blocks it on enforcing roles, this holds for the
+// privileged ones (bootstrap, import, dev owner) too.
 func (q *Queries) EnsureCustomer(ctx context.Context, arg EnsureCustomerParams) (uuid.UUID, error) {
 	row := q.db.QueryRow(ctx, ensureCustomer, arg.ID, arg.MerchantID, arg.Subject)
 	var id uuid.UUID
@@ -65,10 +69,18 @@ func (q *Queries) EnsureCustomer(ctx context.Context, arg EnsureCustomerParams) 
 	return id, err
 }
 
-const ensureCustomerRow = `-- name: EnsureCustomerRow :exec
-INSERT INTO openrails.customers (id, merchant_id, subject)
-VALUES ($1, $2, $3)
-ON CONFLICT DO NOTHING
+const ensureCustomerRow = `-- name: EnsureCustomerRow :one
+WITH inserted AS (
+  INSERT INTO openrails.customers (id, merchant_id, subject)
+  VALUES ($1, $2, $3)
+  ON CONFLICT (id) DO NOTHING
+  RETURNING id
+)
+SELECT id FROM inserted
+UNION ALL
+SELECT c.id FROM openrails.customers c
+WHERE c.id = $1 AND c.merchant_id = $2
+LIMIT 1
 `
 
 type EnsureCustomerRowParams struct {
@@ -77,10 +89,15 @@ type EnsureCustomerRowParams struct {
 	Subject    *string
 }
 
-// FK-target materialization before commerce inserts; no-op when present.
-func (q *Queries) EnsureCustomerRow(ctx context.Context, arg EnsureCustomerRowParams) error {
-	_, err := q.db.Exec(ctx, ensureCustomerRow, arg.ID, arg.MerchantID, arg.Subject)
-	return err
+// FK-target materialization before commerce inserts; no-op when present. It
+// RETURNS the id it materialized so a conflicting row owned by ANOTHER merchant
+// yields no row rather than a silent success (#889): FK checks bypass RLS, so a
+// silent no-op would let the caller's row attach to a foreign customer.
+func (q *Queries) EnsureCustomerRow(ctx context.Context, arg EnsureCustomerRowParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, ensureCustomerRow, arg.ID, arg.MerchantID, arg.Subject)
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
 }
 
 const lockCustomerForMerchant = `-- name: LockCustomerForMerchant :one
@@ -219,6 +236,7 @@ ON CONFLICT (id) DO UPDATE SET
   subject = EXCLUDED.subject,
   issuer = COALESCE(EXCLUDED.issuer, openrails.customers.issuer),
   last_seen_at = now()
+WHERE openrails.customers.merchant_id = EXCLUDED.merchant_id
 RETURNING id
 `
 
@@ -230,6 +248,9 @@ type UpsertCustomerBySubjectParams struct {
 
 // Customer identity is the merchant plus the host/AuthKit stable UUID subject.
 // The row id is that subject UUID; issuer is kept only as last-seen audit source.
+// The merchant_id guard refuses a subject already registered under a DIFFERENT
+// merchant (#889) — one AuthKit instance can serve several merchants, and the
+// unguarded upsert handed the second merchant an id owned by the first.
 func (q *Queries) UpsertCustomerBySubject(ctx context.Context, arg UpsertCustomerBySubjectParams) (uuid.UUID, error) {
 	row := q.db.QueryRow(ctx, upsertCustomerBySubject, arg.Subject, arg.MerchantID, arg.Issuer)
 	var id uuid.UUID

--- a/internal/db/queries/customers.sql
+++ b/internal/db/queries/customers.sql
@@ -4,19 +4,34 @@
 -- name: EnsureCustomer :one
 -- Materialize (or refresh) the customers row for a payable UUID id under a
 -- merchant. The caller supplies id (the payable UUID). ON CONFLICT refreshes
--- last_seen_at so concurrent first-touch is safe.
+-- last_seen_at so concurrent first-touch is safe. The merchant_id guard makes a
+-- foreign id return NO ROW instead of re-pointing another merchant's customer
+-- (#889) — RLS already blocks it on enforcing roles, this holds for the
+-- privileged ones (bootstrap, import, dev owner) too.
 INSERT INTO openrails.customers (id, merchant_id, subject)
 VALUES (sqlc.arg(id), sqlc.arg(merchant_id), sqlc.arg(subject))
 ON CONFLICT (id) DO UPDATE SET
   subject = EXCLUDED.subject,
   last_seen_at = now()
+WHERE openrails.customers.merchant_id = EXCLUDED.merchant_id
 RETURNING id;
 
--- name: EnsureCustomerRow :exec
--- FK-target materialization before commerce inserts; no-op when present.
-INSERT INTO openrails.customers (id, merchant_id, subject)
-VALUES (sqlc.arg(id), sqlc.arg(merchant_id), sqlc.arg(subject))
-ON CONFLICT DO NOTHING;
+-- name: EnsureCustomerRow :one
+-- FK-target materialization before commerce inserts; no-op when present. It
+-- RETURNS the id it materialized so a conflicting row owned by ANOTHER merchant
+-- yields no row rather than a silent success (#889): FK checks bypass RLS, so a
+-- silent no-op would let the caller's row attach to a foreign customer.
+WITH inserted AS (
+  INSERT INTO openrails.customers (id, merchant_id, subject)
+  VALUES (sqlc.arg(id), sqlc.arg(merchant_id), sqlc.arg(subject))
+  ON CONFLICT (id) DO NOTHING
+  RETURNING id
+)
+SELECT id FROM inserted
+UNION ALL
+SELECT c.id FROM openrails.customers c
+WHERE c.id = sqlc.arg(id) AND c.merchant_id = sqlc.arg(merchant_id)
+LIMIT 1;
 
 -- name: LockCustomerForMerchant :one
 SELECT id FROM openrails.customers
@@ -71,10 +86,14 @@ WHERE c.merchant_id = sqlc.arg(merchant_id)
 -- name: UpsertCustomerBySubject :one
 -- Customer identity is the merchant plus the host/AuthKit stable UUID subject.
 -- The row id is that subject UUID; issuer is kept only as last-seen audit source.
+-- The merchant_id guard refuses a subject already registered under a DIFFERENT
+-- merchant (#889) — one AuthKit instance can serve several merchants, and the
+-- unguarded upsert handed the second merchant an id owned by the first.
 INSERT INTO openrails.customers (id, merchant_id, issuer, subject)
 VALUES (sqlc.arg(subject)::uuid, sqlc.arg(merchant_id), sqlc.narg(issuer), sqlc.arg(subject))
 ON CONFLICT (id) DO UPDATE SET
   subject = EXCLUDED.subject,
   issuer = COALESCE(EXCLUDED.issuer, openrails.customers.issuer),
   last_seen_at = now()
+WHERE openrails.customers.merchant_id = EXCLUDED.merchant_id
 RETURNING id;

--- a/internal/http/handlers/billing_import.go
+++ b/internal/http/handlers/billing_import.go
@@ -1,10 +1,12 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
 	"github.com/open-rails/openrails/internal/billingimport"
+	"github.com/open-rails/openrails/internal/db"
 	httprequest "github.com/open-rails/openrails/internal/http/request"
 	"github.com/open-rails/openrails/pkg/api"
 	"github.com/open-rails/openrails/pkg/merchant"
@@ -49,6 +51,17 @@ func ImportDeclaredBilling(r *httprequest.Request) {
 	})
 	if err != nil {
 		msg := err.Error()
+		// A book naming a customer that belongs to another merchant is an
+		// unusable book, not a server fault (#889).
+		if errors.Is(err, db.ErrCustomerOwnedByAnotherMerchant) {
+			r.APIError(&api.APIError{
+				HTTPStatus: http.StatusBadRequest,
+				Type:       api.ErrorTypeInvalidRequest,
+				Code:       "customer_owned_by_another_merchant",
+				Message:    msg,
+			})
+			return
+		}
 		if strings.Contains(msg, "required") || strings.Contains(msg, "invalid") {
 			r.ErrorJSON(http.StatusBadRequest, msg)
 			return

--- a/internal/integrationharness/billing_import_http_test.go
+++ b/internal/integrationharness/billing_import_http_test.go
@@ -142,17 +142,11 @@ func TestBillingImportHTTP(t *testing.T) {
 
 	t.Run("wrong-merchant credential cannot bind the book", func(t *testing.T) {
 		b := surface.ProvisionOwnedMerchant("bimp" + sfx)
-		// B posts A's book: the price uuid belongs to A, so under B's RLS scope
-		// every row blocks — nothing lands under A OR B.
+		// B posts A's book: its customer uuids are A's customers, so the book is
+		// refused at the door (#889) — nothing lands under A OR B.
 		status, body := requestJSON(t, http.MethodPost, importURL, b.APIKey, book)
-		require.Equalf(t, http.StatusOK, status, "wrong merchant import: %s", string(body))
-		var res importResult
-		require.NoError(t, json.Unmarshal(body, &res))
-		require.ElementsMatch(t, sourceIDs, res.Blocked)
-		require.Empty(t, res.Imported)
-		for _, reason := range res.Reasons {
-			require.Contains(t, reason, "price not found")
-		}
+		require.Equalf(t, http.StatusBadRequest, status, "wrong merchant import: %s", string(body))
+		require.Contains(t, string(body), "owned by another merchant")
 		var n int
 		require.NoError(t, pool.QueryRow(ctx,
 			`SELECT count(*) FROM openrails.subscriptions WHERE merchant_id=$1`, b.MerchantID.UUID()).Scan(&n))

--- a/internal/modules/money/enterprise_invoicing_integration_test.go
+++ b/internal/modules/money/enterprise_invoicing_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/open-rails/openrails/internal/db"
 	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/dbtest"
 	"github.com/open-rails/openrails/internal/modules/money"
@@ -300,9 +301,9 @@ func TestEnterpriseInvoicing_CustomerInvoiceProfileRejectsCrossMerchantPayer(t *
 
 	profile := money.CustomerInvoiceProfile{CollectionMethod: money.CollectionChargeAutomatically}
 	created, err := svc.EnsureCustomerInvoiceProfile(ctx, foreignPayer, profile)
-	require.ErrorContains(t, err, "payer belongs to another merchant")
+	require.ErrorIs(t, err, db.ErrCustomerOwnedByAnotherMerchant)
 	require.False(t, created)
-	require.ErrorContains(t, svc.SetCustomerInvoiceProfile(ctx, foreignPayer, profile), "payer belongs to another merchant")
+	require.ErrorIs(t, svc.SetCustomerInvoiceProfile(ctx, foreignPayer, profile), db.ErrCustomerOwnedByAnotherMerchant)
 }
 
 // TestEnterpriseInvoicing_PastWindowFinalizeAttachesAccruals pins the #798

--- a/internal/modules/money/invoice_profile.go
+++ b/internal/modules/money/invoice_profile.go
@@ -10,6 +10,7 @@ import (
 	safecast "github.com/ccoveille/go-safecast/v2"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/open-rails/openrails/internal/db"
 	"github.com/open-rails/openrails/internal/db/gen"
 	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/pkg/identity"
@@ -104,7 +105,7 @@ func (s *MoneyService) writeCustomerInvoiceProfile(ctx context.Context, payer id
 		})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				return fmt.Errorf("invoice profile payer belongs to another merchant")
+				return fmt.Errorf("%w: invoice profile payer %s", db.ErrCustomerOwnedByAnotherMerchant, payer)
 			}
 			return fmt.Errorf("lock invoice profile payer: %w", err)
 		}

--- a/internal/modules/money/money_service.go
+++ b/internal/modules/money/money_service.go
@@ -477,9 +477,7 @@ func ensureCustomer(ctx context.Context, q *gen.Queries, tenantID, tsid uuid.UUI
 		}
 		tenantID = tid.UUID()
 	}
-	return q.EnsureCustomerRow(ctx, gen.EnsureCustomerRowParams{
-		ID: tsid, MerchantID: tenantID, Subject: stringPtr(tsid.String()),
-	})
+	return db.EnsureCustomerRowQ(ctx, q, tenantID, tsid)
 }
 
 func stringPtr(s string) *string { return &s }


### PR DESCRIPTION
Closes the remaining #889 audit item. The per-merchant system customer
(`db.SystemCustomerID(merchantID)`) and the loud per-merchant alert fan-out
already landed on `dev` (6855c26e); both verified green here — see below.

`openrails.customers.id` is globally unique while the rows are merchant-isolated
under FORCE RLS, so an id already owned by another merchant was absorbed silently:

- `EnsureCustomer` / `UpsertCustomerBySubject` — `ON CONFLICT (id) DO UPDATE`
  re-pointed the foreign row on any privileged (RLS-bypassing) connection
  (bootstrap, import, dev owner role) and returned an id the caller does not own.
- `EnsureCustomerRow` — `ON CONFLICT DO NOTHING` was a no-op, and since FK checks
  bypass RLS the caller's commerce row then FK'd into another merchant's customer.

## Changes

- Both upserts carry a `merchant_id` guard: a foreign id yields NO row, surfaced
  as `db.ErrCustomerOwnedByAnotherMerchant`.
- `EnsureCustomerRow` settles an empty result with a locking re-read, so a
  concurrent first-touch of the same customer converges instead of being
  misread as a foreign owner.
- money's duplicate `ensureCustomer` delegates to `db.EnsureCustomerRowQ`; the
  invoice-profile cross-merchant guard reuses the same sentinel.
- A billing-import book naming another merchant's customers is now refused at
  the door with `400 customer_owned_by_another_merchant` instead of relying on
  the per-row price lookup to block it (behaviour change to `POST /v1/import/billing`;
  the harness test's intent — nothing lands under either merchant — is unchanged).

## Tests

Failing-before, passing-after (`internal/db`): `TestEnsureCustomerID_RefusesCrossMerchantClaim`,
`TestEnsureCustomerRow_RefusesCrossMerchantClaim`, plus idempotent-repeat and
concurrent-first-touch regressions.

Green: `go build ./...`, `go vet ./...`, `go vet -tags integration ./...`, unit
`go test ./...`, `sqlc generate`/`vet`, query audit, sql + migration lints, and
integration for db, controlplane, money, subscriptions, checkout, payments,
paymentmethods, productaccess, entitlements, river, http/handlers,
integrationharness, tests, pkg/embedded, pkg/service, modules/*.