### PR TITLE
or#290: provider certification matrix

### DIFF
--- a/.github/workflows/live-gated-integration.yml
+++ b/.github/workflows/live-gated-integration.yml
@@ -95,11 +95,11 @@ jobs:
   # tag that ran in NO suite. It self-skips without STRIPE_SECRET_KEY. The vet
   # step compiles the tag even when the secret is absent, so bit-rot in the
   # tagged file goes red here instead of rotting silently.
-  # KNOWN-RED until a one-line fix lands in the (currently fenced) file:
-  # stripe_model_b_integration_test.go:214 must become
-  #   {Rail: models.RailStripe, Stripe: &config.StripeRailConfig{SecretKey: key}}
-  # (RailMerchantAccountConfig lost its flat SecretKey in the payment-provider
-  # restructure).
+  # The KNOWN-RED note that used to live here is resolved: the tagged file
+  # compiles on dev (`go vet -tags stripe_integration ./internal/modules/subscriptions/`).
+  # This job is what promotes the Stripe tier-change cells in
+  # docs/rails/certification-matrix.md off `modeled` — TODO(#268) asks for
+  # exactly this run to confirm the live proration amount.
   stripe-model-b:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/solana-devnet-integration.yml
+++ b/.github/workflows/solana-devnet-integration.yml
@@ -26,7 +26,7 @@ on:
   workflow_dispatch:
     inputs:
       run_multirebill:
-        description: 'Also run the multi-HOUR multi-rebill test (TestDevnetMultiRebillHourly, ~3h). Off by default — too slow/expensive for the daily run.'
+        description: 'Also run the multi-HOUR multi-rebill test (TestDevnetSustainedRebill, ~3h). Off by default — too slow/expensive for the daily run.'
         type: boolean
         default: false
 
@@ -90,4 +90,4 @@ jobs:
             echo "HELIUS_API_KEY, SOLANA_DEVNET_PAYER_KEY and SOLANA_DEVNET_SUBSCRIBER_KEY secrets are required" >&2
             exit 1
           fi
-          go test -tags devnet -run TestDevnetMultiRebillHourly -v -timeout 3h ./internal/modules/solana/recurring/...
+          go test -tags devnet -run TestDevnetSustainedRebill -v -timeout 3h ./internal/modules/solana/recurring/...

