### PR TITLE
feat(admin): improve settings and navigation UI

### DIFF
--- a/web/admin/pnpm-lock.yaml
+++ b/web/admin/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion@5.0.7: 5.0.9
+  fast-uri@3.1.3: 3.1.5
+  ip-address@10.2.0: 10.3.1
+  undici@7.28.0: 7.29.0
+
 importers:
 
   .:
@@ -55,7 +61,7 @@ importers:
         version: 3.9.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@16.13.1)(react@19.2.7)(redux@5.0.1)
       shadcn:
         specifier: ^4.13.0
-        version: 4.13.0(typescript@6.0.3)
+        version: 4.16.1(typescript@6.0.3)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -71,7 +77,7 @@ importers:
     devDependencies:
       '@eslint/js':
         specifier: ^10
-        version: 10.0.1(eslint@10.6.0(jiti@2.7.0))
+        version: 10.0.1(eslint@10.8.0(jiti@2.7.0))
       '@types/node':
         specifier: ^24
         version: 24.13.2
@@ -86,13 +92,13 @@ importers:
         version: 6.0.3(vite@8.1.3(@types/node@24.13.2)(jiti@2.7.0))
       eslint:
         specifier: ^10
-        version: 10.6.0(jiti@2.7.0)
+        version: 10.8.0(jiti@2.7.0)
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
-        version: 7.1.1(eslint@10.6.0(jiti@2.7.0))
+        version: 7.1.1(eslint@10.8.0(jiti@2.7.0))
       eslint-plugin-react-refresh:
         specifier: ^0.5.2
-        version: 0.5.3(eslint@10.6.0(jiti@2.7.0))
+        version: 0.5.3(eslint@10.8.0(jiti@2.7.0))
       globals:
         specifier: ^17
         version: 17.7.0
@@ -107,7 +113,7 @@ importers:
         version: 6.0.3
       typescript-eslint:
         specifier: ^8
