### PR TITLE
or#881 + or#782: Solana mints come from the registry; cross-merchant denial proven on the business surfaces

### DIFF
--- a/config/merchants_config.example.yaml
+++ b/config/merchants_config.example.yaml
@@ -137,16 +137,22 @@ merchants:
             # embedded boot plane also sets them, these settings win (#699).
             rpc_provider: helius # helius | public; empty defaults to helius
             rpc_api_key: replace-with-helius-api-key
-            # `tokens` is OPTIONAL and additive (or#881). The curated registry
-            # (SOL, USDC, PYUSD, USD1, USDG on mainnet; SOL, USDC, PYUSD on
-            # devnet) is always available — declare a token ONLY to add one the
-            # registry does not carry. Do not restate a canonical mint: a
-            # re-typed mint address is a money-path paste error waiting to
-            # happen, and it is the one value here you cannot get wrong by
-            # omitting it. Declaring a registry symbol overrides that ONE entry
-            # and leaves the rest of the registry intact.
-            # `decimals` is not accepted (or#817): they are read from the SPL
-            # mint on-chain, never from config.
+            # `tokens` is OPTIONAL and additive (or#881). The built-in registry
+            # (SOL, USDC, USDT, PYUSD, USD1, USDG on mainnet; SOL, USDC, PYUSD
+            # on devnet) is always available, so there is normally nothing to
+            # declare here at all.
+            #   - built-in symbol: SELECT it (`USDC: {}`) — its mint comes from
+            #     the registry. Declaring `mint:` for a built-in symbol is an
+            #     ERROR, even when the address agrees: a mint you can type is a
+            #     mint you can mistype, and a wrong one accepts payment in a
+            #     different token than the one you priced.
+            #   - custom token: `mint:` is REQUIRED — there the mint IS the
+            #     token's identity, so it is genuinely yours to declare.
+            #   - `decimals` is not accepted (or#817): read from the SPL mint
+            #     on-chain, never from config.
+            # Under test_mode the registry's devnet column applies; a built-in
+            # symbol with no devnet mint (USDT/USD1/USDG) is declared there like
+            # any other ad-hoc devnet token, with an explicit mint.
             #
             # tokens:
             #   MYTK: { name: My Token, mint: replace-with-spl-mint-address }

--- a/config/solana_settings.go
+++ b/config/solana_settings.go
@@ -110,9 +110,14 @@ func ValidateSolanaAccountSettings(settings map[string]any) error {
 	return nil
 }
 
-// ApplyTo overlays the declared settings onto a boot-plane SolanaRailConfig
+// ApplyTo overlays the declared RPC settings onto a boot-plane SolanaRailConfig
 // (store-wins, #699) and returns a NEW config; base is never mutated. A nil
 // base starts from an empty config (standalone: the store is the only plane).
+//
+// Tokens are NOT resolved here (or#881): a declaration selects built-in symbols
+// out of a per-NETWORK mint registry, which this layer cannot see. The caller
+// that knows the network resolves them —
+// internal/modules/solana/tokens.ResolveDeclared.
 func (s SolanaAccountSettings) ApplyTo(base *SolanaRailConfig) *SolanaRailConfig {
 	out := &SolanaRailConfig{}
 	if base != nil {
@@ -130,18 +135,6 @@ func (s SolanaAccountSettings) ApplyTo(base *SolanaRailConfig) *SolanaRailConfig
 	if s.RPCAPIKey != "" {
 		out.RPCAPIKey = s.RPCAPIKey
 	}
-	// or#881: declared tokens EXTEND/OVERRIDE the base set per symbol; they do
-	// not replace it. Replacement meant adding one custom token forced the
-	// merchant to re-type every canonical mint they still wanted — a paste
-	// hazard manufactured by the config shape, on a money path.
-	if len(s.Tokens) > 0 {
-		if out.Tokens == nil {
-			out.Tokens = make(map[string]TokenConfig, len(s.Tokens))
-		}
-		for k, v := range s.Tokens {
-			out.Tokens[k] = v
-		}
-	}
 	return out
 }
 
@@ -154,7 +147,9 @@ func settingString(key string, raw any) (string, error) {
 }
 
 // settingTokens decodes the tokens map. Values arrive as generic maps from
-// either the YAML manifest or the stored evidence JSON.
+// either the YAML manifest or the stored evidence JSON. It decodes SHAPE only —
+// mint semantics are network-dependent and belong to
+// internal/modules/solana/tokens.ResolveDeclared.
 func settingTokens(raw any) (map[string]TokenConfig, error) {
 	entries, err := settingAnyMap("tokens", raw)
 	if err != nil {
@@ -191,9 +186,10 @@ func settingTokens(raw any) (map[string]TokenConfig, error) {
 				return nil, fmt.Errorf("solana settings: tokens.%s has unknown field %q (want mint, name)", symbol, key)
 			}
 		}
-		if strings.TrimSpace(token.Mint) == "" {
-			return nil, fmt.Errorf("solana settings: tokens.%s requires mint", symbol)
-		}
+		// A missing mint is NOT an error here: for a built-in symbol it is the
+		// correct declaration (or#881 — the mint comes from the registry), and
+		// which symbols are built-in depends on the network, which this layer
+		// does not know. solana/tokens.ResolveDeclared rules on it.
 		out[symbol] = token
 	}
 	return out, nil

--- a/config/solana_settings_test.go
+++ b/config/solana_settings_test.go
@@ -28,6 +28,7 @@ func TestParseSolanaAccountSettings(t *testing.T) {
 		require.Equal(t, "helius", s.RPCProvider)
 		require.Equal(t, "key-123", s.RPCAPIKey)
 		require.Equal(t, "USD Coin", s.Tokens["USDC"].Name)
+		require.Equal(t, "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", s.Tokens["USDC"].Mint)
 	})
 
 	// #817: decimals belong to the mint on-chain. A merchant-declared copy could
@@ -42,15 +43,24 @@ func TestParseSolanaAccountSettings(t *testing.T) {
 		require.ErrorContains(t, err, "read from the SPL mint on-chain")
 	})
 
