### PR TITLE
or#882 + or#884: delete the per-PSP environment knob and the flat merchant-secret names

### DIFF
--- a/cmd/openrails/runserver_mode1_integration_test.go
+++ b/cmd/openrails/runserver_mode1_integration_test.go
@@ -114,7 +114,6 @@ merchants:
     psps:
       mobius:
         nmi:
-          environment: test
           account_id: "579145"
           secrets:
             security_key: sandbox-security-key

--- a/config/config.go
+++ b/config/config.go
@@ -130,9 +130,8 @@ type Config struct {
 	// including production — a staging (or production) deployment running
 	// sandbox rails under full non-dev hard gates is a legitimate, common
 	// shape, not a footgun. Nothing here special-cases env=production; the
-	// credential guarantees this field attaches (live-key refusal above,
-	// ExpectedProviderEnvironment's cross-check against each configured rail
-	// account's declared Environment) are what keep a sandbox posture honest
+	// credential guarantees this field attaches (live-key refusal above, the
+	// NMI live-gateway probe) are what keep a sandbox posture honest
 	// regardless of Env. Set test_mode=live explicitly to run live credentials
 	// locally in development.
 	TestMode CredentialPosture `koanf:"test_mode,omitempty"`
@@ -619,8 +618,9 @@ const (
 	ProviderEnvironmentLive = "live"
 )
 
-// ExpectedProviderEnvironment is the environment every provider account must
-// declare for the given test_mode: test under sandbox, live in production.
+// ExpectedProviderEnvironment is the environment every provider account runs in
+// for the given test_mode: test under sandbox, live in production. It is DERIVED
+// (#882) — a PSP never declares it.
 func ExpectedProviderEnvironment(testMode bool) string {
 	if testMode {
 		return ProviderEnvironmentTest
@@ -659,11 +659,6 @@ type PSPConfig struct {
 	// e.g. 945280-0000, #697), or Solana wallet (#592: operator-declared).
 	// REQUIRED — ValidateRailSet rejects an empty one.
 	AccountID string
-	// Environment is test|live — an ASSERTION cross-checked against test_mode
-	// (#641/#711), not a behavior selector. Sandbox-vs-live behavior is driven by
-	// test_mode alone; a declared environment that contradicts it refuses to
-	// boot. Empty → derived from test_mode.
-	Environment string
 	// Archived keeps an account addressable for existing obligations and inbound
 	// provider events, but excludes it from new checkout/subscription work.
 	Archived bool
@@ -784,18 +779,6 @@ func ValidateRailAccountID(rail models.Rail, accountID string) error {
 		return fmt.Errorf("CCBill account_id uses a dash: clientAccnum-clientSubacc, e.g. 945280-0000 (got %q)", accountID)
 	}
 	return nil
-}
-
-// EffectiveEnvironment returns the account's declared environment (test|live), or
-// the test_mode-derived default when unset (#641). An explicitly-set value that
-// contradicts test_mode is rejected by ValidateRailSet.
-func (p *PSPConfig) EffectiveEnvironment(testMode bool) string {
-	if p != nil {
-		if env := strings.ToLower(strings.TrimSpace(p.Environment)); env != "" {
-			return env
-		}
-	}
-	return ExpectedProviderEnvironment(testMode)
 }
 
 func (p *PSPConfig) normalizeTypedBlock(name string) error {
@@ -1175,9 +1158,8 @@ func Validate(cfg *Config) error {
 		// disabling every other hard gate, or lie as live with no rail
 		// credentials). What actually prevents a sandbox posture from being
 		// misused in a genuinely-live deployment is rail-credential
-		// validation, not the environment string: ExpectedProviderEnvironment
-		// cross-checks every configured rail account's declared Environment
-		// against TestMode (ValidateRailSet/validateRails below), and
+		// validation, not the environment string: the NMI live-gateway probe
+		// asks the gateway itself whether the credentials are live, and
 		// validateStripeKeyForTestMode hard-rejects a live secret key
 		// (sk_live_/rk_live_) whenever TestMode is sandbox, in every
 		// environment including production. A deployment that declares
@@ -1476,19 +1458,6 @@ func validateRails(cfg *Config, rails PSPSet, isDev bool) error {
 		}
 		if err := proc.normalizeTypedBlock(name); err != nil {
 			return err
-		}
-
-		// #641: all-test or all-live — a declared environment is an ASSERTION
-		// cross-checked against test_mode (not a behavior selector; test_mode
-		// alone drives sandbox posture). Empty is derived and always passes.
-		if env := strings.ToLower(strings.TrimSpace(proc.Environment)); env != "" {
-			if env != ProviderEnvironmentTest && env != ProviderEnvironmentLive {
-				return fmt.Errorf("rail '%s' has unknown environment '%s' (want test|live)", name, env)
-			}
-			testMode := cfg != nil && cfg.IsTestMode()
-			if want := ExpectedProviderEnvironment(testMode); env != want {
-				return fmt.Errorf("rail '%s' declares environment=%s but test_mode=%v requires environment=%s (a deployment is all-test or all-live; never mix)", name, env, testMode, want)
-			}
 		}
 
 		effectiveType := proc.EffectiveRail(name)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -660,32 +660,22 @@ func TestCatalogTargetSelectors(t *testing.T) {
 	require.False(t, ok)
 }
 
-// TestRailEnvironmentMustMatchTestMode covers the #641 "all-test or all-live"
-// guard: an account whose declared environment contradicts test_mode is rejected;
-// a matching or unset (derived) environment passes.
-func TestRailEnvironmentMustMatchTestMode(t *testing.T) {
-	// test_mode=sandbox rejects a live-declared account.
-	err := ValidateRailSet(&Config{ProviderWriteMode: ProviderWriteModeFull, TestMode: CredentialPostureSandbox}, PSPSet{
-		"stripe": {Rail: models.RailStripe, Environment: "live", Stripe: &StripeRailConfig{SecretKey: "sk_test_x"}},
-	})
-	require.ErrorContains(t, err, "requires environment=test")
+// TestRailEnvironmentDerivesFromTestMode covers #882: a PSP has NO environment
+// axis to contradict — test_mode alone decides, and every PSP in a deployment
+// therefore lands in the same environment.
+func TestRailEnvironmentDerivesFromTestMode(t *testing.T) {
+	require.Equal(t, ProviderEnvironmentTest, ExpectedProviderEnvironment(true))
+	require.Equal(t, ProviderEnvironmentLive, ExpectedProviderEnvironment(false))
 
-	// test_mode=live (production) rejects a test-declared account.
-	cfgLive := &Config{Env: "development", ProviderWriteMode: ProviderWriteModeFull, TestMode: CredentialPostureLive}
-	require.ErrorContains(t, ValidateRailSet(cfgLive, PSPSet{
-		"stripe": {Rail: models.RailStripe, Environment: "test", Stripe: &StripeRailConfig{SecretKey: "sk_live_x"}},
-	}), "requires environment=live")
-
-	// A garbage environment is rejected.
-	require.ErrorContains(t, ValidateRailSet(cfgLive, PSPSet{
-		"stripe": {Rail: models.RailStripe, Environment: "staging", Stripe: &StripeRailConfig{SecretKey: "sk_live_x"}},
-	}), "unknown environment")
-
-	// Matching environment passes; unset (derived from test_mode) passes.
-	require.NoError(t, ValidateRailSet(cfgLive, PSPSet{
-		"stripe": {Rail: models.RailStripe, Environment: "live", Stripe: &StripeRailConfig{SecretKey: "sk_live_x"}},
+	sandbox := &Config{Env: "development", ProviderWriteMode: ProviderWriteModeFull, TestMode: CredentialPostureSandbox}
+	require.Equal(t, ProviderEnvironmentTest, ExpectedProviderEnvironment(sandbox.IsTestMode()))
+	require.NoError(t, ValidateRailSet(sandbox, PSPSet{
+		"stripe": {Rail: models.RailStripe, Stripe: &StripeRailConfig{SecretKey: "sk_test_x"}},
 	}))
-	require.NoError(t, ValidateRailSet(cfgLive, PSPSet{
+
+	live := &Config{Env: "development", ProviderWriteMode: ProviderWriteModeFull, TestMode: CredentialPostureLive}
+	require.Equal(t, ProviderEnvironmentLive, ExpectedProviderEnvironment(live.IsTestMode()))
+	require.NoError(t, ValidateRailSet(live, PSPSet{
 		"stripe": {Rail: models.RailStripe, Stripe: &StripeRailConfig{SecretKey: "sk_live_x"}},
 	}))
 }

--- a/config/merchants_config.example.yaml
+++ b/config/merchants_config.example.yaml
@@ -2,10 +2,9 @@ version: 1
 
 # Store real secrets in Hashicorp Vault and overlay them into this manifest.
 #
-# Per-account `environment: test|live` is an ASSERTION cross-checked against the
-# deployment's test_mode — NOT a behavior selector (test_mode alone drives
-# sandbox posture; a contradiction refuses to boot). Omitted = derived from
-# test_mode.
+# A PSP does NOT declare an environment (#882). test_mode alone decides: sandbox
+# => test, live => live, for every PSP in the deployment. The `-sandbox` keys
+# below are just a second account on the same rail, not a second environment.
 #
 # Solana runtime knobs (#711) live in the solana account's `settings` block
 # below. Solana provider account identity is derived from the signer public key.
@@ -43,7 +42,6 @@ merchants:
     psps:
       mobius:
         nmi:
-          environment: live
           account_id: "1234567"
           settings:
             tokenization_url: https://secure.networkmerchants.com/token/Collect.js
@@ -54,7 +52,6 @@ merchants:
 
       mobius-sandbox:
         nmi:
-          environment: test
           account_id: "7654321"
           settings:
             tokenization_url: https://secure.networkmerchants.com/token/Collect.js
@@ -65,7 +62,6 @@ merchants:
 
       paykings:
         nmi:
-          environment: live
           account_id: "5551234"
           archived: true
           settings:
@@ -85,7 +81,6 @@ merchants:
       # custodial secret is the custodian's PRIVATE application key.
       mobius-bt:
         nmi:
-          environment: test
           account_id: "7654322"
           settings:
             custodian: basis_theory
@@ -99,7 +94,6 @@ merchants:
 
       ccbill:
         ccbill:
-          environment: live
           # CCBill composite identity is dash-joined: clientAccnum-clientSubacc (#697).
           account_id: "999999-0000"
           # Webhook source IPs are CCBill's documented provider-wide ranges,
@@ -111,7 +105,6 @@ merchants:
 
       stripe:
         stripe:
-          environment: live
           account_id: acct_1AbCdEfGhIjKlMnOp
           secrets:
             secret_key: replace-with-live-stripe-secret-key
@@ -119,7 +112,6 @@ merchants:
 
       stripe-sandbox:
         stripe:
-          environment: test
           account_id: acct_1ZyXwVuTsRqPoNmL
           secrets:
             secret_key: replace-with-test-stripe-secret-key
@@ -127,7 +119,6 @@ merchants:
 
       solana:
         solana:
-          environment: live
           archived: false
           signer: { mode: local_keypair }
           settings:
@@ -156,7 +147,6 @@ merchants:
       # Alternative Solana signer using Hashicorp Vault Transit.
       solana-vault:
         solana:
-          environment: live
           archived: false
           signer: { mode: vault_transit, key: openrails-solana-local-stack }
 

--- a/docs/merchant-provisioning.md
+++ b/docs/merchant-provisioning.md
@@ -84,7 +84,6 @@ merchants:
     psps:                          # operator-declared rail accounts
       mobius:
         nmi:
-          environment: live
           account_id: "100001"
           settings:
             tokenization_key: replace-with-nmi-tokenization-key
@@ -108,10 +107,10 @@ Per merchant:
 - `delegated_invoker_wasted_spend_windows` — per-invoker windowed spend caps.
 - `psps.<key>.<rail>` — one entry per PSP. `key` is the manifest PSP name
   catalog `psp_links` and checkout use ("mobius"); the rail nests inside.
-  Fields: `environment` (`test`|`live` — an **assertion** cross-checked
-  against the deployment's `test_mode`, not a behavior selector; a
-  contradiction refuses to boot), `account_id`, `archived`, non-secret
-  `settings`, `secrets`, and (Solana) `signer`.
+  Fields: `account_id`, `archived`, non-secret `settings`, `secrets`, and
+  (Solana) `signer`. There is NO `environment` (#882) — it is derived from the
+  deployment's `test_mode` (sandbox ⇒ `test`, live ⇒ `live`), so a deployment is
+  all-test or all-live; a manifest still declaring it fails loudly.
 
 `account_id` is operator-declared, per rail (never derived from credentials at
 runtime — details in `docs/rails/*.md`):

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -493,8 +493,8 @@ verdict refuses from cache without re-probing (a crash loop costs one
 declined auth total), a fresh `simulated` verdict skips the probe, a rotated
 key or stale verdict re-probes, and cache failures degrade to probing.
 Sandbox is allowed in every environment (#762) — what keeps it honest is
-rail-credential validation (the live-key refusal, plus each PSP's declared
-`environment` cross-checked against `test_mode`), not the environment string.
+rail-credential validation (the live-key refusal and the NMI live-gateway
+probe, which ask the credential itself), not the environment string.
 
 ### Cutover: booting against production credentials
 

--- a/docs/rails/ccbill.md
+++ b/docs/rails/ccbill.md
@@ -38,7 +38,6 @@ secret-store prefix `psps/…`):
 psps:
   ccbill:               # PSP key — reserved gateway, must be "ccbill"
     ccbill:             # rail
-      environment: live # or "test"
       # clientAccnum-clientSubacc, dash-joined:
       account_id: "999999-0000"
       secrets:
@@ -130,8 +129,8 @@ non-retryable. Events are deduplicated by transaction id / payload hash.
 
 ### Sandbox testing
 
-Set the global `test_mode: sandbox` (and typically `environment: test` on the
-PSP entry). Sandbox posture routes FlexForm URLs to
+Set the global `test_mode: sandbox` — it is the only environment switch (#882).
+Sandbox posture routes FlexForm URLs to
 `https://sandbox-api.ccbill.com/wap-frontflex/flexforms/...` instead of
 `api.ccbill.com`. To post webhooks from a local harness, declare its source
 explicitly, e.g. `ccbill_webhook_ip_allowlist: ["127.0.0.1/32"]` — sandbox

--- a/docs/rails/nmi.md
+++ b/docs/rails/nmi.md
@@ -47,7 +47,6 @@ merchants:
     psps:
       mobius:                 # your name for this PSP (any slug)
         nmi:                  # the rail
-          environment: live   # assertion cross-checked against test_mode
           account_id: "1234567"  # dashboard "Gateway ID"
           settings:
             tokenization_url: https://secure.networkmerchants.com/token/Collect.js
@@ -58,9 +57,8 @@ merchants:
 ```
 
 Store real secret values in Vault (or the encrypted DB store) and overlay them;
-never commit them. `environment: test|live` does not select behavior — the
-deployment-level `test_mode` does — it is an assertion, and a contradiction
-refuses boot.
+never commit them. A PSP declares no environment (#882): the deployment-level
+`test_mode` decides, and every PSP in the deployment follows it.
 
 ### Webhook registration
 
@@ -96,9 +94,9 @@ see `docs/dev/local-webhooks.md`.
 ### Sandbox testing
 
 Ask your ISO for a **sandbox/test gateway account** — most provision one on
-request. Declare it as its own PSP entry (`mobius-sandbox` in the example
-manifest) with `environment: test`, and run the deployment with
-`test_mode: sandbox` (env `TEST_MODE=sandbox`).
+request. Declare it as its own PSP entry and run the deployment with
+`test_mode: sandbox` (env `TEST_MODE=sandbox`), which is what puts every PSP in
+the test environment.
 
 An NMI sandbox is otherwise undetectable: same URLs, and the security key
 carries no test marker (unlike Stripe's `sk_test_` prefix). So under

--- a/docs/rails/solana.md
+++ b/docs/rails/solana.md
@@ -33,7 +33,6 @@ derived from the signer's public key (a declared value is ignored with a warning
 psps:
   solana:
     solana:
-      environment: live          # assertion cross-checked against test_mode; omit to derive
       signer: { mode: local_keypair }
       settings:
         # Optional destination wallet; defaults to the signer public key.
@@ -52,7 +51,6 @@ psps:
   # Alternative: Vault Transit signer — no private_key secret at all.
   solana-vault:
     solana:
-      environment: live
       signer: { mode: vault_transit, key: openrails-solana-<slug> }
 ```
 
@@ -138,8 +136,8 @@ and pays gas; funds move from the subscriber's ATA to the merchant's ATA.
 ### Devnet testing
 
 The network is derived structurally from the deployment's `test_mode`:
-sandbox → **devnet**, live → mainnet. There is no independent network knob;
-`environment: test` on the account is only an assertion cross-checked at boot.
+sandbox → **devnet**, live → mainnet. There is no independent network knob, and
+a PSP declares no environment of its own (#882).
 
 To exercise the flows on devnet:
 

--- a/docs/rails/stripe.md
+++ b/docs/rails/stripe.md
@@ -28,7 +28,6 @@ merchants:
     psps:
       stripe:                    # PSP name (reserved gateway name)
         stripe:                  # rail block
-          environment: live      # assertion, cross-checked against test_mode (test|live)
           account_id: acct_XXXXXXXXXXXXXXXX
           secrets:
             secret_key: sk_live_...                # or rk_live_...
@@ -123,11 +122,12 @@ required for the hosted flow. Completion arrives via `checkout.session.completed
 
 ### Sandbox testing
 
-Set `test_mode: sandbox`, declare the PSP with `environment: test` and a test key
-(`sk_test_…` / `rk_test_…`). The live-key-under-sandbox boot refusal guarantees a
-sandbox deployment can never hold a credential that moves real money. Use Stripe's
-standard test cards. `test_mode` is orthogonal to the environment axis — a fully
-gated production-style deployment can legitimately run sandbox rails.
+Set `test_mode: sandbox` and declare the PSP with a test key (`sk_test_…` /
+`rk_test_…`); the PSP's environment follows `test_mode` and is not declarable
+(#882). The live-key-under-sandbox boot refusal guarantees a sandbox deployment
+can never hold a credential that moves real money. Use Stripe's standard test
+cards. `test_mode` is orthogonal to `env` — a fully gated production-style
+deployment can legitimately run sandbox rails.
 
 ### Read-only safety gate
 

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -122,13 +122,13 @@ secret/openrails/merchants/<merchant-slug>/<name>     # value under KV-v2 field 
 ```
 
 Slugs (not ids) make operator-written paths deterministic and readable. The names are identical
-across backends — switching to Vault changes only the physical path. Canonical names:
+across backends — switching to Vault changes only the physical path.
+
+There is exactly ONE canonical name shape, for every rail (#884 retired the flat
+`<rail>/<purpose>` spellings — they were write-only and never read):
 
 | Secret | `<name>` |
 |---|---|
-| Stripe API key | `stripe/secret_key` |
-| Stripe webhook signing secret | `stripe/webhook_signing_secret` |
-| Stripe thin-event signing secret | `stripe/webhook_signing_secret_thin` |
 | PSP-scoped credential (all rails) | `psps/<rail>/<live\|test>/<account_id>/<key>` |
 
 The `psps/` prefix is the durable per-PSP shape — one merchant can run multiple accounts on a
@@ -139,7 +139,7 @@ CCBill `accnum-subacc`, Solana signer address); `<key>` is a rail-registry crede
 ```sh
 vault kv put secret/openrails/merchants/acme/psps/nmi/live/<gateway-id>/security_key value="$NMI_SECURITY_KEY"
 vault kv put secret/openrails/merchants/acme/psps/ccbill/live/<accnum-subacc>/salt value="$CCBILL_SALT"
-vault kv put secret/openrails/merchants/acme/stripe/secret_key value="$STRIPE_SECRET_KEY"
+vault kv put secret/openrails/merchants/acme/psps/stripe/live/<acct-id>/secret_key value="$STRIPE_SECRET_KEY"
 ```
 
 `psps/solana/<env>/<address>/private_key` (local-keypair signer) is operator-only — it is never

--- a/embed/ccbill_webhook_integration_test.go
+++ b/embed/ccbill_webhook_integration_test.go
@@ -304,7 +304,7 @@ func TestAPIMode_CCBillWebhookNewSaleSuccessEndToEnd(t *testing.T) {
 	t.Cleanup(adminServer.Close)
 
 	// Layer A, MODE 2: arm the ccbill account over the management API.
-	payload := fmt.Sprintf(`{"environment":"test","account_id":%q,"credentials":{"salt":"api-salt-%s"}}`, ccbillAccount, slug)
+	payload := fmt.Sprintf(`{"account_id":%q,"credentials":{"salt":"api-salt-%s"}}`, ccbillAccount, slug)
 	req, err := http.NewRequest(http.MethodPut, adminServer.URL+"/v1/merchant/payment-providers/ccbill", strings.NewReader(payload))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")

--- a/embed/ccbill_webhook_integration_test.go
+++ b/embed/ccbill_webhook_integration_test.go
@@ -218,9 +218,8 @@ func TestManifestMode_CCBillWebhookNewSaleSuccessEndToEnd(t *testing.T) {
 		PSPs: map[string]embed.PSPConfig{
 			"ccbill": {
 				"ccbill": {
-					Environment: "test",
-					AccountID:   ccbillAccount,
-					Secrets:     map[string]string{"salt": "test-salt-" + slug},
+					AccountID: ccbillAccount,
+					Secrets:   map[string]string{"salt": "test-salt-" + slug},
 				},
 			},
 		},

--- a/embed/checkout_psp_selector_integration_test.go
+++ b/embed/checkout_psp_selector_integration_test.go
@@ -39,23 +39,20 @@ func TestCheckoutPreGate_PSPKeySelector(t *testing.T) {
 		// Two armed NMI PSPs: the rail kind is ambiguous, the keys are exact.
 		"mobius-sandbox": {
 			"nmi": {
-				Environment: "live",
-				AccountID:   fmt.Sprintf("gw-a-%d", nano),
-				Secrets:     map[string]string{"security_key": "sk-a-" + slug},
+				AccountID: fmt.Sprintf("gw-a-%d", nano),
+				Secrets:   map[string]string{"security_key": "sk-a-" + slug},
 			},
 		},
 		"paykings": {
 			"nmi": {
-				Environment: "live",
-				AccountID:   fmt.Sprintf("gw-b-%d", nano),
-				Secrets:     map[string]string{"security_key": "sk-b-" + slug},
+				AccountID: fmt.Sprintf("gw-b-%d", nano),
+				Secrets:   map[string]string{"security_key": "sk-b-" + slug},
 			},
 		},
 		// One armed CCBill PSP: the bare rail kind stays unambiguous.
 		"ccbill": {
 			"ccbill": {
-				Environment: "live",
-				AccountID:   fmt.Sprintf("94%04d-0000", nano%10_000),
+				AccountID: fmt.Sprintf("94%04d-0000", nano%10_000),
 				Secrets: map[string]string{
 					"datalink_username": "dl-user-" + slug,
 					"datalink_password": "dl-pass-" + slug,

--- a/embed/manifest_mode_integration_test.go
+++ b/embed/manifest_mode_integration_test.go
@@ -378,7 +378,7 @@ func TestManifestMode_MutationRoutesRejected405(t *testing.T) {
 	}
 
 	// Provider-config writes.
-	assertManifestDriven(do(http.MethodPut, "/v1/merchant/payment-providers/stripe", `{"environment":"live","account_id":"acct_x"}`))
+	assertManifestDriven(do(http.MethodPut, "/v1/merchant/payment-providers/stripe", `{"account_id":"acct_x"}`))
 	assertManifestDriven(do(http.MethodDelete, "/v1/merchant/payment-providers/stripe", ""))
 	// Catalog mutations — including plan-only publish (documented: the plan is
 	// computed at boot from the YAML; the CLI dry-run remains available).
@@ -435,7 +435,7 @@ func TestAPIMode_MutationRoutesWork(t *testing.T) {
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
-	payload := fmt.Sprintf(`{"environment":"live","account_id":"acct_%d","credentials":{"webhook_signing_secret":"whsec_%d"}}`, nano, nano)
+	payload := fmt.Sprintf(`{"account_id":"acct_%d","credentials":{"webhook_signing_secret":"whsec_%d"}}`, nano, nano)
 	req, err := http.NewRequest(http.MethodPut, server.URL+"/v1/merchant/payment-providers/stripe", strings.NewReader(payload))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")

--- a/embed/manifest_mode_integration_test.go
+++ b/embed/manifest_mode_integration_test.go
@@ -60,7 +60,6 @@ merchants:
     psps:
       mobius:
         nmi:
-          environment: live
           account_id: %q
 `, slug, slug, gatewayID))
 }

--- a/embed/manifest_mode_integration_test.go
+++ b/embed/manifest_mode_integration_test.go
@@ -468,7 +468,7 @@ func TestManifestMode_APIModeRefusesManifestTruth(t *testing.T) {
 	_, err = rt.UpsertMerchantConfig(ctx, slug, embed.MerchantConfig{
 		DisplayName: slug,
 		PSPs: map[string]embed.PSPConfig{
-			"mobius": {"nmi": {Environment: "live", AccountID: "579145", Secrets: map[string]string{"security_key": "k"}}},
+			"mobius": {"nmi": {AccountID: "579145", Secrets: map[string]string{"security_key": "k"}}},
 		},
 	})
 	require.Error(t, err)
@@ -616,8 +616,7 @@ func TestManifestMode_CheckoutPreGateAcceptsDBArmedRail(t *testing.T) {
 	rt, id := bootManifestRuntimeWithRailAccounts(t, ctx, dsn, slug, map[string]embed.PSPConfig{
 		"ccbill": {
 			"ccbill": {
-				Environment: "live",
-				AccountID:   ccbillAccount,
+				AccountID: ccbillAccount,
 				Secrets: map[string]string{
 					"datalink_username": "dl-user-" + slug,
 					"datalink_password": "dl-pass-" + slug,
@@ -671,8 +670,7 @@ func TestManifestMode_ProviderRoutesDeriveWebhooksFromDBArmedAccounts(t *testing
 	rt, _ := bootManifestRuntimeWithRailAccounts(t, ctx, dsn, slug, map[string]embed.PSPConfig{
 		"ccbill": {
 			"ccbill": {
-				Environment: "live",
-				AccountID:   ccbillAccount,
+				AccountID: ccbillAccount,
 				Secrets: map[string]string{
 					"datalink_username": "dl-user-" + slug,
 					"datalink_password": "dl-pass-" + slug,

--- a/embed/provision_integration_test.go
+++ b/embed/provision_integration_test.go
@@ -39,10 +39,10 @@ func TestUpsertMerchantConfig_SeedsRailMerchantAccounts(t *testing.T) {
 		DisplayName: slug,
 		PSPs: map[string]embed.PSPConfig{
 			"mobius": {
-				"nmi": {Environment: "live", AccountID: "579145"},
+				"nmi": {AccountID: "579145"},
 			},
 			"ccbill": {
-				"ccbill": {Environment: "live", AccountID: "945280-0000"},
+				"ccbill": {AccountID: "945280-0000"},
 			},
 		},
 	}

--- a/embed/pull_arming_integration_test.go
+++ b/embed/pull_arming_integration_test.go
@@ -54,15 +54,13 @@ func TestEmbeddedPullArming_ManifestSecretsNoPaymentProviders(t *testing.T) {
 		PSPs: map[string]embed.PSPConfig{
 			"mobius": {
 				"nmi": {
-					Environment: "live",
-					AccountID:   nmiAccount,
-					Secrets:     map[string]string{"security_key": securityKey},
+					AccountID: nmiAccount,
+					Secrets:   map[string]string{"security_key": securityKey},
 				},
 			},
 			"ccbill": {
 				"ccbill": {
-					Environment: "live",
-					AccountID:   ccbillAccount,
+					AccountID: ccbillAccount,
 					Secrets: map[string]string{
 						"datalink_username": "dl-user-" + slug,
 						"datalink_password": "dl-pass-" + slug,
@@ -217,9 +215,8 @@ func TestPullProviderCLI_ManifestModeArmsFromManifestPlane(t *testing.T) {
 		PSPs: map[string]embed.PSPConfig{
 			"mobius": {
 				"nmi": {
-					Environment: "live",
-					AccountID:   nmiAccount,
-					Secrets:     map[string]string{"security_key": securityKey},
+					AccountID: nmiAccount,
+					Secrets:   map[string]string{"security_key": securityKey},
 				},
 			},
 		},
@@ -262,8 +259,7 @@ func TestPullProviderCLI_ManifestModeMissingSecretRailNotArmed(t *testing.T) {
 		PSPs: map[string]embed.PSPConfig{
 			"mobius": {
 				"nmi": {
-					Environment: "live",
-					AccountID:   nmiAccount,
+					AccountID: nmiAccount,
 				},
 			},
 		},

--- a/internal/bootstrap/bootstrap_manifest.go
+++ b/internal/bootstrap/bootstrap_manifest.go
@@ -163,12 +163,11 @@ func validateManifestRailMerchantAccount(slug string, key string, account PSPCon
 		if rail == "" {
 			return fmt.Errorf("merchant %q accounts.%s rail is required", slug, key)
 		}
-		// Omitted environment is valid — it follows deployment posture at
-		// reconcile time (#681); explicit values must normalize.
-		if strings.TrimSpace(cfg.Environment) != "" {
-			if _, err := normalizeProviderEnvironment(cfg.Environment); err != nil {
-				return fmt.Errorf("merchant %q accounts.%s.%s.%w", slug, key, rail, err)
-			}
+		// #882: environment is DERIVED from test_mode, never declared. The field
+		// could only ever agree (a no-op) or disagree (refuse to boot), so it is
+		// retired — a manifest that still carries it fails loudly.
+		if strings.TrimSpace(cfg.LegacyEnvironment) != "" {
+			return fmt.Errorf("merchant %q psps.%s.%s.environment was removed (#882): the environment is derived from test_mode (sandbox => test, live => live) — delete the key", slug, key, rail)
 		}
 		for secretKey := range cfg.Secrets {
 			if _, err := merchants.NormalizePSPSecretKey(rail, secretKey); err != nil {

--- a/internal/bootstrap/merchant_dump.go
+++ b/internal/bootstrap/merchant_dump.go
@@ -136,10 +136,11 @@ func DumpMerchantConfig(ctx context.Context, cfg *config.Config, cp *controlplan
 		if localKey == "" {
 			localKey = railMerchantAccountDumpKey(a.Rail, a.Environment, a.AccountID)
 		}
+		// #882: environment is derived from test_mode, so it is never emitted —
+		// dumping it would round-trip into the removal error on apply.
 		account := ProviderRailAccountConfig{
-			Environment: a.Environment,
-			AccountID:   a.AccountID,
-			Archived:    a.Archived,
+			AccountID: a.AccountID,
+			Archived:  a.Archived,
 		}
 		if signer := railMerchantAccountSignerFromEvidence(a.Evidence); signer != nil {
 			account.Signer = signer

--- a/internal/bootstrap/merchant_env_test.go
+++ b/internal/bootstrap/merchant_env_test.go
@@ -70,7 +70,6 @@ merchants:
     psps:
       mobius:
         nmi:
-          environment: live
           account_id: "579145"
           secrets:
             security_key: public-placeholder
@@ -107,7 +106,6 @@ merchants:
     psps:
       mobius-sandbox:
         nmi:
-          environment: test
           account_id: "681902"
           secrets:
             security_key: public-placeholder
@@ -199,7 +197,6 @@ merchants:
     psps:
       mobius-sandbox:
         nmi:
-          environment: test
           account_id: "681902"
           secrets:
             security_key: public-placeholder

--- a/internal/bootstrap/merchant_manifest.go
+++ b/internal/bootstrap/merchant_manifest.go
@@ -318,8 +318,8 @@ func mergeInvoiceConfig(dst, src *InvoiceConfig) {
 }
 
 func mergeProviderRailAccountConfig(dst *ProviderRailAccountConfig, src ProviderRailAccountConfig) {
-	if strings.TrimSpace(src.Environment) != "" {
-		dst.Environment = src.Environment
+	if strings.TrimSpace(src.LegacyEnvironment) != "" {
+		dst.LegacyEnvironment = src.LegacyEnvironment
 	}
 	if strings.TrimSpace(src.AccountID) != "" {
 		dst.AccountID = src.AccountID
@@ -449,14 +449,15 @@ type MerchantProfileConfig struct {
 type PSPConfig map[string]ProviderRailAccountConfig
 
 type ProviderRailAccountConfig struct {
-	// Environment (test|live) is an ASSERTION cross-checked against the
-	// deployment's test_mode (#641/#711), not a behavior selector — test_mode
-	// alone drives sandbox posture. Omitted derives from test_mode.
-	Environment string                           `yaml:"environment,omitempty" koanf:"environment"`
-	AccountID   string                           `yaml:"account_id,omitempty" koanf:"account_id"`
-	Archived    bool                             `yaml:"archived,omitempty" koanf:"archived"`
-	Signer      *RailMerchantAccountSignerConfig `yaml:"signer,omitempty" koanf:"signer"`
-	Secrets     map[string]string                `yaml:"secrets,omitempty" koanf:"secrets"`
+	// LegacyEnvironment keeps the retired `environment:` key parseable ONLY so a
+	// manifest that still declares it fails loudly (#882). The environment is
+	// DERIVED from test_mode — it never was anything else, since a declared value
+	// that disagreed refused to boot and one that agreed was a no-op.
+	LegacyEnvironment string                           `yaml:"environment,omitempty" koanf:"environment"`
+	AccountID         string                           `yaml:"account_id,omitempty" koanf:"account_id"`
+	Archived          bool                             `yaml:"archived,omitempty" koanf:"archived"`
+	Signer            *RailMerchantAccountSignerConfig `yaml:"signer,omitempty" koanf:"signer"`
+	Secrets           map[string]string                `yaml:"secrets,omitempty" koanf:"secrets"`
 	// Settings are per-account NON-SECRET runtime knobs, stored on the
 	// psps row (NMI: tokenization_key/tokenization_url;
 	// Solana: rpc_provider, rpc_api_key, tokens,
@@ -889,7 +890,7 @@ func pruneManifestSecrets(ctx context.Context, cfg *config.Config, merchantID me
 	declared := map[string]struct{}{}
 	for _, entry := range pspEntries(mt.PSPs) {
 		rail := normalizeManifestRail(entry.rail)
-		environment, err := manifestProviderEnvironment(cfg, entry.config.Environment)
+		environment, err := manifestProviderEnvironment(cfg, entry.config)
 		if err != nil {
 			return err
 		}
@@ -963,7 +964,7 @@ func resolveManifestRailAccount(ctx context.Context, cfg *config.Config, rail st
 	if out.rail == "" {
 		return out, fmt.Errorf("provider account rail is required")
 	}
-	environment, err := manifestProviderEnvironment(cfg, account.Environment)
+	environment, err := manifestProviderEnvironment(cfg, account)
 	if err != nil {
 		return out, err
 	}
@@ -1352,25 +1353,14 @@ func solanaTransitPublicKey(ctx context.Context, transit solana.TransitClient, k
 	return solanago.PublicKeyFromBytes(raw).String(), nil
 }
 
-func normalizeProviderEnvironment(raw string) (string, error) {
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "live", "prod", "production", "mainnet":
-		return "live", nil
-	case "test", "sandbox", "devnet", "testnet":
-		return "test", nil
-	default:
-		return "", fmt.Errorf("provider account environment must be live or test")
+// manifestProviderEnvironment derives a PSP's environment from deployment
+// posture (#681/#882 — test under test_mode, live otherwise). It is never
+// declared: a manifest that still carries `environment:` fails loudly here.
+func manifestProviderEnvironment(cfg *config.Config, account ProviderRailAccountConfig) (string, error) {
+	if strings.TrimSpace(account.LegacyEnvironment) != "" {
+		return "", fmt.Errorf("psp `environment:` is no longer configurable (#882) — it is derived from test_mode (sandbox => test, live => live); remove the key")
 	}
-}
-
-// manifestProviderEnvironment resolves a manifest-declared provider environment:
-// omitted follows deployment posture (#681 — test under test_mode, live
-// otherwise); explicit values are normalized strictly.
-func manifestProviderEnvironment(cfg *config.Config, raw string) (string, error) {
-	if strings.TrimSpace(raw) == "" {
-		return config.ExpectedProviderEnvironment(cfg != nil && cfg.IsTestMode()), nil
-	}
-	return normalizeProviderEnvironment(raw)
+	return config.ExpectedProviderEnvironment(cfg != nil && cfg.IsTestMode()), nil
 }
 
 func normalizeManifestRail(raw string) string {

--- a/internal/bootstrap/merchant_manifest_integration_test.go
+++ b/internal/bootstrap/merchant_manifest_integration_test.go
@@ -188,8 +188,7 @@ func TestReconcileMerchantManifestAppliesMerchantConfiguration(t *testing.T) {
 	mt.PSPs = map[string]PSPConfig{
 		"stripe": {
 			"stripe": {
-				Environment: "test",
-				AccountID:   "acct_test_123",
+				AccountID: "acct_test_123",
 				Secrets: map[string]string{
 					"secret_key": "sk_test_bootstrap",
 				},
@@ -250,8 +249,7 @@ func TestReconcileMerchantManifestStoresCCBillTypedSecrets(t *testing.T) {
 	mt.PSPs = map[string]PSPConfig{
 		"ccbill": {
 			"ccbill": {
-				Environment: "live",
-				AccountID:   "900000-0000",
+				AccountID: "900000-0000",
 				Secrets: map[string]string{
 					"salt":              "secret",
 					"datalink_username": "merchant-user",
@@ -302,9 +300,8 @@ func TestReconcileMerchantManifestRejectsCCBillSlashAccountID(t *testing.T) {
 	mt.PSPs = map[string]PSPConfig{
 		"ccbill": {
 			"ccbill": {
-				Environment: "live",
-				AccountID:   "900000/0000",
-				Secrets:     map[string]string{"salt": "secret"},
+				AccountID: "900000/0000",
+				Secrets:   map[string]string{"salt": "secret"},
 			},
 		},
 	}
@@ -336,8 +333,7 @@ func TestReconcileMerchantManifestStoresSolanaRailMerchantAccountConfig(t *testi
 	mt.PSPs = map[string]PSPConfig{
 		"solana": {
 			"solana": {
-				Environment: "live",
-				Signer:      &RailMerchantAccountSignerConfig{Mode: "local_keypair"},
+				Signer: &RailMerchantAccountSignerConfig{Mode: "local_keypair"},
 				Settings: map[string]any{
 					"recipient_wallet": recipientWallet,
 				},
@@ -400,12 +396,13 @@ func TestMerchantConfigPushDumpRoundTrip(t *testing.T) {
 		{Key: "burst", Window: "15m", Limit: 5_000_000},
 		{Key: "sustained", Window: "5h", Limit: 20_000_000},
 	}
-	// NMI gateway "mobius": live and sandbox accounts side by side (#646).
+	// NMI gateway "mobius": two accounts side by side (#646). Both land in the
+	// deployment's derived environment — #882 removed the per-PSP knob, so one
+	// deployment can no longer mix test and live accounts.
 	mt.PSPs = map[string]PSPConfig{
 		"mobius": {
 			"nmi": {
-				Environment: "live",
-				AccountID:   "579145",
+				AccountID: "579145",
 				Settings: map[string]any{
 					"tokenization_url": "https://secure.networkmerchants.com/token/Collect.js",
 					"tokenization_key": "live-token",
@@ -417,8 +414,7 @@ func TestMerchantConfigPushDumpRoundTrip(t *testing.T) {
 		},
 		"mobius-sandbox": {
 			"nmi": {
-				Environment: "test",
-				AccountID:   "681902",
+				AccountID: "681902",
 				Secrets: map[string]string{
 					"security_key": "test-security",
 				},
@@ -427,8 +423,7 @@ func TestMerchantConfigPushDumpRoundTrip(t *testing.T) {
 		// #697: CCBill composite identity is dash-joined (clientAccnum-clientSubacc).
 		"ccbill": {
 			"ccbill": {
-				Environment: "live",
-				AccountID:   "945280-0000",
+				AccountID: "945280-0000",
 				Secrets: map[string]string{
 					"salt": "flexform-salt",
 				},
@@ -459,11 +454,28 @@ func TestMerchantConfigPushDumpRoundTrip(t *testing.T) {
 	require.Equal(t, threshold, gotThreshold)
 	require.Equal(t, floor, gotFloor)
 
+	// #882: every PSP lands in the environment derived from test_mode.
+	derivedEnv := config.ExpectedProviderEnvironment(cfg.IsTestMode())
+	var envs []string
+	rows, err := pool.Query(ctx, `SELECT environment FROM openrails.psps WHERE merchant_id = $1::uuid`, merchantID)
+	require.NoError(t, err)
+	for rows.Next() {
+		var e string
+		require.NoError(t, rows.Scan(&e))
+		envs = append(envs, e)
+	}
+	rows.Close()
+	require.NoError(t, rows.Err())
+	require.Len(t, envs, 3)
+	for _, e := range envs {
+		require.Equal(t, derivedEnv, e, "a deployment is all-test or all-live (#882)")
+	}
+
 	// The manifest PSP map key persists as the provider account key.
 	var liveKey string
 	require.NoError(t, pool.QueryRow(ctx, `
 		SELECT key FROM openrails.psps
-		WHERE merchant_id = $1::uuid AND rail = 'nmi' AND environment = 'live'
+		WHERE merchant_id = $1::uuid AND rail = 'nmi' AND account_id = '579145'
 	`, merchantID).Scan(&liveKey))
 	require.Equal(t, "mobius", liveKey)
 
@@ -498,27 +510,31 @@ func TestMerchantConfigPushDumpRoundTrip(t *testing.T) {
 	require.Equal(t, "5h", gotWindows["sustained"].Window)
 
 	require.Len(t, d.PSPs, 3)
-	byEnv := map[string]ProviderRailAccountConfig{}
+	byAccount := map[string]ProviderRailAccountConfig{}
 	var ccbillDump ProviderRailAccountConfig
 	for _, account := range d.PSPs {
 		require.Len(t, account, 1)
 		for rail, a := range account {
+			// #882: the dump never re-emits `environment:` — it would round-trip
+			// straight into the removal error on apply.
+			require.Empty(t, a.LegacyEnvironment)
 			if rail == "ccbill" {
 				ccbillDump = a
 				continue
 			}
-			byEnv[a.Environment] = a
+			byAccount[a.AccountID] = a
 		}
 	}
 	// #697: the dash-form CCBill composite id survives push⇄dump verbatim.
 	require.Equal(t, "945280-0000", ccbillDump.AccountID)
-	require.Equal(t, "579145", byEnv["live"].AccountID)
-	require.False(t, byEnv["live"].Archived)
-	require.False(t, byEnv["test"].Archived)
-	require.Empty(t, byEnv["live"].Secrets, "redacted dump omits secret values entirely")
-	require.NotContains(t, byEnv["live"].Secrets, "tokenization_key")
-	require.Equal(t, "https://secure.networkmerchants.com/token/Collect.js", byEnv["live"].Settings["tokenization_url"])
-	require.Equal(t, "live-token", byEnv["live"].Settings["tokenization_key"])
+	require.Contains(t, byAccount, "579145")
+	require.Contains(t, byAccount, "681902")
+	require.False(t, byAccount["579145"].Archived)
+	require.False(t, byAccount["681902"].Archived)
+	require.Empty(t, byAccount["579145"].Secrets, "redacted dump omits secret values entirely")
+	require.NotContains(t, byAccount["579145"].Secrets, "tokenization_key")
+	require.Equal(t, "https://secure.networkmerchants.com/token/Collect.js", byAccount["579145"].Settings["tokenization_url"])
+	require.Equal(t, "live-token", byAccount["579145"].Settings["tokenization_key"])
 
 	// the dump re-marshals to valid YAML that re-parses (round-trip closure).
 	encoded, err := MarshalMerchantManifest(dumped)
@@ -547,8 +563,7 @@ func TestReconcileMerchantManifestUsesConfiguredVaultSecretBackend(t *testing.T)
 	mt.PSPs = map[string]PSPConfig{
 		"stripe": {
 			"stripe": {
-				Environment: "test",
-				AccountID:   "acct_vault_123",
+				AccountID: "acct_vault_123",
 				Secrets: map[string]string{
 					"secret_key": "sk_test_vault_bootstrap",
 				},
@@ -600,8 +615,7 @@ func TestReconcileMerchantManifestUsesEncryptedDBSecretBackend(t *testing.T) {
 	mt.PSPs = map[string]PSPConfig{
 		"stripe": {
 			"stripe": {
-				Environment: "test",
-				AccountID:   "acct_db_123",
+				AccountID: "acct_db_123",
 				Secrets: map[string]string{
 					"secret_key": "sk_test_db_bootstrap",
 				},

--- a/internal/bootstrap/merchant_manifest_integration_test.go
+++ b/internal/bootstrap/merchant_manifest_integration_test.go
@@ -197,7 +197,7 @@ func TestReconcileMerchantManifestAppliesMerchantConfiguration(t *testing.T) {
 	}
 	manifest.Merchants["cozy-art"] = mt
 
-	require.NoError(t, ReconcileMerchantManifestData(ctx, apiModeReconcileConfig(), cp, manifest, MerchantManifestReconcileOptions{Insert: true}))
+	require.NoError(t, ReconcileMerchantManifestData(ctx, sandboxModeReconcileConfig(), cp, manifest, MerchantManifestReconcileOptions{Insert: true}))
 
 	var merchantID string
 	require.NoError(t, pool.QueryRow(ctx, `SELECT id::text FROM openrails.merchants WHERE slug = 'cozy-art'`).Scan(&merchantID))
@@ -412,9 +412,13 @@ func TestMerchantConfigPushDumpRoundTrip(t *testing.T) {
 				},
 			},
 		},
-		"mobius-sandbox": {
+		// Archived: with both NMI accounts in the SAME derived environment
+		// (#882), "the active account for new work" must be unambiguous — an
+		// archived sibling still round-trips through dump.
+		"mobius-secondary": {
 			"nmi": {
 				AccountID: "681902",
+				Archived:  true,
 				Secrets: map[string]string{
 					"security_key": "test-security",
 				},
@@ -530,7 +534,7 @@ func TestMerchantConfigPushDumpRoundTrip(t *testing.T) {
 	require.Contains(t, byAccount, "579145")
 	require.Contains(t, byAccount, "681902")
 	require.False(t, byAccount["579145"].Archived)
-	require.False(t, byAccount["681902"].Archived)
+	require.True(t, byAccount["681902"].Archived, "the archived sibling survives push -> dump")
 	require.Empty(t, byAccount["579145"].Secrets, "redacted dump omits secret values entirely")
 	require.NotContains(t, byAccount["579145"].Secrets, "tokenization_key")
 	require.Equal(t, "https://secure.networkmerchants.com/token/Collect.js", byAccount["579145"].Settings["tokenization_url"])
@@ -551,7 +555,7 @@ func TestReconcileMerchantManifestUsesConfiguredVaultSecretBackend(t *testing.T)
 	pool := newMerchantManifestTestPool(t)
 	cp := newMerchantManifestControlPlane(t, pool)
 	vault := newMerchantManifestVault(t)
-	cfg := &config.Config{Env: "development", MerchantSource: config.MerchantSourceAPI, Vault: &config.VaultConfig{
+	cfg := &config.Config{Env: "development", MerchantSource: config.MerchantSourceAPI, TestMode: config.CredentialPostureSandbox, Vault: &config.VaultConfig{
 		Enabled:    true,
 		Address:    vault.Address,
 		AuthMethod: "token",
@@ -606,7 +610,7 @@ func TestReconcileMerchantManifestUsesEncryptedDBSecretBackend(t *testing.T) {
 	for i := range key {
 		key[i] = byte(i + 1)
 	}
-	cfg := &config.Config{Env: "development", MerchantSource: config.MerchantSourceAPI, Encryption: &config.EncryptionConfig{
+	cfg := &config.Config{Env: "development", MerchantSource: config.MerchantSourceAPI, TestMode: config.CredentialPostureSandbox, Encryption: &config.EncryptionConfig{
 		MasterKey: base64.StdEncoding.EncodeToString(key),
 	}}
 
@@ -834,6 +838,15 @@ func applyMerchantManifestTestSchema(t *testing.T, ctx context.Context, pool *pg
 // development, and the DB secret store refuses a plaintext posture outside it.
 func apiModeReconcileConfig() *config.Config {
 	return &config.Config{Env: "development", MerchantSource: config.MerchantSourceAPI}
+}
+
+// sandboxModeReconcileConfig is apiModeReconcileConfig under test_mode=sandbox.
+// #882: that posture is the ONLY thing that puts a PSP in the test environment,
+// so a test asserting `psps/<rail>/test/…` must declare it.
+func sandboxModeReconcileConfig() *config.Config {
+	cfg := apiModeReconcileConfig()
+	cfg.TestMode = config.CredentialPostureSandbox
+	return cfg
 }
 
 func newMerchantManifestControlPlane(t *testing.T, pool *pgxpool.Pool) *controlplane.ControlPlane {

--- a/internal/bootstrap/merchant_manifest_test.go
+++ b/internal/bootstrap/merchant_manifest_test.go
@@ -43,13 +43,11 @@ merchants:
     psps:
       stripe:
         stripe:
-          environment: test
           account_id: acct_test_123
           secrets:
             secret_key: sk_test_123
       mobius:
         nmi:
-          environment: live
           account_id: mobius-profile-id
           settings:
             tokenization_url: https://secure.networkmerchants.com/token/Collect.js
@@ -104,46 +102,47 @@ func TestExampleMerchantConfigManifestParses(t *testing.T) {
 	// Solana.
 	accts := m.PSPs
 	require.Len(t, accts, 9)
-	type key struct{ name, env string }
-	byName := map[key]ProviderRailAccountConfig{}
+	byName := map[string]ProviderRailAccountConfig{}
 	byRail := map[string]string{}
 	for name, account := range accts {
 		require.Len(t, account, 1)
 		for rail, cfg := range account {
-			byName[key{name, cfg.Environment}] = cfg
+			// #882: the example declares no `environment:` — it is derived.
+			require.Empty(t, cfg.LegacyEnvironment)
+			byName[name] = cfg
 			byRail[name] = rail
 		}
 	}
-	// NMI gateway "mobius": live gateway-id + its sandbox.
+	// NMI gateway "mobius" plus a second account on the same rail.
 	require.Equal(t, "nmi", byRail["mobius"])
-	require.Equal(t, "1234567", byName[key{"mobius", "live"}].AccountID)
-	require.False(t, byName[key{"mobius", "live"}].Archived)
-	require.Equal(t, "replace-with-live-nmi-tokenization-key", byName[key{"mobius", "live"}].Settings["tokenization_key"])
-	require.Equal(t, "7654321", byName[key{"mobius-sandbox", "test"}].AccountID)
+	require.Equal(t, "1234567", byName["mobius"].AccountID)
+	require.False(t, byName["mobius"].Archived)
+	require.Equal(t, "replace-with-live-nmi-tokenization-key", byName["mobius"].Settings["tokenization_key"])
+	require.Equal(t, "7654321", byName["mobius-sandbox"].AccountID)
 
 	// or#879 custody: an NMI PSP whose cards are held by Basis Theory. The rail
 	// is nmi (it always was); the custodian identity and its private
 	// application key hang off that same PSP.
 	require.Equal(t, "nmi", byRail["mobius-bt"])
-	require.Equal(t, "7654322", byName[key{"mobius-bt", "test"}].AccountID)
-	btSettings := byName[key{"mobius-bt", "test"}].Settings
+	require.Equal(t, "7654322", byName["mobius-bt"].AccountID)
+	btSettings := byName["mobius-bt"].Settings
 	custody, err := config.ParseCustodySettings(btSettings)
 	require.NoError(t, err)
 	require.True(t, custody.ThirdParty())
 	require.Equal(t, models.CustodianBasisTheory, custody.Custodian)
 	require.Equal(t, "replace-with-bt-tenant-id", custody.AccountID)
-	require.Equal(t, "replace-with-bt-private-application-key", byName[key{"mobius-bt", "test"}].Secrets[config.CustodianSecretAPIKey])
+	require.Equal(t, "replace-with-bt-private-application-key", byName["mobius-bt"].Secrets[config.CustodianSecretAPIKey])
 	// A second NMI gateway (paykings) is archived/drain-only in the example.
-	require.True(t, byName[key{"paykings", "live"}].Archived)
-	// Stripe live + test side by side.
-	require.Equal(t, "acct_1AbCdEfGhIjKlMnOp", byName[key{"stripe", "live"}].AccountID)
-	require.Equal(t, "acct_1ZyXwVuTsRqPoNmL", byName[key{"stripe-sandbox", "test"}].AccountID)
+	require.True(t, byName["paykings"].Archived)
+	// Two Stripe accounts side by side.
+	require.Equal(t, "acct_1AbCdEfGhIjKlMnOp", byName["stripe"].AccountID)
+	require.Equal(t, "acct_1ZyXwVuTsRqPoNmL", byName["stripe-sandbox"].AccountID)
 	// CCBill — one account.
-	require.Equal(t, "999999-0000", byName[key{"ccbill", "live"}].AccountID)
+	require.Equal(t, "999999-0000", byName["ccbill"].AccountID)
 
 	// #711: the example's solana settings block carries the runtime knobs and
 	// passes the strict push-time validation.
-	solanaSettings := byName[key{"solana", "live"}].Settings
+	solanaSettings := byName["solana"].Settings
 	require.NoError(t, config.ValidateSolanaAccountSettings(solanaSettings))
 	parsed, err := config.ParseSolanaAccountSettings(solanaSettings)
 	require.NoError(t, err)
@@ -332,9 +331,11 @@ merchants:
 			want: "unknown field \"role\"",
 		},
 		{
-			name: "invalid provider account environment",
-			body: base("    psps:\n      stripe:\n        stripe:\n          environment: moon\n          account_id: acct_test_123\n"),
-			want: "environment must be live or test",
+			// #882: environment is derived from test_mode, never declared —
+			// even a value that would have AGREED is refused.
+			name: "declared psp environment is retired",
+			body: base("    psps:\n      stripe:\n        stripe:\n          environment: live\n          account_id: acct_test_123\n"),
+			want: "psps.stripe.stripe.environment was removed (#882)",
 		},
 		{
 			name: "solana network is not a provider-account knob",
@@ -370,7 +371,7 @@ func TestMarshalMerchantManifestEmitsPSPsKey(t *testing.T) {
 			"cozy-art": {
 				DisplayName: "Cozy Art",
 				PSPs: map[string]PSPConfig{
-					"stripe": {"stripe": {Environment: "test", AccountID: "acct_test_123"}},
+					"stripe": {"stripe": {AccountID: "acct_test_123"}},
 				},
 			},
 		},
@@ -395,7 +396,7 @@ func TestParseMerchantConfigManifestSolanaAccountIDIgnored(t *testing.T) {
 	_, err := ParseMerchantConfigManifest([]byte(withAccountID))
 	require.NoError(t, err, "declared solana account_id is ignored, not a parse error")
 
-	noSigner := base("    psps:\n      solana:\n        solana:\n          environment: live\n")
+	noSigner := base("    psps:\n      solana:\n        solana:\n          archived: false\n")
 	_, err = ParseMerchantConfigManifest([]byte(noSigner))
 	require.ErrorContains(t, err, "requires a signer", "solana with no signer has no key to derive account_id from")
 }

--- a/internal/bootstrap/merchant_seed_integration_test.go
+++ b/internal/bootstrap/merchant_seed_integration_test.go
@@ -41,7 +41,6 @@ func TestMode2SeedOnceImporterFlow(t *testing.T) {
 	mt.PSPs = map[string]PSPConfig{
 		"stripe": {
 			"stripe": {
-				Environment: "test",
 				AccountID:   "acct_seed_851",
 				Secrets: map[string]string{
 					"secret_key": "sk_test_seed_851",

--- a/internal/bootstrap/merchant_seed_integration_test.go
+++ b/internal/bootstrap/merchant_seed_integration_test.go
@@ -28,7 +28,7 @@ func TestMode2SeedOnceImporterFlow(t *testing.T) {
 	for i := range key {
 		key[i] = byte(i + 1)
 	}
-	cfg := &config.Config{Env: "development", MerchantSource: config.MerchantSourceAPI, Encryption: &config.EncryptionConfig{
+	cfg := &config.Config{Env: "development", MerchantSource: config.MerchantSourceAPI, TestMode: config.CredentialPostureSandbox, Encryption: &config.EncryptionConfig{
 		MasterKey: base64.StdEncoding.EncodeToString(key),
 	}}
 
@@ -41,7 +41,7 @@ func TestMode2SeedOnceImporterFlow(t *testing.T) {
 	mt.PSPs = map[string]PSPConfig{
 		"stripe": {
 			"stripe": {
-				AccountID:   "acct_seed_851",
+				AccountID: "acct_seed_851",
 				Secrets: map[string]string{
 					"secret_key": "sk_test_seed_851",
 				},

--- a/internal/bootstrap/nmi_probe_arm_integration_test.go
+++ b/internal/bootstrap/nmi_probe_arm_integration_test.go
@@ -50,7 +50,6 @@ func nmiManifestWithSecurityKey(securityKey string) *BillingConfig {
 	mt.PSPs = map[string]PSPConfig{
 		"mobius": {
 			"nmi": {
-				Environment: "test",
 				AccountID:   "681902",
 				Secrets: map[string]string{
 					"security_key": securityKey,
@@ -192,7 +191,6 @@ func TestReconcileMerchantManifestNMIProbeSkippedOutsideTestMode(t *testing.T) {
 	mt.PSPs = map[string]PSPConfig{
 		"mobius": {
 			"nmi": {
-				Environment: "live",
 				AccountID:   "681902",
 				Secrets:     map[string]string{"security_key": "live-security-key-prod"},
 			},

--- a/internal/bootstrap/nmi_probe_arm_integration_test.go
+++ b/internal/bootstrap/nmi_probe_arm_integration_test.go
@@ -50,7 +50,7 @@ func nmiManifestWithSecurityKey(securityKey string) *BillingConfig {
 	mt.PSPs = map[string]PSPConfig{
 		"mobius": {
 			"nmi": {
-				AccountID:   "681902",
+				AccountID: "681902",
 				Secrets: map[string]string{
 					"security_key": securityKey,
 				},
@@ -191,8 +191,8 @@ func TestReconcileMerchantManifestNMIProbeSkippedOutsideTestMode(t *testing.T) {
 	mt.PSPs = map[string]PSPConfig{
 		"mobius": {
 			"nmi": {
-				AccountID:   "681902",
-				Secrets:     map[string]string{"security_key": "live-security-key-prod"},
+				AccountID: "681902",
+				Secrets:   map[string]string{"security_key": "live-security-key-prod"},
 			},
 		},
 	}

--- a/internal/integrationharness/merchant_payment_providers_http_test.go
+++ b/internal/integrationharness/merchant_payment_providers_http_test.go
@@ -45,8 +45,7 @@ func TestStandaloneMerchantPaymentProviderConfigHTTP(t *testing.T) {
 
 	accountID := "acct_" + strings.ReplaceAll(uuid.NewString(), "-", "")
 	status, body := requestJSON(t, http.MethodPut, surface.BaseURL+"/v1/merchant/payment-providers/stripe", adminToken, map[string]any{
-		"environment": "live",
-		"account_id":  accountID,
+		"account_id": accountID,
 		"public_config": map[string]string{
 			"publishable_key": "pk_test_" + strings.ReplaceAll(uuid.NewString(), "-", ""),
 		},
@@ -64,16 +63,31 @@ func TestStandaloneMerchantPaymentProviderConfigHTTP(t *testing.T) {
 	require.Equal(t, accountID, putResp.PaymentProvider.AccountID)
 	require.True(t, putResp.PaymentProvider.Credentials["webhook_signing_secret"].Configured)
 
+	// #882: the request declared NO environment — the server derived it from the
+	// deployment's test_mode. Every later read filters on that derived value.
+	env := putResp.PaymentProvider.Environment
+	require.Contains(t, []string{"live", "test"}, env)
+
+	// A caller still sending `environment` is REFUSED over the wire, not
+	// silently ignored — including a value that AGREES with the derived one.
+	for _, declared := range []string{env, "moon"} {
+		retiredStatus, retiredBody := requestJSON(t, http.MethodPut, surface.BaseURL+"/v1/merchant/payment-providers/stripe", adminToken, map[string]any{
+			"environment": declared,
+			"account_id":  accountID,
+		})
+		require.Equal(t, http.StatusBadRequest, retiredStatus, string(retiredBody))
+		require.Contains(t, string(retiredBody), "was removed (#882)", string(retiredBody))
+	}
+
 	deniedReadStatus, deniedReadBody := requestJSON(t, http.MethodGet, surface.BaseURL+"/v1/merchant/payment-providers", deniedToken, nil)
 	require.Equal(t, http.StatusForbidden, deniedReadStatus, string(deniedReadBody))
 
 	deniedWriteStatus, deniedWriteBody := requestJSON(t, http.MethodPut, surface.BaseURL+"/v1/merchant/payment-providers/stripe", readToken, map[string]any{
-		"environment": "live",
-		"account_id":  accountID,
+		"account_id": accountID,
 	})
 	require.Equal(t, http.StatusForbidden, deniedWriteStatus, string(deniedWriteBody))
 
-	getStatus, getBody := requestJSON(t, http.MethodGet, surface.BaseURL+"/v1/merchant/payment-providers/stripe?environment=live", readToken, nil)
+	getStatus, getBody := requestJSON(t, http.MethodGet, surface.BaseURL+"/v1/merchant/payment-providers/stripe?environment="+env, readToken, nil)
 	require.Equal(t, http.StatusOK, getStatus, string(getBody))
 	require.NotContains(t, string(getBody), "whsec_")
 	var getResp struct {
@@ -84,19 +98,18 @@ func TestStandaloneMerchantPaymentProviderConfigHTTP(t *testing.T) {
 
 	invalidAccountID := "nmi_" + strings.ReplaceAll(uuid.NewString(), "-", "")
 	invalidStatus, invalidBody := requestJSON(t, http.MethodPut, surface.BaseURL+"/v1/merchant/payment-providers/nmi", adminToken, map[string]any{
-		"environment": "live",
-		"account_id":  invalidAccountID,
+		"account_id": invalidAccountID,
 		"credentials": map[string]string{
 			"tokenization_url": "http://example.test/collect.js",
 		},
 	})
 	require.Equal(t, http.StatusBadRequest, invalidStatus, string(invalidBody))
 
-	listStatus, listBody := requestJSON(t, http.MethodGet, surface.BaseURL+"/v1/merchant/payment-providers?provider=nmi&environment=live", readToken, nil)
+	listStatus, listBody := requestJSON(t, http.MethodGet, surface.BaseURL+"/v1/merchant/payment-providers?provider=nmi&environment="+env, readToken, nil)
 	require.Equal(t, http.StatusOK, listStatus, string(listBody))
 	require.NotContains(t, string(listBody), invalidAccountID)
 
-	deleteStatus, deleteBody := requestJSON(t, http.MethodDelete, surface.BaseURL+"/v1/merchant/payment-providers/stripe?environment=live", adminToken, nil)
+	deleteStatus, deleteBody := requestJSON(t, http.MethodDelete, surface.BaseURL+"/v1/merchant/payment-providers/stripe?environment="+env, adminToken, nil)
 	require.Equal(t, http.StatusOK, deleteStatus, string(deleteBody))
 	var deleteResp struct {
 		PaymentProvider merchants.PaymentProviderConfig `json:"payment_provider"`
@@ -106,10 +119,10 @@ func TestStandaloneMerchantPaymentProviderConfigHTTP(t *testing.T) {
 	require.True(t, deleteResp.PaymentProvider.Drained, string(deleteBody))
 	require.Equal(t, int64(0), deleteResp.PaymentProvider.OpenObligations)
 
-	afterDeleteStatus, afterDeleteBody := requestJSON(t, http.MethodGet, surface.BaseURL+"/v1/merchant/payment-providers/stripe?environment=live", readToken, nil)
+	afterDeleteStatus, afterDeleteBody := requestJSON(t, http.MethodGet, surface.BaseURL+"/v1/merchant/payment-providers/stripe?environment="+env, readToken, nil)
 	require.Equal(t, http.StatusNotFound, afterDeleteStatus, string(afterDeleteBody))
 
-	archivedStatus, archivedBody := requestJSON(t, http.MethodGet, surface.BaseURL+"/v1/merchant/payment-providers?provider=stripe&environment=live&status=archived", readToken, nil)
+	archivedStatus, archivedBody := requestJSON(t, http.MethodGet, surface.BaseURL+"/v1/merchant/payment-providers?provider=stripe&environment="+env+"&status=archived", readToken, nil)
 	require.Equal(t, http.StatusOK, archivedStatus, string(archivedBody))
 	var archivedResp struct {
 		Data []merchants.PaymentProviderConfig `json:"data"`

--- a/internal/integrationharness/rail_seeding.go
+++ b/internal/integrationharness/rail_seeding.go
@@ -44,7 +44,7 @@ func SeedRailMerchantAccounts(ctx context.Context, t *testing.T, rt *app.Runtime
 		require.NotEmpty(t, rail, "rail for account %q", name)
 		accountID := proc.EffectiveAccountID()
 		require.NotEmpty(t, accountID, "account_id for account %q", name)
-		environment := proc.EffectiveEnvironment(testMode)
+		environment := config.ExpectedProviderEnvironment(testMode)
 
 		var evidence []byte
 		if settings := railAccountSettings(proc); len(settings) > 0 {

--- a/internal/merchants/credentials.go
+++ b/internal/merchants/credentials.go
@@ -53,9 +53,6 @@ func (s *Service) LoadStripeCredentials(ctx context.Context, id merchant.ID) (St
 	if s.secrets == nil {
 		return creds, nil
 	}
-	if s.pool == nil {
-		return s.loadStripeCredentialsByName(ctx, id, SecretStripeSecretKey, SecretStripeWebhookSigning, SecretStripeWebhookSigningThin, SecretStripeWebhookSigningPrevious)
-	}
 	scope, ok, err := s.activePSPSecretScope(ctx, id, "stripe", s.providerEnvironment)
 	if err != nil {
 		return creds, err
@@ -89,9 +86,6 @@ func (s *Service) LoadNMIWebhookSigningSecret(ctx context.Context, id merchant.I
 	if strings.ToLower(strings.TrimSpace(provider)) != string(models.RailNMI) {
 		return "", nil
 	}
-	if s.pool == nil {
-		return s.secretValue(ctx, id, SecretNMIWebhookSigning)
-	}
 	scope, ok, err := s.activePSPSecretScope(ctx, id, "nmi", s.providerEnvironment)
 	if err != nil {
 		return "", err
@@ -118,10 +112,6 @@ func (s *Service) LoadNMITokenizationConfig(ctx context.Context, id merchant.ID,
 	collectURL := ""
 	switch strings.ToLower(strings.TrimSpace(provider)) {
 	case string(models.RailNMI):
-		if s.pool == nil {
-			cfg.CollectJSURL = DefaultNMICollectJSURL
-			return cfg, nil
-		}
 		scope, ok, err := s.activePSPSecretScope(ctx, id, "nmi", s.providerEnvironment)
 		if err != nil {
 			return cfg, err
@@ -909,14 +899,6 @@ func (s *Service) PutCredential(ctx context.Context, id merchant.ID, name, value
 // RotateCredential is PutCredential with action="rotate".
 func (s *Service) RotateCredential(ctx context.Context, id merchant.ID, name, value string) (Secret, error) {
 	return s.PutCredential(ctx, id, name, value)
-}
-
-// TestStripeCredential verifies a merchant's stored Stripe secret key works WITHOUT
-// charging, by listing the account's balance via the Stripe API. tester is the
-// verification function (so this stays testable without a live Stripe); when nil,
-// a default real Stripe balance check is used. It records a "test" audit row.
-func (s *Service) TestStripeCredential(ctx context.Context, id merchant.ID, tester func(ctx context.Context, secretKey string) error) error {
-	return s.ValidateCredential(ctx, id, SecretStripeSecretKey, "", tester)
 }
 
 // CountActivePSPsForRail is how many PSPs the merchant has ACTIVE for new work

--- a/internal/merchants/lifecycle_integration_test.go
+++ b/internal/merchants/lifecycle_integration_test.go
@@ -391,7 +391,7 @@ func TestDelete_RequiresExport(t *testing.T) {
 		SELECT $1::uuid, id FROM subject
 	`, tn.ID.String())
 	require.NoError(t, err)
-	_, err = svc.secrets.Put(ctx, tn.ID, SecretStripeSecretKey, "sk")
+	_, err = svc.secrets.Put(ctx, tn.ID, "psps/stripe/live/acct_884_test/secret_key", "sk")
 	require.NoError(t, err)
 
 	svc.WithDestructivePolicy(allowAllDestructive{})

--- a/internal/merchants/nmi_probe_arm_integration_test.go
+++ b/internal/merchants/nmi_probe_arm_integration_test.go
@@ -70,7 +70,6 @@ func TestUpsertPaymentProviderConfigRefusesLiveNMIUnderTestMode(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = svc.UpsertPaymentProviderConfig(ctx, tn.ID, "nmi", UpsertPaymentProviderConfigRequest{
-		Environment: "test",
 		AccountID:   "arm-348-live",
 		Credentials: map[string]string{"security_key": "live-security-key"},
 	})
@@ -98,7 +97,6 @@ func TestUpsertPaymentProviderConfigArmsSimulatedNMIUnderTestMode(t *testing.T) 
 	require.NoError(t, err)
 
 	cfg, err := svc.UpsertPaymentProviderConfig(ctx, tn.ID, "nmi", UpsertPaymentProviderConfigRequest{
-		Environment: "test",
 		AccountID:   "arm-348-sim",
 		Credentials: map[string]string{"security_key": "sandbox-security-key"},
 	})
@@ -124,7 +122,6 @@ func TestUpsertPaymentProviderConfigProbeIndeterminateNeverRefuses(t *testing.T)
 	require.NoError(t, err)
 
 	_, err = svc.UpsertPaymentProviderConfig(ctx, tn.ID, "nmi", UpsertPaymentProviderConfigRequest{
-		Environment: "test",
 		AccountID:   "arm-348-indeterminate",
 		Credentials: map[string]string{"security_key": "unclear-security-key"},
 	})
@@ -148,7 +145,6 @@ func TestUpsertPaymentProviderConfigCooldownRespected(t *testing.T) {
 	require.NoError(t, err)
 
 	req := UpsertPaymentProviderConfigRequest{
-		Environment: "test",
 		AccountID:   "arm-348-cooldown",
 		Credentials: map[string]string{"security_key": "live-cooldown-key"},
 	}
@@ -184,7 +180,6 @@ func TestUpsertPaymentProviderConfigSkipsTestModeProbeOutsideTestMode(t *testing
 	require.NoError(t, err)
 
 	_, err = svc.UpsertPaymentProviderConfig(ctx, tn.ID, "nmi", UpsertPaymentProviderConfigRequest{
-		Environment: "live",
 		AccountID:   "arm-348-prod",
 		Credentials: map[string]string{"security_key": "live-prod-key"},
 	})
@@ -211,7 +206,6 @@ func TestUpsertPaymentProviderConfigRefusesUsingExistingStoredKey(t *testing.T) 
 	require.NoError(t, err)
 
 	_, err = svc.UpsertPaymentProviderConfig(ctx, tn.ID, "nmi", UpsertPaymentProviderConfigRequest{
-		Environment: "test",
 		AccountID:   "arm-348-existing",
 		Credentials: map[string]string{"security_key": "was-sandbox-then-rotated-live"},
 	})
@@ -232,7 +226,6 @@ func TestUpsertPaymentProviderConfigRefusesUsingExistingStoredKey(t *testing.T) 
 	svc.nmiProbeV5BaseURL = liveServer.URL
 
 	_, err = svc.UpsertPaymentProviderConfig(ctx, tn.ID, "nmi", UpsertPaymentProviderConfigRequest{
-		Environment:  "test",
 		AccountID:    "arm-348-existing",
 		PublicConfig: map[string]string{"note": "unrelated update"},
 	})

--- a/internal/merchants/payment_provider_config.go
+++ b/internal/merchants/payment_provider_config.go
@@ -55,12 +55,16 @@ type PaymentProviderDefinition struct {
 }
 
 // UpsertPaymentProviderConfigRequest creates or replaces one provider account.
+// There is no `environment` field (#882): a deployment is all-test or all-live,
+// so the environment is derived from the deployment's test_mode posture.
 type UpsertPaymentProviderConfigRequest struct {
-	Environment  string            `json:"environment"`
 	Enabled      *bool             `json:"enabled"`
 	AccountID    string            `json:"account_id"`
 	PublicConfig map[string]string `json:"public_config"`
 	Credentials  map[string]string `json:"credentials"`
+	// LegacyEnvironment stays bound ONLY so a caller still sending `environment`
+	// is refused instead of silently ignored (#882).
+	LegacyEnvironment string `json:"environment,omitempty"`
 }
 
 type railMerchantAccountEvidence struct {
@@ -174,12 +178,10 @@ func (s *Service) UpsertPaymentProviderConfig(ctx context.Context, id merchant.I
 	if !supportedPaymentProvider(rail) {
 		return PaymentProviderConfig{}, fmt.Errorf("merchants: unsupported payment rail %q", rail)
 	}
-	environment := strings.TrimSpace(req.Environment)
-	if environment == "" {
-		environment = s.providerEnvironment // deployment posture (#681)
-	} else if environment = normalizeProviderSecretEnvironment(environment); environment == "" {
-		return PaymentProviderConfig{}, fmt.Errorf("merchants: provider environment must be live or test")
+	if strings.TrimSpace(req.LegacyEnvironment) != "" {
+		return PaymentProviderConfig{}, fmt.Errorf("merchants: `environment` was removed (#882): the environment is derived from the deployment's test_mode (currently %q) — drop the field", s.providerEnvironment)
 	}
+	environment := s.providerEnvironment // derived from test_mode (#681/#882)
 	accountID := strings.TrimSpace(req.AccountID)
 	if accountID == "" {
 		return PaymentProviderConfig{}, fmt.Errorf("merchants: provider account_id required")

--- a/internal/merchants/payment_provider_config_test.go
+++ b/internal/merchants/payment_provider_config_test.go
@@ -47,10 +47,7 @@ func TestPaymentProviderConfigFromRowRedactsCredentials(t *testing.T) {
 		LastVerifiedAt: &now,
 		CreatedAt:      now,
 		UpdatedAt:      now,
-	}, []MerchantSecretStatus{{
-		SecretDefinition: SecretDefinition{Name: secretName},
-		Configured:       true,
-	}})
+	}, []MerchantSecretStatus{{Name: secretName, Configured: true}})
 
 	if got.PublicConfig["publishable_key"] != "pk_live_123" {
 		t.Fatalf("public_config = %#v", got.PublicConfig)
@@ -81,10 +78,7 @@ func TestPaymentProviderConfigFromRowHidesUnprovenTimestamp(t *testing.T) {
 		Environment:    "live",
 		AccountID:      "gateway",
 		LastVerifiedAt: &now,
-	}, []MerchantSecretStatus{{
-		SecretDefinition: SecretDefinition{Name: secretName},
-		Configured:       true,
-	}})
+	}, []MerchantSecretStatus{{Name: secretName, Configured: true}})
 
 	if got.LastVerifiedAt != nil || got.Credentials["security_key"].LastValidatedAt != nil {
 		t.Fatal("an auto-stamped timestamp without probe evidence must stay hidden")
@@ -144,7 +138,7 @@ func TestValidateScopedStripeCredentialDoesNotPersist(t *testing.T) {
 	}
 	if statuses, err := svc.ListSecretStatuses(context.Background(), id); err != nil {
 		t.Fatal(err)
-	} else if len(statuses) != len(merchantSecretRegistry) {
+	} else if len(statuses) != 0 {
 		t.Fatalf("validation should not create provider-account secrets, got %d statuses", len(statuses))
 	}
 }

--- a/internal/merchants/psp_environment_derived_integration_test.go
+++ b/internal/merchants/psp_environment_derived_integration_test.go
@@ -1,0 +1,85 @@
+//go:build integration
+
+package merchants
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/db"
+)
+
+func pspEnvironment(t *testing.T, svc *Service, accountID string) string {
+	t.Helper()
+	var env string
+	require.NoError(t, svc.pool.QueryRow(context.Background(), `
+		SELECT environment FROM openrails.psps WHERE account_id = $1
+	`, accountID).Scan(&env))
+	return env
+}
+
+// #882: the PSP environment is DERIVED from the deployment's test_mode. A
+// caller that still sends `environment` is refused, not silently ignored —
+// tolerating it would keep teaching a knob that no longer exists.
+func TestUpsertPaymentProviderConfigRefusesDeclaredEnvironment(t *testing.T) {
+	pool := newTestPool(t)
+	svc, err := NewService(db.WrapPool(pool, ""), NewMemorySecretStore(), "live")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	tn, _, err := svc.Provision(ctx, ProvisionRequest{Slug: "psp-env-882", PermissionGroupID: "group-psp-env-882"})
+	require.NoError(t, err)
+
+	// Even an AGREEING declaration is refused.
+	for i, declared := range []string{"live", "test", "moon"} {
+		_, err = svc.UpsertPaymentProviderConfig(ctx, tn.ID, "ccbill", UpsertPaymentProviderConfigRequest{
+			LegacyEnvironment: declared,
+			AccountID:         "99882" + string(rune('0'+i)) + "-0000",
+			Credentials:       map[string]string{"salt": "salt-882"},
+		})
+		require.ErrorContains(t, err, "`environment` was removed (#882)", "declared environment=%s", declared)
+	}
+
+	var count int
+	require.NoError(t, svc.pool.QueryRow(ctx, `
+		SELECT count(*) FROM openrails.psps WHERE account_id LIKE '99882%'
+	`).Scan(&count))
+	require.Zero(t, count, "a refused arm must never persist the PSP row")
+}
+
+// The derived environment still lands on the psps row, in BOTH postures.
+func TestUpsertPaymentProviderConfigDerivesEnvironmentFromTestMode(t *testing.T) {
+	pool := newTestPool(t)
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		posture string
+		slug    string
+		account string
+	}{
+		{posture: "live", slug: "psp-env-live-882", account: "888201-0000"},
+		{posture: "test", slug: "psp-env-test-882", account: "888202-0000"},
+	} {
+		svc, err := NewService(db.WrapPool(pool, ""), NewMemorySecretStore(), tc.posture)
+		require.NoError(t, err)
+		tn, _, err := svc.Provision(ctx, ProvisionRequest{Slug: tc.slug, PermissionGroupID: "group-" + tc.slug})
+		require.NoError(t, err)
+
+		cfg, err := svc.UpsertPaymentProviderConfig(ctx, tn.ID, "ccbill", UpsertPaymentProviderConfigRequest{
+			AccountID:   tc.account,
+			Credentials: map[string]string{"salt": "salt-" + tc.posture},
+		})
+		require.NoError(t, err)
+		require.Equal(t, tc.posture, cfg.Environment)
+		require.Equal(t, tc.posture, pspEnvironment(t, svc, tc.account))
+
+		// The scoped secret name carries the same derived environment segment,
+		// so the credential is resolvable at request time.
+		name, ok, err := svc.ActivePSPSecretName(ctx, tn.ID, "ccbill", tc.posture, "salt")
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.Equal(t, "psps/ccbill/"+tc.posture+"/"+tc.account+"/salt", name)
+	}
+}

--- a/internal/merchants/secret_name_traversal_test.go
+++ b/internal/merchants/secret_name_traversal_test.go
@@ -36,8 +36,8 @@ func TestSecretNameRejectsTraversal(t *testing.T) {
 
 	// Ordinary names still work.
 	for _, name := range []string{
-		SecretStripeSecretKey,
-		SecretNMISecurityKey,
+		"psps/stripe/live/acct_884_test/secret_key",
+		"psps/nmi/live/100884/security_key",
 		"psps/nmi/production/579145/security_key",
 	} {
 		if got := cleanSecretName(name); got == "" {

--- a/internal/merchants/secrets.go
+++ b/internal/merchants/secrets.go
@@ -22,55 +22,12 @@ import (
 	"github.com/open-rails/openrails/pkg/merchant"
 )
 
-// Canonical per-merchant secret names. The store namespaces values by
-// (merchant id, name); these are the well-known names OpenRails reads at request
-// time. A managed (Vault-backed) deployment keeps the SAME names but resolves
-// them to a merchant-scoped Vault path.
-const (
-	// SecretStripeSecretKey is the merchant's Stripe API secret key (BYO or Connect).
-	SecretStripeSecretKey = "stripe/secret_key"
-	// SecretStripeWebhookSigning is the merchant's Stripe webhook signing secret,
-	// used to verify inbound webhooks AFTER merchant resolution.
-	SecretStripeWebhookSigning = "stripe/webhook_signing_secret"
-	// SecretStripeWebhookSigningThin is the merchant's Stripe "thin" Event
-	// Destination signing secret (a single endpoint may receive both).
-	SecretStripeWebhookSigningThin = "stripe/webhook_signing_secret_thin"
-	// SecretStripeWebhookSigningPrevious is the outgoing signing secret kept
-	// through an api_version rollover (#856), so deliveries still queued on the
-	// superseded endpoint keep verifying while both endpoints run.
-	SecretStripeWebhookSigningPrevious = "stripe/webhook_signing_secret_previous"
-	// SecretNMISecurityKey is the legacy broad NMI security-key secret.
-	SecretNMISecurityKey = "nmi/mobius/security_key"
-	// SecretNMITokenizationURL overrides the Collect.js script URL for a
-	// merchant/provider. Most NMI accounts use DefaultNMICollectJSURL.
-	SecretNMITokenizationURL = "nmi/mobius/tokenization_url"
-	// SecretNMIWebhookSigning is the merchant's NMI webhook signing
-	// secret, used to verify inbound webhooks after merchant/provider resolution.
-	SecretNMIWebhookSigning = "nmi/mobius/webhook_signing_secret"
-)
-
-// SecretDefinition describes one OpenRails-owned merchant secret. It is the
-// canonical registry used by status APIs, docs, validation, and runbooks.
-type SecretDefinition struct {
-	Name              string `json:"name"`
-	Rail              string `json:"rail"`
-	Purpose           string `json:"purpose"`
-	DisplayLabel      string `json:"display_label"`
-	ManualVault       bool   `json:"manual_vault"`
-	MerchantWritable  bool   `json:"merchant_writable"`
-	Validation        string `json:"validation"`
-	PlaintextReadable bool   `json:"plaintext_readable"`
-}
-
-var merchantSecretRegistry = []SecretDefinition{
-	{Name: SecretStripeSecretKey, Rail: "stripe", Purpose: "api_key", DisplayLabel: "Stripe secret key", ManualVault: true, MerchantWritable: true, Validation: "stripe_balance_check"},
-	{Name: SecretStripeWebhookSigning, Rail: "stripe", Purpose: "webhook_signing", DisplayLabel: "Stripe webhook signing secret", ManualVault: true, MerchantWritable: true, Validation: "format"},
-	{Name: SecretStripeWebhookSigningThin, Rail: "stripe", Purpose: "webhook_signing", DisplayLabel: "Stripe thin event signing secret", ManualVault: true, MerchantWritable: true, Validation: "format"},
-	{Name: SecretStripeWebhookSigningPrevious, Rail: "stripe", Purpose: "webhook_signing", DisplayLabel: "Stripe previous webhook signing secret (rollover overlap)", ManualVault: true, MerchantWritable: true, Validation: "format"},
-	{Name: SecretNMISecurityKey, Rail: "nmi", Purpose: "security_key", DisplayLabel: "NMI security key", ManualVault: true, MerchantWritable: true, Validation: "presence"},
-	{Name: SecretNMITokenizationURL, Rail: "nmi", Purpose: "tokenization_url", DisplayLabel: "NMI Collect.js URL", ManualVault: true, MerchantWritable: true, Validation: "url", PlaintextReadable: true},
-	{Name: SecretNMIWebhookSigning, Rail: "nmi", Purpose: "webhook_signing", DisplayLabel: "NMI webhook signing secret", ManualVault: true, MerchantWritable: true, Validation: "presence"},
-}
+// A merchant secret has exactly ONE spelling: the PSP-scoped name
+// `psps/<rail>/<environment>/<account_id>/<key>` built by PSPSecretName. The
+// flat `<rail>/<purpose>` names (stripe/secret_key, nmi/mobius/security_key, …)
+// were retired in #884 — they were write-only surface, read only on a
+// `pool == nil` branch that no production construction can reach, and they baked
+// a PSP key ("mobius") into names presented as rail-generic.
 
 // PSPSecretName returns the canonical secret-store name for a
 // provider-account-owned credential. The merchant id still namespaces the store;
@@ -125,11 +82,9 @@ func ParsePSPSecretName(name string) (rail, environment, accountID, key string, 
 }
 
 // SecretWritable reports whether a merchant operator may write the secret name.
+// Only PSP-scoped names qualify (#884): a retired flat name parses as
+// unscoped and is refused.
 func SecretWritable(name string) bool {
-	name = cleanSecretName(name)
-	if def, ok := SecretDefinitionFor(name); ok {
-		return def.MerchantWritable
-	}
 	rail, _, _, key, ok, err := ParsePSPSecretName(name)
 	if !ok || err != nil {
 		return false
@@ -169,23 +124,17 @@ func normalizeProviderSecretEnvironment(environment string) string {
 	}
 }
 
-// SecretDefinitionFor returns a registry entry by stable secret name.
-func SecretDefinitionFor(name string) (SecretDefinition, bool) {
-	name = cleanSecretName(name)
-	for _, d := range merchantSecretRegistry {
-		if d.Name == name {
-			return d, true
-		}
-	}
-	return SecretDefinition{}, false
-}
-
-// MerchantSecretStatus is the read-only dashboard/admin view of a merchant secret.
-// It never contains plaintext.
+// MerchantSecretStatus is the read-only dashboard/admin view of one merchant
+// secret slot. It never contains plaintext. The advertised slots come from the
+// rail credential registry (#884) — the same source the money path reads with.
 type MerchantSecretStatus struct {
-	SecretDefinition
-	Configured bool `json:"configured"`
-	Version    int  `json:"version,omitempty"`
+	Name             string `json:"name"`
+	Rail             string `json:"rail"`
+	Key              string `json:"key"`
+	DisplayLabel     string `json:"display_label"`
+	MerchantWritable bool   `json:"merchant_writable"`
+	Configured       bool   `json:"configured"`
+	Version          int    `json:"version,omitempty"`
 }
 
 // ErrSecretNotFound is returned by a MerchantSecretStore when no secret exists for

--- a/internal/merchants/secrets_cache_test.go
+++ b/internal/merchants/secrets_cache_test.go
@@ -80,7 +80,7 @@ func TestCachedSecretStore_TTLHitThenExpiry(t *testing.T) {
 	ctx := context.Background()
 	backend := newCountingStore()
 	id := dbtest.TestMerchantID
-	if _, err := backend.Put(ctx, id, SecretStripeSecretKey, "sk_1"); err != nil {
+	if _, err := backend.Put(ctx, id, "psps/stripe/live/acct_884_test/secret_key", "sk_1"); err != nil {
 		t.Fatal(err)
 	}
 	backend.puts = 0 // reset; we only count cache-driven backend hits below
@@ -89,7 +89,7 @@ func TestCachedSecretStore_TTLHitThenExpiry(t *testing.T) {
 
 	// First Get is a miss -> 1 backend read; second within TTL is served cached.
 	for i := 0; i < 3; i++ {
-		got, err := cache.Get(ctx, id, SecretStripeSecretKey)
+		got, err := cache.Get(ctx, id, "psps/stripe/live/acct_884_test/secret_key")
 		if err != nil || got.Value != "sk_1" {
 			t.Fatalf("get %d: %v / %q", i, err, got.Value)
 		}
@@ -100,7 +100,7 @@ func TestCachedSecretStore_TTLHitThenExpiry(t *testing.T) {
 
 	// Advance past TTL -> next Get re-reads the backend.
 	advance(46 * time.Second)
-	if _, err := cache.Get(ctx, id, SecretStripeSecretKey); err != nil {
+	if _, err := cache.Get(ctx, id, "psps/stripe/live/acct_884_test/secret_key"); err != nil {
 		t.Fatal(err)
 	}
 	if backend.gets != 2 {
@@ -114,14 +114,14 @@ func TestCachedSecretStore_PutRefreshesImmediately(t *testing.T) {
 	id := dbtest.TestMerchantID
 	cache, _ := withClock(t, backend, 45*time.Second)
 
-	if _, err := cache.Put(ctx, id, SecretStripeSecretKey, "sk_old"); err != nil {
+	if _, err := cache.Put(ctx, id, "psps/stripe/live/acct_884_test/secret_key", "sk_old"); err != nil {
 		t.Fatal(err)
 	}
 	// Rotate through the cache; the new value must be visible with NO backend Get.
-	if _, err := cache.Put(ctx, id, SecretStripeSecretKey, "sk_new"); err != nil {
+	if _, err := cache.Put(ctx, id, "psps/stripe/live/acct_884_test/secret_key", "sk_new"); err != nil {
 		t.Fatal(err)
 	}
-	got, err := cache.Get(ctx, id, SecretStripeSecretKey)
+	got, err := cache.Get(ctx, id, "psps/stripe/live/acct_884_test/secret_key")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,17 +139,17 @@ func TestCachedSecretStore_DeleteInvalidates(t *testing.T) {
 	id := dbtest.TestMerchantID
 	cache, _ := withClock(t, backend, 45*time.Second)
 
-	if _, err := cache.Put(ctx, id, SecretStripeSecretKey, "sk_1"); err != nil {
+	if _, err := cache.Put(ctx, id, "psps/stripe/live/acct_884_test/secret_key", "sk_1"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := cache.Get(ctx, id, SecretStripeSecretKey); err != nil { // populate cache
+	if _, err := cache.Get(ctx, id, "psps/stripe/live/acct_884_test/secret_key"); err != nil { // populate cache
 		t.Fatal(err)
 	}
-	if err := cache.Delete(ctx, id, SecretStripeSecretKey); err != nil {
+	if err := cache.Delete(ctx, id, "psps/stripe/live/acct_884_test/secret_key"); err != nil {
 		t.Fatal(err)
 	}
 	// After delete the cached copy must be gone -> a fresh backend read that 404s.
-	if _, err := cache.Get(ctx, id, SecretStripeSecretKey); !errors.Is(err, ErrSecretNotFound) {
+	if _, err := cache.Get(ctx, id, "psps/stripe/live/acct_884_test/secret_key"); !errors.Is(err, ErrSecretNotFound) {
 		t.Fatalf("post-delete Get = %v, want ErrSecretNotFound", err)
 	}
 }
@@ -162,15 +162,15 @@ func TestCachedSecretStore_ErrorsNotCached(t *testing.T) {
 
 	// Backend transiently unavailable: the error must propagate and NOT be cached.
 	backend.getErr = ErrSecretBackendUnavailable
-	if _, err := cache.Get(ctx, id, SecretStripeSecretKey); !errors.Is(err, ErrSecretBackendUnavailable) {
+	if _, err := cache.Get(ctx, id, "psps/stripe/live/acct_884_test/secret_key"); !errors.Is(err, ErrSecretBackendUnavailable) {
 		t.Fatalf("get = %v, want ErrSecretBackendUnavailable", err)
 	}
 	// Recovery: backend now returns a value; the cache must not be pinned on the error.
 	backend.getErr = nil
-	if _, err := backend.Put(ctx, id, SecretStripeSecretKey, "sk_ok"); err != nil {
+	if _, err := backend.Put(ctx, id, "psps/stripe/live/acct_884_test/secret_key", "sk_ok"); err != nil {
 		t.Fatal(err)
 	}
-	got, err := cache.Get(ctx, id, SecretStripeSecretKey)
+	got, err := cache.Get(ctx, id, "psps/stripe/live/acct_884_test/secret_key")
 	if err != nil || got.Value != "sk_ok" {
 		t.Fatalf("after recovery: %v / %q", err, got.Value)
 	}
@@ -203,7 +203,7 @@ func (e errVaultKV) ListSecrets(context.Context, string) ([]string, error) { ret
 func TestVaultSecretStore_UnreachableIsBackendUnavailableNotAbsent(t *testing.T) {
 	ctx := context.Background()
 	store := NewVaultSecretStore("secret", errVaultKV{err: errors.New("dial tcp: connection refused")}, staticMerchantSlugResolver{dbtest.TestMerchantID.String(): dbtest.TestMerchantSlug})
-	_, err := store.Get(ctx, dbtest.TestMerchantID, SecretStripeSecretKey)
+	_, err := store.Get(ctx, dbtest.TestMerchantID, "psps/stripe/live/acct_884_test/secret_key")
 	if !errors.Is(err, ErrSecretBackendUnavailable) {
 		t.Fatalf("unreachable Get = %v, want wraps ErrSecretBackendUnavailable", err)
 	}
@@ -215,7 +215,7 @@ func TestVaultSecretStore_UnreachableIsBackendUnavailableNotAbsent(t *testing.T)
 func TestVaultSecretStore_AbsentIsNotFound(t *testing.T) {
 	ctx := context.Background()
 	store := NewVaultSecretStore("secret", newFakeVaultKV(), staticMerchantSlugResolver{dbtest.TestMerchantID.String(): dbtest.TestMerchantSlug}) // empty store -> no value
-	_, err := store.Get(ctx, dbtest.TestMerchantID, SecretStripeSecretKey)
+	_, err := store.Get(ctx, dbtest.TestMerchantID, "psps/stripe/live/acct_884_test/secret_key")
 	if !errors.Is(err, ErrSecretNotFound) {
 		t.Fatalf("absent Get = %v, want ErrSecretNotFound", err)
 	}
@@ -230,7 +230,7 @@ func TestVaultSecretStore_StubWrapsBackendUnavailable(t *testing.T) {
 	if !errors.Is(ErrVaultNotConfigured, ErrSecretBackendUnavailable) {
 		t.Fatal("ErrVaultNotConfigured must wrap ErrSecretBackendUnavailable")
 	}
-	_, err := NewVaultSecretStore("secret", nil, staticMerchantSlugResolver{dbtest.TestMerchantID.String(): dbtest.TestMerchantSlug}).Get(context.Background(), dbtest.TestMerchantID, SecretStripeSecretKey)
+	_, err := NewVaultSecretStore("secret", nil, staticMerchantSlugResolver{dbtest.TestMerchantID.String(): dbtest.TestMerchantSlug}).Get(context.Background(), dbtest.TestMerchantID, "psps/stripe/live/acct_884_test/secret_key")
 	if !errors.Is(err, ErrSecretBackendUnavailable) {
 		t.Fatalf("stub Get = %v, want wraps ErrSecretBackendUnavailable", err)
 	}

--- a/internal/merchants/secrets_encrypted_test.go
+++ b/internal/merchants/secrets_encrypted_test.go
@@ -51,7 +51,7 @@ func TestEncryptedSecretStore_RoundTrips(t *testing.T) {
 	}
 	tA := merchant.ID(uuid.New())
 
-	put, err := store.Put(ctx, tA, SecretStripeSecretKey, "sk_live_abc")
+	put, err := store.Put(ctx, tA, "psps/stripe/live/acct_884_test/secret_key", "sk_live_abc")
 	if err != nil {
 		t.Fatalf("Put: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestEncryptedSecretStore_RoundTrips(t *testing.T) {
 	}
 
 	// The INNER store must hold ciphertext, never the plaintext.
-	raw, err := inner.Get(ctx, tA, SecretStripeSecretKey)
+	raw, err := inner.Get(ctx, tA, "psps/stripe/live/acct_884_test/secret_key")
 	if err != nil {
 		t.Fatalf("inner Get: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestEncryptedSecretStore_RoundTrips(t *testing.T) {
 		t.Fatal("inner store must hold ciphertext, not plaintext")
 	}
 
-	got, err := store.Get(ctx, tA, SecretStripeSecretKey)
+	got, err := store.Get(ctx, tA, "psps/stripe/live/acct_884_test/secret_key")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
@@ -82,12 +82,12 @@ func TestEncryptedSecretStore_IdempotentRotation(t *testing.T) {
 	store, _ := NewEncryptedSecretStore(NewMemorySecretStore(), newEnc(t))
 	tA := merchant.ID(uuid.New())
 
-	v1, _ := store.Put(ctx, tA, SecretStripeSecretKey, "sk_1")
-	v1again, _ := store.Put(ctx, tA, SecretStripeSecretKey, "sk_1")
+	v1, _ := store.Put(ctx, tA, "psps/stripe/live/acct_884_test/secret_key", "sk_1")
+	v1again, _ := store.Put(ctx, tA, "psps/stripe/live/acct_884_test/secret_key", "sk_1")
 	if v1again.Version != v1.Version {
 		t.Fatalf("re-putting the same plaintext must not bump version (%d -> %d)", v1.Version, v1again.Version)
 	}
-	v2, _ := store.Put(ctx, tA, SecretStripeSecretKey, "sk_2")
+	v2, _ := store.Put(ctx, tA, "psps/stripe/live/acct_884_test/secret_key", "sk_2")
 	if v2.Version != v1.Version+1 {
 		t.Fatalf("changing the value must bump version, got %d want %d", v2.Version, v1.Version+1)
 	}
@@ -101,12 +101,12 @@ func TestEncryptedSecretStore_CrossMerchantIsolation(t *testing.T) {
 	tA := merchant.ID(uuid.New())
 	tB := merchant.ID(uuid.New())
 
-	if _, err := store.Put(ctx, tA, SecretStripeSecretKey, "A-secret"); err != nil {
+	if _, err := store.Put(ctx, tA, "psps/stripe/live/acct_884_test/secret_key", "A-secret"); err != nil {
 		t.Fatalf("Put A: %v", err)
 	}
 	// Merchant B has its own DEK; merchant A's ciphertext is unreadable as B.
-	rawA, _ := inner.Get(ctx, tA, SecretStripeSecretKey)
-	if _, err := enc.Decrypt(ctx, tB, crypto.SecretAAD(tB, SecretStripeSecretKey), rawA.Value); err == nil {
+	rawA, _ := inner.Get(ctx, tA, "psps/stripe/live/acct_884_test/secret_key")
+	if _, err := enc.Decrypt(ctx, tB, crypto.SecretAAD(tB, "psps/stripe/live/acct_884_test/secret_key"), rawA.Value); err == nil {
 		t.Fatal("merchant B must not decrypt merchant A's stored secret")
 	}
 }
@@ -136,26 +136,26 @@ func TestEncryptedSecretStore_CiphertextIsBoundToItsRow(t *testing.T) {
 	store, _ := NewEncryptedSecretStore(inner, enc)
 	tA := merchant.ID(uuid.New())
 
-	if _, err := store.Put(ctx, tA, SecretStripeWebhookSigning, "whsec_real"); err != nil {
+	if _, err := store.Put(ctx, tA, "psps/stripe/live/acct_884_test/webhook_signing_secret", "whsec_real"); err != nil {
 		t.Fatalf("Put webhook secret: %v", err)
 	}
-	blob, err := inner.Get(ctx, tA, SecretStripeWebhookSigning)
+	blob, err := inner.Get(ctx, tA, "psps/stripe/live/acct_884_test/webhook_signing_secret")
 	if err != nil {
 		t.Fatalf("read raw ciphertext: %v", err)
 	}
 
 	// Relocate the ciphertext into a DIFFERENT name for the SAME merchant —
 	// exactly what a DB-write actor can do.
-	if _, err := inner.Put(ctx, tA, SecretStripeSecretKey, blob.Value); err != nil {
+	if _, err := inner.Put(ctx, tA, "psps/stripe/live/acct_884_test/secret_key", blob.Value); err != nil {
 		t.Fatalf("relocate blob: %v", err)
 	}
-	if _, err := store.Get(ctx, tA, SecretStripeSecretKey); err == nil {
+	if _, err := store.Get(ctx, tA, "psps/stripe/live/acct_884_test/secret_key"); err == nil {
 		t.Fatal("a ciphertext moved into another (merchant, name) row must NOT decrypt: " +
 			"AAD binds it to the row it was sealed for (SEC-24 item 1)")
 	}
 
 	// The row it belongs to still round-trips.
-	got, err := store.Get(ctx, tA, SecretStripeWebhookSigning)
+	got, err := store.Get(ctx, tA, "psps/stripe/live/acct_884_test/webhook_signing_secret")
 	if err != nil {
 		t.Fatalf("original row must still decrypt: %v", err)
 	}

--- a/internal/merchants/secrets_status.go
+++ b/internal/merchants/secrets_status.go
@@ -4,70 +4,64 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/url"
+	"sort"
 	"strings"
 
 	"github.com/open-rails/openrails/pkg/merchant"
 )
 
-// ListSecretStatuses returns the registry plus configured/audit state for a
-// merchant. It never returns plaintext values.
+// ListSecretStatuses returns one status per PSP-scoped secret the merchant
+// actually holds, described from the rail credential registry (#884). It never
+// returns plaintext values.
+//
+// It advertises what is READ, not a static catalogue: a merchant's credential
+// slots are a function of the PSPs it declared, and those per-PSP slots are
+// already reported by PaymentProviderDefinitions + PaymentProviderConfig.
+// Names are sorted so the view is stable across calls.
 func (s *Service) ListSecretStatuses(ctx context.Context, id merchant.ID) ([]MerchantSecretStatus, error) {
 	if id.IsZero() {
 		return nil, validateSecretRef(id, "x")
 	}
-	configured := map[string]struct{}{}
-	if s.secrets != nil {
-		names, err := s.secrets.List(ctx, id)
-		if err != nil {
-			return nil, err
-		}
-		for _, n := range names {
-			configured[cleanSecretName(n)] = struct{}{}
+	if s.secrets == nil {
+		return nil, nil
+	}
+	names, err := s.secrets.List(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	cleaned := make([]string, 0, len(names))
+	for _, n := range names {
+		if c := cleanSecretName(n); c != "" {
+			cleaned = append(cleaned, c)
 		}
 	}
+	sort.Strings(cleaned)
 
-	out := make([]MerchantSecretStatus, 0, len(merchantSecretRegistry))
-	for _, def := range merchantSecretRegistry {
-		st := MerchantSecretStatus{SecretDefinition: def}
-		if _, ok := configured[def.Name]; ok {
-			st.Configured = true
-			if s.secrets != nil {
-				if sec, err := s.secrets.Get(ctx, id, def.Name); err == nil {
-					st.Version = sec.Version
-				} else if !errors.Is(err, ErrSecretNotFound) {
-					return nil, err
-				}
-			}
-		}
-		out = append(out, st)
-	}
-	for name := range configured {
-		if _, ok := SecretDefinitionFor(name); ok {
+	out := make([]MerchantSecretStatus, 0, len(cleaned))
+	seen := map[string]struct{}{}
+	for _, name := range cleaned {
+		if _, dup := seen[name]; dup {
 			continue
 		}
+		seen[name] = struct{}{}
 		rail, _, _, key, ok, err := ParsePSPSecretName(name)
 		if !ok || err != nil {
+			// A stored name that is not a PSP-scoped credential slot is not a
+			// credential OpenRails reads — never advertise it as one.
 			continue
 		}
 		st := MerchantSecretStatus{
-			SecretDefinition: SecretDefinition{
-				Name:             name,
-				Rail:             rail,
-				Purpose:          key,
-				DisplayLabel:     rail + " " + key,
-				ManualVault:      true,
-				MerchantWritable: true,
-				Validation:       "presence",
-			},
-			Configured: true,
+			Name:             name,
+			Rail:             rail,
+			Key:              key,
+			DisplayLabel:     rail + " " + key,
+			MerchantWritable: SecretWritable(name),
+			Configured:       true,
 		}
-		if s.secrets != nil {
-			if sec, err := s.secrets.Get(ctx, id, name); err == nil {
-				st.Version = sec.Version
-			} else if !errors.Is(err, ErrSecretNotFound) {
-				return nil, err
-			}
+		if sec, err := s.secrets.Get(ctx, id, name); err == nil {
+			st.Version = sec.Version
+		} else if !errors.Is(err, ErrSecretNotFound) {
+			return nil, err
 		}
 		out = append(out, st)
 	}
@@ -125,15 +119,14 @@ func validateSecretValue(ctx context.Context, name, value string, stripeTester f
 }
 
 func isStripeSecretKeyName(name string) bool {
-	if cleanSecretName(name) == SecretStripeSecretKey {
-		return true
-	}
 	rail, _, _, key, ok, err := ParsePSPSecretName(name)
 	return ok && err == nil && rail == "stripe" && key == "secret_key"
 }
 
+// validateSecretValueLocal applies per-(rail, key) format rules to a
+// PSP-scoped credential. Names are always scoped (#884), so the rules key off
+// the parsed rail/key rather than a second flat spelling.
 func validateSecretValueLocal(name, value string) error {
-	name = cleanSecretName(name)
 	value = strings.TrimSpace(value)
 	rail, _, _, key, scoped, err := ParsePSPSecretName(name)
 	if err != nil {
@@ -142,33 +135,19 @@ func validateSecretValueLocal(name, value string) error {
 	if value == "" {
 		return errors.New("empty")
 	}
-	if scoped {
-		switch {
-		case rail == "stripe" && key == "secret_key":
-			name = SecretStripeSecretKey
-		case rail == "stripe" && key == "webhook_signing_secret":
-			name = SecretStripeWebhookSigning
-		case rail == "stripe" && key == "webhook_signing_secret_thin":
-			name = SecretStripeWebhookSigningThin
-		case rail == "stripe" && key == "webhook_signing_secret_previous":
-			name = SecretStripeWebhookSigningPrevious
-		case rail == "nmi" && key == "tokenization_url":
-			name = SecretNMITokenizationURL
-		}
+	if !scoped {
+		return nil
 	}
-	switch name {
-	case SecretStripeSecretKey:
-		if !strings.HasPrefix(value, "sk_") {
-			return errors.New("invalid_format")
-		}
-	case SecretStripeWebhookSigning, SecretStripeWebhookSigningThin, SecretStripeWebhookSigningPrevious:
-		if !strings.HasPrefix(value, "whsec_") {
-			return errors.New("invalid_format")
-		}
-	case SecretNMITokenizationURL:
-		u, err := url.Parse(value)
-		if err != nil || u.Scheme != "https" || u.Host == "" {
-			return errors.New("invalid_format")
+	if rail == "stripe" {
+		switch key {
+		case "secret_key":
+			if !strings.HasPrefix(value, "sk_") {
+				return errors.New("invalid_format")
+			}
+		case "webhook_signing_secret", "webhook_signing_secret_thin", "webhook_signing_secret_previous":
+			if !strings.HasPrefix(value, "whsec_") {
+				return errors.New("invalid_format")
+			}
 		}
 	}
 	return nil

--- a/internal/merchants/secrets_test.go
+++ b/internal/merchants/secrets_test.go
@@ -20,10 +20,10 @@ func TestMemSecretStore_RoundTripPerMerchant(t *testing.T) {
 	}
 
 	// Put for merchant A, then Get round-trips.
-	if _, err := store.Put(ctx, a, SecretStripeSecretKey, "sk_a"); err != nil {
+	if _, err := store.Put(ctx, a, "psps/stripe/live/acct_884_test/secret_key", "sk_a"); err != nil {
 		t.Fatalf("put A: %v", err)
 	}
-	got, err := store.Get(ctx, a, SecretStripeSecretKey)
+	got, err := store.Get(ctx, a, "psps/stripe/live/acct_884_test/secret_key")
 	if err != nil {
 		t.Fatalf("get A: %v", err)
 	}
@@ -32,16 +32,16 @@ func TestMemSecretStore_RoundTripPerMerchant(t *testing.T) {
 	}
 
 	// Merchant B does NOT see merchant A's secret (namespacing).
-	if _, err := store.Get(ctx, b, SecretStripeSecretKey); !errors.Is(err, ErrSecretNotFound) {
+	if _, err := store.Get(ctx, b, "psps/stripe/live/acct_884_test/secret_key"); !errors.Is(err, ErrSecretNotFound) {
 		t.Fatalf("get B before put = %v, want ErrSecretNotFound", err)
 	}
 
 	// Put for merchant B with a DIFFERENT value; A's value is unchanged.
-	if _, err := store.Put(ctx, b, SecretStripeSecretKey, "sk_b"); err != nil {
+	if _, err := store.Put(ctx, b, "psps/stripe/live/acct_884_test/secret_key", "sk_b"); err != nil {
 		t.Fatalf("put B: %v", err)
 	}
-	gotA, _ := store.Get(ctx, a, SecretStripeSecretKey)
-	gotB, _ := store.Get(ctx, b, SecretStripeSecretKey)
+	gotA, _ := store.Get(ctx, a, "psps/stripe/live/acct_884_test/secret_key")
+	gotB, _ := store.Get(ctx, b, "psps/stripe/live/acct_884_test/secret_key")
 	if gotA.Value != "sk_a" || gotB.Value != "sk_b" {
 		t.Fatalf("cross-merchant leak: A=%q B=%q", gotA.Value, gotB.Value)
 	}
@@ -52,17 +52,17 @@ func TestMemSecretStore_RotationVersioning(t *testing.T) {
 	store := NewMemorySecretStore()
 	id := dbtest.TestMerchantID
 
-	v1, _ := store.Put(ctx, id, SecretStripeWebhookSigning, "whsec_1")
+	v1, _ := store.Put(ctx, id, "psps/stripe/live/acct_884_test/webhook_signing_secret", "whsec_1")
 	if v1.Version != 1 {
 		t.Fatalf("first put version = %d, want 1", v1.Version)
 	}
 	// Same value = idempotent no-op rotation (version unchanged).
-	v1again, _ := store.Put(ctx, id, SecretStripeWebhookSigning, "whsec_1")
+	v1again, _ := store.Put(ctx, id, "psps/stripe/live/acct_884_test/webhook_signing_secret", "whsec_1")
 	if v1again.Version != 1 {
 		t.Fatalf("idempotent put version = %d, want 1", v1again.Version)
 	}
 	// New value bumps version.
-	v2, _ := store.Put(ctx, id, SecretStripeWebhookSigning, "whsec_2")
+	v2, _ := store.Put(ctx, id, "psps/stripe/live/acct_884_test/webhook_signing_secret", "whsec_2")
 	if v2.Version != 2 {
 		t.Fatalf("rotated put version = %d, want 2", v2.Version)
 	}
@@ -73,8 +73,8 @@ func TestMemSecretStore_DeleteAndList(t *testing.T) {
 	store := NewMemorySecretStore()
 	id := dbtest.TestMerchantID
 
-	_, _ = store.Put(ctx, id, SecretStripeSecretKey, "sk")
-	_, _ = store.Put(ctx, id, SecretStripeWebhookSigning, "wh")
+	_, _ = store.Put(ctx, id, "psps/stripe/live/acct_884_test/secret_key", "sk")
+	_, _ = store.Put(ctx, id, "psps/stripe/live/acct_884_test/webhook_signing_secret", "wh")
 
 	names, err := store.List(ctx, id)
 	if err != nil {
@@ -85,13 +85,13 @@ func TestMemSecretStore_DeleteAndList(t *testing.T) {
 	}
 
 	// Delete is idempotent.
-	if err := store.Delete(ctx, id, SecretStripeSecretKey); err != nil {
+	if err := store.Delete(ctx, id, "psps/stripe/live/acct_884_test/secret_key"); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
-	if err := store.Delete(ctx, id, SecretStripeSecretKey); err != nil {
+	if err := store.Delete(ctx, id, "psps/stripe/live/acct_884_test/secret_key"); err != nil {
 		t.Fatalf("delete (idempotent): %v", err)
 	}
-	if _, err := store.Get(ctx, id, SecretStripeSecretKey); !errors.Is(err, ErrSecretNotFound) {
+	if _, err := store.Get(ctx, id, "psps/stripe/live/acct_884_test/secret_key"); !errors.Is(err, ErrSecretNotFound) {
 		t.Fatalf("get after delete = %v, want ErrSecretNotFound", err)
 	}
 }
@@ -99,10 +99,10 @@ func TestMemSecretStore_DeleteAndList(t *testing.T) {
 func TestMemSecretStore_ZeroMerchantRejected(t *testing.T) {
 	ctx := context.Background()
 	store := NewMemorySecretStore()
-	if _, err := store.Get(ctx, merchant.ID{}, SecretStripeSecretKey); err == nil {
+	if _, err := store.Get(ctx, merchant.ID{}, "psps/stripe/live/acct_884_test/secret_key"); err == nil {
 		t.Fatal("get with zero merchant should error")
 	}
-	if _, err := store.Put(ctx, merchant.ID{}, SecretStripeSecretKey, "x"); err == nil {
+	if _, err := store.Put(ctx, merchant.ID{}, "psps/stripe/live/acct_884_test/secret_key", "x"); err == nil {
 		t.Fatal("put with zero merchant should error")
 	}
 }
@@ -113,7 +113,7 @@ func TestServiceCredentialManagement_WriteOnlyStatusAndDelete(t *testing.T) {
 	store := NewMemorySecretStore()
 	svc := &Service{secrets: store}
 
-	sec, err := svc.PutCredential(ctx, id, SecretStripeWebhookSigning, "whsec_123")
+	sec, err := svc.PutCredential(ctx, id, "psps/stripe/live/acct_884_test/webhook_signing_secret", "whsec_123")
 	if err != nil {
 		t.Fatalf("put credential: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestServiceCredentialManagement_WriteOnlyStatusAndDelete(t *testing.T) {
 	}
 	found := false
 	for _, st := range statuses {
-		if st.Name != SecretStripeWebhookSigning {
+		if st.Name != "psps/stripe/live/acct_884_test/webhook_signing_secret" {
 			continue
 		}
 		found = true
@@ -136,13 +136,13 @@ func TestServiceCredentialManagement_WriteOnlyStatusAndDelete(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Fatalf("status for %s not found", SecretStripeWebhookSigning)
+		t.Fatalf("status for %s not found", "psps/stripe/live/acct_884_test/webhook_signing_secret")
 	}
 
-	if err := svc.DeleteCredential(ctx, id, SecretStripeWebhookSigning); err != nil {
+	if err := svc.DeleteCredential(ctx, id, "psps/stripe/live/acct_884_test/webhook_signing_secret"); err != nil {
 		t.Fatalf("delete credential: %v", err)
 	}
-	if _, err := store.Get(ctx, id, SecretStripeWebhookSigning); !errors.Is(err, ErrSecretNotFound) {
+	if _, err := store.Get(ctx, id, "psps/stripe/live/acct_884_test/webhook_signing_secret"); !errors.Is(err, ErrSecretNotFound) {
 		t.Fatalf("get after delete = %v, want ErrSecretNotFound", err)
 	}
 }
@@ -154,7 +154,7 @@ func TestServiceCredentialManagement_ValidateOnlyDoesNotSave(t *testing.T) {
 	svc := &Service{secrets: store}
 
 	called := false
-	err := svc.ValidateCredential(ctx, id, SecretStripeSecretKey, "sk_test_123", func(context.Context, string) error {
+	err := svc.ValidateCredential(ctx, id, "psps/stripe/live/acct_884_test/secret_key", "sk_test_123", func(context.Context, string) error {
 		called = true
 		return nil
 	})
@@ -164,7 +164,7 @@ func TestServiceCredentialManagement_ValidateOnlyDoesNotSave(t *testing.T) {
 	if !called {
 		t.Fatal("stripe tester was not called")
 	}
-	if _, err := store.Get(ctx, id, SecretStripeSecretKey); !errors.Is(err, ErrSecretNotFound) {
+	if _, err := store.Get(ctx, id, "psps/stripe/live/acct_884_test/secret_key"); !errors.Is(err, ErrSecretNotFound) {
 		t.Fatalf("validate-only saved secret: %v", err)
 	}
 }
@@ -176,11 +176,29 @@ func TestServiceCredentialManagement_RejectsUnknownAndInvalidSecrets(t *testing.
 	if _, err := svc.PutCredential(ctx, dbtest.TestMerchantID, "unknown/provider_key", "secret"); err == nil {
 		t.Fatal("unknown secret should be rejected")
 	}
-	if _, err := svc.PutCredential(ctx, dbtest.TestMerchantID, SecretStripeSecretKey, "not-stripe"); err == nil {
+	if _, err := svc.PutCredential(ctx, dbtest.TestMerchantID, "psps/stripe/live/acct_884_test/secret_key", "not-stripe"); err == nil {
 		t.Fatal("invalid Stripe secret should be rejected")
 	}
-	if _, err := svc.PutCredential(ctx, dbtest.TestMerchantID, SecretNMITokenizationURL, "http://example.test/Collect.js"); err == nil {
-		t.Fatal("invalid NMI tokenization URL should be rejected")
+	// #884: the retired flat names are not a second spelling of a credential —
+	// a write to one is refused like any unknown name.
+	for _, retired := range []string{
+		"stripe/secret_key",
+		"stripe/webhook_signing_secret",
+		"stripe/webhook_signing_secret_thin",
+		"stripe/webhook_signing_secret_previous",
+		"nmi/mobius/security_key",
+		"nmi/mobius/tokenization_url",
+		"nmi/mobius/webhook_signing_secret",
+	} {
+		if _, err := svc.PutCredential(ctx, dbtest.TestMerchantID, retired, "whatever"); err == nil {
+			t.Fatalf("retired flat secret name %q must be rejected", retired)
+		}
+		if SecretWritable(retired) {
+			t.Fatalf("retired flat secret name %q must not be writable", retired)
+		}
+		if err := svc.DeleteCredential(ctx, dbtest.TestMerchantID, retired); err == nil {
+			t.Fatalf("retired flat secret name %q must not be deletable", retired)
+		}
 	}
 }
 
@@ -248,10 +266,10 @@ func TestVaultSecretStore_StubFailsClosed(t *testing.T) {
 	ctx := context.Background()
 	store := NewVaultSecretStore("secret", nil, staticMerchantSlugResolver{dbtest.TestMerchantID.String(): dbtest.TestMerchantSlug}) // no live client
 	id := dbtest.TestMerchantID
-	if _, err := store.Get(ctx, id, SecretStripeSecretKey); !errors.Is(err, ErrVaultNotConfigured) {
+	if _, err := store.Get(ctx, id, "psps/stripe/live/acct_884_test/secret_key"); !errors.Is(err, ErrVaultNotConfigured) {
 		t.Fatalf("stub Get = %v, want ErrVaultNotConfigured", err)
 	}
-	if _, err := store.Put(ctx, id, SecretStripeSecretKey, "x"); !errors.Is(err, ErrVaultNotConfigured) {
+	if _, err := store.Put(ctx, id, "psps/stripe/live/acct_884_test/secret_key", "x"); !errors.Is(err, ErrVaultNotConfigured) {
 		t.Fatalf("stub Put = %v, want ErrVaultNotConfigured", err)
 	}
 }
@@ -262,10 +280,10 @@ func TestVaultSecretStore_RoundTripWithFakeClient(t *testing.T) {
 	store := NewVaultSecretStore("secret", fake, staticMerchantSlugResolver{dbtest.TestMerchantID.String(): "cozy-art"})
 	id := dbtest.TestMerchantID
 
-	if _, err := store.Put(ctx, id, SecretStripeSecretKey, "sk_live"); err != nil {
+	if _, err := store.Put(ctx, id, "psps/stripe/live/acct_884_test/secret_key", "sk_live"); err != nil {
 		t.Fatalf("put: %v", err)
 	}
-	got, err := store.Get(ctx, id, SecretStripeSecretKey)
+	got, err := store.Get(ctx, id, "psps/stripe/live/acct_884_test/secret_key")
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
@@ -277,7 +295,7 @@ func TestVaultSecretStore_RoundTripWithFakeClient(t *testing.T) {
 		t.Fatalf("expected one vault path, got %d", len(fake.data))
 	}
 	for p := range fake.data {
-		if want := "secret/openrails/merchants/cozy-art/" + SecretStripeSecretKey; p != want {
+		if want := "secret/openrails/merchants/cozy-art/" + "psps/stripe/live/acct_884_test/secret_key"; p != want {
 			t.Fatalf("vault path = %q, want %q", p, want)
 		}
 	}

--- a/internal/merchants/secrets_write_restricted_test.go
+++ b/internal/merchants/secrets_write_restricted_test.go
@@ -66,10 +66,10 @@ func TestWriteRestrictedSecretStoreAllowsOtherSecrets(t *testing.T) {
 	})
 
 	const value = "sk_test_123"
-	if _, err := store.Put(context.Background(), dbtest.TestMerchantID, SecretStripeSecretKey, value); err != nil {
+	if _, err := store.Put(context.Background(), dbtest.TestMerchantID, "psps/stripe/live/acct_884_test/secret_key", value); err != nil {
 		t.Fatalf("put unrestricted secret: %v", err)
 	}
-	got, err := store.Get(context.Background(), dbtest.TestMerchantID, SecretStripeSecretKey)
+	got, err := store.Get(context.Background(), dbtest.TestMerchantID, "psps/stripe/live/acct_884_test/secret_key")
 	if err != nil {
 		t.Fatalf("get unrestricted secret: %v", err)
 	}

--- a/internal/merchantsecrets/store_integration_test.go
+++ b/internal/merchantsecrets/store_integration_test.go
@@ -118,17 +118,17 @@ func TestBuild_ProdDBStoreWithKey_RoundTripsEncrypted(t *testing.T) {
 
 	mid, _ := registerMerchant(t, ctx, pool, "dbrt") // merchant_deks FK needs a real merchant
 	const plaintext = "sk_live_667_roundtrip"
-	_, err = store.Secrets.Put(ctx, mid, merchants.SecretStripeSecretKey, plaintext)
+	_, err = store.Secrets.Put(ctx, mid, "psps/stripe/live/acct_884_test/secret_key", plaintext)
 	require.NoError(t, err)
 
-	got, err := store.Secrets.Get(ctx, mid, merchants.SecretStripeSecretKey)
+	got, err := store.Secrets.Get(ctx, mid, "psps/stripe/live/acct_884_test/secret_key")
 	require.NoError(t, err)
 	require.Equal(t, plaintext, got.Value)
 
 	var raw string
 	require.NoError(t, dbtest.SharedMerchantPool(t, mid.UUID()).QueryRow(ctx,
 		`SELECT value FROM openrails.merchant_secrets WHERE merchant_id=$1::uuid AND name=$2`,
-		mid.String(), merchants.SecretStripeSecretKey).Scan(&raw))
+		mid.String(), "psps/stripe/live/acct_884_test/secret_key").Scan(&raw))
 	require.NotEqual(t, plaintext, raw, "DB row must hold ciphertext, not plaintext")
 	require.NotContains(t, raw, plaintext)
 }
@@ -161,6 +161,6 @@ func TestBuild_DevDBStoreNoMasterKey_RefusesSolanaPrivateKey(t *testing.T) {
 
 	// The refusal is targeted, not a blanket plaintext ban: dev still stores
 	// ordinary credentials.
-	_, err = store.Secrets.Put(ctx, mid, merchants.SecretStripeSecretKey, "sk_test_sec20")
+	_, err = store.Secrets.Put(ctx, mid, "psps/stripe/live/acct_884_test/secret_key", "sk_test_sec20")
 	require.NoError(t, err)
 }

--- a/internal/merchantsecrets/vault_scenarios_integration_test.go
+++ b/internal/merchantsecrets/vault_scenarios_integration_test.go
@@ -182,7 +182,7 @@ func TestVaultFullStack_PaymentProviderConfigRotationAndIsolation(t *testing.T) 
 	// PUT /v1/merchant/payment-providers equivalent (service level; the HTTP
 	// handler delegates here): declares the account and stores credentials.
 	cfgA, err := svc.UpsertPaymentProviderConfig(ctx, midA, "nmi", merchants.UpsertPaymentProviderConfigRequest{
-		AccountID:   acctA,
+		AccountID: acctA,
 		Credentials: map[string]string{
 			"security_key":           "sk-full-A-1",
 			"webhook_signing_secret": "wh-full-A-1",
@@ -295,9 +295,9 @@ func TestVaultCapabilityGating_RealPolicies(t *testing.T) {
 
 		// Secrets round-trip through Postgres, not Vault.
 		mid, _ := registerMerchant(t, ctx, pool, "vcg-db") // merchant_deks FK needs a real merchant
-		_, err = store.Secrets.Put(ctx, mid, merchants.SecretNMISecurityKey, "db-backed")
+		_, err = store.Secrets.Put(ctx, mid, "psps/nmi/live/100884/security_key", "db-backed")
 		require.NoError(t, err)
-		got, err := store.Secrets.Get(ctx, mid, merchants.SecretNMISecurityKey)
+		got, err := store.Secrets.Get(ctx, mid, "psps/nmi/live/100884/security_key")
 		require.NoError(t, err)
 		require.Equal(t, "db-backed", got.Value)
 	})

--- a/internal/merchantsecrets/vault_scenarios_integration_test.go
+++ b/internal/merchantsecrets/vault_scenarios_integration_test.go
@@ -182,7 +182,6 @@ func TestVaultFullStack_PaymentProviderConfigRotationAndIsolation(t *testing.T) 
 	// PUT /v1/merchant/payment-providers equivalent (service level; the HTTP
 	// handler delegates here): declares the account and stores credentials.
 	cfgA, err := svc.UpsertPaymentProviderConfig(ctx, midA, "nmi", merchants.UpsertPaymentProviderConfigRequest{
-		Environment: "live",
 		AccountID:   acctA,
 		Credentials: map[string]string{
 			"security_key":           "sk-full-A-1",
@@ -211,7 +210,6 @@ func TestVaultFullStack_PaymentProviderConfigRotationAndIsolation(t *testing.T) 
 
 	// Second merchant configured independently.
 	_, err = svc.UpsertPaymentProviderConfig(ctx, midB, "nmi", merchants.UpsertPaymentProviderConfigRequest{
-		Environment: "live",
 		AccountID:   acctB,
 		Credentials: map[string]string{"security_key": "sk-full-B-1"},
 	})
@@ -219,7 +217,6 @@ func TestVaultFullStack_PaymentProviderConfigRotationAndIsolation(t *testing.T) 
 
 	// Rotate A via a second PUT: new value live immediately, KV version bumps.
 	_, err = svc.UpsertPaymentProviderConfig(ctx, midA, "nmi", merchants.UpsertPaymentProviderConfigRequest{
-		Environment: "live",
 		AccountID:   acctA,
 		Credentials: map[string]string{"security_key": "sk-full-A-2"},
 	})

--- a/internal/modules/money/merchant_collection_wiring.go
+++ b/internal/modules/money/merchant_collection_wiring.go
@@ -231,10 +231,9 @@ func (b *MerchantCollectionAdapterBuilder) stripeAdapter(ctx context.Context, sv
 		// from the scope this adapter was armed for.
 		Rails: railresolve.FixedSet{
 			string(models.RailStripe): {
-				Rail:        models.RailStripe,
-				AccountID:   scope.AccountID,
-				Environment: scope.Environment,
-				Stripe:      &config.StripeRailConfig{SecretKey: secretKey},
+				Rail:      models.RailStripe,
+				AccountID: scope.AccountID,
+				Stripe:    &config.StripeRailConfig{SecretKey: secretKey},
 			},
 		},
 	}

--- a/internal/railresolve/railresolve.go
+++ b/internal/railresolve/railresolve.go
@@ -161,10 +161,9 @@ func (s *MerchantsSource) RailConfig(ctx context.Context, rail, accountID string
 		return nil, fmt.Errorf("rail %s account %q: %w", rail, accountID, ErrRailNotArmed)
 	}
 	out := &config.PSPConfig{
-		Key:         scope.Key,
-		Rail:        models.Rail(scope.Rail),
-		AccountID:   scope.AccountID,
-		Environment: scope.Environment,
+		Key:       scope.Key,
+		Rail:      models.Rail(scope.Rail),
+		AccountID: scope.AccountID,
 	}
 	switch models.Rail(scope.Rail) {
 	case models.RailStripe:

--- a/internal/reconcile/merchant_wiring_integration_test.go
+++ b/internal/reconcile/merchant_wiring_integration_test.go
@@ -61,7 +61,6 @@ func TestMerchantFetcherBuilder_StoreArmsDeclaredAccount(t *testing.T) {
 
 	storeKey := "store-key-" + sfx
 	_, err := svc.UpsertPaymentProviderConfig(context.Background(), mid, "nmi", merchants.UpsertPaymentProviderConfigRequest{
-		Environment: "live",
 		AccountID:   "8811" + sfx,
 		Credentials: map[string]string{"security_key": storeKey},
 	})
@@ -108,7 +107,6 @@ func TestMerchantFetcherBuilder_DeclaredAccountNeverFallsBackAcrossPlanes(t *tes
 
 	// Account row declared, but the security_key secret was never seeded.
 	_, err := svc.UpsertPaymentProviderConfig(context.Background(), mid, "nmi", merchants.UpsertPaymentProviderConfigRequest{
-		Environment: "live",
 		AccountID:   "8833" + sfx,
 	})
 	require.NoError(t, err)

--- a/internal/reconcile/merchant_wiring_integration_test.go
+++ b/internal/reconcile/merchant_wiring_integration_test.go
@@ -107,7 +107,7 @@ func TestMerchantFetcherBuilder_DeclaredAccountNeverFallsBackAcrossPlanes(t *tes
 
 	// Account row declared, but the security_key secret was never seeded.
 	_, err := svc.UpsertPaymentProviderConfig(context.Background(), mid, "nmi", merchants.UpsertPaymentProviderConfigRequest{
-		AccountID:   "8833" + sfx,
+		AccountID: "8833" + sfx,
 	})
 	require.NoError(t, err)
 

--- a/internal/river/jobs_provider_refresh_pull_integration_test.go
+++ b/internal/river/jobs_provider_refresh_pull_integration_test.go
@@ -193,7 +193,6 @@ func seedLocalCCBillSub(t *testing.T, dbi *db.DB, mid merchant.ID, railSubID str
 func seedProviderAccount(t *testing.T, svc *merchants.Service, mid merchant.ID, rail, accountID string, credentials map[string]string) {
 	t.Helper()
 	_, err := svc.UpsertPaymentProviderConfig(context.Background(), mid, rail, merchants.UpsertPaymentProviderConfigRequest{
-		Environment: "live",
 		AccountID:   accountID,
 		Credentials: credentials,
 	})

--- a/pkg/embedded/controlplane/payment_provider_integration_test.go
+++ b/pkg/embedded/controlplane/payment_provider_integration_test.go
@@ -28,8 +28,7 @@ func TestUpsertPaymentProviderConfig(t *testing.T) {
 
 	const signingSecret = "whsec_integration_test"
 	provider, err := embcp.UpsertPaymentProviderConfig(ctx, e.App(), provisioned.MerchantID, "stripe", embcp.UpsertPaymentProviderConfigRequest{
-		Environment: "test",
-		AccountID:   "acct_" + suffix,
+		AccountID: "acct_" + suffix,
 		PublicConfig: map[string]string{
 			"publishable_key": "pk_test_" + suffix,
 		},

--- a/web/admin/src/lib/api/endpoints.ts
+++ b/web/admin/src/lib/api/endpoints.ts
@@ -317,8 +317,8 @@ export const listPaymentProviders = () =>
     provider_definitions: PaymentProviderDefinition[]
   }>("/merchant/payment-providers")
 
+// #882: no `environment` — it is derived from the deployment's test_mode.
 export interface UpsertProviderRequest {
-  environment?: string
   account_id: string
   public_config?: Record<string, string>
   credentials?: Record<string, string>

--- a/web/admin/src/pages/settings/index.tsx
+++ b/web/admin/src/pages/settings/index.tsx
@@ -326,7 +326,6 @@ function ProviderDialog({
   const [open, setOpen] = React.useState(false)
   const [rail, setRail] = React.useState("")
   const [accountID, setAccountID] = React.useState("")
-  const [environment, setEnvironment] = React.useState("")
   const [credentials, setCredentials] = React.useState<Record<string, string>>(
     {}
   )
@@ -344,8 +343,9 @@ function ProviderDialog({
           <DialogTitle>Configure payment provider</DialogTitle>
           <DialogDescription>
             account_id is operator-declared per rail (NMI gateway id, Stripe
-            acct_…, CCBill clientAccnum-clientSubacc, Solana wallet).
-            Credentials are stored in the secret backend.
+            acct_…, CCBill clientAccnum-clientSubacc, Solana wallet). The
+            environment follows the deployment's test_mode. Credentials are
+            stored in the secret backend.
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-3">
@@ -369,9 +369,6 @@ function ProviderDialog({
           </Field>
           <Field label="Account id" id="pv-acct">
             <Input id="pv-acct" value={accountID} onChange={(e) => setAccountID(e.target.value)} />
-          </Field>
-          <Field label="Environment (live | test, empty = deployment default)" id="pv-env">
-            <Input id="pv-env" value={environment} onChange={(e) => setEnvironment(e.target.value)} />
           </Field>
           {selectedProvider?.credential_keys.map((name) => (
             <Field key={name} label={name} id={`pv-credential-${name}`}>
@@ -401,7 +398,6 @@ function ProviderDialog({
               try {
                 await putPaymentProvider(rail, {
                   account_id: accountID.trim(),
-                  ...(environment ? { environment } : {}),
                   ...(Object.keys(creds).length ? { credentials: creds } : {}),
                 })
                 setCredentials({})


### PR DESCRIPTION
Two merchant-config-surface deletions. Doctrine: a field a merchant can set is a field they can get wrong — delete the knob rather than validate it. Prelaunch hard cuts, no aliases, retired keys fail loudly.

**Rebased onto `dev` after the chaos wave (#215) and #212 merged.** Conflicts resolved so that my deletions win for the surfaces they remove, and chaos's or#879 custody shape / or#812 validation stand untouched around them. Details at the bottom.

## or#882 — per-PSP `environment: test|live` is deleted

The field could only ever agree or refuse to boot. `EffectiveEnvironment` returned the declared value, else `ExpectedProviderEnvironment(test_mode)`; `ValidateRailSet` then rejected any declared value that differed ("a deployment is all-test or all-live; never mix"). The only legal value was the derivable one, so the field carried no information.

It also checked config against config. It could never notice that a key labelled `live` is actually a sandbox key. The checks that ask the *credential* — the NMI live-gateway probe and the Stripe live-key boot refusal — are untouched and are what actually keep a sandbox posture honest.

**Every declaration surface dies:**
- **Mode 1** — `merchants.<slug>.psps.<key>.<rail>.environment` fails loudly at manifest load with a removal error, following the `allowed_cidrs` / `providers`→`psps` precedent. **Even an agreeing value is refused**: tolerating it keeps the knob alive and keeps teaching it.
- **Mode 2** — `UpsertPaymentProviderConfigRequest.Environment` is out of the contract. The field stays *bound* only so a caller still sending it gets a 400 with the removal error instead of silent truncation; the server derives from `s.providerEnvironment`.
- **Admin console** — the Environment input is gone (the response still shows the derived value).

**What is untouched:** the DERIVED environment. It remains the `psps` natural key and the `psps/<rail>/<env>/<account_id>/<key>` secret-path segment, fed everywhere by `ExpectedProviderEnvironment(test_mode)`. No migration — `psps.environment` keeps its column.

Two follow-ons that mattered:
- `merchant_dump.go` stopped emitting `environment:`, or a dump → apply round-trip would have walked straight into the removal error (the same blocker or#883 flagged for `expiry_hours`).
- Three test surfaces sent `environment` as **raw JSON** in the PUT body, which a struct-field sweep can't see. They now get the 400 the removal is meant to produce, and the standalone HTTP test proves the whole round trip: request declares nothing → response carries the derived value → every later read filters on *that* value → re-sending the field, even agreeing, is refused.

The shipped example manifest declared `environment:` on all 8 PSPs — including a `live` and a `test` account side by side, a mix `ValidateRailSet` would have refused had the manifest path ever run it. Deleting the axis closes that hole rather than plugging it.

## or#884 (part 1) — the seven flat merchant-secret names are deleted

**The write-only claim, verified — and stronger than "no caller happens to hit it".** `internal/merchants/credentials.go` read the flat names only on the `s.pool == nil` branch. `merchants.NewService` **refuses a nil pool** (`"merchants: pgx pool is required"`, `lifecycle.go:79`). The only constructor that can produce `pool == nil` is `NewSecretManagementService`, and its **single caller in the entire tree is a test** (`payment_provider_config_test.go:130`). Every production construction — `internal/app/merchants_wiring.go`, `internal/http/server.go`, `internal/bootstrap/merchant_manifest.go`, `pkg/embedded/pull_provider.go` (×2), `embed/provision.go` — goes through `NewService`/`NewDirectoryService`, both of which hard-refuse nil. The branch was unreachable in production **by construction**, not by convention.

Deleted: the 7 constants, `merchantSecretRegistry`, `SecretDefinitionFor`, the 3 `pool == nil` fallbacks, and `TestStripeCredential` (its only reason to exist was reaching the flat Stripe name; it had zero callers).

`ListSecretStatuses` is rebuilt on what is actually read: one status per PSP-scoped secret the merchant holds, described from the rail credential registry, sorted for stability. It no longer advertises seven slots nobody resolves. **Blast radius is zero** — no HTTP route serves it; `payment_provider_config.go` uses it purely as a configured-name lookup set keyed by scoped names, so the merchant-facing `/v1/merchant/payment-providers` view is unchanged. Chaos's new custody credential (`custodian_api_key`) is a PSP-scoped slot resolved through `requireSecret`, so it rides the same scoped path with nothing to adapt.

Format validation now keys off the parsed `(rail, key)` instead of remapping a scoped name back onto a flat one. That drops the unreachable `nmi/tokenization_url` case: `tokenization_url` is not a registered NMI credential key, so `ParsePSPSecretName` errors before reaching it — the live Collect.js override is the psps *setting*, not a secret.

Writing, deleting, or validating any retired name now fails loudly as an unknown secret.

## or#884 (part 2) — moot, deliberately skipped

The `vaulted_card.settings.nt_charges` knob was **already handled by or#879/#880**, now merged: `config/vaultedcard_settings.go` is gone and its successor `config/custodian_settings.go:49` lists `nt_charges` in the retired-keys map with a removal error. Building it here would have targeted a shape that no longer exists. Nothing in this PR touches custody.

## Tests and gates

New: manifest with a declared `environment` fails loudly (incl. the agreeing case); the API upsert refuses a declared `environment` and persists nothing; the derived environment lands correctly on the psps row **and** in the scoped secret name in both `test` and `live` postures; the HTTP surface returns 400 with the removal error; every retired flat secret name is refused for write/delete/writable-check.

- **Unit**: full suite green.
- **Integration** (dedicated Postgres + Redis, `-p 1`): full sweep of `./internal/... ./pkg/... ./embed/... ./cmd/...` green.
- **golangci-lint** v2.6.0 `--timeout=15m`: 0 issues. **sql-lint**: clean (40 reviewed exemptions). **migration-lint**: clean (24 files). **gofmt**: clean.
- **Admin console**: `eslint` 0 errors (1 pre-existing warning in an untouched file), `tsc --noEmit` clean. `pnpm install` itself fails on this box for a pre-existing lockfile supply-chain policy hit (`semver@6.3.1`), unrelated to this PR — I did not touch the lockfile.
- `go vet -tags console_assets` fails identically on `origin/dev` (needs `scripts/build-admin-console.sh` to produce `dist/` first, which CI does).

Every failure I saw during this work was either fixed here or confirmed identical on an `origin/dev` baseline worktree before being set aside. One embed failure and one cmd fixture in the merged waves *were* mine (surfaces still declaring `environment`); both are fixed.

## Rebase resolution

Two conflicts, both in surfaces chaos also reworked:
- `config/merchants_config.example.yaml` — kept chaos's or#879 `mobius-bt` custody PSP (custody as a modifier on the nmi rail, not a rail of its own), minus its `environment: test` line.
- `internal/bootstrap/merchant_manifest_test.go` — kept chaos's or#879 custody assertions, re-keyed onto the name-only `byName` map that replaced the `{name, env}` composite key.

`internal/merchants/secrets.go` and `secrets_status.go` were untouched by chaos, so the or#884 half rebased clean.