-        version: 8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
+        version: 8.62.1(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
       vite:
         specifier: ^8
         version: 8.1.3(@types/node@24.13.2)(jiti@2.7.0)
@@ -304,8 +310,8 @@ packages:
     resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/config-helpers@0.6.0':
-    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+  '@eslint/config-helpers@0.7.0':
+    resolution: {integrity: sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/core@1.2.1':
@@ -858,9 +864,9 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1172,8 +1178,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.6.0:
-    resolution: {integrity: sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==}
+  eslint@10.8.0:
+    resolution: {integrity: sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -1256,8 +1262,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1432,8 +1438,8 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.3.1:
+    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -2154,8 +2160,8 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  shadcn@4.13.0:
-    resolution: {integrity: sha512-5fuJ4jI/GcPeA/iTL4cJivCZuYQGXz/N3bIzyd+Gd/FM6xUCy2MxGG+LaDQuw2cjNy9zGPSFPTEmI048UwPTZA==}
+  shadcn@4.16.1:
+    resolution: {integrity: sha512-XLFzfNNIUPlUlyheFEzj0H4Vnhi9nI0nl3Nfgg8HYXW1FkUVhVT1X+mgmOUW8aWL5SeG0A+yJIV5fm3Hr9MVkQ==}
     engines: {node: '>=20.18.1'}
     hasBin: true
 
@@ -2316,8 +2322,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.3.0:
@@ -2684,7 +2690,7 @@ snapshots:
       open: 8.4.2
       picomatch: 4.0.5
       systeminformation: 5.31.12
-      undici: 7.28.0
+      undici: 7.29.0
       which: 4.0.0
       yocto-spinner: 1.2.0
 
@@ -2706,9 +2712,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.6.0(jiti@2.7.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.8.0(jiti@2.7.0))':
     dependencies:
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -2721,7 +2727,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.6.0':
+  '@eslint/config-helpers@0.7.0':
     dependencies:
       '@eslint/core': 1.2.1
 
@@ -2729,9 +2735,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.6.0(jiti@2.7.0))':
+  '@eslint/js@10.0.1(eslint@10.8.0(jiti@2.7.0))':
     optionalDependencies:
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -3051,15 +3057,15 @@ snapshots:
 
   '@types/validate-npm-package-name@4.0.2': {}
 
-  '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.62.1(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.62.1
-      '@typescript-eslint/type-utils': 8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.62.1(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.62.1(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.62.1
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -3067,14 +3073,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.62.1(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.62.1
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.62.1
       debug: 4.4.3
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -3097,13 +3103,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.62.1(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.62.1(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
       debug: 4.4.3
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -3126,13 +3132,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.62.1(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.6.0(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.62.1
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -3176,7 +3182,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3212,7 +3218,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3442,20 +3448,20 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-react-hooks@7.1.1(eslint@10.6.0(jiti@2.7.0)):
+  eslint-plugin-react-hooks@7.1.1(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/parser': 7.29.7
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
       hermes-parser: 0.25.1
       zod: 4.4.3
       zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-refresh@0.5.3(eslint@10.6.0(jiti@2.7.0)):
+  eslint-plugin-react-refresh@0.5.3(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)
 
   eslint-scope@9.1.2:
     dependencies:
@@ -3468,12 +3474,12 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.6.0(jiti@2.7.0):
+  eslint@10.8.0(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.6.0(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.8.0(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
-      '@eslint/config-helpers': 0.6.0
+      '@eslint/config-helpers': 0.7.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
       '@humanfs/node': 0.16.8
@@ -3565,7 +3571,7 @@ snapshots:
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.3.1
 
   express@5.2.1:
     dependencies:
@@ -3616,7 +3622,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -3774,7 +3780,7 @@ snapshots:
 
   internmap@2.0.3: {}
 
-  ip-address@10.2.0: {}
+  ip-address@10.3.1: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -3987,7 +3993,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -4369,7 +4375,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@4.13.0(typescript@6.0.3):
+  shadcn@4.16.1(typescript@6.0.3):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/parser': 7.29.7
@@ -4399,7 +4405,7 @@ snapshots:
       tailwind-merge: 3.6.0
       ts-morph: 26.0.0
       tsconfig-paths: 4.2.0
-      undici: 7.28.0
+      undici: 7.29.0
       validate-npm-package-name: 7.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
@@ -4538,13 +4544,13 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typescript-eslint@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3):
+  typescript-eslint@8.62.1(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.62.1(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.62.1(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
-      eslint: 10.6.0(jiti@2.7.0)
+      '@typescript-eslint/utils': 8.62.1(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.8.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -4553,7 +4559,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicorn-magic@0.3.0: {}
 

--- a/web/admin/pnpm-workspace.yaml
+++ b/web/admin/pnpm-workspace.yaml
@@ -1,6 +1,12 @@
 packages:
   - '.'
 
+overrides:
+  brace-expansion@5.0.7: 5.0.9
+  fast-uri@3.1.3: 3.1.5
+  ip-address@10.2.0: 10.3.1
+  undici@7.28.0: 7.29.0
+
 pmOnFail: error
 ignoreScripts: true
 ignorePnpmfile: true

--- a/web/admin/src/components/app-sidebar.tsx
+++ b/web/admin/src/components/app-sidebar.tsx
@@ -2,22 +2,19 @@
 // (inset variant, brand header, nav, footer user menu, rail).
 import { HugeiconsIcon } from "@hugeicons/react"
 import {
-  ArrowUpDownIcon,
+  Add01Icon,
   CreditCardIcon,
   DashboardCircleIcon,
-  Logout01Icon,
-  MoonIcon,
   PackageIcon,
   RepeatIcon,
   Settings01Icon,
-  Sun01Icon,
+  Tick02Icon,
+  UnfoldMoreIcon,
   UserGroupIcon,
   Wrench01Icon,
 } from "@hugeicons/core-free-icons"
-import { Link, useLocation, useNavigate } from "react-router-dom"
+import { Link, useLocation } from "react-router-dom"
 
-import { useTheme } from "@/components/theme-provider"
-import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -30,7 +27,6 @@ import {
 import {
   Sidebar,
   SidebarContent,
-  SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
   SidebarGroupLabel,
@@ -57,26 +53,7 @@ export function AppSidebar() {
   return (
     <Sidebar variant="inset" collapsible="icon">
       <SidebarHeader>
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <SidebarMenuButton
-              size="lg"
-              render={
-                <Link to="/">
-                  <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-primary text-sm font-semibold text-primary-foreground">
-                    µ
-                  </div>
-                  <div className="grid flex-1 text-left text-sm leading-tight">
-                    <span className="truncate font-medium">OpenRails</span>
-                    <span className="truncate text-xs text-muted-foreground">
-                      Merchant console
-                    </span>
-                  </div>
-                </Link>
-              }
-            />
-          </SidebarMenuItem>
-        </SidebarMenu>
+        <MerchantSwitcher />
       </SidebarHeader>
       <SidebarContent>
         <SidebarGroup>
@@ -105,26 +82,16 @@ export function AppSidebar() {
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
-      <SidebarFooter>
-        <UserMenu />
-      </SidebarFooter>
       <SidebarRail />
     </Sidebar>
   )
 }
 
-function UserMenu() {
-  const { me, logout } = useAuth()
-  const { theme, setTheme } = useTheme()
-  const navigate = useNavigate()
-  if (!me) return null
-
-  const name = me.username || me.email || "Signed in"
-  const initials = name.slice(0, 2).toUpperCase()
-  const dark =
-    theme === "dark" ||
-    (theme === "system" &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches)
+function MerchantSwitcher() {
+  const { activeMerchant, merchants, selectMerchant } = useAuth()
+  const label = activeMerchant?.instance_slug ?? "Select merchant"
+  const role = activeMerchant?.role ?? "Merchant console"
+  const initials = activeMerchant?.instance_slug.slice(0, 2) ?? "µ"
 
   return (
     <SidebarMenu>
@@ -134,63 +101,68 @@ function UserMenu() {
             render={
               <SidebarMenuButton
                 size="lg"
+                tooltip={label}
                 className="data-open:bg-sidebar-accent"
               >
-                <Avatar className="size-8 rounded-lg">
-                  <AvatarFallback className="rounded-lg">
-                    {initials}
-                  </AvatarFallback>
-                </Avatar>
-                <div className="grid flex-1 text-left leading-tight">
-                  <span className="truncate text-sm font-medium">{name}</span>
-                  {me.email && me.username && (
-                    <span className="truncate text-xs text-muted-foreground">
-                      {me.email}
-                    </span>
-                  )}
-                </div>
+                <span className="flex aspect-square size-8 shrink-0 items-center justify-center rounded-lg bg-primary text-xs font-semibold text-primary-foreground uppercase">
+                  {initials}
+                </span>
+                <span className="grid min-w-0 flex-1 text-left leading-tight">
+                  <span className="truncate text-sm font-medium">{label}</span>
+                  <span className="truncate text-xs text-muted-foreground capitalize">
+                    {role}
+                  </span>
+                </span>
                 <HugeiconsIcon
-                  icon={ArrowUpDownIcon}
-                  className="ml-auto size-4"
+                  icon={UnfoldMoreIcon}
+                  className="ml-auto size-4 shrink-0"
                 />
               </SidebarMenuButton>
             }
           />
-          <DropdownMenuContent side="top" align="start" className="min-w-56">
+          <DropdownMenuContent side="bottom" align="start" className="min-w-60">
             <DropdownMenuGroup>
-              <DropdownMenuLabel className="font-normal">
-                <div className="grid leading-tight">
-                  <span className="text-sm font-medium">{name}</span>
-                  {me.email && (
-                    <span className="text-xs text-muted-foreground">
-                      {me.email}
-                    </span>
-                  )}
-                </div>
+              <DropdownMenuLabel className="text-xs text-muted-foreground">
+                Merchants
               </DropdownMenuLabel>
+              {merchants.map((merchant) => {
+                const active =
+                  merchant.instance_slug === activeMerchant?.instance_slug
+                return (
+                  <DropdownMenuItem
+                    key={merchant.instance_slug}
+                    onClick={() => selectMerchant(merchant.instance_slug)}
+                    className="gap-2 py-2"
+                  >
+                    <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-[10px] font-semibold uppercase">
+                      {merchant.instance_slug.slice(0, 2)}
+                    </span>
+                    <span className="grid min-w-0 flex-1 leading-tight">
+                      <span className="truncate text-sm">
+                        {merchant.instance_slug}
+                      </span>
+                      <span className="truncate text-xs text-muted-foreground capitalize">
+                        {merchant.role}
+                      </span>
+                    </span>
+                    {active && (
+                      <HugeiconsIcon
+                        icon={Tick02Icon}
+                        className="ml-auto size-4 shrink-0 text-primary"
+                      />
+                    )}
+                  </DropdownMenuItem>
+                )
+              })}
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={() => navigate("/settings")}>
-              <HugeiconsIcon icon={Settings01Icon} />
-              Settings
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => setTheme(dark ? "light" : "dark")}>
-              {dark ? (
-                <HugeiconsIcon icon={Sun01Icon} />
-              ) : (
-                <HugeiconsIcon icon={MoonIcon} />
-              )}
-              {dark ? "Light mode" : "Dark mode"}
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
             <DropdownMenuItem
-              onClick={async () => {
-                await logout()
-                navigate("/login")
+              onClick={() => {
+                window.location.href = "/account?create=merchant"
               }}
             >
-              <HugeiconsIcon icon={Logout01Icon} />
-              Sign out
+              <HugeiconsIcon icon={Add01Icon} />
+              Create merchant
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/web/admin/src/components/site-header.tsx
+++ b/web/admin/src/components/site-header.tsx
@@ -1,6 +1,15 @@
-import { Link } from "react-router-dom"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  Logout01Icon,
+  MoonIcon,
+  Settings01Icon,
+  Sun01Icon,
+} from "@hugeicons/core-free-icons"
+import { Link, useNavigate } from "react-router-dom"
 
 import { NotificationBell } from "@/components/notification-bell"
+import { useTheme } from "@/components/theme-provider"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -9,8 +18,19 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import { Separator } from "@/components/ui/separator"
 import { SidebarTrigger } from "@/components/ui/sidebar"
+import { useAuth } from "@/lib/auth"
 
 export function SiteHeader({ title }: { title: string }) {
   return (
@@ -38,7 +58,80 @@ export function SiteHeader({ title }: { title: string }) {
       </Breadcrumb>
       <div className="ml-auto flex items-center gap-2">
         <NotificationBell />
+        <UserMenu />
       </div>
     </header>
+  )
+}
+
+function UserMenu() {
+  const { me, logout } = useAuth()
+  const { theme, setTheme } = useTheme()
+  const navigate = useNavigate()
+  if (!me) return null
+
+  const name = me.username || me.email || "Signed in"
+  const initials = name.slice(0, 2).toUpperCase()
+  const dark =
+    theme === "dark" ||
+    (theme === "system" &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches)
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Account menu"
+            className="rounded-lg p-0"
+          >
+            <Avatar className="size-7 rounded-md">
+              <AvatarFallback className="rounded-md text-xs">
+                {initials}
+              </AvatarFallback>
+            </Avatar>
+          </Button>
+        }
+      />
+      <DropdownMenuContent side="bottom" align="end" className="min-w-56">
+        <DropdownMenuGroup>
+          <DropdownMenuLabel className="font-normal">
+            <div className="grid leading-tight">
+              <span className="text-sm font-medium">{name}</span>
+              {me.email && (
+                <span className="text-xs text-muted-foreground">
+                  {me.email}
+                </span>
+              )}
+            </div>
+          </DropdownMenuLabel>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={() => navigate("/settings")}>
+          <HugeiconsIcon icon={Settings01Icon} />
+          Settings
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme(dark ? "light" : "dark")}>
+          {dark ? (
+            <HugeiconsIcon icon={Sun01Icon} />
+          ) : (
+            <HugeiconsIcon icon={MoonIcon} />
+          )}
+          {dark ? "Light mode" : "Dark mode"}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onClick={async () => {
+            await logout()
+            navigate("/login")
+          }}
+        >
+          <HugeiconsIcon icon={Logout01Icon} />
+          Sign out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   )
 }

--- a/web/admin/src/index.css
+++ b/web/admin/src/index.css
@@ -128,3 +128,21 @@
     @apply font-sans;
   }
 }
+
+button:not(:disabled),
+select:not(:disabled),
+[role="button"]:not([aria-disabled="true"]),
+[data-slot="button"]:not(:disabled):not([aria-disabled="true"]):not([data-disabled]),
+[data-slot="select-trigger"]:not(:disabled):not([aria-disabled="true"]):not([data-disabled]),
+[data-slot="select-item"]:not([aria-disabled="true"]):not([data-disabled]),
+[data-slot="dropdown-menu-trigger"]:not(:disabled):not([aria-disabled="true"]):not([data-disabled]),
+[data-slot="dropdown-menu-item"]:not([aria-disabled="true"]):not([data-disabled]),
+[data-slot="dropdown-menu-sub-trigger"]:not([aria-disabled="true"]):not([data-disabled]),
+[data-slot="dropdown-menu-checkbox-item"]:not([aria-disabled="true"]):not([data-disabled]),
+[data-slot="dropdown-menu-radio-item"]:not([aria-disabled="true"]):not([data-disabled]),
+[role="menuitem"]:not([aria-disabled="true"]):not([data-disabled]),
+[role="menuitemcheckbox"]:not([aria-disabled="true"]):not([data-disabled]),
+[role="menuitemradio"]:not([aria-disabled="true"]):not([data-disabled]),
+[role="option"]:not([aria-disabled="true"]):not([data-disabled]) {
+  cursor: pointer;
+}

--- a/web/admin/src/lib/api/types.ts
+++ b/web/admin/src/lib/api/types.ts
@@ -512,6 +512,17 @@ export interface Me {
   entitlements?: string[]
 }
 
+export interface MerchantMembership {
+  persona: string
+  instance_slug: string
+  role: string
+}
+
+export interface MerchantMembershipList {
+  object: "list"
+  data: MerchantMembership[]
+}
+
 // --- Alerting (#736) ---
 
 export type AlertSeverity = "warning" | "critical"

--- a/web/admin/src/lib/auth.tsx
+++ b/web/admin/src/lib/auth.tsx
@@ -20,7 +20,13 @@ import {
   setUnauthorizedHandler,
   type BootstrapConfig,
 } from "@/lib/api/client"
-import type { AuthCapabilities, AuthTokens, Me } from "@/lib/api/types"
+import type {
+  AuthCapabilities,
+  AuthTokens,
+  Me,
+  MerchantMembership,
+  MerchantMembershipList,
+} from "@/lib/api/types"
 
 interface AuthState {
   ready: boolean
@@ -28,12 +34,53 @@ interface AuthState {
   config?: BootstrapConfig
   capabilities?: AuthCapabilities
   me: Me | null
+  merchants: MerchantMembership[]
+  activeMerchant?: MerchantMembership
+  selectMerchant: (slug: string) => void
   loginWithPassword: (login: string, password: string) => Promise<void>
   startOIDC: (providerId: string) => void
   logout: () => Promise<void>
 }
 
 const AuthContext = React.createContext<AuthState | undefined>(undefined)
+
+function merchantMemberships(groups: MerchantMembershipList) {
+  return [...groups.data]
+    .filter((group) => group.persona === "merchant")
+    .sort((a, b) => a.instance_slug.localeCompare(b.instance_slug))
+}
+
+async function loadIdentity(
+  expectedSession: NonNullable<ReturnType<typeof getTokens>>
+) {
+  const who = await authApi<Me>("/me")
+  const groups = await authApi<MerchantMembershipList>("/me/groups")
+  if (!sameTokenSession(expectedSession, getTokens())) {
+    throw new Error("Your session changed while your account was loading")
+  }
+
+  const merchants = merchantMemberships(groups)
+  const storedSession = getTokens()
+  if (!storedSession) {
+    throw new Error("Your session ended while your account was loading")
+  }
+  const activeMerchant =
+    merchants.find(
+      (merchant) => merchant.instance_slug === storedSession.merchant
+    ) ?? merchants[0]
+
+  if (storedSession.merchant !== activeMerchant?.instance_slug) {
+    const updated = {
+      ...storedSession,
+      merchant: activeMerchant?.instance_slug,
+    }
+    if (!setTokensIfCurrent(updated, storedSession)) {
+      throw new Error("Your session changed while your account was loading")
+    }
+  }
+
+  return { who, merchants, activeMerchant }
+}
 
 // consumeOIDCFragment reads AuthKit's browser-OIDC fragment redirect
 // (#access_token=…&refresh_token=…&merchant=…) if present and stores the
@@ -65,9 +112,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [config, setConfig] = React.useState<BootstrapConfig>()
   const [capabilities, setCapabilities] = React.useState<AuthCapabilities>()
   const [me, setMe] = React.useState<Me | null>(null)
+  const [merchants, setMerchants] = React.useState<MerchantMembership[]>([])
+  const [activeMerchant, setActiveMerchant] =
+    React.useState<MerchantMembership>()
 
   React.useEffect(() => {
-    setUnauthorizedHandler(() => setMe(null))
+    setUnauthorizedHandler(() => {
+      setMe(null)
+      setMerchants([])
+      setActiveMerchant(undefined)
+    })
     return () => setUnauthorizedHandler(null)
   }, [])
 
@@ -90,8 +144,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         const session = getTokens()
         if (session) {
           try {
-            const who = await authApi<Me>("/me")
-            if (!cancelled && sameTokenSession(session, getTokens())) setMe(who)
+            const identity = await loadIdentity(session)
+            if (!cancelled) {
+              setMe(identity.who)
+              setMerchants(identity.merchants)
+              setActiveMerchant(identity.activeMerchant)
+            }
           } catch (err) {
             if (
               err instanceof ApiError &&
@@ -142,13 +200,38 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       if (!setTokensIfCurrent(session, expectedSession)) {
         throw new Error("Your session changed while sign-in was completing")
       }
-      const who = await authApi<Me>("/me")
-      if (!sameTokenSession(session, getTokens())) {
-        throw new Error("Your session changed while sign-in was completing")
-      }
-      setMe(who)
+      const identity = await loadIdentity(session)
+      setMe(identity.who)
+      setMerchants(identity.merchants)
+      setActiveMerchant(identity.activeMerchant)
     },
     []
+  )
+
+  const selectMerchant = React.useCallback(
+    (slug: string) => {
+      const selected = merchants.find(
+        (merchant) => merchant.instance_slug === slug
+      )
+      const session = getTokens()
+      if (
+        !selected ||
+        !session ||
+        session.merchant === selected.instance_slug
+      ) {
+        return
+      }
+      if (
+        !setTokensIfCurrent(
+          { ...session, merchant: selected.instance_slug },
+          session
+        )
+      ) {
+        return
+      }
+      window.location.reload()
+    },
+    [merchants]
   )
 
   const startOIDC = React.useCallback((providerId: string) => {
@@ -161,6 +244,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const session = getTokens()
     setTokens(null)
     setMe(null)
+    setMerchants([])
+    setActiveMerchant(undefined)
     if (!session) return
     try {
       await logoutSession(session)
@@ -176,6 +261,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       config,
       capabilities,
       me,
+      merchants,
+      activeMerchant,
+      selectMerchant,
       loginWithPassword,
       startOIDC,
       logout,
@@ -186,6 +274,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       config,
       capabilities,
       me,
+      merchants,
+      activeMerchant,
+      selectMerchant,
       loginWithPassword,
       startOIDC,
       logout,

--- a/web/admin/src/pages/catalog/index.tsx
+++ b/web/admin/src/pages/catalog/index.tsx
@@ -70,7 +70,7 @@ import { priceIntervalLabel } from "@/pages/catalog/price-format"
 import { PriceChangeWizard } from "@/pages/catalog/price-wizard"
 
 const LINE_TAB =
-  "flex-none px-0 group-data-horizontal/tabs:after:bottom-[-1px]"
+  "flex-none px-0 after:bg-primary group-data-horizontal/tabs:after:bottom-[-1px]"
 
 function catalogCopilotEnabled(): boolean {
   try {
@@ -116,7 +116,7 @@ export function CatalogPage() {
       >
         <TabsList
           variant="line"
-          className="w-full justify-start gap-6 rounded-none border-b border-border p-0"
+          className="w-full justify-start gap-6 rounded-none p-0"
         >
           <TabsTrigger value="products" className={LINE_TAB}>
             Products

--- a/web/admin/src/pages/payments/index.tsx
+++ b/web/admin/src/pages/payments/index.tsx
@@ -258,17 +258,17 @@ export function PaymentsPage() {
       <Tabs value={view} onValueChange={(v) => setParam("view", v ?? "")}>
         <TabsList
           variant="line"
-          className="w-full justify-start gap-6 rounded-none border-b border-border p-0"
+          className="w-full justify-start gap-6 rounded-none p-0"
         >
           <TabsTrigger
             value=""
-            className="flex-none px-0 group-data-horizontal/tabs:after:bottom-[-1px]"
+            className="flex-none px-0 after:bg-primary group-data-horizontal/tabs:after:bottom-[-1px]"
           >
             All
           </TabsTrigger>
           <TabsTrigger
             value="refunds"
-            className="flex-none px-0 group-data-horizontal/tabs:after:bottom-[-1px]"
+            className="flex-none px-0 after:bg-primary group-data-horizontal/tabs:after:bottom-[-1px]"
           >
             Refunds
           </TabsTrigger>

--- a/web/admin/src/pages/settings/alerts.tsx
+++ b/web/admin/src/pages/settings/alerts.tsx
@@ -14,13 +14,6 @@ import { TypedConfirmDialog } from "@/components/typed-confirm-dialog"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
-import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -210,8 +203,8 @@ export function AlertsTab() {
   const templateList = templates.data?.data ?? []
 
   return (
-    <div className="flex max-w-4xl flex-col gap-6">
-      <AlertEmailCard
+    <div className="flex max-w-4xl flex-col gap-10">
+      <AlertEmailSection
         key={settings.data?.alert_email ?? "∅"}
         settings={settings.data ?? undefined}
         loading={settings.loading}
@@ -237,7 +230,7 @@ export function AlertsTab() {
 
 // --- Alert email -----------------------------------------------------------
 
-function AlertEmailCard({
+function AlertEmailSection({
   settings,
   loading,
   onSaved,
@@ -246,7 +239,7 @@ function AlertEmailCard({
   loading: boolean
   onSaved: () => void
 }) {
-  // Initial value is seeded from props; the parent remounts this card (key on
+  // Initial value is seeded from props; the parent remounts this section (key on
   // alert_email) when the saved value changes, so no props→state effect.
   const initial = settings?.alert_email ?? ""
   const [email, setEmail] = React.useState(initial)
@@ -255,51 +248,53 @@ function AlertEmailCard({
   const dirty = email.trim() !== initial
 
   return (
-    <Card className="max-w-xl">
-      <CardHeader>
-        <CardTitle className="text-sm">Alert email</CardTitle>
-        <CardDescription>
-          Where operator alerts are sent when a rule uses the email channel.
-          Leave empty and the email channel stays inactive — alerts fail soft to
-          in-app and any webhooks.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="grid grid-cols-[1fr_auto] gap-2">
+    <section className="grid gap-5">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="grid gap-1">
+          <h2 className="text-base font-semibold">Email delivery</h2>
+          <p className="text-sm text-muted-foreground">
+            Send email alerts to this address.
+          </p>
+        </div>
+        <Button
+          size="sm"
+          disabled={busy || loading || !dirty}
+          onClick={async () => {
+            setBusy(true)
+            try {
+              // Preserve existing settings; only change alert_email.
+              await putMerchantSettings({
+                ...(settings ?? {}),
+                alert_email: email.trim() || undefined,
+              })
+              toast.success(
+                email.trim() ? "Alert email saved" : "Alert email cleared"
+              )
+              onSaved()
+            } catch (err) {
+              toastApiError(err, "Save alert email")
+            } finally {
+              setBusy(false)
+            }
+          }}
+        >
+          {busy ? "Saving…" : "Save"}
+        </Button>
+      </div>
+      <div className="grid gap-2 md:grid-cols-[11rem_minmax(0,1fr)] md:items-center md:gap-6">
+        <Label htmlFor="alert-email">Alert email</Label>
+        <div className="min-w-0">
           <Input
+            id="alert-email"
             type="email"
             placeholder="alerts@example.com"
             value={email}
             disabled={loading}
             onChange={(e) => setEmail(e.target.value)}
           />
-          <Button
-            variant="outline"
-            disabled={busy || loading || !dirty}
-            onClick={async () => {
-              setBusy(true)
-              try {
-                // Preserve existing settings; only change alert_email.
-                await putMerchantSettings({
-                  ...(settings ?? {}),
-                  alert_email: email.trim() || undefined,
-                })
-                toast.success(
-                  email.trim() ? "Alert email saved" : "Alert email cleared"
-                )
-                onSaved()
-              } catch (err) {
-                toastApiError(err, "Save alert email")
-              } finally {
-                setBusy(false)
-              }
-            }}
-          >
-            {busy ? "Saving…" : "Save"}
-          </Button>
         </div>
-      </CardContent>
-    </Card>
+      </div>
+    </section>
   )
 }
 
@@ -369,14 +364,13 @@ function RulesSection({
   const canCreate = templates.length > 0
 
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h2 className="text-sm font-medium">Alert rules</h2>
-          <p className="max-w-2xl text-sm text-muted-foreground">
-            Threshold alerts run on a slow cadence over your live metrics and
-            push a warning the moment a threshold is crossed — before a rail
-            fines you or churn spikes.
+    <section className="grid gap-5">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="grid max-w-2xl gap-1">
+          <h2 className="text-base font-semibold">Alert rules</h2>
+          <p className="text-sm text-pretty text-muted-foreground">
+            Monitor billing risks and notify your team when thresholds are
+            crossed.
           </p>
         </div>
         {canCreate ? (
@@ -396,61 +390,38 @@ function RulesSection({
       {loading || templatesLoading ? (
         <p className="text-sm text-muted-foreground">Loading…</p>
       ) : rules.length === 0 ? (
-        <Card className="border-dashed">
-          <CardContent className="flex flex-col items-center gap-3 py-10 text-center">
-            <HugeiconsIcon
-              icon={Notification01Icon}
-              className="size-6 text-muted-foreground"
-            />
-            <div>
-              <p className="text-sm font-medium">No alert rules yet</p>
-              <p className="mx-auto mt-1 max-w-md text-sm text-muted-foreground">
-                Alerting watches the metrics that can fine or bankrupt you —
-                chargeback ratio, dunning spikes, credit depletion, expiring
-                cards — and notifies you when a threshold is crossed. Start from
-                a template.
-              </p>
-            </div>
-            {canCreate && (
-              <RuleDialog
+        <p className="py-2 text-sm text-muted-foreground">
+          No alert rules configured.
+        </p>
+      ) : (
+        <Table className="min-w-[48rem]">
+          <TableHeader>
+            <TableRow>
+              <TableHead className="text-muted-foreground">Rule</TableHead>
+              <TableHead className="text-muted-foreground">Severity</TableHead>
+              <TableHead className="text-muted-foreground">Channels</TableHead>
+              <TableHead className="text-muted-foreground">State</TableHead>
+              <TableHead className="text-muted-foreground">Enabled</TableHead>
+              <TableHead className="text-right text-muted-foreground">
+                Action
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rules.map((r) => (
+              <RuleRow
+                key={r.id}
+                rule={r}
                 templates={templates}
                 webhooks={webhooks}
                 alertEmail={alertEmail}
-                onDone={onChanged}
-                cta
+                onChanged={onChanged}
               />
-            )}
-          </CardContent>
-        </Card>
-      ) : (
-        <div className="overflow-x-auto rounded-md border">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Rule</TableHead>
-                <TableHead>Severity</TableHead>
-                <TableHead>Channels</TableHead>
-                <TableHead>State</TableHead>
-                <TableHead>Enabled</TableHead>
-                <TableHead />
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {rules.map((r) => (
-                <RuleRow
-                  key={r.id}
-                  rule={r}
-                  templates={templates}
-                  webhooks={webhooks}
-                  alertEmail={alertEmail}
-                  onChanged={onChanged}
-                />
-              ))}
-            </TableBody>
-          </Table>
-        </div>
+            ))}
+          </TableBody>
+        </Table>
       )}
-    </div>
+    </section>
   )
 }
 
@@ -504,7 +475,7 @@ function RuleRow({
 
   return (
     <TableRow className={rule.enabled ? undefined : "opacity-60"}>
-      <TableCell>
+      <TableCell className="py-3">
         <span className="font-medium">{label}</span>
         {def?.digest && (
           <span className="block text-xs text-muted-foreground">
@@ -512,13 +483,13 @@ function RuleRow({
           </span>
         )}
       </TableCell>
-      <TableCell>
+      <TableCell className="py-3">
         <SeverityBadge severity={rule.severity} />
       </TableCell>
-      <TableCell>
+      <TableCell className="py-3">
         <ChannelSummary channels={rule.channels} />
       </TableCell>
-      <TableCell>
+      <TableCell className="py-3">
         {firing ? (
           <Badge
             variant="secondary"
@@ -530,7 +501,7 @@ function RuleRow({
           <span className="text-xs text-muted-foreground">ok</span>
         )}
       </TableCell>
-      <TableCell>
+      <TableCell className="py-3">
         <Switch
           checked={rule.enabled}
           disabled={busy}
@@ -544,7 +515,7 @@ function RuleRow({
           }
         />
       </TableCell>
-      <TableCell className="text-right">
+      <TableCell className="py-3 text-right">
         <div className="flex justify-end gap-1">
           <Button variant="ghost" size="sm" disabled={busy} onClick={runTest}>
             <HugeiconsIcon icon={SentIcon} className="size-3.5" /> Test
@@ -599,7 +570,6 @@ function RuleDialog({
   alertEmail,
   onDone,
   trigger,
-  cta,
 }: {
   rule?: AlertRule
   templates: AlertTemplateInfo[]
@@ -607,7 +577,6 @@ function RuleDialog({
   alertEmail: string
   onDone: () => void
   trigger?: React.ReactElement
-  cta?: boolean
 }) {
   const editing = !!rule
   const [open, setOpen] = React.useState(false)
@@ -708,8 +677,7 @@ function RuleDialog({
         render={
           trigger ?? (
             <Button size="sm">
-              <HugeiconsIcon icon={Add01Icon} className="size-4" />{" "}
-              {cta ? "Create your first rule" : "New rule"}
+              <HugeiconsIcon icon={Add01Icon} className="size-4" /> New rule
             </Button>
           )
         }
@@ -933,16 +901,12 @@ function WebhooksSection({
   onChanged: () => void
 }) {
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h2 className="text-sm font-medium">Webhooks</h2>
-          <p className="max-w-2xl text-sm text-muted-foreground">
-            Deliver alerts to a chat channel or your own receiver. Paste a
-            Discord or Slack channel webhook URL — no bot needed — or point
-            “generic” at your own endpoint. There is no standalone test for a
-            webhook — add it to a rule&apos;s channels and use that rule&apos;s
-            Test button.
+    <section className="grid gap-5">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="grid max-w-2xl gap-1">
+          <h2 className="text-base font-semibold">Webhooks</h2>
+          <p className="text-sm text-pretty text-muted-foreground">
+            Send alerts to Discord, Slack, or your own endpoint.
           </p>
         </div>
         <WebhookDialog onDone={onChanged} />
@@ -950,30 +914,29 @@ function WebhooksSection({
       {loading ? (
         <p className="text-sm text-muted-foreground">Loading…</p>
       ) : webhooks.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          No webhooks yet. Add one to route alerts to Discord, Slack, or a
-          custom URL.
+        <p className="py-2 text-sm text-muted-foreground">
+          No webhooks configured.
         </p>
       ) : (
-        <div className="overflow-x-auto rounded-md border">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Name</TableHead>
-                <TableHead>Format</TableHead>
-                <TableHead>URL</TableHead>
-                <TableHead />
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {webhooks.map((w) => (
-                <WebhookRow key={w.id} webhook={w} onChanged={onChanged} />
-              ))}
-            </TableBody>
-          </Table>
-        </div>
+        <Table className="min-w-[36rem]">
+          <TableHeader>
+            <TableRow>
+              <TableHead className="text-muted-foreground">Name</TableHead>
+              <TableHead className="text-muted-foreground">Format</TableHead>
+              <TableHead className="text-muted-foreground">URL</TableHead>
+              <TableHead className="text-right text-muted-foreground">
+                Action
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {webhooks.map((w) => (
+              <WebhookRow key={w.id} webhook={w} onChanged={onChanged} />
+            ))}
+          </TableBody>
+        </Table>
       )}
-    </div>
+    </section>
   )
 }
 
@@ -987,14 +950,17 @@ function WebhookRow({
   const [confirmOpen, setConfirmOpen] = React.useState(false)
   return (
     <TableRow className={webhook.enabled === false ? "opacity-60" : undefined}>
-      <TableCell className="font-medium">{webhook.name}</TableCell>
-      <TableCell>
+      <TableCell className="py-3 font-medium">{webhook.name}</TableCell>
+      <TableCell className="py-3">
         <Badge variant="secondary">{webhook.format}</Badge>
       </TableCell>
-      <TableCell className="max-w-[22rem] truncate text-xs" title={webhook.url}>
+      <TableCell
+        className="max-w-[22rem] truncate py-3 text-xs text-muted-foreground"
+        title={webhook.url}
+      >
         {webhook.url}
       </TableCell>
-      <TableCell className="text-right">
+      <TableCell className="py-3 text-right">
         <div className="flex justify-end gap-1">
           <Button
             variant="ghost"

--- a/web/admin/src/pages/settings/alerts.tsx
+++ b/web/admin/src/pages/settings/alerts.tsx
@@ -203,7 +203,7 @@ export function AlertsTab() {
   const templateList = templates.data?.data ?? []
 
   return (
-    <div className="flex max-w-4xl flex-col gap-10">
+    <div className="flex flex-col gap-10">
       <AlertEmailSection
         key={settings.data?.alert_email ?? "∅"}
         settings={settings.data ?? undefined}

--- a/web/admin/src/pages/settings/api-keys.tsx
+++ b/web/admin/src/pages/settings/api-keys.tsx
@@ -1,3 +1,10 @@
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  Copy02Icon,
+  CopyCheckIcon,
+  ViewIcon,
+  ViewOffIcon,
+} from "@hugeicons/core-free-icons"
 import * as React from "react"
 import { toast } from "sonner"
 
@@ -70,30 +77,37 @@ export function ApiKeysTab() {
   const keys = data?.data ?? []
 
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex items-start justify-between gap-4">
-        <p className="max-w-2xl text-sm text-muted-foreground">
-          Scoped credentials for agents and integrations. A key holds one role
-          of the merchant catalog; least privilege (Viewer) is the default. The
-          secret is shown once at creation and can never be retrieved again —
-          only revoked.
-        </p>
-        <CreateKeyDialog onDone={reload} />
-      </div>
-      {keys.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No API keys yet.</p>
-      ) : (
-        <div className="overflow-x-auto rounded-md border">
-          <Table>
+    <div>
+      <section className="grid gap-5">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="grid max-w-2xl gap-1">
+            <h2 className="text-base font-semibold">API keys</h2>
+            <p className="text-sm text-pretty text-muted-foreground">
+              Create scoped credentials for integrations. Secrets are shown
+              once.
+            </p>
+          </div>
+          <CreateKeyDialog onDone={reload} />
+        </div>
+        {keys.length === 0 ? (
+          <p className="py-2 text-sm text-muted-foreground">
+            No API keys created.
+          </p>
+        ) : (
+          <Table className="min-w-[52rem]">
             <TableHeader>
               <TableRow>
-                <TableHead>Name</TableHead>
-                <TableHead>Role</TableHead>
-                <TableHead>Key</TableHead>
-                <TableHead>Created</TableHead>
-                <TableHead>Last used</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead />
+                <TableHead className="text-muted-foreground">Name</TableHead>
+                <TableHead className="text-muted-foreground">Role</TableHead>
+                <TableHead className="text-muted-foreground">Prefix</TableHead>
+                <TableHead className="text-muted-foreground">Created</TableHead>
+                <TableHead className="text-muted-foreground">
+                  Last used
+                </TableHead>
+                <TableHead className="text-muted-foreground">Status</TableHead>
+                <TableHead className="text-right text-muted-foreground">
+                  Action
+                </TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -102,8 +116,8 @@ export function ApiKeysTab() {
               ))}
             </TableBody>
           </Table>
-        </div>
-      )}
+        )}
+      </section>
     </div>
   )
 }
@@ -126,16 +140,20 @@ function KeyRow({
   const status = keyStatus(apiKey)
   return (
     <TableRow className={status !== "active" ? "opacity-60" : undefined}>
-      <TableCell className="font-medium">{apiKey.name}</TableCell>
-      <TableCell>
-        <Badge variant="secondary">{apiKey.role}</Badge>
+      <TableCell className="py-3 font-medium">{apiKey.name}</TableCell>
+      <TableCell className="py-3">
+        <Badge variant="secondary" className="capitalize">
+          {apiKey.role}
+        </Badge>
       </TableCell>
-      <TableCell className="text-xs">{apiKey.prefix}…</TableCell>
-      <TableCell>{formatDate(apiKey.created_at)}</TableCell>
-      <TableCell>
+      <TableCell className="py-3 font-mono text-xs text-muted-foreground">
+        {apiKey.prefix}
+      </TableCell>
+      <TableCell className="py-3">{formatDate(apiKey.created_at)}</TableCell>
+      <TableCell className="py-3">
         {apiKey.last_used_at ? formatDate(apiKey.last_used_at) : "never"}
       </TableCell>
-      <TableCell>
+      <TableCell className="py-3">
         {status === "active" ? (
           <Badge
             variant="secondary"
@@ -144,10 +162,12 @@ function KeyRow({
             active
           </Badge>
         ) : (
-          <Badge variant="secondary">{status}</Badge>
+          <Badge variant="secondary" className="capitalize">
+            {status}
+          </Badge>
         )}
       </TableCell>
-      <TableCell className="text-right">
+      <TableCell className="py-3 text-right">
         {status === "active" && (
           <>
             <Button
@@ -284,6 +304,18 @@ function ShowOnceSecret({
   onClose: () => void
 }) {
   const [copied, setCopied] = React.useState(false)
+  const [revealed, setRevealed] = React.useState(false)
+
+  const copySecret = async () => {
+    try {
+      await copyText(minted.secret)
+      setCopied(true)
+      toast.success("Key copied to clipboard")
+    } catch {
+      toast.error("Copy failed — reveal and copy the key manually")
+    }
+  }
+
   return (
     <>
       <DialogHeader>
@@ -301,23 +333,27 @@ function ShowOnceSecret({
           <span className="font-medium">{minted.name}</span>{" "}
           <Badge variant="secondary">{minted.role}</Badge>
         </p>
-        <div className="flex items-center gap-2">
-          <code className="min-w-0 flex-1 overflow-x-auto rounded-md border bg-muted px-3 py-2 text-xs whitespace-nowrap">
-            {minted.secret}
+        <div className="flex flex-wrap items-center gap-2">
+          <code className="min-w-0 flex-1 overflow-x-auto rounded-md border bg-muted px-3 py-2 font-mono text-xs whitespace-nowrap">
+            {revealed ? minted.secret : `${minted.prefix}_••••••••••••••••`}
           </code>
           <Button
             variant="outline"
             size="sm"
-            onClick={async () => {
-              try {
-                await navigator.clipboard.writeText(minted.secret)
-                setCopied(true)
-                toast.success("Key copied to clipboard")
-              } catch {
-                toast.error("Copy failed — select the key text manually")
-              }
-            }}
+            aria-pressed={revealed}
+            onClick={() => setRevealed((current) => !current)}
           >
+            <HugeiconsIcon
+              icon={revealed ? ViewOffIcon : ViewIcon}
+              className="size-4"
+            />
+            {revealed ? "Hide" : "Show"}
+          </Button>
+          <Button variant="outline" size="sm" onClick={copySecret}>
+            <HugeiconsIcon
+              icon={copied ? CopyCheckIcon : Copy02Icon}
+              className="size-4"
+            />
             {copied ? "Copied" : "Copy"}
           </Button>
         </div>
@@ -331,4 +367,29 @@ function ShowOnceSecret({
       </DialogFooter>
     </>
   )
+}
+
+async function copyText(value: string): Promise<void> {
+  if (navigator.clipboard?.writeText && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(value)
+      return
+    } catch {
+      // Fall back for browsers that expose the API but deny clipboard access.
+    }
+  }
+
+  const textarea = document.createElement("textarea")
+  textarea.value = value
+  textarea.readOnly = true
+  textarea.style.position = "fixed"
+  textarea.style.opacity = "0"
+  document.body.appendChild(textarea)
+  textarea.select()
+
+  try {
+    if (!document.execCommand("copy")) throw new Error("Copy failed")
+  } finally {
+    textarea.remove()
+  }
 }

--- a/web/admin/src/pages/settings/index.tsx
+++ b/web/admin/src/pages/settings/index.tsx
@@ -376,79 +376,119 @@ function ProvidersTab() {
 
   if (loading) return <p className="text-sm text-muted-foreground">Loading…</p>
 
+  const providerDefinitions = data?.provider_definitions ?? []
+
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex justify-end">
-        <ProviderDialog
-          providerDefinitions={data?.provider_definitions ?? []}
-          onDone={reload}
-        />
-      </div>
-      {!data?.data?.length ? (
-        <p className="text-sm text-muted-foreground">
-          No payment providers configured.
-        </p>
-      ) : (
-        <div className="overflow-x-auto rounded-md border">
-          <Table>
+    <div className="max-w-4xl">
+      <section className="grid gap-5">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="grid gap-1">
+            <h2 className="text-base font-semibold">Payment providers</h2>
+            <p className="text-sm text-muted-foreground">
+              Configure the payment rails this merchant can use.
+            </p>
+          </div>
+          <ProviderDialog
+            providerDefinitions={providerDefinitions}
+            onDone={reload}
+          />
+        </div>
+        {!data?.data?.length ? (
+          <p className="py-2 text-sm text-muted-foreground">
+            No payment providers configured.
+          </p>
+        ) : (
+          <Table className="min-w-[44rem]">
             <TableHeader>
               <TableRow>
-                <TableHead>Rail</TableHead>
-                <TableHead>Environment</TableHead>
-                <TableHead>Account</TableHead>
-                <TableHead>Credentials</TableHead>
-                <TableHead>State</TableHead>
-                <TableHead />
+                <TableHead className="text-muted-foreground">
+                  Provider
+                </TableHead>
+                <TableHead className="text-muted-foreground">
+                  Environment
+                </TableHead>
+                <TableHead className="text-muted-foreground">
+                  Credentials
+                </TableHead>
+                <TableHead className="text-muted-foreground">State</TableHead>
+                <TableHead className="text-right text-muted-foreground">
+                  Action
+                </TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {data.data.map((p) => (
-                <ProviderRow key={p.id} provider={p} onDone={reload} />
+              {data.data.map((provider) => (
+                <ProviderRow
+                  key={provider.id}
+                  provider={provider}
+                  definition={providerDefinitions.find(
+                    (definition) => definition.rail === provider.rail
+                  )}
+                  onDone={reload}
+                />
               ))}
             </TableBody>
           </Table>
-        </div>
-      )}
+        )}
+      </section>
     </div>
   )
 }
 
 function ProviderRow({
   provider,
+  definition,
   onDone,
 }: {
   provider: PaymentProviderConfig
+  definition?: PaymentProviderDefinition
   onDone: () => void
 }) {
   const [busy, setBusy] = React.useState(false)
   return (
     <TableRow className={provider.archived ? "opacity-60" : undefined}>
-      <TableCell className="font-medium">{provider.rail}</TableCell>
-      <TableCell>{provider.environment}</TableCell>
-      <TableCell className="text-xs">{provider.account_id}</TableCell>
-      <TableCell>
-        <span className="flex flex-wrap gap-1">
-          {Object.entries(provider.credentials).map(([name, c]) => (
-            <Badge
-              key={name}
-              variant="secondary"
-              className={
-                c.configured
-                  ? ""
-                  : "bg-amber-500/15 text-amber-600 dark:text-amber-400"
-              }
-              title={
-                c.last_validated_at
-                  ? `validated ${formatDate(c.last_validated_at)}`
-                  : undefined
-              }
-            >
-              {name}
-            </Badge>
-          ))}
-        </span>
+      <TableCell className="py-3">
+        <div className="grid min-w-0 leading-tight">
+          <span className="font-medium">
+            {definition?.display_name ?? provider.rail}
+          </span>
+          <span className="truncate text-xs text-muted-foreground">
+            {provider.rail} · {provider.account_id}
+          </span>
+        </div>
       </TableCell>
-      <TableCell>
+      <TableCell className="py-3 capitalize">
+        {provider.environment || "Default"}
+      </TableCell>
+      <TableCell className="py-3">
+        {Object.keys(provider.credentials).length > 0 ? (
+          <span className="flex flex-wrap gap-1">
+            {Object.entries(provider.credentials).map(([name, credential]) => (
+              <Badge
+                key={name}
+                variant="secondary"
+                className={
+                  credential.configured
+                    ? ""
+                    : "bg-amber-500/15 text-amber-600 dark:text-amber-400"
+                }
+                title={
+                  credential.last_validated_at
+                    ? `Validated ${formatDate(credential.last_validated_at)}`
+                    : credential.configured
+                      ? "Configured"
+                      : "Not configured"
+                }
+              >
+                {name}
+              </Badge>
+            ))}
+          </span>
+        ) : (
+          <span className="text-sm text-muted-foreground">None required</span>
+        )}
+      </TableCell>
+      <TableCell className="py-3">
         {provider.archived ? (
           <Badge variant="secondary">archived</Badge>
         ) : provider.drained ? (
@@ -467,7 +507,7 @@ function ProviderRow({
           </Badge>
         )}
       </TableCell>
-      <TableCell className="text-right">
+      <TableCell className="py-3 text-right">
         {!provider.archived && (
           <Button
             variant="outline"

--- a/web/admin/src/pages/settings/index.tsx
+++ b/web/admin/src/pages/settings/index.tsx
@@ -51,17 +51,37 @@ import { AlertsTab } from "./alerts"
 import { ApiKeysTab } from "./api-keys"
 import { TeamTab } from "./team"
 
+const LINE_TAB =
+  "flex-none px-0 after:bg-primary group-data-horizontal/tabs:after:bottom-[-1px]"
+
 export function SettingsPage() {
   return (
     <Tabs defaultValue="merchant" className="flex flex-col gap-4">
-      <TabsList>
-        <TabsTrigger value="merchant">Merchant</TabsTrigger>
-        <TabsTrigger value="team">Team</TabsTrigger>
-        <TabsTrigger value="alerts">Alerts</TabsTrigger>
-        <TabsTrigger value="providers">Payment providers</TabsTrigger>
-        <TabsTrigger value="api-keys">API keys</TabsTrigger>
-        <TabsTrigger value="customer-controls">Customer controls</TabsTrigger>
-      </TabsList>
+      <div className="overflow-x-auto">
+        <TabsList
+          variant="line"
+          className="w-max min-w-full justify-start gap-6 rounded-none p-0"
+        >
+          <TabsTrigger value="merchant" className={LINE_TAB}>
+            Merchant
+          </TabsTrigger>
+          <TabsTrigger value="team" className={LINE_TAB}>
+            Team
+          </TabsTrigger>
+          <TabsTrigger value="alerts" className={LINE_TAB}>
+            Alerts
+          </TabsTrigger>
+          <TabsTrigger value="providers" className={LINE_TAB}>
+            Payment providers
+          </TabsTrigger>
+          <TabsTrigger value="api-keys" className={LINE_TAB}>
+            API keys
+          </TabsTrigger>
+          <TabsTrigger value="customer-controls" className={LINE_TAB}>
+            Customer controls
+          </TabsTrigger>
+        </TabsList>
+      </div>
       <TabsContent value="merchant">
         <MerchantSettingsTab />
       </TabsContent>
@@ -91,7 +111,7 @@ function MerchantSettingsTab() {
   }, [error])
   if (loading) return <p className="text-sm text-muted-foreground">Loading…</p>
   return (
-    <div className="grid gap-4">
+    <div className="grid max-w-3xl gap-10">
       <MerchantProfileForm initial={data?.profile} />
       <RepriceNoticeWindowForm initial={data?.reprice_notice_window_days} />
     </div>
@@ -114,73 +134,138 @@ function MerchantProfileForm({
   const [fromEmail, setFromEmail] = React.useState(initial?.from_email ?? "")
   const [supportURL, setSupportURL] = React.useState(initial?.support_url ?? "")
   const [logoURL, setLogoURL] = React.useState(initial?.logo_url ?? "")
+  const [savedProfile, setSavedProfile] = React.useState({
+    displayName: initial?.display_name ?? "",
+    fromEmail: initial?.from_email ?? "",
+    supportURL: initial?.support_url ?? "",
+    logoURL: initial?.logo_url ?? "",
+  })
   const [busy, setBusy] = React.useState(false)
+  const [editing, setEditing] = React.useState(false)
+
+  const reset = () => {
+    setDisplayName(savedProfile.displayName)
+    setFromEmail(savedProfile.fromEmail)
+    setSupportURL(savedProfile.supportURL)
+    setLogoURL(savedProfile.logoURL)
+  }
+
+  const save = async (event: React.FormEvent) => {
+    event.preventDefault()
+    setBusy(true)
+    try {
+      await putMerchantSettings({
+        profile: {
+          display_name: displayName || undefined,
+          from_email: fromEmail || undefined,
+          support_url: supportURL || undefined,
+          logo_url: logoURL || undefined,
+        },
+      })
+      setSavedProfile({ displayName, fromEmail, supportURL, logoURL })
+      toast.success("Profile saved")
+      setEditing(false)
+    } catch (err) {
+      toastApiError(err, "Save profile")
+    } finally {
+      setBusy(false)
+    }
+  }
 
   return (
-    <Card className="max-w-xl">
-      <CardHeader>
-        <CardTitle className="text-sm">Merchant profile</CardTitle>
-        <CardDescription>
-          Shown on invoices and customer-facing emails.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="grid gap-3">
-        <Field label="Display name" id="s-name">
-          <Input
-            id="s-name"
-            value={displayName}
-            onChange={(e) => setDisplayName(e.target.value)}
-          />
-        </Field>
-        <Field label="From email" id="s-email">
-          <Input
-            id="s-email"
-            type="email"
-            value={fromEmail}
-            onChange={(e) => setFromEmail(e.target.value)}
-          />
-        </Field>
-        <Field label="Support URL" id="s-support">
-          <Input
-            id="s-support"
-            value={supportURL}
-            onChange={(e) => setSupportURL(e.target.value)}
-          />
-        </Field>
-        <Field label="Logo URL" id="s-logo">
-          <Input
-            id="s-logo"
-            value={logoURL}
-            onChange={(e) => setLogoURL(e.target.value)}
-          />
-        </Field>
-        <div>
-          <Button
-            disabled={busy}
-            onClick={async () => {
-              setBusy(true)
-              try {
-                await putMerchantSettings({
-                  profile: {
-                    display_name: displayName || undefined,
-                    from_email: fromEmail || undefined,
-                    support_url: supportURL || undefined,
-                    logo_url: logoURL || undefined,
-                  },
-                })
-                toast.success("Settings saved")
-              } catch (err) {
-                toastApiError(err, "Save settings")
-              } finally {
-                setBusy(false)
-              }
-            }}
-          >
-            {busy ? "Saving…" : "Save"}
-          </Button>
+    <section className="grid gap-5">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="grid gap-1">
+          <h2 className="text-base font-semibold">Merchant profile</h2>
+          <p className="text-sm text-pretty text-muted-foreground">
+            Customer-facing merchant details used on invoices and emails.
+          </p>
         </div>
-      </CardContent>
-    </Card>
+        {editing ? (
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={busy}
+              onClick={() => {
+                reset()
+                setEditing(false)
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              size="sm"
+              form="merchant-profile-form"
+              disabled={busy}
+            >
+              {busy ? "Saving…" : "Save"}
+            </Button>
+          </div>
+        ) : (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setEditing(true)}
+          >
+            Edit
+          </Button>
+        )}
+      </div>
+
+      {editing ? (
+        <form id="merchant-profile-form" onSubmit={save} className="grid gap-4">
+          <SettingEditField label="Display name" id="s-name">
+            <Input
+              id="s-name"
+              value={displayName}
+              onChange={(event) => setDisplayName(event.target.value)}
+              autoComplete="organization"
+            />
+          </SettingEditField>
+          <SettingEditField label="From email" id="s-email">
+            <Input
+              id="s-email"
+              type="email"
+              value={fromEmail}
+              onChange={(event) => setFromEmail(event.target.value)}
+              autoComplete="email"
+            />
+          </SettingEditField>
+          <SettingEditField label="Support URL" id="s-support">
+            <Input
+              id="s-support"
+              type="url"
+              value={supportURL}
+              onChange={(event) => setSupportURL(event.target.value)}
+              placeholder="https://example.com/support"
+            />
+          </SettingEditField>
+          <SettingEditField label="Logo URL" id="s-logo">
+            <Input
+              id="s-logo"
+              type="url"
+              value={logoURL}
+              onChange={(event) => setLogoURL(event.target.value)}
+              placeholder="https://example.com/logo.png"
+            />
+          </SettingEditField>
+        </form>
+      ) : (
+        <dl className="grid gap-4">
+          <SettingDetail
+            label="Display name"
+            value={savedProfile.displayName}
+          />
+          <SettingDetail label="From email" value={savedProfile.fromEmail} />
+          <SettingDetail label="Support URL" value={savedProfile.supportURL} />
+          <SettingDetail label="Logo URL" value={savedProfile.logoURL} />
+        </dl>
+      )}
+    </section>
   )
 }
 
@@ -191,53 +276,92 @@ function MerchantProfileForm({
 // it regardless of what the console shows.
 function RepriceNoticeWindowForm({ initial }: { initial?: number }) {
   const [days, setDays] = React.useState(String(initial ?? 30))
+  const [savedDays, setSavedDays] = React.useState(String(initial ?? 30))
   const [busy, setBusy] = React.useState(false)
+  const [editing, setEditing] = React.useState(false)
   const parsed = Number(days)
   const valid = days.trim() !== "" && Number.isInteger(parsed) && parsed >= 0
 
+  const save = async (event: React.FormEvent) => {
+    event.preventDefault()
+    setBusy(true)
+    try {
+      await putMerchantSettings({
+        reprice_notice_window_days: parsed,
+      })
+      setSavedDays(days)
+      toast.success("Notice window saved")
+      setEditing(false)
+    } catch (err) {
+      toastApiError(err, "Save notice window")
+    } finally {
+      setBusy(false)
+    }
+  }
+
   return (
-    <Card className="max-w-xl">
-      <CardHeader>
-        <CardTitle className="text-sm">Price-increase notice window</CardTitle>
-        <CardDescription>
-          Minimum days' advance notice a scheduled subscription price INCREASE
-          must give existing subscribers before it takes effect. Decreases are
-          never gated. Default 30 days.
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="grid gap-3">
-        <Field label="Notice window (days)" id="s-notice-window">
-          <Input
-            id="s-notice-window"
-            type="number"
-            step="1"
-            min="0"
-            value={days}
-            onChange={(e) => setDays(e.target.value)}
-          />
-        </Field>
-        <div>
-          <Button
-            disabled={busy || !valid}
-            onClick={async () => {
-              setBusy(true)
-              try {
-                await putMerchantSettings({
-                  reprice_notice_window_days: parsed,
-                })
-                toast.success("Settings saved")
-              } catch (err) {
-                toastApiError(err, "Save settings")
-              } finally {
-                setBusy(false)
-              }
-            }}
-          >
-            {busy ? "Saving…" : "Save"}
-          </Button>
+    <section className="grid gap-5">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="grid max-w-2xl gap-1">
+          <h2 className="text-base font-semibold">Pricing policies</h2>
+          <p className="text-sm text-pretty text-muted-foreground">
+            Set how much notice customers receive before a price increase.
+          </p>
         </div>
-      </CardContent>
-    </Card>
+        {editing ? (
+          <div className="flex items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={busy}
+              onClick={() => {
+                setDays(savedDays)
+                setEditing(false)
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              size="sm"
+              form="notice-window-form"
+              disabled={busy || !valid}
+            >
+              {busy ? "Saving…" : "Save"}
+            </Button>
+          </div>
+        ) : (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setEditing(true)}
+          >
+            Edit
+          </Button>
+        )}
+      </div>
+
+      {editing ? (
+        <form id="notice-window-form" onSubmit={save}>
+          <SettingEditField label="Notice period (days)" id="s-notice-window">
+            <Input
+              id="s-notice-window"
+              type="number"
+              step="1"
+              min="0"
+              value={days}
+              onChange={(event) => setDays(event.target.value)}
+            />
+          </SettingEditField>
+        </form>
+      ) : (
+        <dl>
+          <SettingDetail label="Notice period" value={`${savedDays} days`} />
+        </dl>
+      )}
+    </section>
   )
 }
 
@@ -611,6 +735,40 @@ function Field({
     <div className="grid gap-1.5">
       <Label htmlFor={id}>{label}</Label>
       {children}
+    </div>
+  )
+}
+
+function SettingDetail({ label, value }: { label: string; value?: string }) {
+  return (
+    <div className="grid gap-1.5 md:grid-cols-[11rem_minmax(0,1fr)] md:gap-6">
+      <dt className="text-sm text-muted-foreground">{label}</dt>
+      <dd
+        className={
+          value
+            ? "min-w-0 text-sm break-words"
+            : "text-sm text-muted-foreground"
+        }
+      >
+        {value || "Not set"}
+      </dd>
+    </div>
+  )
+}
+
+function SettingEditField({
+  label,
+  id,
+  children,
+}: {
+  label: string
+  id: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="grid gap-2 md:grid-cols-[11rem_minmax(0,1fr)] md:items-center md:gap-6">
+      <Label htmlFor={id}>{label}</Label>
+      <div className="min-w-0">{children}</div>
     </div>
   )
 }

--- a/web/admin/src/pages/settings/index.tsx
+++ b/web/admin/src/pages/settings/index.tsx
@@ -4,13 +4,6 @@ import { toast } from "sonner"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
-import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -654,111 +647,170 @@ function CustomerControlsTab() {
   const [customerID, setCustomerID] = React.useState("")
   const [currency, setCurrency] = React.useState("usd")
   const [result, setResult] = React.useState<{
+    customerID: string
+    currency: string
     creditLimit: number
     trustLevel: string
   }>()
   const [newLimit, setNewLimit] = React.useState("")
-  const [busy, setBusy] = React.useState(false)
+  const [lookupBusy, setLookupBusy] = React.useState(false)
+  const [saveBusy, setSaveBusy] = React.useState(false)
+  const parsedNewLimit = microsFromInput(newLimit)
+  const newLimitValid =
+    newLimit !== "" && parsedNewLimit !== null && parsedNewLimit >= 0
 
-  const lookup = async () => {
-    setBusy(true)
+  const lookup = async (event: React.FormEvent) => {
+    event.preventDefault()
+    const nextCustomerID = customerID.trim()
+    const nextCurrency = currency.trim().toLowerCase()
+    setLookupBusy(true)
     try {
       const [cl, tt] = await Promise.all([
-        getCreditLimit(customerID.trim(), currency.trim()),
-        getTrustLevel(customerID.trim(), currency.trim()),
+        getCreditLimit(nextCustomerID, nextCurrency),
+        getTrustLevel(nextCustomerID, nextCurrency),
       ])
       setResult({
+        customerID: nextCustomerID,
+        currency: cl.currency || nextCurrency,
         creditLimit: cl.credit_limit_amount,
         trustLevel: tt.trust_level,
       })
+      setNewLimit("")
     } catch (err) {
       toastApiError(err, "Lookup customer controls")
       setResult(undefined)
     } finally {
-      setBusy(false)
+      setLookupBusy(false)
     }
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-sm">Credit limit & trust level</CardTitle>
-        <CardDescription>
-          Per-customer, per-currency: the arrears credit limit is writable; the
-          trust level is graduated by spend history (read-only here).
-        </CardDescription>
-      </CardHeader>
-      <CardContent className="grid gap-3">
-        <div className="grid grid-cols-[1fr_8rem_auto] gap-2">
-          <Input
-            placeholder="customer id (UUID)"
-            value={customerID}
-            onChange={(e) => setCustomerID(e.target.value)}
-          />
-          <Input
-            placeholder="currency"
-            value={currency}
-            onChange={(e) => setCurrency(e.target.value)}
-          />
-          <Button
-            variant="outline"
-            disabled={busy || !customerID.trim() || !currency.trim()}
-            onClick={lookup}
-          >
-            Look up
-          </Button>
+    <div className="grid gap-10">
+      <section className="grid gap-5">
+        <div className="grid gap-1">
+          <h2 className="text-base font-semibold">Customer lookup</h2>
+          <p className="text-sm text-muted-foreground">
+            Find a customer by ID and currency.
+          </p>
         </div>
-        {result && (
-          <div className="grid gap-3 rounded-md border p-3 text-sm">
-            <p>
-              Trust level:{" "}
-              <Badge variant="secondary">
-                {result.trustLevel || "default"}
-              </Badge>
+        <form
+          onSubmit={lookup}
+          className="grid gap-4 md:grid-cols-[minmax(0,1fr)_10rem_auto] md:items-end"
+        >
+          <Field label="Customer ID" id="customer-controls-id">
+            <Input
+              id="customer-controls-id"
+              placeholder="Customer UUID"
+              value={customerID}
+              onChange={(event) => setCustomerID(event.target.value)}
+            />
+          </Field>
+          <Field label="Currency" id="customer-controls-currency">
+            <Input
+              id="customer-controls-currency"
+              placeholder="USD"
+              value={currency}
+              onChange={(event) => setCurrency(event.target.value)}
+            />
+          </Field>
+          <Button
+            type="submit"
+            variant="outline"
+            disabled={
+              lookupBusy || saveBusy || !customerID.trim() || !currency.trim()
+            }
+          >
+            {lookupBusy ? "Looking up…" : "Look up"}
+          </Button>
+        </form>
+      </section>
+
+      {result && (
+        <section className="grid gap-5">
+          <div className="grid gap-1">
+            <h2 className="text-base font-semibold">Credit and trust</h2>
+            <p className="text-sm text-muted-foreground">
+              <span className="font-mono text-xs break-all text-foreground">
+                {result.customerID}
+              </span>{" "}
+              · {result.currency.toUpperCase()}
             </p>
-            <p>
-              Credit limit:{" "}
-              {result.creditLimit
-                ? formatMicros(result.creditLimit, currency)
-                : "off (0)"}
-            </p>
-            <div className="grid grid-cols-[1fr_auto] gap-2">
-              <Input
-                placeholder={`new limit in ${currency} (major units, 0 = off)`}
-                type="number"
-                step="any"
-                min="0"
-                value={newLimit}
-                onChange={(e) => setNewLimit(e.target.value)}
-              />
-              <Button
-                disabled={
-                  busy || newLimit === "" || microsFromInput(newLimit) === null
-                }
-                onClick={async () => {
-                  setBusy(true)
-                  try {
-                    await setCreditLimit(
-                      customerID.trim(),
-                      currency.trim(),
-                      microsFromInput(newLimit) ?? 0
-                    )
-                    toast.success("Credit limit updated")
-                    lookup()
-                  } catch (err) {
-                    toastApiError(err, "Set credit limit")
-                  } finally {
-                    setBusy(false)
-                  }
-                }}
-              >
-                Set limit
-              </Button>
-            </div>
           </div>
-        )}
-      </CardContent>
-    </Card>
+          <dl className="grid gap-4">
+            <SettingDetail
+              label="Trust level"
+              value={result.trustLevel || "Default"}
+            />
+            <SettingDetail
+              label="Credit limit"
+              value={
+                result.creditLimit
+                  ? formatMicros(result.creditLimit, result.currency)
+                  : "Off"
+              }
+            />
+          </dl>
+          <form
+            onSubmit={async (event) => {
+              event.preventDefault()
+              if (
+                newLimit === "" ||
+                parsedNewLimit === null ||
+                parsedNewLimit < 0
+              )
+                return
+              setSaveBusy(true)
+              try {
+                await setCreditLimit(
+                  result.customerID,
+                  result.currency,
+                  parsedNewLimit
+                )
+                setResult((current) =>
+                  current
+                    ? { ...current, creditLimit: parsedNewLimit }
+                    : current
+                )
+                setNewLimit("")
+                toast.success("Credit limit updated")
+              } catch (err) {
+                toastApiError(err, "Set credit limit")
+              } finally {
+                setSaveBusy(false)
+              }
+            }}
+          >
+            <SettingEditField
+              label={`New limit (${result.currency.toUpperCase()})`}
+              id="customer-controls-limit"
+            >
+              <div className="grid gap-1.5">
+                <div className="flex gap-2">
+                  <Input
+                    id="customer-controls-limit"
+                    placeholder="0.00"
+                    type="number"
+                    step="any"
+                    min="0"
+                    value={newLimit}
+                    onChange={(event) => setNewLimit(event.target.value)}
+                  />
+                  <Button
+                    type="submit"
+                    disabled={saveBusy || lookupBusy || !newLimitValid}
+                  >
+                    {saveBusy ? "Updating…" : "Update"}
+                  </Button>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Enter 0 to turn credit off.
+                </p>
+              </div>
+            </SettingEditField>
+          </form>
+        </section>
+      )}
+    </div>
   )
 }
 

--- a/web/admin/src/pages/settings/index.tsx
+++ b/web/admin/src/pages/settings/index.tsx
@@ -111,7 +111,7 @@ function MerchantSettingsTab() {
   }, [error])
   if (loading) return <p className="text-sm text-muted-foreground">Loading…</p>
   return (
-    <div className="grid max-w-3xl gap-10">
+    <div className="grid gap-10">
       <MerchantProfileForm initial={data?.profile} />
       <RepriceNoticeWindowForm initial={data?.reprice_notice_window_days} />
     </div>
@@ -379,7 +379,7 @@ function ProvidersTab() {
   const providerDefinitions = data?.provider_definitions ?? []
 
   return (
-    <div className="max-w-4xl">
+    <div>
       <section className="grid gap-5">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="grid gap-1">
@@ -680,7 +680,7 @@ function CustomerControlsTab() {
   }
 
   return (
-    <Card className="max-w-xl">
+    <Card>
       <CardHeader>
         <CardTitle className="text-sm">Credit limit & trust level</CardTitle>
         <CardDescription>

--- a/web/admin/src/pages/settings/team.tsx
+++ b/web/admin/src/pages/settings/team.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import { toast } from "sonner"
 
 import { TypedConfirmDialog } from "@/components/typed-confirm-dialog"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -100,14 +101,15 @@ export function TeamTab() {
   const ownerCount = team.filter((m) => m.role === "owner").length
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="flex flex-col gap-3">
-        <div className="flex items-start justify-between gap-4">
-          <p className="max-w-2xl text-sm text-muted-foreground">
-            People who can sign in to this merchant console. Each teammate holds
-            one role; only owners can manage the team. A merchant must always
-            keep at least one owner.
-          </p>
+    <div className="flex max-w-4xl flex-col gap-10">
+      <section className="grid gap-5">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="grid gap-1">
+            <h2 className="text-base font-semibold">Team members</h2>
+            <p className="text-sm text-muted-foreground">
+              Manage access and roles. At least one owner is required.
+            </p>
+          </div>
           <InviteDialog
             invitesEnabled={invites.data?.invites_enabled ?? false}
             onDone={reload}
@@ -116,51 +118,58 @@ export function TeamTab() {
         {team.length === 0 ? (
           <p className="text-sm text-muted-foreground">No team members yet.</p>
         ) : (
-          <div className="overflow-x-auto rounded-md border">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Member</TableHead>
-                  <TableHead>Role</TableHead>
-                  <TableHead />
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {team.map((m) => (
-                  <MemberRow
-                    key={m.user_id}
-                    member={m}
-                    isLastOwner={m.role === "owner" && ownerCount <= 1}
-                    onDone={reload}
-                  />
-                ))}
-              </TableBody>
-            </Table>
-          </div>
+          <Table className="min-w-[36rem]">
+            <TableHeader>
+              <TableRow>
+                <TableHead className="text-muted-foreground">Member</TableHead>
+                <TableHead className="w-40 text-muted-foreground">
+                  Role
+                </TableHead>
+                <TableHead className="w-24 text-right text-muted-foreground">
+                  Action
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {team.map((m) => (
+                <MemberRow
+                  key={m.user_id}
+                  member={m}
+                  isLastOwner={m.role === "owner" && ownerCount <= 1}
+                  onDone={reload}
+                />
+              ))}
+            </TableBody>
+          </Table>
         )}
-      </div>
+      </section>
 
       {pending.length > 0 && (
-        <div className="flex flex-col gap-3">
-          <h3 className="text-sm font-medium">Pending invites</h3>
-          <div className="overflow-x-auto rounded-md border">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Role</TableHead>
-                  <TableHead>Created</TableHead>
-                  <TableHead>Expires</TableHead>
-                  <TableHead />
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {pending.map((inv) => (
-                  <InviteRow key={inv.id} invite={inv} onDone={reload} />
-                ))}
-              </TableBody>
-            </Table>
+        <section className="grid gap-5">
+          <div className="grid gap-1">
+            <h2 className="text-base font-semibold">Pending invites</h2>
+            <p className="text-sm text-muted-foreground">
+              Invitations awaiting acceptance.
+            </p>
           </div>
-        </div>
+          <Table className="min-w-[36rem]">
+            <TableHeader>
+              <TableRow>
+                <TableHead className="text-muted-foreground">Role</TableHead>
+                <TableHead className="text-muted-foreground">Created</TableHead>
+                <TableHead className="text-muted-foreground">Expires</TableHead>
+                <TableHead className="w-24 text-right text-muted-foreground">
+                  Action
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {pending.map((inv) => (
+                <InviteRow key={inv.id} invite={inv} onDone={reload} />
+              ))}
+            </TableBody>
+          </Table>
+        </section>
       )}
     </div>
   )
@@ -177,17 +186,29 @@ function MemberRow({
 }) {
   const [confirmOpen, setConfirmOpen] = React.useState(false)
   const label = member.email || member.username || member.user_id
+  const initials = (member.username || member.email || "Member")
+    .slice(0, 2)
+    .toUpperCase()
   return (
     <TableRow>
-      <TableCell className="font-medium">
-        {label}
-        {member.username && member.email && (
-          <span className="ml-2 text-xs text-muted-foreground">
-            {member.username}
-          </span>
-        )}
+      <TableCell className="py-3">
+        <div className="flex items-center gap-3">
+          <Avatar className="size-8 rounded-lg">
+            <AvatarFallback className="rounded-lg text-xs">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+          <div className="grid min-w-0 leading-tight">
+            <span className="truncate font-medium">{label}</span>
+            {member.username && member.email && (
+              <span className="truncate text-xs text-muted-foreground">
+                @{member.username}
+              </span>
+            )}
+          </div>
+        </div>
       </TableCell>
-      <TableCell>
+      <TableCell className="py-3">
         <RoleSelect
           value={member.role}
           disabled={isLastOwner}
@@ -205,9 +226,9 @@ function MemberRow({
           }}
         />
       </TableCell>
-      <TableCell className="text-right">
+      <TableCell className="py-3 text-right">
         <Button
-          variant="outline"
+          variant="destructive"
           size="sm"
           disabled={isLastOwner}
           title={isLastOwner ? "The last owner cannot be removed" : undefined}
@@ -280,16 +301,18 @@ function InviteRow({
   const [busy, setBusy] = React.useState(false)
   return (
     <TableRow>
-      <TableCell>
+      <TableCell className="py-3">
         <Badge variant="secondary">{roleLabel(invite.role)}</Badge>
       </TableCell>
-      <TableCell>{formatDate(invite.created_at)}</TableCell>
-      <TableCell>
+      <TableCell className="py-3 text-muted-foreground">
+        {formatDate(invite.created_at)}
+      </TableCell>
+      <TableCell className="py-3 text-muted-foreground">
         {invite.expires_at ? formatDate(invite.expires_at) : "never"}
       </TableCell>
-      <TableCell className="text-right">
+      <TableCell className="py-3 text-right">
         <Button
-          variant="outline"
+          variant="destructive"
           size="sm"
           disabled={busy}
           onClick={async () => {

--- a/web/admin/src/pages/settings/team.tsx
+++ b/web/admin/src/pages/settings/team.tsx
@@ -101,7 +101,7 @@ export function TeamTab() {
   const ownerCount = team.filter((m) => m.role === "owner").length
 
   return (
-    <div className="flex max-w-4xl flex-col gap-10">
+    <div className="flex flex-col gap-10">
       <section className="grid gap-5">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="grid gap-1">

--- a/web/admin/src/pages/subscriptions/index.tsx
+++ b/web/admin/src/pages/subscriptions/index.tsx
@@ -271,13 +271,13 @@ export function SubscriptionsPage() {
       <Tabs value={status} onValueChange={(v) => setParam("status", v ?? "")}>
         <TabsList
           variant="line"
-          className="w-full justify-start gap-6 rounded-none border-b border-border p-0"
+          className="w-full justify-start gap-6 rounded-none p-0"
         >
           {statusTabs.map((t) => (
             <TabsTrigger
               key={t.value}
               value={t.value}
-              className="flex-none px-0 group-data-horizontal/tabs:after:bottom-[-1px]"
+              className="flex-none px-0 after:bg-primary group-data-horizontal/tabs:after:bottom-[-1px]"
             >
               {t.label}
             </TabsTrigger>


### PR DESCRIPTION
## Summary

- add merchant switching and move the account menu into the Admin header
- refresh Settings tabs and redesign Merchant, Team, Alerts, Payment providers, API keys, and Customer controls
- make Settings content full width and remove unnecessary card and table shells
- add reliable copy plus hide/reveal controls for newly minted API-key secrets
- bind credit-limit updates to the customer and currency returned by lookup

## Why

The Admin settings experience used inconsistent layouts, restrictive width caps, verbose copy, and controls that were difficult to scan or operate. The API-key clipboard flow also relied solely on the browser Clipboard API, while Customer controls could update a different customer after the lookup fields changed.

## Validation

- `pnpm build`
- `pnpm lint` (passes with the existing TanStack Table compiler warning)
- Prettier
- `git diff --check`