--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ The agent-facing guide itself lives at [docs/agent-integration.md](docs/agent-in
 
 **Payment rails** — per-rail setup: credentials, the manifest entry, webhooks, sandbox testing:
 
+- [Certification matrix](docs/rails/certification-matrix.md) — which flows each rail supports, and what evidence backs each one
 - [NMI](docs/rails/nmi.md) (MobiusPay, PaymentCloud, PayKings, and other NMI-backed ISOs)
 - [Stripe](docs/rails/stripe.md)
 - [CCBill](docs/rails/ccbill.md)

--- a/docs/rails/ccbill.md
+++ b/docs/rails/ccbill.md
@@ -1,5 +1,9 @@
 # CCBill
 
+> Which flows are supported on this rail, and how well each one is verified:
+> [rail certification matrix](certification-matrix.md). Read it before relying on
+> CCBill refunds — that wire is modeled, not verified.
+
 CCBill is a hosted-checkout payment processor commonly used by high-risk and
 adult/subscription businesses. In OpenRails it is a **reserved gateway**: the
 rail and the PSP name are both `ccbill` (unlike NMI, where a PSP gets its own

--- a/docs/rails/certification-matrix.md
+++ b/docs/rails/certification-matrix.md
@@ -1,0 +1,167 @@
+# Rail certification matrix
+
+What each payment rail actually does, and how well we know it.
+
+A cell's status answers one question: **what evidence do we have that this flow
+works on this rail?** Not "did someone write the code" — code is necessary and
+never sufficient. Providers' documentation is wrong often enough that an
+unverified wire is a guess, so this document distinguishes guesses from
+observations and refuses to round the former up.
+
+## Statuses
+
+| Status | Means | Evidence required |
+|---|---|---|
+| `live-verified` | The wire was exercised against the provider's **real** gateway — production account, real money or real account state. | A dated probe record or a test run naming the account posture. Covers only the exact operation probed. |
+| `sandbox-verified` | The wire was exercised against the provider's **sandbox / test-mode / devnet** endpoint by a named automated test. | Test function name + the CI lane that runs it + its cadence. |
+| `modeled` | Code is complete and covered by hermetic tests (fake HTTP, recorded fixtures), but **no real provider response has ever confirmed the shape**. | Nothing beyond source. This is the default for anything not verified. |
+| `limited` | Works, with a named restriction that changes what a customer can do. The restriction is a fact of the rail or a deliberate design choice — not a code gap. | The caveat must name the restriction. Verification level appears in the evidence line. |
+| `unsupported` | The flow does not execute on this rail. Marked **(guarded)** when a request is refused with an error, **(silent)** when the input is accepted and ignored. | — |
+
+`unsupported (silent)` is a defect class, not a design: it means a merchant can
+declare something the rail will quietly drop. Those cells are called out below.
+
+### What demotes a status
+
+- **A wire change demotes.** Changing a rail adapter's request or response
+  shape drops every affected cell to `modeled` until it is re-verified. This is
+  the rule the PR process below enforces.
+- **A dead test demotes.** A `sandbox-verified` cell whose test is deleted,
+  permanently skipped, or has not run green in 60 days decays to `modeled`.
+- **Verification does not generalize.** `live-verified` on one operation says
+  nothing about its siblings. A verified `cancelSubscription` does not certify
+  `refundTransaction` on the same endpoint.
+
+## Verification lanes
+
+Everything in the `sandbox-verified` and `live-verified` columns comes from one
+of these. Nothing else in the repo touches a real provider.
+
+| Lane | Workflow | Cadence | Reaches |
+|---|---|---|---|
+| NMI sandbox | `.github/workflows/live-gated-integration.yml` job `nmi-sandbox` | weekly, Mon 06:00 UTC | real NMI sandbox gateway |
+| Live invoice collection | same file, job `live-invoice-collection` | weekly | Stripe test mode + NMI sandbox |
+| Stripe Model-B upgrade | same file, job `stripe-model-b` | weekly | Stripe test mode |
+| Solana devnet | `.github/workflows/solana-devnet-integration.yml` job `devnet-service-layer` | daily 07:00 UTC | Solana devnet, real USDC |
+| Solana sustained rebill | same file, job `devnet-multirebill` | on demand (~3h) | Solana devnet, real USDC |
+| Hermetic integration | `.github/workflows/ci.yaml` | every PR | Postgres + Redis testcontainers, fake provider HTTP |
+
+Each live-gated test `t.Skip`s when its credential secret is absent, so a green
+run is not by itself proof the lane executed. Several provider-reaching tests
+exist outside these lanes (the Stripe catalog `TestLive*` pair, the Solana
+devnet tier-change and failure-path tests, `TestSolanaDevnetMoneyMovementProof`)
+— no workflow runs them, so they back no cell.
+
+**CCBill has no automated lane.** Every CCBill cell below is either hermetic or
+rests on a single dated manual probe.
+
+## Checkout and enrollment
+
+| Flow | NMI | CCBill | Stripe | Solana |
+|---|---|---|---|---|
+| One-off purchase | `sandbox-verified` | `unsupported` (guarded) — rail is subscription-only | `modeled` | `modeled` |
+| Subscription enrollment | `sandbox-verified` | `modeled` | `modeled` | `sandbox-verified` (devnet) |
+| Free trial (zero-amount first phase) | `unsupported` (silent) | `limited` — validated inbound, never originated | `modeled` | `unsupported` (silent) |
+| Paid introductory first phase | `unsupported` (silent) | `limited` — validated inbound, never originated | `unsupported` (guarded) | `unsupported` (silent) |
+
+- **One-off, NMI** — `internal/integrations/nmi/payments.go:59` (v5 `payments/sale`). last-verified: weekly / env: sandbox / how: `TestNMILiveLifecycleE2E` step 5.
+- **One-off, CCBill** — refused at `internal/modules/checkout/service.go:485`. Subscription-only rail.
+- **One-off, Stripe** — hosted Checkout `mode=payment`, `internal/modules/checkout/service.go:1264`. env: code-read + hermetic / how: `TestCheckoutSessionStripeRedirect` (fake Stripe transport). The redirect leg is covered; the `checkout.session.completed` activation leg is deliberately not, per the test's own header note.
+- **One-off, Solana** — Solana Pay, `transfer_request` and `transaction_request`. A one-time devnet observation exists (2026-06-29, `TestSolanaDevnetMoneyMovementProof`, confirmed 1 USDC transfer), but **no lane re-runs it**: the test is gated on `OPENRAILS_TEST_SOLANA_PRIVATE_KEY` and its on-chain leg is non-fatal, so it is not standing evidence. Stays `modeled`.
+- **Enrollment, NMI** — classic `recurring=add_subscription`, atomic first-charge + enroll. last-verified: weekly / env: sandbox / how: `TestNMILiveLifecycleE2E` steps 6-7.
+- **Enrollment, CCBill** — FlexForm redirect; the subscription exists only once `NewSaleSuccess` arrives. No CCBill lane exists, so the outbound URL and the inbound payload are both pinned against hand-authored fixtures.
+- **Enrollment, Stripe** — hosted Checkout `mode=subscription`; membership is created by fetch-and-converge, not from the webhook payload.
+- **Enrollment, Solana** — `init_subscription_authority` + `subscribe`, period 1 pulled atomically. last-verified: daily / env: devnet / how: `TestDevnetLifecycle/FastPlan`.
+- **Trials** — the catalog's first-phase (`Price.GetTrial`) has exactly two readers: Stripe checkout and CCBill webhook amount validation. NMI and Solana enrollment never read it, and nothing rejects the combination, so **a trial declared on an NMI or Solana price is silently dropped and the subscriber is charged the full amount immediately**. Stripe refuses a *paid* intro explicitly (`service.go:1211`); a zero-amount trial becomes `subscription_data[trial_end]`. CCBill trial terms live in the FlexForm — OpenRails only validates the billed amount against the catalog trial.
+
+## Billing lifecycle
+
+| Flow | NMI | CCBill | Stripe | Solana |
+|---|---|---|---|---|
+| Rebill / recurring charge | `modeled` | `modeled` | `limited` — provider-driven, ingest only | `modeled` |
+| Dunning / retry | `modeled` | `limited` — provider owns cadence | `unsupported` (by design) | `modeled` |
+| Cancel — user | `sandbox-verified` | `live-verified` | `modeled` | `limited` — dedicated endpoints only |
+| Cancel — merchant/admin | `limited` — see caveat | `limited` — split-brain | `modeled` | `unsupported` (guarded) |
+| Cancel — provider-initiated | `modeled` | `modeled` | `modeled` | `modeled` |
+| Tier change — upgrade | `modeled` | `modeled` | `modeled` | `modeled` |
+| Tier change — downgrade | `modeled` | `unsupported` (guarded) | `modeled` | `modeled` |
+| Bulk plan migration (reprice) | `modeled` | `unsupported` — needs user action | `modeled` | `unsupported` — needs user action |
+
+- **Rebill, NMI** — classic `recurring=rebill_subscription`, driven by our dunning worker. Heavily covered by integration tests, but **never live-verified**: an NMI sandbox cannot advance time, so no lane has ever observed a real rebill.
+- **Rebill, CCBill** — CCBill owns the schedule; OpenRails follows `RenewalSuccess`/`RenewalFailure`. Retry pacing is read from CCBill's own `nextRetryDate`, capped at 72h.
+- **Rebill, Stripe** — Stripe rebills and dunns itself; the dunning worker never processes Stripe cohorts (`OpenRailsDrivenDunning=false`). OpenRails ingests `invoice.paid` / `invoice.payment_failed` as wake-ups and converges from a fetched invoice.
+- **Rebill, Solana** — `transfer_subscription` pull, driven by an hourly cranker. The daily devnet lane exercises the instruction only as part of the atomic subscribe bundle (period 1), so it proves the on-chain instruction lands — **not** that the cranker bills a second period. Recurrence across a real period rollover is covered only by `TestDevnetSustainedRebill` and `TestDevnetFailurePaths`, and **no scheduled lane runs either** (see findings). Missed periods are never back-billed by design; a delegate revocation is terminal and skips dunning.
+- **Cancel (user), NMI** — deferred delete with an undo window, else immediate `DELETE /v5/subscriptions/{id}`. last-verified: weekly / env: sandbox / how: `TestNMILiveLifecycleE2E` step 9.
+- **Cancel (user), CCBill** — DataLink `cancelSubscription`. last-verified: 2026-07-03 / env: **live production account** / how: manual probe, success envelope `<results>1</results>` confirmed on a long-dead subscription; pinned by `TestCancelSubscription_SuccessShapes`.
+- **Cancel (user), Solana** — `limited`: the on-chain `cancel_subscription` path works and is covered by the daily devnet lane (`TestDevnetLifecycle/FastPlan`), but it is reachable **only** through the dedicated `solana-cancel-tx` / `solana-cancel` endpoints. The rail-agnostic `POST /subscriptions/:id/cancel` falls through the cancel worker's default branch into a facade with no Solana case and errors permanently (`user_service.go:538`).
+- **Cancel (merchant), NMI** — `limited`: `internal/modules/subscriptions/admin_service.go:176` calls the gateway **synchronously with no durable intent and no verify leg**, unlike the user path. An unresolvable PSP logs a warning and returns nil, so the local row flips to cancelled while NMI keeps rebilling.
+- **Cancel (merchant), CCBill** — `limited`: the admin subscriptions API refuses CCBill (`admin_service.go:215`), while the findings-queue `cancel_and_refund` action supports it (`admin_findings_actions.go:319`). Same operation, two answers depending on entry point.
+- **Cancel (merchant), Solana** — refused; a cancel is a transaction the subscriber's wallet must sign.
+- **Cancel (provider-initiated)** — all rails converge from *fetched* provider truth rather than trusting the payload. NMI and Stripe treat a 404 as provider-confirmed-gone; CCBill consumes `Cancellation`/`Expiration`; Solana reads the chain.
+- **Tier change** — NMI: immediate proration charge + new subscription, downgrade deferred to period end. CCBill: upgrade is an `originalSubscriptionId` FlexForm redirect, downgrade refused (`service.go:2229`). Stripe: Model-B anchor reset with `always_invoice`; **carries an explicit `TODO(#268)` saying the live invoice amount must be verified on a real Stripe test upgrade** — the `stripe-model-b` lane exists for exactly this. Solana: a single atomic on-chain transaction via the dedicated `solana-tier-change` endpoints.
+- **Bulk plan migration** — CCBill and Solana are classified `capabilityUserAction` (`plan_migration.go:183`): the rail cannot be repriced server-side, so rows land `blocked` and are surfaced rather than automated.
+
+## Money reversal
+
+| Flow | NMI | CCBill | Stripe | Solana |
+|---|---|---|---|---|
+| Refund — full | `modeled` | `modeled` — wire provisional | `modeled` | `unsupported` (guarded) |
+| Refund — partial | `modeled` | `modeled` — amount encoding is a guess | `modeled` | `unsupported` (guarded) |
+| Chargeback / dispute ingestion | `limited` — webhook-only, unrecoverable if missed | `modeled` | `modeled` | `unsupported` — impossible on-chain |
+
+- **Refund, CCBill** — the single weakest cell in this document, and deliberately marked so in the source. `internal/integrations/ccbill/subscription_management.go:280` carries a `WIRE PROVISIONAL` block: the request shape is modeled on the cancel pattern, never confirmed by a successful round-trip. Three specific unknowns remain — the success/partial/already-refunded result codes, whether `amount` is decimal dollars (assumed) or cents, and whether `transactionId` actually narrows the refund to that charge. Even the subaccount parameter name (`clientSubacc` vs `usingSubacc`) is unconfirmed. The one live datum is a 2026-07-03 safe fail-probe that returned `-7` against a 12-year-old transaction: it proves the request reaches CCBill and that the failure path moves no money, and nothing more. Every refund test asserts against hand-authored strings; the only *captured* production golden on this endpoint is `ViewSubscriptionStatus`. **Do not read this cell as "refunds work on CCBill."**
+- **Refund verification, CCBill** — CCBill exposes no per-transaction refund read, only per-subscription counters, so an ambiguous refund can never be attributed to a specific charge. Non-zero counters stay `Ambiguous` for operator resolution.
+- **Refund, Solana** — refused at `internal/http/handlers/admin_payments.go:284`. A pull-based on-chain rail has no reverse authorization; a refund is a fresh outbound transfer, which OpenRails does not model.
+- **Chargeback, NMI** — `limited` for two reasons: it is the only NMI handler that trusts the webhook payload rather than re-fetching, and NMI's read APIs do not expose chargebacks at all (`internal/reconcile/nmi.go:60` declares `Chargebacks: false`). **A missed `chargeback.batch.complete` delivery is unrecoverable** — no backfill path exists. An unparseable batch body is logged and swallowed.
+- **Chargeback, CCBill** — ingested from webhooks *and* recoverable from the DataLink chargeback export, so unlike NMI a missed delivery is repairable.
+
+## Payment instruments
+
+| Flow | NMI | CCBill | Stripe | Solana |
+|---|---|---|---|---|
+| Add / vault a payment method | `sandbox-verified` | `unsupported` — provider owns the vault | `limited` — portal-delegated | `unsupported` — wallet, not an instrument |
+| Update / delete a payment method | `modeled` | `unsupported` (guarded) | `limited` — portal-delegated | n/a |
+| Swap a subscription's payment source | `modeled` | `unsupported` (guarded) | `unsupported` | n/a |
+| Account Updater | `unsupported` — events logged, no action | `unsupported` — invisible to us | `unsupported` — nothing consumed | n/a |
+| Charge a saved method (arrears settlement, auto top-up) | `sandbox-verified` | `unsupported` — no adapter | `sandbox-verified` | `unsupported` — no adapter |
+| Credits bundled with a purchase or renewal | `modeled` | `modeled` | `modeled` | `modeled` |
+| Standalone credit-purchase price | `unsupported` — not wired on any rail | `unsupported` | `unsupported` | `unsupported` |
+
+- **Vaulting, NMI** — Collect.js tokenization → customer vault. last-verified: weekly / env: sandbox / how: `TestLiveCollectJSTokenVaultCreate`, `TestLiveSandboxStoredCredentialCITThenMIT`. Note the lifecycle E2E vaults **directly at NMI**, so the OpenRails payment-method API surface is not itself live-exercised.
+- **Payment methods, Stripe** — `limited`: there is no first-party CRUD. `RailPaymentMethodService` is NMI-only, so a Stripe request fails with **`PSP 'stripe' is not configured`** — which reads as a misconfiguration rather than an unsupported rail. Mutation is delegated to Stripe's Billing Portal (`stripe_portal.go:23`), and `payment_method.attached` is recorded passively.
+- **Account Updater** — no rail consumes it. NMI receives `acu.summary.*` and logs them without touching the vault or the local card record (`internal/modules/webhooks/nmi.go:383`). Stripe's card updater is not subscribed to at all. The only working Account Updater in the repo belongs to the Basis Theory custodian, which is a different rail — do not read it as coverage here.
+- **Charge saved method** — gated by `SupportsChargeSavedMethod` in the rail registry: NMI and Stripe only. last-verified: weekly / env: sandbox + Stripe test mode / how: `TestChargeOutstanding_NMISandbox_CollectsRealCharge`, `TestLiveNMIInvoiceCollectionAgainstSandbox`, `TestLiveStripeInvoiceCollectionAgainstTestAccount`. CCBill and Solana have no collection adapter, so arrears settlement and auto top-up do not exist on those rails.
+- **Credits** — three different things, often conflated. (1) Credits declared on a product's `credits_spec` are granted rail-agnostically when a purchase or renewal registers, so they follow whatever checkout works on the rail. (2) Auto top-up charges a saved method and is therefore NMI/Stripe only. (3) A standalone **catalog credit-purchase price** can be declared and quoted, but `DepositCatalogCreditPurchase` has **no production caller** — the surface is defined and tested, never wired. That is a gap on every rail, not a per-rail limitation.
+
+## Catalog and reconciliation
+
+| Flow | NMI | CCBill | Stripe | Solana |
+|---|---|---|---|---|
+| Product push | `unsupported` — no product concept | `unsupported` — manual | `modeled` | n/a |
+| Price / plan push | `modeled` | `unsupported` — manual link only | `modeled` | `sandbox-verified` (devnet) |
+| Catalog update propagation | `unsupported` — no-op | `unsupported` — no-op | `modeled` | `unsupported` — plan is immutable |
+| Catalog drift detection (pull) | `modeled` | `unsupported` — structurally impossible | `modeled` | `modeled` |
+| Inbound event ingestion | `sandbox-verified` | `modeled` | `modeled` | `modeled` — polling, not webhooks |
+| Provider reconciliation pull | `modeled` | `modeled` — column mapping unverified | `modeled` | `modeled` |
+| Settlement / payout ingestion | `unsupported` | `unsupported` | `unsupported` | n/a |
+
+- **Price push, NMI** — recurring plans only; a non-recurring price returns `errPendingManualLink`. The lifecycle E2E creates its plan **out of band** via raw `recurring=add_plan`, so the adapter's own push path has never run against the sandbox.
+- **Price push, Stripe** — find-or-create by content-addressed `lookup_key`. Two tests do reach Stripe test mode (`TestLiveStripeCatalogAutoCreateReusesContentKeys`, `TestLiveStripeExtrasListing`) but **no workflow runs either**, so they are not standing evidence. Both also carry **no build tag** — they compile into a default `go test ./...` and are held back only by an env check.
+- **Price push, CCBill** — `AutoCreate` always returns `errPendingManualLink`; the operator creates the FlexForm in CCBill's admin and links `flex_id` + `form_name`. This surfaces as `pending_manual_actions` on the price rather than an error, which is the intended behavior.
+- **Catalog update, NMI** — `Update` is a deliberate no-op: amount and frequency are immutable post-create and `is_active` is not representable.
+- **Drift detection, CCBill** — impossible, not missing: FlexForms are write-only redirect URLs and DataLink exports members, not catalog objects. There is no catalog-list endpoint to diff against, so CCBill is excluded from the reconciliation job by design.
+- **Webhooks, CCBill** — the rail has **no HMAC**; source IP is the only transport authentication. Inbound fixtures are hand-authored, not captured deliveries.
+- **Event ingestion, Solana** — the rail emits nothing. Confirmation arrives by polling: a Solana Pay reference poller, slot-gated reads (`ReadUntilConsistent` / `*AtSlot`) so a read after a confirm cannot observe stale state, and a reconcile fetcher over locally-known PDAs. Note the reconcile fetcher's own reads deliberately skip the slot gate (`internal/reconcile/solana.go:158`).
+- **Reconciliation pull, CCBill** — the DataLink transaction-export **column mapping has never been validated against a live account** (`internal/integrations/ccbill/datalink_export.go:23`); the typed accessors are best-effort and the raw fields are authoritative.
+- **Settlement ingestion** — no rail has it. The `payment_settlement_events` feed is an OpenRails-internal pending/ack queue, not provider payout reconciliation. There is no Stripe balance-transaction or payout call site.
+
+## Maintenance
+
+Three rules, and they are the whole process:
+
+1. A PR that changes a rail adapter's **wire behavior** — request fields, response
+   parsing, endpoints, signing — must update the affected cells in the same PR.
+2. If the change was not re-verified against the provider, the new status is
+   `modeled`. Do not carry a stale `live-verified` across a wire change.
+3. When a live or sandbox verification happens, record the date, the environment,
+   and the command or test name. Never the credentials, account ids, or amounts.

--- a/docs/rails/nmi.md
+++ b/docs/rails/nmi.md
@@ -1,5 +1,8 @@
 # NMI (high-risk gateway) setup
 
+> Which flows are supported on this rail, and how well each one is verified:
+> [rail certification matrix](certification-matrix.md).
+
 ### What NMI is, and where your ISO fits
 
 NMI is white-label gateway software. High-risk ISOs/resellers — MobiusPay,

--- a/docs/rails/solana.md
+++ b/docs/rails/solana.md
@@ -1,5 +1,8 @@
 # Solana rail — merchant setup
 
+> Which flows are supported on this rail, and how well each one is verified:
+> [rail certification matrix](certification-matrix.md).
+
 Solana is the self-custody rail: there is no third-party PSP account. You receive
 funds directly into a wallet you control, and OpenRails signs recurring pulls with
 a merchant key you provide. One-time payments use Solana Pay; recurring

--- a/docs/rails/stripe.md
+++ b/docs/rails/stripe.md
@@ -1,5 +1,8 @@
 # Stripe
 
+> Which flows are supported on this rail, and how well each one is verified:
+> [rail certification matrix](certification-matrix.md).
+
 Connect a Stripe account to OpenRails as a PSP on the `stripe` rail. Stripe is a
 reserved gateway: the PSP name is `stripe` (a sandbox account is conventionally
 `stripe-sandbox`). Checkout uses Stripe-hosted pages — the browser is redirected to

--- a/pkg/service/catalog_provider_nmi.go
+++ b/pkg/service/catalog_provider_nmi.go
@@ -30,8 +30,8 @@ import (
 //     a recurring provider day cadence (NMI requires a frequency). When no NMI rail is
 //     configured, falls back to errPendingManualLink so the operator can link
 //     a control-center plan manually.
-//   - Update: propagates display_name via EditRecurringPlan; rejects financial
-//     changes (amount/frequency are immutable post-create in NMI).
+//   - Update: no-op. Amount/frequency are immutable post-create and is_active is
+//     not representable, so no mutable field is left to propagate.
 //   - Verify: live GetRecurringPlanByID + diff plan_name.
 //
 // Divergence from Stripe: on price deactivation OpenRails does NOT delete the


### PR DESCRIPTION
Publishes `docs/rails/certification-matrix.md` — every customer-visible flow crossed with the four rails, each cell carrying a status plus the evidence behind it.

The document's value is honesty about verification, not coverage claims. Statuses separate what a real gateway confirmed from what we only modeled, and default to `modeled` whenever no provider response has ever confirmed a wire.

## Taxonomy

`live-verified` (real gateway, real account state) / `sandbox-verified` (provider sandbox, test mode or devnet, by a named test in a named lane) / `modeled` (code complete, hermetic tests only — the default) / `limited` (works, named restriction) / `unsupported`, split `(guarded)` vs `(silent)`.

Demotion is explicit: a wire change or a dead test drops a cell back to `modeled`, and verification never generalizes from one operation to its siblings. The maintenance process is three lines.

## How cells were established

By reading the rail adapters, handlers and tests on dev, and by mapping every provider-reaching test to the workflow that actually runs it. Anything with no lane behind it is `modeled`, however "live" the test is named.

## Where the code contradicted the docs or the tracker

- **CCBill refunds are modeled only.** The source already says so (`WIRE PROVISIONAL`), but `docs/rails/ccbill.md` presented DataLink refunds as a working feature. The amount encoding (decimal dollars vs cents) and the subaccount parameter name are both unconfirmed guesses; the one live datum is a 2026-07-03 fail-probe returning `-7`.
- **Trials are silently dropped on NMI and Solana.** `Price.GetTrial` has two readers (Stripe checkout, CCBill webhook validation). Nothing rejects a trial on the other two rails, so the subscriber is charged the full amount immediately.
- **Stripe has no first-party payment-method CRUD** and fails with `PSP 'stripe' is not configured`, which reads as a misconfiguration rather than an unsupported rail.
- **No rail consumes Account Updater**; NMI logs the events and does nothing. The working implementation belongs to the Basis Theory custodian, a different rail.
- **No rail ingests provider settlement.** `payment_settlement_events` is an internal queue, not payout reconciliation.
- NMI chargebacks are webhook-only and unrecoverable if a delivery is missed; merchant-initiated cancel on NMI has no durable intent, and on CCBill it is split-brain between two entry points.

## Three records fixed because they made lanes look stronger than they are

- The `solana-devnet` workflow ran `-run TestDevnetMultiRebillHourly` — a name that has not existed since the devnet tests were consolidated. `go test` matched nothing and exited 0, so the on-demand multi-rebill lane has been a **silent no-op**. Now points at `TestDevnetSustainedRebill`.
- The `live-gated` workflow carried a stale `KNOWN-RED` note for `stripe-model-b`; the tagged file compiles on dev.
- `catalog_provider_nmi.go`'s package doc claimed `Update` propagates `display_name`; `Update` is a deliberate no-op.

## Verification

`go build ./...` and `go vet ./pkg/service/` green; both workflow files parse. No integration suites run.

Cross-linked from all four rail guides and the README.