+	// or#881: a mint-less entry is the CORRECT declaration for a built-in
+	// symbol, so this layer (which does not know the network) accepts it and
+	// solana/tokens.ResolveDeclared rules on it.
+	t.Run("a token may be declared without a mint", func(t *testing.T) {
+		s, err := ParseSolanaAccountSettings(map[string]any{
+			"tokens": map[string]any{"usdc": map[string]any{}},
+		})
+		require.NoError(t, err)
+		require.Contains(t, s.Tokens, "USDC")
+		require.Empty(t, s.Tokens["USDC"].Mint)
+	})
+
 	t.Run("malformed values fail loudly", func(t *testing.T) {
 		_, err := ParseSolanaAccountSettings(map[string]any{"rpc_provider": "quicknode"})
 		require.ErrorContains(t, err, "rpc_provider must be helius or public")
 
 		_, err = ParseSolanaAccountSettings(map[string]any{"rpc_provider": "public", "rpc_api_key": "k"})
 		require.ErrorContains(t, err, "public cannot use rpc_api_key")
-
-		_, err = ParseSolanaAccountSettings(map[string]any{"tokens": map[string]any{"USDC": map[string]any{"name": "No Mint"}}})
-		require.ErrorContains(t, err, "requires mint")
 
 		_, err = ParseSolanaAccountSettings(map[string]any{"tokens": map[string]any{"USDC": map[string]any{"mint": "m", "decimls": 6}}})
 		require.ErrorContains(t, err, "unknown field")
@@ -83,17 +93,18 @@ func TestSolanaAccountSettingsApplyTo(t *testing.T) {
 	}
 	overlay := SolanaAccountSettings{
 		RPCAPIKey: "store-key",
-		Tokens:    map[string]TokenConfig{"USDC": {Mint: "EPj"}},
+		Tokens:    map[string]TokenConfig{"USDC": {}},
 	}
 
 	out := overlay.ApplyTo(base)
 	// Store-wins on declared knobs (#699); undeclared knobs keep the boot value.
 	require.Equal(t, "helius", out.RPCProvider)
 	require.Equal(t, "store-key", out.RPCAPIKey)
-	// or#881: tokens merge PER SYMBOL. Declaring USDC must not delete SOL —
-	// replacement forced merchants to re-type canonical mints to keep them.
-	require.Equal(t, map[string]TokenConfig{"SOL": {Mint: "So1"}, "USDC": {Mint: "EPj"}}, out.Tokens)
 	require.Equal(t, "devnet", out.Network)
+	// or#881: ApplyTo does NOT resolve tokens — a declaration selects symbols
+	// out of a per-NETWORK mint registry this layer cannot see. The base set
+	// passes through untouched; solana/tokens.ResolveDeclared rules on it.
+	require.Equal(t, map[string]TokenConfig{"SOL": {Mint: "So1"}}, out.Tokens)
 
 	// base is never mutated.
 	require.Equal(t, "boot-key", base.RPCAPIKey)
@@ -102,12 +113,7 @@ func TestSolanaAccountSettingsApplyTo(t *testing.T) {
 	// nil base: standalone, where the store is the only plane.
 	out = overlay.ApplyTo(nil)
 	require.Equal(t, "store-key", out.RPCAPIKey)
-	require.Equal(t, map[string]TokenConfig{"USDC": {Mint: "EPj"}}, out.Tokens)
-
-	// A token declaration overrides that one symbol and nothing else.
-	out = SolanaAccountSettings{Tokens: map[string]TokenConfig{"SOL": {Mint: "Other"}}}.ApplyTo(base)
-	require.Equal(t, map[string]TokenConfig{"SOL": {Mint: "Other"}}, out.Tokens)
-	require.Equal(t, "So1", base.Tokens["SOL"].Mint) // base untouched
+	require.Empty(t, out.Tokens)
 
 	// empty overlay returns an unchanged copy.
 	out = (SolanaAccountSettings{}).ApplyTo(base)

--- a/docs/rails/solana.md
+++ b/docs/rails/solana.md
@@ -40,12 +40,13 @@ psps:
         recipient_wallet: 9hSR6S7WPtxmTojgo6GG3k4yDPecgJY292j7xrsUGWBu
         rpc_provider: helius     # helius | public; empty defaults to helius
         rpc_api_key: replace-with-helius-api-key   # forbidden with rpc_provider: public
-        tokens:                  # accepted tokens: SYMBOL -> { name, mint }
-                                 # decimals are NOT configurable: they are read from the
-                                 # SPL mint on-chain, which is the source of truth.
-                                 # A `decimals:` key here is rejected.
-          SOL:  { name: Solana,   mint: So11111111111111111111111111111111111111112 }
-          USDC: { name: USD Coin, mint: EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v }
+        # tokens is OPTIONAL — the built-in registry below is always accepted.
+        tokens:
+          USDC: {}               # built-in symbol: SELECTED, mint from the registry.
+                                 # Declaring `mint:` here is an ERROR.
+          MYTK: { name: My Token, mint: replace-with-spl-mint-address }
+                                 # custom symbol: `mint:` is REQUIRED.
+                                 # `decimals:` is rejected on both — read on-chain.
       secrets:
         private_key: replace-with-base58-private-key   # local_keypair mode only
 
@@ -58,6 +59,35 @@ psps:
 
 `settings` keys are strictly validated: a typo'd key fails the manifest push
 loudly. Known keys: `rpc_provider`, `rpc_api_key`, `tokens`, `recipient_wallet`.
+
+#### Accepted tokens
+
+OpenRails ships a built-in mint registry, and it is the source of truth for a
+well-known token's on-chain identity:
+
+| network | built-in symbols |
+|---|---|
+| mainnet | `SOL`, `USDC`, `USDT`, `PYUSD`, `USD1`, `USDG` |
+| devnet (`test_mode`) | `SOL`, `USDC`, `PYUSD` |
+
+Every symbol in the registry is accepted without declaring anything. A `tokens`
+declaration is **additive** — it extends the registry per symbol, it never
+replaces it, so adding one custom token cannot drop the canonical set.
+
+- **Built-in symbol** — select it (`USDC: {}`); `name:` may be overridden.
+  Declaring `mint:` is an error *even when the address is correct*: a mint you
+  can type is a mint you can mistype, and a wrong mint accepts payment in a
+  different token than the one you priced.
+- **Custom symbol** — `mint:` is required; there the mint *is* the token's
+  identity.
+- **`decimals`** — never configurable (#817): read from the SPL mint on-chain.
+- **Under `test_mode`** the devnet column applies. Devnet mints are
+  per-deployment artefacts with no canonical address, so a built-in symbol with
+  no devnet entry (`USDT`, `USD1`, `USDG`) is simply not built-in there —
+  declare it like any other ad-hoc devnet token, with an explicit `mint:`.
+
+A misdeclared token set is fail-closed: the manifest push is rejected, and a PSP
+whose stored settings are misdeclared does not arm.
 
 ### One-time payments (buyer's view)
 

--- a/internal/bootstrap/merchant_manifest.go
+++ b/internal/bootstrap/merchant_manifest.go
@@ -37,6 +37,7 @@ import (
 	"github.com/open-rails/openrails/internal/merchantsecrets"
 	"github.com/open-rails/openrails/internal/modules/catalog"
 	"github.com/open-rails/openrails/internal/modules/merchantconfig"
+	solanatokens "github.com/open-rails/openrails/internal/modules/solana/tokens"
 	"github.com/open-rails/openrails/internal/modules/webhooks"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
@@ -975,6 +976,16 @@ func resolveManifestRailAccount(ctx context.Context, cfg *config.Config, rail st
 		if err := config.ValidateSolanaAccountSettings(account.Settings); err != nil {
 			return out, fmt.Errorf("provider account %q: %w", out.rail, err)
 		}
+		// or#881: the token declaration is resolved against the built-in mint
+		// registry for THIS account's network, so a restated built-in mint or a
+		// custom token with no mint fails the push instead of at arm time.
+		settings, err := config.ParseSolanaAccountSettings(account.Settings)
+		if err != nil {
+			return out, fmt.Errorf("provider account %q: %w", out.rail, err)
+		}
+		if _, err := solanatokens.ResolveDeclared(manifestSolanaNetwork(environment), settings.Tokens); err != nil {
+			return out, fmt.Errorf("provider account %q: %w", out.rail, err)
+		}
 	}
 	// or#879: custody is a MODIFIER on any rail, so its settings are validated
 	// for every PSP — a typo'd or retired custody key fails the push loudly
@@ -1371,6 +1382,15 @@ func manifestProviderEnvironment(cfg *config.Config, raw string) (string, error)
 		return config.ExpectedProviderEnvironment(cfg != nil && cfg.IsTestMode()), nil
 	}
 	return normalizeProviderEnvironment(raw)
+}
+
+// manifestSolanaNetwork maps a PSP environment onto the Solana network the same
+// way railresolve does at arm time (#349: network derives from test_mode alone).
+func manifestSolanaNetwork(environment string) string {
+	if environment == config.ProviderEnvironmentTest {
+		return "devnet"
+	}
+	return "mainnet"
 }
 
 func normalizeManifestRail(raw string) string {

--- a/internal/http/handlers/admin_catalog.go
+++ b/internal/http/handlers/admin_catalog.go
@@ -37,7 +37,11 @@ func writeCatalogError(r *httprequest.Request, err error) {
 	// Map known business errors to stable status codes + machine-readable codes.
 	msg := strings.ToLower(err.Error())
 	switch {
-	case strings.Contains(msg, "not found"):
+	// or#782: product_not_found/price_not_found (the stable codes the lookup
+	// helpers rewrite "sql: no rows" into) match on the UNDERSCORE form — without
+	// it every missing-or-foreign id fell through to a 500, so a cross-merchant
+	// read was denied while looking like a server fault.
+	case strings.Contains(msg, "not found"), strings.Contains(msg, "not_found"):
 		r.ErrorJSON(http.StatusNotFound, err.Error())
 	case strings.Contains(msg, "duplicate key"),
 		strings.Contains(msg, "already exists"):

--- a/internal/integrationharness/cross_merchant_surface_isolation_test.go
+++ b/internal/integrationharness/cross_merchant_surface_isolation_test.go
@@ -1,0 +1,358 @@
+//go:build integration
+
+package integrationharness
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/controlplane"
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// or#782 task 3: the data-plane half of the cross-merchant isolation suite.
+// cross_merchant_isolation_test.go proves the CREDENTIAL surfaces (api keys,
+// remote-application JWTs, delegated admins); these prove the merchant's own
+// BUSINESS surfaces — catalog, customers, subscriptions, payments and inbound
+// webhooks — over the same real HTTP boundary against a server running as
+// openrails_app, where RLS actually enforces.
+//
+// Until dev connected as a NOBYPASSRLS role these routes were only ever
+// exercised through a superuser, so a handler that leans on RLS for scoping
+// (rather than carrying its own merchant predicate) leaked everything and every
+// dev test still passed. One focused test per surface, each asserting BOTH
+// halves: merchant A cannot read or mutate B's row, and B's row is undamaged.
+
+// isolationPair is two live merchants on one standalone server: A is the
+// bootstrapped test merchant, B is freshly provisioned. Both tokens carry the
+// same permission set, so a denial is never explainable by permissions.
+type isolationPair struct {
+	h       *Harness
+	surface *Surface
+	aToken  string
+	bToken  string
+	bSlug   string
+	bID     merchant.ID
+}
+
+func newIsolationPair(t *testing.T, ctx context.Context) isolationPair {
+	t.Helper()
+	h := New(t, ctx)
+	surface := h.StartStandalone("usd") // runs as openrails_app: real RLS enforces
+	b := surface.ProvisionOwnedMerchant("iso" + strings.ReplaceAll(uuid.NewString(), "-", "")[:16])
+
+	perms := []string{
+		controlplane.PermMerchantCatalogRead,
+		controlplane.PermMerchantCatalogUpdate,
+		controlplane.PermMerchantCustomerSettingsRead,
+		controlplane.PermMerchantCustomerSettingsUpdate,
+		controlplane.PermMerchantPaymentsRead,
+		controlplane.PermMerchantSubscriptionsRead,
+		controlplane.PermMerchantSubscriptionsUpdate,
+	}
+	return isolationPair{
+		h:       h,
+		surface: surface,
+		aToken:  surface.MintAPIKey(dbtest.TestMerchantSlug, "iso-a-"+uuid.NewString(), perms),
+		bToken:  surface.MintAPIKey(b.MerchantSlug, "iso-b-"+uuid.NewString(), perms),
+		bSlug:   b.MerchantSlug,
+		bID:     b.MerchantID,
+	}
+}
+
+func (p isolationPair) url(path string) string { return p.surface.BaseURL + path }
+
+// bRows are merchant B's seeded billing rows. They are written through an
+// RLS-ENFORCING merchant-pinned pool (h.MerchantPool), i.e. the production
+// posture — the fixture proves B can write its OWN rows, it never bypasses.
+type bRows struct {
+	customerID     uuid.UUID
+	productID      uuid.UUID
+	priceID        uuid.UUID
+	subscriptionID uuid.UUID
+	paymentID      uuid.UUID
+}
+
+func seedMerchantBillingRows(t *testing.T, ctx context.Context, pool *pgxpool.Pool, mid merchant.ID) bRows {
+	t.Helper()
+	suffix := strings.ReplaceAll(uuid.NewString(), "-", "")[:12]
+	out := bRows{
+		customerID:     uuid.New(),
+		productID:      uuid.New(),
+		priceID:        uuid.New(),
+		subscriptionID: uuid.New(),
+		paymentID:      uuid.New(),
+	}
+	_, err := pool.Exec(ctx, `
+		INSERT INTO openrails.customers (id, merchant_id) VALUES ($1, $2)
+	`, out.customerID, mid.UUID())
+	require.NoError(t, err, "seed customer")
+
+	_, err = pool.Exec(ctx, `
+		INSERT INTO openrails.products (id, merchant_id, key, display_name)
+		VALUES ($1, $2, $3, $3)
+	`, out.productID, mid.UUID(), "isoprod-"+suffix)
+	require.NoError(t, err, "seed product")
+
+	_, err = pool.Exec(ctx, `
+		INSERT INTO openrails.prices (id, merchant_id, product_id, key, amount, currency)
+		VALUES ($1, $2, $3, $4, 1000000, 'USD')
+	`, out.priceID, mid.UUID(), out.productID, "isoprice-"+suffix)
+	require.NoError(t, err, "seed price")
+
+	_, err = pool.Exec(ctx, `
+		INSERT INTO openrails.subscriptions
+			(id, merchant_id, customer_id, product_id, price_id, status, rail, rail_subscription_id)
+		VALUES ($1, $2, $3, $4, $5, 'active', 'nmi', $6)
+	`, out.subscriptionID, mid.UUID(), out.customerID, out.productID, out.priceID, "isosub-"+suffix)
+	require.NoError(t, err, "seed subscription")
+
+	_, err = pool.Exec(ctx, `
+		INSERT INTO openrails.payments
+			(id, merchant_id, customer_id, price_id, subscription_id, rail, transaction_id,
+			 amount, list_amount, currency, status)
+		VALUES ($1, $2, $3, $4, $5, 'nmi', $6, 1000000, 1000000, 'USD', 'completed')
+	`, out.paymentID, mid.UUID(), out.customerID, out.priceID, out.subscriptionID, "isotxn-"+suffix)
+	require.NoError(t, err, "seed payment")
+
+	return out
+}
+
+// TestCrossMerchantCatalogIsolationHTTP: merchant B's product, created through
+// the live catalog write route, is invisible and immutable to merchant A.
+func TestCrossMerchantCatalogIsolationHTTP(t *testing.T) {
+	ctx := context.Background()
+	p := newIsolationPair(t, ctx)
+
+	key := "isocat" + strings.ReplaceAll(uuid.NewString(), "-", "")[:12]
+	status, body := requestJSON(t, http.MethodPost, p.url("/v1/merchant/catalog/products"), p.bToken, map[string]any{
+		"key":          key,
+		"display_name": "Merchant B Product",
+	})
+	require.Equalf(t, http.StatusCreated, status, "B creates its own product: %s", string(body))
+	var created struct {
+		ID string `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(body, &created))
+	require.NotEmpty(t, created.ID)
+
+	// A lists: B's product must not appear at all.
+	status, body = requestJSON(t, http.MethodGet, p.url("/v1/merchant/catalog/products?limit=100"), p.aToken, nil)
+	require.Equalf(t, http.StatusOK, status, "A lists its own catalog: %s", string(body))
+	require.NotContainsf(t, string(body), created.ID, "merchant A listed merchant B's product")
+	require.NotContainsf(t, string(body), key, "merchant A listed merchant B's product key")
+
+	// A reads it directly, by id and by the merchant-scoped key.
+	status, body = requestJSON(t, http.MethodGet, p.url("/v1/merchant/catalog/products/"+created.ID), p.aToken, nil)
+	require.Equalf(t, http.StatusNotFound, status, "A read B's product by id: %s", string(body))
+	status, body = requestJSON(t, http.MethodGet, p.url("/v1/merchant/catalog/products/by-key/"+key), p.aToken, nil)
+	require.Equalf(t, http.StatusNotFound, status, "A read B's product by key: %s", string(body))
+
+	// A mutates it.
+	status, body = requestJSON(t, http.MethodPatch, p.url("/v1/merchant/catalog/products/"+created.ID), p.aToken, map[string]any{
+		"display_name": "Stolen By A",
+	})
+	require.NotContainsf(t, []int{http.StatusOK, http.StatusCreated, http.StatusNoContent}, status,
+		"merchant A mutated merchant B's product: %s", string(body))
+
+	// B's row is intact.
+	status, body = requestJSON(t, http.MethodGet, p.url("/v1/merchant/catalog/products/"+created.ID), p.bToken, nil)
+	require.Equalf(t, http.StatusOK, status, "B still reads its own product: %s", string(body))
+	require.Contains(t, string(body), "Merchant B Product")
+	require.NotContains(t, string(body), "Stolen By A")
+}
+
+// TestCrossMerchantCustomerIsolationHTTP: the #740 customer list/search and the
+// per-customer profile route are merchant-scoped.
+func TestCrossMerchantCustomerIsolationHTTP(t *testing.T) {
+	ctx := context.Background()
+	p := newIsolationPair(t, ctx)
+	rows := seedMerchantBillingRows(t, ctx, p.h.MerchantPool(p.bID.UUID()), p.bID)
+
+	status, body := requestJSON(t, http.MethodGet, p.url("/v1/merchant/customers?limit=100"), p.bToken, nil)
+	require.Equalf(t, http.StatusOK, status, "B lists its own customers: %s", string(body))
+	require.Containsf(t, string(body), rows.customerID.String(), "B must see its own customer: %s", string(body))
+
+	status, body = requestJSON(t, http.MethodGet, p.url("/v1/merchant/customers?limit=100"), p.aToken, nil)
+	require.Equalf(t, http.StatusOK, status, "A lists its own customers: %s", string(body))
+	require.NotContainsf(t, string(body), rows.customerID.String(), "merchant A listed merchant B's customer")
+
+	// Search by the exact id must not become a cross-merchant lookup either.
+	status, body = requestJSON(t, http.MethodGet,
+		p.url("/v1/merchant/customers?limit=100&q="+rows.customerID.String()), p.aToken, nil)
+	require.Equalf(t, http.StatusOK, status, "A searches its own customers: %s", string(body))
+	require.NotContainsf(t, string(body), rows.customerID.String(), "merchant A searched up merchant B's customer")
+
+	// The per-customer billing profile answers with A's (empty) view, never B's.
+	status, body = requestJSON(t, http.MethodGet,
+		p.url("/v1/merchant/customers/"+rows.customerID.String()), p.aToken, nil)
+	if status == http.StatusOK {
+		var profile adminBillingProfileSnapshot
+		require.NoError(t, json.Unmarshal(body, &profile))
+		require.Emptyf(t, profile.CreditBalance, "merchant A saw merchant B's customer balances: %s", string(body))
+	} else {
+		require.Equalf(t, http.StatusNotFound, status, "A's view of B's customer must be empty or absent: %s", string(body))
+	}
+}
+
+// TestCrossMerchantSubscriptionIsolationHTTP: read AND the destructive cancel.
+func TestCrossMerchantSubscriptionIsolationHTTP(t *testing.T) {
+	ctx := context.Background()
+	p := newIsolationPair(t, ctx)
+	rows := seedMerchantBillingRows(t, ctx, p.h.MerchantPool(p.bID.UUID()), p.bID)
+	subID := rows.subscriptionID.String()
+
+	status, body := requestJSON(t, http.MethodGet, p.url("/v1/merchant/subscriptions?limit=100"), p.bToken, nil)
+	require.Equalf(t, http.StatusOK, status, "B lists its own subscriptions: %s", string(body))
+	require.Containsf(t, string(body), subID, "B must see its own subscription: %s", string(body))
+
+	status, body = requestJSON(t, http.MethodGet, p.url("/v1/merchant/subscriptions?limit=100"), p.aToken, nil)
+	require.Equalf(t, http.StatusOK, status, "A lists its own subscriptions: %s", string(body))
+	require.NotContainsf(t, string(body), subID, "merchant A listed merchant B's subscription")
+
+	status, body = requestJSON(t, http.MethodGet, p.url("/v1/merchant/subscriptions/"+subID), p.aToken, nil)
+	require.Equalf(t, http.StatusNotFound, status, "A read B's subscription: %s", string(body))
+
+	// Cancellation is the highest-consequence write on this surface (or#664:
+	// entitlements must never be lost to someone else's request).
+	status, body = requestJSON(t, http.MethodPost, p.url("/v1/merchant/subscriptions/"+subID+"/cancel"), p.aToken, map[string]any{
+		"cancel_type": "immediate",
+	})
+	require.NotContainsf(t, []int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, status,
+		"merchant A cancelled merchant B's subscription: %s", string(body))
+
+	status, body = requestJSON(t, http.MethodGet, p.url("/v1/merchant/subscriptions/"+subID), p.bToken, nil)
+	require.Equalf(t, http.StatusOK, status, "B still reads its own subscription: %s", string(body))
+	require.Containsf(t, string(body), "active", "B's subscription must still be active: %s", string(body))
+}
+
+// TestCrossMerchantPaymentIsolationHTTP: payment history and the refund route.
+func TestCrossMerchantPaymentIsolationHTTP(t *testing.T) {
+	ctx := context.Background()
+	p := newIsolationPair(t, ctx)
+	rows := seedMerchantBillingRows(t, ctx, p.h.MerchantPool(p.bID.UUID()), p.bID)
+	payID := rows.paymentID.String()
+
+	status, body := requestJSON(t, http.MethodGet, p.url("/v1/merchant/payments?limit=100"), p.bToken, nil)
+	require.Equalf(t, http.StatusOK, status, "B lists its own payments: %s", string(body))
+	require.Containsf(t, string(body), payID, "B must see its own payment: %s", string(body))
+
+	status, body = requestJSON(t, http.MethodGet, p.url("/v1/merchant/payments?limit=100"), p.aToken, nil)
+	require.Equalf(t, http.StatusOK, status, "A lists its own payments: %s", string(body))
+	require.NotContainsf(t, string(body), payID, "merchant A listed merchant B's payment")
+
+	status, body = requestJSON(t, http.MethodGet, p.url("/v1/merchant/payments/"+payID), p.aToken, nil)
+	require.Equalf(t, http.StatusNotFound, status, "A read B's payment: %s", string(body))
+
+	// A refund moves money out of B's account — the write that must never cross.
+	status, body = requestJSON(t, http.MethodPost, p.url("/v1/merchant/payments/"+payID+"/refunds"), p.aToken, map[string]any{
+		"amount": 1000000,
+		"reason": "cross-merchant refund attempt",
+	})
+	require.NotContainsf(t, []int{http.StatusOK, http.StatusCreated, http.StatusAccepted}, status,
+		"merchant A refunded merchant B's payment: %s", string(body))
+
+	// B's customer payment history is likewise A-invisible.
+	status, body = requestJSON(t, http.MethodGet,
+		p.url("/v1/merchant/customers/"+rows.customerID.String()+"/payments"), p.aToken, nil)
+	require.NotContainsf(t, string(body), payID,
+		"merchant A read merchant B's customer payment history (status %d)", status)
+}
+
+// TestCrossMerchantWebhookIsolationHTTP: inbound provider webhooks are the one
+// unauthenticated write surface — the caller presents a signature, not a token.
+// A merchant's webhook secret must therefore authorize delivery into THAT
+// merchant only, and the state a delivery creates must land under the addressed
+// merchant alone.
+//
+// Both merchants are freshly provisioned here (not the shared test merchant):
+// psps identities are globally unique and other tests in this package arm the
+// test merchant's stripe account, so a private pair keeps rail resolution
+// unambiguous.
+func TestCrossMerchantWebhookIsolationHTTP(t *testing.T) {
+	ctx := context.Background()
+	h := New(t, ctx)
+	surface := h.StartStandalone("usd")
+	rt := surface.App().Runtime
+	require.NotNil(t, rt)
+
+	suffix := strings.ReplaceAll(uuid.NewString(), "-", "")[:12]
+	a := surface.ProvisionOwnedMerchant("isowha" + suffix)
+	b := surface.ProvisionOwnedMerchant("isowhb" + suffix)
+	aSecret, bSecret := "whsec_a_"+suffix, "whsec_b_"+suffix
+
+	arm := func(m OwnedMerchant, tag, secret string) {
+		t.Helper()
+		SeedRailMerchantAccounts(ctx, t, rt, m.MerchantID, config.PSPSet{
+			"stripe-iso-" + tag: {
+				Rail:      models.RailStripe,
+				AccountID: "acct_iso_" + tag + "_" + suffix,
+				Stripe:    &config.StripeRailConfig{SecretKey: "sk_test_" + tag + "_" + suffix, WebhookSigningSecret: secret},
+			},
+		})
+	}
+	arm(a, "a", aSecret)
+	arm(b, "b", bSecret)
+
+	stripeCustomer := "cus_iso_" + suffix
+	event := []byte(`{"id":"evt_iso_` + suffix + `","type":"customer.created","data":{"object":{"id":"` + stripeCustomer + `"}}}`)
+	post := func(slug, secret string) (int, string) {
+		t.Helper()
+		return postSignedStripeWebhook(t, surface.BaseURL+"/v1/merchants/"+slug+"/webhooks/stripe", event, secret)
+	}
+
+	// The signature is verified against the ADDRESSED merchant's own PSP secret,
+	// so neither merchant's secret can deliver into the other.
+	status, resp := post(a.MerchantSlug, bSecret)
+	require.Equalf(t, http.StatusUnauthorized, status, "B's webhook secret delivered into A: %s", resp)
+	status, resp = post(b.MerchantSlug, aSecret)
+	require.Equalf(t, http.StatusUnauthorized, status, "A's webhook secret delivered into B: %s", resp)
+
+	// B's own secret delivers into B.
+	status, resp = post(b.MerchantSlug, bSecret)
+	require.Equalf(t, http.StatusOK, status, "B's own webhook secret must deliver on B's path: %s", resp)
+
+	// The delivered state belongs to B alone: A's authenticated reads of the
+	// surfaces a provider event writes never see it.
+	aToken := surface.MintAPIKey(a.MerchantSlug, "iso-wh-a-"+uuid.NewString(), []string{
+		controlplane.PermMerchantCustomerSettingsRead,
+		controlplane.PermMerchantPaymentsRead,
+		controlplane.PermMerchantSubscriptionsRead,
+	})
+	for _, path := range []string{
+		"/v1/merchant/customers?limit=100",
+		"/v1/merchant/payments?limit=100",
+		"/v1/merchant/subscriptions?limit=100",
+	} {
+		status, out := requestJSON(t, http.MethodGet, surface.BaseURL+path, aToken, nil)
+		require.Equalf(t, http.StatusOK, status, "A reads %s: %s", path, string(out))
+		require.NotContainsf(t, string(out), stripeCustomer, "webhook state delivered to B surfaced under A via %s", path)
+		require.NotContainsf(t, string(out), "acct_iso_b_"+suffix, "B's PSP surfaced under A via %s", path)
+	}
+}
+
+func postSignedStripeWebhook(t *testing.T, url string, body []byte, secret string) (int, string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Stripe-Signature", stripeSignature(secret, body))
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, string(raw)
+}

--- a/internal/integrationharness/rail_seeding.go
+++ b/internal/integrationharness/rail_seeding.go
@@ -14,6 +14,7 @@ import (
 	"github.com/open-rails/openrails/internal/app"
 	"github.com/open-rails/openrails/internal/db/gen"
 	"github.com/open-rails/openrails/internal/merchants"
+	solanatokens "github.com/open-rails/openrails/internal/modules/solana/tokens"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
 
@@ -47,7 +48,7 @@ func SeedRailMerchantAccounts(ctx context.Context, t *testing.T, rt *app.Runtime
 		environment := proc.EffectiveEnvironment(testMode)
 
 		var evidence []byte
-		if settings := railAccountSettings(proc); len(settings) > 0 {
+		if settings := railAccountSettings(proc, testMode); len(settings) > 0 {
 			raw, err := json.Marshal(map[string]any{"settings": settings})
 			require.NoError(t, err)
 			evidence = raw
@@ -107,10 +108,15 @@ func railAccountSecrets(proc *config.PSPConfig) map[string]string {
 
 // railAccountSettings maps the typed Solana block onto the rail-account
 // settings evidence shape (#711).
-func railAccountSettings(proc *config.PSPConfig) map[string]any {
+func railAccountSettings(proc *config.PSPConfig, testMode bool) map[string]any {
 	if proc.Solana == nil {
 		return nil
 	}
+	network := "mainnet"
+	if testMode {
+		network = "devnet"
+	}
+	registry := solanatokens.ForNetwork(network)
 	settings := map[string]any{}
 	if proc.Solana.RPCProvider != "" {
 		settings[config.SolanaSettingRPCProvider] = proc.Solana.RPCProvider
@@ -121,7 +127,17 @@ func railAccountSettings(proc *config.PSPConfig) map[string]any {
 	if len(proc.Solana.Tokens) > 0 {
 		tokens := map[string]any{}
 		for symbol, token := range proc.Solana.Tokens {
-			tokens[symbol] = map[string]any{"mint": token.Mint, "name": token.Name}
+			// or#881: a built-in symbol is SELECTED — its mint comes from the
+			// registry and restating it is a push error. Emit the declaration a
+			// real manifest would carry, not a restatement.
+			entry := map[string]any{}
+			if token.Name != "" {
+				entry["name"] = token.Name
+			}
+			if _, builtin := registry[strings.ToUpper(strings.TrimSpace(symbol))]; !builtin {
+				entry["mint"] = token.Mint
+			}
+			tokens[symbol] = entry
 		}
 		settings[config.SolanaSettingTokens] = tokens
 	}

--- a/internal/modules/solana/recurring/allowlist.go
+++ b/internal/modules/solana/recurring/allowlist.go
@@ -27,6 +27,9 @@ import (
 //
 //   - USDC  — plain SPL Token, no extensions → eligible (create_plan ACCEPTED on devnet).
 //   - USD1  — plain SPL Token, no extensions → eligible (World Liberty Financial USD; mainnet only).
+//   - USDT  — plain SPL Token, so extension-eligible, but NOT allowlisted: no
+//     devnet deployment exists to run create_plan against, so it stays one-off
+//     until that verification is done.
 //   - PYUSD — Token-2022 w/ PermanentDelegate+TransferFee → REJECTED (devnet error 121 mintHasPermanentDelegate).
 //   - USDG  — Token-2022 w/ PermanentDelegate+TransferFee+ConfidentialTransfer+TransferHook → rejected.
 //   - SOL / volatile — excluded: on-chain plan amounts are immutable, so only a

--- a/internal/modules/solana/tokens/registry_test.go
+++ b/internal/modules/solana/tokens/registry_test.go
@@ -1,0 +1,97 @@
+package tokens
+
+import (
+	"context"
+	"testing"
+
+	solanago "github.com/gagliardetto/solana-go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	solanaint "github.com/open-rails/openrails/internal/integrations/solana"
+)
+
+// registryDecimals pins the base-unit precision each registry mint reports
+// on-chain, verified 2026-08-04 via getAccountInfo (jsonParsed) against
+// api.mainnet-beta.solana.com / api.devnet.solana.com. The runtime NEVER reads
+// this table — decimals come from the mint at conversion time (#817) — it exists
+// so a mistyped registry address is caught here: a wrong address does not have
+// these decimals, and most do not decode as a mint at all.
+var registryDecimals = map[string]int{
+	// mainnet
+	"So11111111111111111111111111111111111111112":  9, // SOL   (Tokenkeg)
+	"EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v": 6, // USDC  (Tokenkeg)
+	"Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB": 6, // USDT  (Tokenkeg)
+	"2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo": 6, // PYUSD (Token-2022)
+	"USD1ttGY1N17NEEHLmELoaybftRBUSErhqYiQzvEmuB":  6, // USD1  (Tokenkeg)
+	"2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH": 6, // USDG  (Token-2022)
+	// devnet
+	"4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU": 6, // USDC devnet
+	"CXk2AMBfi3TwaEL2468s6zP8xq9NxTXjp9gjMgzeUynM": 6, // PYUSD devnet
+}
+
+// fakeMint serves the recorded on-chain layout for a registry mint. Tests never
+// touch a real RPC; this is the injectable seam solanaint.ReadMintDecimals reads
+// through in production.
+type fakeMint map[string]int
+
+func (f fakeMint) GetAccountData(_ context.Context, address solanago.PublicKey) ([]byte, error) {
+	decimals, ok := f[address.String()]
+	if !ok {
+		return nil, nil // absent account: ReadMintDecimals must fail closed
+	}
+	data := make([]byte, solanaint.MintAccountSize)
+	data[44] = byte(decimals)
+	data[45] = 1 // is_initialized
+	return data, nil
+}
+
+// or#881: every address in the registry must be a real, decodable mint pubkey
+// whose on-chain precision is payable. The registry is the ONE place a mint is
+// written down now, so a typo here is not caught by a merchant's review.
+func TestRegistryMintsAreValidAndPayable(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	reader := fakeMint(registryDecimals)
+
+	for _, network := range []string{"mainnet", "devnet"} {
+		for symbol, token := range ForNetwork(network) {
+			pk, err := solanago.PublicKeyFromBase58(token.Mint)
+			require.NoErrorf(t, err, "%s/%s mint is not a valid base58 pubkey", network, symbol)
+
+			decimals, err := solanaint.ReadMintDecimals(ctx, reader, pk)
+			require.NoErrorf(t, err, "%s/%s mint %s is not in the verified set", network, symbol, token.Mint)
+			require.NoErrorf(t, config.ValidateTokenDecimals(symbol, decimals),
+				"%s/%s on-chain decimals are not payable", network, symbol)
+		}
+	}
+}
+
+// The stablecoin peg registry and the mint registry both write down a mint.
+// They must never disagree: the peg registry is the trust anchor for the $1.00
+// parity grant, so a drifted copy would grant parity to the wrong mint.
+func TestStablecoinMintsAgreeWithRegistry(t *testing.T) {
+	t.Parallel()
+	mainnet := DefaultSupportedTokens()
+	for _, sc := range knownStablecoins {
+		token, ok := mainnet[sc.Symbol]
+		if !ok {
+			continue // a known peg that is not an accepted token (EURC)
+		}
+		require.Equalf(t, token.Mint, sc.Mint, "%s mint disagrees between the two registries", sc.Symbol)
+	}
+}
+
+// Devnet mints are a separate column, never the mainnet address under another
+// name — SOL is the one deliberate exception (same native-mint pubkey).
+func TestDevnetRegistryDoesNotReuseMainnetMints(t *testing.T) {
+	t.Parallel()
+	mainnet := DefaultSupportedTokens()
+	for symbol, token := range DefaultDevnetTokens() {
+		if symbol == "SOL" {
+			require.Equal(t, mainnet["SOL"].Mint, token.Mint, "native SOL shares one mint across networks")
+			continue
+		}
+		require.NotEqualf(t, mainnet[symbol].Mint, token.Mint, "%s devnet mint must not be the mainnet address", symbol)
+	}
+}

--- a/internal/modules/solana/tokens/resolve.go
+++ b/internal/modules/solana/tokens/resolve.go
@@ -1,0 +1,95 @@
+package tokens
+
+import (
+	"strings"
+
+	"github.com/open-rails/openrails/config"
+)
+
+// ResolveDeclared turns a merchant's DECLARED token map into the accepted token
+// set for network (or#881).
+//
+// Select-and-restrict, not restate:
+//
+//   - A registry symbol is SELECTED by name — `tokens: {USDC: {}}`. Its mint
+//     comes from ForNetwork(network). Declaring `mint:` for it is an ERROR even
+//     when the address agrees: a value a merchant can type is a value they can
+//     get wrong, and a wrong mint here accepts payment in a different token than
+//     the one that was priced.
+//   - A custom symbol still REQUIRES `mint:` — there the mint IS the token's
+//     identity, so it is genuinely declared rather than restated.
+//   - Declarations EXTEND the registry per symbol; they never replace it, so
+//     adding one custom token cannot silently drop the canonical set.
+//
+// TEST MODE (devnet): the registry has its own devnet column, so USDC/SOL/PYUSD
+// select identically there. Registry symbols with no devnet entry are not
+// registry symbols ON DEVNET — a devnet deployment that needs one declares it
+// like any other ad-hoc token, with an explicit mint. That is deliberate:
+// devnet mints are per-deployment artefacts with no canonical address to
+// protect, and devnet money is fake (the whole #360 pricing policy is skipped
+// there), so the restatement hazard the rule exists to prevent does not apply.
+func ResolveDeclared(network string, declared map[string]config.TokenConfig) (map[string]config.TokenConfig, error) {
+	registry := ForNetwork(network)
+	out := make(map[string]config.TokenConfig, len(registry)+len(declared))
+	for symbol, token := range registry {
+		out[symbol] = token
+	}
+	for rawSymbol, token := range declared {
+		symbol := strings.ToUpper(strings.TrimSpace(rawSymbol))
+		if symbol == "" {
+			return nil, errEmptySymbol
+		}
+		mint := strings.TrimSpace(token.Mint)
+		known, isRegistry := registry[symbol]
+		switch {
+		case isRegistry && mint != "":
+			return nil, &DeclaredRegistryMintError{Symbol: symbol, Network: normalizeNetwork(network), RegistryMint: known.Mint}
+		case isRegistry:
+			if name := strings.TrimSpace(token.Name); name != "" {
+				known.Name = name
+			}
+			out[symbol] = known
+		case mint == "":
+			return nil, &MissingMintError{Symbol: symbol, Network: normalizeNetwork(network)}
+		default:
+			token.Mint = mint
+			out[symbol] = token
+		}
+	}
+	return out, nil
+}
+
+// DeclaredRegistryMintError: a built-in token's mint was restated in config.
+type DeclaredRegistryMintError struct {
+	Symbol       string
+	Network      string
+	RegistryMint string
+}
+
+func (e *DeclaredRegistryMintError) Error() string {
+	return "solana tokens: " + e.Symbol + " is a built-in token — remove tokens." + e.Symbol +
+		".mint and declare `" + e.Symbol + ": {}`; its " + e.Network + " mint comes from the registry (" + e.RegistryMint + ")"
+}
+
+// MissingMintError: a custom token was named without the mint that identifies it.
+type MissingMintError struct {
+	Symbol  string
+	Network string
+}
+
+func (e *MissingMintError) Error() string {
+	return "solana tokens: " + e.Symbol + " requires mint — it is not a built-in token on " + e.Network
+}
+
+type emptySymbolError struct{}
+
+func (emptySymbolError) Error() string { return "solana tokens: token declared with an empty symbol" }
+
+var errEmptySymbol = emptySymbolError{}
+
+func normalizeNetwork(network string) string {
+	if strings.EqualFold(strings.TrimSpace(network), "devnet") {
+		return "devnet"
+	}
+	return "mainnet"
+}

--- a/internal/modules/solana/tokens/resolve_test.go
+++ b/internal/modules/solana/tokens/resolve_test.go
@@ -1,0 +1,106 @@
+package tokens
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+)
+
+// or#881: the mint of a well-known token comes from the registry. A merchant
+// selects the symbol; they never re-type the address.
+
+func TestResolveDeclared_RegistrySymbolSelectsWithoutAMint(t *testing.T) {
+	t.Parallel()
+
+	out, err := ResolveDeclared("mainnet", map[string]config.TokenConfig{"usdc": {}})
+	require.NoError(t, err)
+	require.Equal(t, DefaultSupportedTokens()["USDC"].Mint, out["USDC"].Mint,
+		"a selected registry symbol carries the registry mint")
+	require.Equal(t, "USD Coin", out["USDC"].Name)
+
+	// devnet has its own column: the same selection resolves the devnet mint.
+	out, err = ResolveDeclared("devnet", map[string]config.TokenConfig{"USDC": {}})
+	require.NoError(t, err)
+	require.Equal(t, DefaultDevnetTokens()["USDC"].Mint, out["USDC"].Mint)
+
+	// name is display-only and may be overridden; the mint is not touched.
+	out, err = ResolveDeclared("mainnet", map[string]config.TokenConfig{"USDC": {Name: "Dollars"}})
+	require.NoError(t, err)
+	require.Equal(t, "Dollars", out["USDC"].Name)
+	require.Equal(t, DefaultSupportedTokens()["USDC"].Mint, out["USDC"].Mint)
+}
+
+func TestResolveDeclared_RegistrySymbolWithDeclaredMintFailsLoudly(t *testing.T) {
+	t.Parallel()
+
+	// Even the CORRECT address is refused: the value can only agree (redundant)
+	// or disagree (accepting payment in a different token than was priced).
+	_, err := ResolveDeclared("mainnet", map[string]config.TokenConfig{
+		"USDC": {Mint: DefaultSupportedTokens()["USDC"].Mint},
+	})
+	require.ErrorContains(t, err, "USDC is a built-in token")
+	require.ErrorContains(t, err, "remove tokens.USDC.mint")
+
+	_, err = ResolveDeclared("mainnet", map[string]config.TokenConfig{
+		"USDC": {Mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1w"}, // one char off
+	})
+	require.ErrorContains(t, err, "built-in token")
+}
+
+func TestResolveDeclared_CustomSymbolRequiresMint(t *testing.T) {
+	t.Parallel()
+
+	_, err := ResolveDeclared("mainnet", map[string]config.TokenConfig{"MYTK": {Name: "My Token"}})
+	require.ErrorContains(t, err, "MYTK requires mint")
+
+	const customMint = "MyTk1111111111111111111111111111111111111111"
+	out, err := ResolveDeclared("mainnet", map[string]config.TokenConfig{
+		"mytk": {Name: "My Token", Mint: customMint},
+	})
+	require.NoError(t, err)
+	require.Equal(t, customMint, out["MYTK"].Mint)
+
+	// Additive: one custom token never costs the merchant the registry.
+	for symbol, want := range DefaultSupportedTokens() {
+		require.Equalf(t, want.Mint, out[symbol].Mint, "registry token %s was dropped or changed", symbol)
+	}
+}
+
+// Test mode: the registry's devnet column is the built-in set there. A mainnet
+// symbol with no devnet deployment is NOT built-in on devnet, so it is declared
+// like any other ad-hoc devnet token — with an explicit mint.
+func TestResolveDeclared_DevnetOnlyBuiltInWhereTheRegistryHasAMint(t *testing.T) {
+	t.Parallel()
+
+	require.NotContains(t, DefaultDevnetTokens(), "USDT", "no canonical devnet USDT")
+
+	_, err := ResolveDeclared("devnet", map[string]config.TokenConfig{"USDT": {}})
+	require.ErrorContains(t, err, "USDT requires mint")
+	require.ErrorContains(t, err, "not a built-in token on devnet")
+
+	const adHoc = "DevUsdt11111111111111111111111111111111111111"
+	out, err := ResolveDeclared("devnet", map[string]config.TokenConfig{"USDT": {Mint: adHoc}})
+	require.NoError(t, err)
+	require.Equal(t, adHoc, out["USDT"].Mint)
+
+	// ...and the same declaration on mainnet is refused, where it matters.
+	_, err = ResolveDeclared("mainnet", map[string]config.TokenConfig{"USDT": {Mint: adHoc}})
+	require.ErrorContains(t, err, "built-in token")
+}
+
+func TestResolveDeclared_NoDeclarationIsTheRegistry(t *testing.T) {
+	t.Parallel()
+
+	out, err := ResolveDeclared("mainnet", nil)
+	require.NoError(t, err)
+	require.Equal(t, DefaultSupportedTokens(), out)
+
+	out, err = ResolveDeclared("devnet", map[string]config.TokenConfig{})
+	require.NoError(t, err)
+	require.Equal(t, DefaultDevnetTokens(), out)
+
+	_, err = ResolveDeclared("mainnet", map[string]config.TokenConfig{"  ": {Mint: "x"}})
+	require.ErrorContains(t, err, "empty symbol")
+}

--- a/internal/modules/solana/tokens/tokens.go
+++ b/internal/modules/solana/tokens/tokens.go
@@ -23,18 +23,34 @@ const (
 	// Hermes feed registry on 2026-06-11:
 	//   https://hermes.pyth.network/v2/price_feeds?query=USDG
 	PythFeedUSDGUSD = "daa58c6a3ce7d4b9c46c32a6e646012c17c4a2b24c08dd8c5e476118b855a7da"
+	// USDT (Tether) — Crypto.USDT/USD. Verified against Pyth's Hermes feed
+	// registry on 2026-08-04:
+	//   https://hermes.pyth.network/v2/price_feeds?query=USDT
+	// (note the near-namesakes USDT0/USDTB/OUSDT in that response — this is the
+	// "TETHER / US DOLLAR" entry).
+	PythFeedUSDTUSD = "2b89b9dc8fdf9f34709a5b106b472f0f39bb6ca9ce04b0fd7f2e971688e2e53b"
 )
 
 func DefaultPythPriceFeeds() map[string]string {
 	return map[string]string{
 		"SOL":   PythFeedSOLUSD,
 		"USDC":  PythFeedUSDCUSD,
+		"USDT":  PythFeedUSDTUSD,
 		"PYUSD": PythFeedPYUSDUSD,
 		"USD1":  PythFeedUSD1USD,
 		"USDG":  PythFeedUSDGUSD,
 	}
 }
 
+// DefaultSupportedTokens is the MAINNET half of the built-in mint registry
+// (or#881). It is the source of truth for a well-known token's on-chain
+// identity: a merchant SELECTS a symbol and never re-types a mint, because a
+// mint a merchant can type is a mint they can get wrong — and a wrong mint here
+// means accepting payment in a different token than the one being priced.
+//
+// Every address below was verified against the chain on 2026-08-04 (owner
+// program + decimals via getAccountInfo on mainnet-beta); registry_test.go pins
+// the decimals through the mint reader.
 func DefaultSupportedTokens() map[string]config.TokenConfig {
 	return map[string]config.TokenConfig{
 		"SOL": {
@@ -44,6 +60,11 @@ func DefaultSupportedTokens() map[string]config.TokenConfig {
 		"USDC": {
 			Name: "USD Coin",
 			Mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+		},
+		// Tether USD — plain SPL Token mint (Tokenkeg), no extensions.
+		"USDT": {
+			Name: "Tether USD",
+			Mint: "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
 		},
 		"PYUSD": {
 			Name: "PayPal USD",
@@ -90,6 +111,9 @@ type StablecoinInfo struct {
 // Mint lookups are the trust anchor: parity is only ever granted to a mint in
 // this registry, so a custom token merely NAMED like a stablecoin cannot buy a
 // $1.00 quote for an arbitrary mint.
+// Mints here MUST agree with the mainnet registry above for every shared symbol
+// (registry_test.go asserts it); EURC is deliberately listed without a registry
+// entry — it is a known peg, not an accepted token.
 var knownStablecoins = []StablecoinInfo{
 	{Symbol: "USDC", Mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", Peg: "usd"},
 	{Symbol: "USDT", Mint: "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB", Peg: "usd"},
@@ -196,6 +220,11 @@ func IsFeedlessStablecoin(symbol string) bool {
 	return strings.TrimSpace(DefaultPythPriceFeeds()[normalized]) == ""
 }
 
+// DefaultDevnetTokens is the DEVNET half of the registry. Devnet mints are
+// per-deployment artefacts, not canonical addresses, so only the three with a
+// stable, widely-used devnet deployment are pinned here. A registry symbol with
+// no devnet entry (USDT/USD1/USDG) is simply not selectable under test_mode;
+// see ResolveDeclared for the ad-hoc-token escape hatch.
 func DefaultDevnetTokens() map[string]config.TokenConfig {
 	return map[string]config.TokenConfig{
 		"SOL": {
@@ -213,6 +242,8 @@ func DefaultDevnetTokens() map[string]config.TokenConfig {
 	}
 }
 
+// ForNetwork returns the built-in registry for a network. The returned map is a
+// fresh copy per call, so callers may mutate it.
 func ForNetwork(network string) map[string]config.TokenConfig {
 	switch strings.ToLower(network) {
 	case "devnet":

--- a/internal/modules/solana/tokens/tokens_test.go
+++ b/internal/modules/solana/tokens/tokens_test.go
@@ -18,9 +18,9 @@ func TestDefaultMainnetTokensAllPriceable(t *testing.T) {
 		require.NotEqual(t, TokenPricingDisabled, decision,
 			"default mainnet token %s must be priceable (feed or USD parity)", symbol)
 	}
-	// USD1/USDG specifically graduated from feedless to feed-backed with
-	// verified Pyth feed ids.
-	for _, symbol := range []string{"USD1", "USDG"} {
+	// USD1/USDG/USDT graduated from feedless to feed-backed with verified Pyth
+	// feed ids.
+	for _, symbol := range []string{"USD1", "USDG", "USDT"} {
 		decision, _ := ClassifyPricing(symbol, DefaultSupportedTokens()[symbol].Mint)
 		require.Equal(t, TokenPricingFeed, decision, "%s has a verified Pyth feed", symbol)
 		require.False(t, IsFeedlessStablecoin(symbol), "%s is no longer feedless", symbol)
@@ -36,7 +36,10 @@ func TestClassifyPricing(t *testing.T) {
 	})
 
 	t.Run("USD-pegged registry mint without feed degrades to parity", func(t *testing.T) {
-		decision, sc := ClassifyPricing("USDT", "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB")
+		// A CUSTOM symbol (no feed of its own) pointing at a known USD mint.
+		// Every shipped registry symbol is feed-backed, so this is the only way
+		// to reach the parity branch now.
+		decision, sc := ClassifyPricing("MYUSD", "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB")
 		require.Equal(t, TokenPricingUSDParity, decision)
 		require.Equal(t, "usd", sc.Peg)
 	})
@@ -54,7 +57,10 @@ func TestClassifyPricing(t *testing.T) {
 	})
 
 	t.Run("parity is mint-anchored: stablecoin SYMBOL with unknown mint gets no parity", func(t *testing.T) {
-		decision, _ := ClassifyPricing("USDT", "FakeMint1111111111111111111111111111111111")
+		// EURC has no feed, so the decision falls through to the mint anchor.
+		// (or#881 closes the feed-backed variant of this by construction: a
+		// registry symbol can no longer carry a declared mint at all.)
+		decision, _ := ClassifyPricing("EURC", "FakeMint1111111111111111111111111111111111")
 		require.Equal(t, TokenPricingDisabled, decision)
 	})
 
@@ -86,8 +92,10 @@ func TestStablecoinRegistryHelpers(t *testing.T) {
 	_, ok = KnownStablecoinByMint("So11111111111111111111111111111111111111112")
 	require.False(t, ok)
 
-	// USDT remains the only feedless USD stablecoin shipped today.
-	require.True(t, IsFeedlessStablecoin("USDT"))
-	require.False(t, IsFeedlessStablecoin("USDC"))
+	// or#881: every USD stablecoin shipped today is feed-backed, so none is
+	// priced at bare parity without depeg protection.
+	for _, symbol := range []string{"USDC", "USDT", "USD1", "USDG", "PYUSD"} {
+		require.Falsef(t, IsFeedlessStablecoin(symbol), "%s must be feed-backed", symbol)
+	}
 	require.False(t, IsFeedlessStablecoin("EURC"))
 }

--- a/internal/railresolve/railresolve.go
+++ b/internal/railresolve/railresolve.go
@@ -226,7 +226,11 @@ func (s *MerchantsSource) RailConfig(ctx context.Context, rail, accountID string
 		if err != nil {
 			return nil, err
 		}
-		out.Solana = SolanaRailConfigFromSettings(settings, s.testMode())
+		solanaCfg, err := SolanaRailConfigFromSettings(settings, s.testMode())
+		if err != nil {
+			return nil, fmt.Errorf("solana account %s: %w", scope.AccountID, err)
+		}
+		out.Solana = solanaCfg
 	default:
 		return nil, fmt.Errorf("rail %s has no typed credential shape", scope.Rail)
 	}
@@ -267,21 +271,23 @@ func (s *MerchantsSource) resolveCustody(ctx context.Context, mid merchant.ID, s
 
 // SolanaRailConfigFromSettings materializes the runtime Solana config from a
 // rail account's declared settings: network derives from test_mode alone
-// (#349), the token set starts as the network's curated list and a declared
-// token extends/overrides it per symbol (or#881 — declaring one custom token
-// must never make the merchant re-type the canonical mints), and the #360
-// token pricing policy drops tokens that cannot function (degrade-not-die).
-func SolanaRailConfigFromSettings(settings config.SolanaAccountSettings, testMode bool) *config.SolanaRailConfig {
+// (#349), the token set is the network's built-in registry extended by the
+// merchant's declarations (or#881 — a built-in symbol is SELECTED, its mint is
+// never restated), and the #360 pricing policy then drops tokens that cannot
+// function (degrade-not-die). A misdeclared token set is fail-closed: the PSP
+// does not arm rather than arming against a mint nobody vouched for.
+func SolanaRailConfigFromSettings(settings config.SolanaAccountSettings, testMode bool) (*config.SolanaRailConfig, error) {
 	network := "mainnet"
 	if testMode {
 		network = "devnet"
 	}
-	out := settings.ApplyTo(&config.SolanaRailConfig{
-		Network: network,
-		Tokens:  solanatokens.ForNetwork(network),
-	})
-	out.Tokens = solanatokens.NormalizeForNetwork(network, out.Tokens)
-	return out
+	resolved, err := solanatokens.ResolveDeclared(network, settings.Tokens)
+	if err != nil {
+		return nil, err
+	}
+	out := settings.ApplyTo(&config.SolanaRailConfig{Network: network})
+	out.Tokens = solanatokens.NormalizeForNetwork(network, resolved)
+	return out, nil
 }
 
 // FixedSet is a static Source over an in-memory PSPSet — a

--- a/internal/railresolve/solana_tokens_test.go
+++ b/internal/railresolve/solana_tokens_test.go
@@ -9,71 +9,70 @@ import (
 	solanatokens "github.com/open-rails/openrails/internal/modules/solana/tokens"
 )
 
-// or#881: a declared `tokens` map used to REPLACE the curated registry
+// or#881: a declared `tokens` map used to REPLACE the built-in registry
 // wholesale, so adding one custom token forced the merchant to re-type every
 // canonical mint they still wanted. Every re-typed mint is a chance to paste a
-// wrong address on a money path. A declaration now extends/overrides the
-// curated set per symbol.
+// wrong address on a money path. A declaration now extends the registry per
+// symbol, and a built-in symbol's mint cannot be declared at all.
 
-func TestSolanaRailConfigFromSettings_CustomTokenExtendsCuratedRegistry(t *testing.T) {
+func TestSolanaRailConfigFromSettings_CustomTokenExtendsRegistry(t *testing.T) {
 	const customMint = "MyTk1111111111111111111111111111111111111111"
 
-	out := SolanaRailConfigFromSettings(config.SolanaAccountSettings{
+	out, err := SolanaRailConfigFromSettings(config.SolanaAccountSettings{
 		Tokens: map[string]config.TokenConfig{
 			"MYTK": {Name: "My Token", Mint: customMint},
 		},
 	}, true) // devnet: no pricing requirements, so nothing is dropped for price reasons
+	require.NoError(t, err)
 
-	curated := solanatokens.ForNetwork("devnet")
-	require.NotEmpty(t, curated)
-	for symbol, want := range curated {
+	registry := solanatokens.ForNetwork("devnet")
+	require.NotEmpty(t, registry)
+	for symbol, want := range registry {
 		got, ok := out.Tokens[symbol]
-		require.Truef(t, ok, "curated token %s was dropped by declaring one custom token", symbol)
-		require.Equalf(t, want.Mint, got.Mint, "curated token %s mint changed", symbol)
+		require.Truef(t, ok, "registry token %s was dropped by declaring one custom token", symbol)
+		require.Equalf(t, want.Mint, got.Mint, "registry token %s mint changed", symbol)
 	}
 	require.Equal(t, customMint, out.Tokens["MYTK"].Mint)
-	require.Len(t, out.Tokens, len(curated)+1)
+	require.Len(t, out.Tokens, len(registry)+1)
 }
 
-func TestSolanaRailConfigFromSettings_MainnetCustomTokenKeepsCuratedMints(t *testing.T) {
-	out := SolanaRailConfigFromSettings(config.SolanaAccountSettings{
+func TestSolanaRailConfigFromSettings_MainnetCustomTokenKeepsRegistryMints(t *testing.T) {
+	out, err := SolanaRailConfigFromSettings(config.SolanaAccountSettings{
 		Tokens: map[string]config.TokenConfig{
 			// A custom token with no Pyth feed is disabled by the #360 pricing
-			// policy — but that must never take the curated set with it.
+			// policy — but that must never take the registry with it.
 			"MYTK": {Mint: "MyTk1111111111111111111111111111111111111111"},
 		},
 	}, false)
+	require.NoError(t, err)
 
 	for symbol, want := range solanatokens.ForNetwork("mainnet") {
 		got, ok := out.Tokens[symbol]
-		require.Truef(t, ok, "curated mainnet token %s was dropped", symbol)
-		require.Equalf(t, want.Mint, got.Mint, "curated mainnet token %s mint changed", symbol)
+		require.Truef(t, ok, "registry mainnet token %s was dropped", symbol)
+		require.Equalf(t, want.Mint, got.Mint, "registry mainnet token %s mint changed", symbol)
 	}
 	require.NotContains(t, out.Tokens, "MYTK", "feedless non-stablecoin should still be disabled")
 }
 
-// A declaration for a curated symbol overrides that ONE entry and leaves the
-// rest of the registry alone.
-func TestSolanaRailConfigFromSettings_DeclarationOverridesOneSymbol(t *testing.T) {
-	const overrideMint = "Ovr11111111111111111111111111111111111111111"
-
-	out := SolanaRailConfigFromSettings(config.SolanaAccountSettings{
-		Tokens: map[string]config.TokenConfig{"USDC": {Mint: overrideMint}},
+// Selecting a built-in symbol takes its mint from the registry; restating that
+// mint is fail-closed — the PSP does not arm.
+func TestSolanaRailConfigFromSettings_BuiltInSymbolIsSelectedNotRestated(t *testing.T) {
+	out, err := SolanaRailConfigFromSettings(config.SolanaAccountSettings{
+		Tokens: map[string]config.TokenConfig{"USDC": {Name: "Dollars"}},
 	}, true)
+	require.NoError(t, err)
+	require.Equal(t, solanatokens.ForNetwork("devnet")["USDC"].Mint, out.Tokens["USDC"].Mint)
+	require.Equal(t, "Dollars", out.Tokens["USDC"].Name)
 
-	require.Equal(t, overrideMint, out.Tokens["USDC"].Mint)
-	curated := solanatokens.ForNetwork("devnet")
-	for symbol, want := range curated {
-		if symbol == "USDC" {
-			continue
-		}
-		require.Equalf(t, want.Mint, out.Tokens[symbol].Mint, "curated token %s changed", symbol)
-	}
-	require.Len(t, out.Tokens, len(curated))
+	_, err = SolanaRailConfigFromSettings(config.SolanaAccountSettings{
+		Tokens: map[string]config.TokenConfig{"USDC": {Mint: "Ovr11111111111111111111111111111111111111111"}},
+	}, true)
+	require.ErrorContains(t, err, "USDC is a built-in token")
 }
 
-// Declaring nothing still yields exactly the curated set.
-func TestSolanaRailConfigFromSettings_NoDeclarationIsCuratedSet(t *testing.T) {
-	out := SolanaRailConfigFromSettings(config.SolanaAccountSettings{}, true)
+// Declaring nothing still yields exactly the registry set.
+func TestSolanaRailConfigFromSettings_NoDeclarationIsTheRegistry(t *testing.T) {
+	out, err := SolanaRailConfigFromSettings(config.SolanaAccountSettings{}, true)
+	require.NoError(t, err)
 	require.Equal(t, solanatokens.NormalizeForNetwork("devnet", solanatokens.ForNetwork("devnet")), out.Tokens)
 }


### PR DESCRIPTION
Two tails.

## or#881 — task 3: the mint comes from the registry; delete the knob

`config/solana_settings.go` still hard-required `tokens.<symbol>.mint` for **every**
symbol, so a merchant hand-copied the canonical USDC mint to declare a token OpenRails
already knew. A mint a merchant can type is a mint they can mistype, and a wrong mint
accepts payment in a different token than the one that was priced.

**New semantics**

- **Built-in symbol** — SELECT it (`USDC: {}`); the mint comes from
  `internal/modules/solana/tokens`. Declaring `mint:` for a built-in symbol is an
  error *even when the address agrees*.
- **Custom symbol** — `mint:` still required; there the mint *is* the token's identity.
- **Additive** — declarations extend the registry per symbol (the landed or#881 merge
  semantics are preserved); one custom token never costs the merchant the built-in set.
- `decimals` stays deleted (#817) — read from the mint on-chain.

`tokens.ResolveDeclared` owns the rule because it knows the network, which `config`
does not; `config/settingTokens` decodes shape only. Enforced at manifest push
(`internal/bootstrap`) and fail-closed at arm time (`railresolve` now returns an
error): a misdeclared PSP does not arm.

**Registry** (`internal/modules/solana/tokens/tokens.go`), all verified on-chain
2026-08-04 via `getAccountInfo` (owner program + decimals):

| symbol | mainnet mint | dec | devnet |
|---|---|---|---|
| SOL | `So1111…112` | 9 | same (native) |
| USDC | `EPjFWdd5…Dt1v` | 6 | `4zMMC9sr…ncDU` (6) |
| USDT | `Es9vMFrz…wNYB` | 6 | — |
| PYUSD | `2b1kV6Dk…4GXo` | 6 | `CXk2AMBf…UynM` (6) |
| USD1 | `USD1ttGY…muB` | 6 | — |
| USDG | `2u1tszSe…jGWH` | 6 | — |

USDT is new, with its Pyth `USDT/USD` feed (`2b89b9dc…e53b`, verified against Hermes),
so it is depeg-protected rather than degraded to bare $1.00 parity. It is **not**
recurring-allowlisted: no devnet deployment exists to verify `create_plan` against.

**Test-mode decision (stated in `resolve.go`)**: the registry has its own devnet
column and it applies under `test_mode`. Devnet mints are per-deployment artefacts
with no canonical address to protect, and devnet money is fake (the #360 pricing
policy is skipped there), so a built-in symbol with no devnet entry
(`USDT`/`USD1`/`USDG`) is simply not built-in on devnet — declare it there like any
other ad-hoc token, with an explicit `mint:`. Same declaration on mainnet is refused.

`registry_test.go` pins every registry mint: valid base58 pubkey, and the verified
on-chain decimals replayed through the mint reader's injectable seam (no RPC in tests)
and checked against `ValidateTokenDecimals`. A second test asserts the stablecoin peg
registry's mints never drift from the mint registry.

Example manifest + `docs/rails/solana.md` updated.

## or#782 — task 3: cross-merchant HTTP coverage

The existing two-merchant suite ran against a server connected as `openrails_app` but
only asserted api-keys, remote-application JWTs and delegated admins. Catalog,
customers, subscriptions, payments and webhooks — the handlers that lean on RLS for
scoping rather than carrying their own predicate — were proven at the DB level only.

`internal/integrationharness/cross_merchant_surface_isolation_test.go`, five focused
tests, each asserting both halves (A is denied; B's row is undamaged). Both tokens
carry the same permission set, so a denial is never explainable by permissions;
fixture rows are written through an RLS-enforcing merchant-pinned pool, never a bypass.

| surface | covered |
|---|---|
| catalog | list, get-by-id, get-by-key, PATCH (mutation) |
| customers | list, search-by-exact-id, per-customer billing profile |
| subscriptions | list, get-by-id, cancel (destructive) |
| payments | list, get-by-id, refund, per-customer payment history |
| webhooks | each merchant's signing secret delivers into that merchant only (401 both directions); delivered state never surfaces under the other merchant's customers/payments/subscriptions reads |

Found by the catalog test: `writeCatalogError` matched `"not found"`, but the lookup
helpers rewrite missing rows to `product_not_found`/`price_not_found`, so every
missing-or-foreign id answered **500**. The read was denied; it just looked like a
server fault. Fixed to match the underscore form.

## Tests

- `go test ./...` (unit): green.
- Integration (testcontainers, `-p 1`): `integrationharness` (60 tests), `bootstrap`,
  `railresolve`, `modules/solana{,/recurring,/tokens}`, `internal/http/...`, `tests`,
  `pkg/service`, `modules/checkout` — all green.
- Gates: `sql-lint` clean, `migration-lint` clean (no migration needed),
  `golangci-lint run ./...` 0 issues.

## Open design point left for the owner

or#881's tracker flags one unruled question that this PR deliberately does **not**
settle: with additive semantics there is still no way to NARROW the built-in set (a
merchant who wants only USDC also accepts SOL/USDT/PYUSD/USD1/USDG). `USDC: {}` now
makes select-and-**restrict** cheap to adopt if that is the wanted reading — it would
be a one-line change in `ResolveDeclared` (seed empty instead of from the registry
when anything is declared) — but it inverts the landed merge behaviour, so it needs a
ruling rather than a guess.