### PR TITLE
or#288: deterministic processor routing, fallback policy and a routing_reason trace

### DIFF
--- a/config/merchants_config.example.yaml
+++ b/config/merchants_config.example.yaml
@@ -41,6 +41,32 @@ merchants:
       - { key: burst, window: 15m, limit: 5_000_000 }
       - { key: sustained, window: 5h, limit: 20_000_000 }
 
+    # or#288 processor routing: ordered rules, FIRST MATCH WINS. `prefer` is both
+    # the ranked candidate list and the whitelist — a PSP the winning rule does
+    # not name cannot be routed to, which is how you pin a product to one rail.
+    # Candidates that cannot serve the price right now (unarmed, archived,
+    # credentials missing, no price link, mode unsupported) are skipped and the
+    # next one is taken; the skipped set and its reasons land on the session's
+    # routing_reason. Entries speak the checkout selector vocabulary (#848): PSP
+    # keys, or a rail kind where exactly one PSP is armed on it.
+    #
+    # OMIT THIS BLOCK ENTIRELY for the built-in order (stripe, nmi, ccbill,
+    # solana) — it is the right answer for a merchant with one PSP per rail.
+    # A declared rule REPLACES the policy whole; a rule with an empty `match`
+    # matches everything and must therefore be last.
+    #
+    # A request that NAMES a PSP always gets that PSP: routing decides only when
+    # checkout's payment.rail is omitted, and an explicit choice never falls back.
+    checkout_routing:
+      # EU subscriptions go to CCBill first, NMI second.
+      - match: { currency: eur, mode: subscription }
+        prefer: [ccbill, mobius]
+      # This one product is card-only; solana must never be offered for it.
+      - match: { product: enterprise }
+        prefer: [stripe, mobius]
+      # Catch-all.
+      - prefer: [mobius, ccbill, solana]
+
     # Operator-declared PSP catalog: one word everywhere — this key, the DB table
     # (openrails.psps) and the merchant-secret name prefix (`psps/…`). One rail each.
     psps:

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -90,7 +90,7 @@ handlers are also mounted under `/v1/me/checkout/*` (delegated token) and
 - `price_id` (required)
 - `mode` (optional) — `one_off` or `subscription`; resolved from the price if omitted
 - `payment` (required):
-  - `rail` (required) — a configured PSP key (e.g. `mobius`) or reserved rail (`ccbill`, `solana`, `stripe`)
+  - `rail` (optional) — a configured PSP key (e.g. `mobius`) or reserved rail (`ccbill`, `solana`, `stripe`). Naming one pins it (never silently switched); omitting it hands the choice to the merchant's routing policy, which falls through unavailable PSPs and records the decision on the session's `routing_reason` (or#288)
   - `payment_method_id` or `payment_token` for NMI-backed rails / Stripe
   - `token_symbol` for `solana`; `flow` — `transfer_request` (default) or `transaction_request` (`wallet` required)
   - billing details for `ccbill`/`stripe`: `email`, `first_name`, `last_name`, `address1`, `city`, `state`, `zip`, `country`
@@ -325,6 +325,7 @@ manifest-guarded like catalog writes).
 | GET | `/v1/merchant/payment-providers/{provider}` | One provider's config (redacted) |
 | PUT | `/v1/merchant/payment-providers/{provider}` | Create/update provider config + secrets |
 | DELETE | `/v1/merchant/payment-providers/{provider}` | Remove provider config |
+| POST | `/v1/merchant/payment-providers/routing/dry-run` | Explain which PSP a checkout would get, and why every other candidate was skipped. Read permission — creates nothing (or#288) |
 
 ### Metrics, dashboard, alerts, notifications
 

--- a/docs/frontend-integration.md
+++ b/docs/frontend-integration.md
@@ -13,7 +13,9 @@ All money amounts are **micros** (millionths of a currency unit): `$5.00 = 5_000
 A **rail** is the gateway kind (`nmi`, `ccbill`, `stripe`, `solana`); a **PSP** is the
 merchant's account on a rail, named by its key (`mobius` = an NMI account). Checkout's
 `payment.rail` value is the PSP key; a bare rail kind is also accepted when the merchant
-has exactly one PSP armed on it (ambiguous kinds 400, naming the armed keys).
+has exactly one PSP armed on it (ambiguous kinds 400, naming the armed keys). Omitting
+`payment.rail` entirely lets the merchant's routing policy pick — see
+[Letting the merchant route](#letting-the-merchant-route).
 
 ### Auth: two shapes
 
@@ -162,7 +164,8 @@ POST /v1/me/checkout
   "price_id": "price_...",
   "mode": "subscription",            // optional; inferred from the price
   "payment": {
-    "rail": "mobius | ccbill | stripe | solana",  // PSP key (rail kind ok if unambiguous)
+    "rail": "mobius | ccbill | stripe | solana",  // PSP key (rail kind ok if unambiguous);
+                                     // omit to let the merchant's routing policy pick
     "payment_method_id": "pm_...",   // saved card — mobius/stripe
     "payment_token": "tok_...",      // fresh browser-tokenized card — mobius/stripe
     "token_symbol": "USDC",          // solana
@@ -175,6 +178,26 @@ POST /v1/me/checkout
 
 Send an `Idempotency-Key` header on create — retries with the same key replay the
 original response instead of double-charging.
+
+#### Letting the merchant route
+
+`payment.rail` is optional. Name a PSP and you get that PSP — an explicit choice is never
+silently switched, because your page has already committed to that PSP's flow. Omit it and
+the merchant's routing policy picks: the first PSP in their preference order that can
+actually serve this price right now, skipping any that is unarmed, archived, missing
+credentials, missing a price link, or unable to serve the mode. Merchants who declare no
+policy get the built-in order (stripe, nmi, ccbill, solana).
+
+Only omit it when your page can drive whatever comes back — read `flow` for the returned
+`payment.rail` from `/v1/checkout-config` and branch on it. If you have already collected a
+card token, name the PSP you tokenized against.
+
+The chosen PSP and the reason for it are recorded on the session
+(`checkout_sessions.routing_reason`), so support can answer "why did this customer get
+CCBill" without guessing. Merchants can preview a decision without creating anything:
+`POST /v1/merchant/payment-providers/routing/dry-run` with `{"price_id": "...", "country":
+"US"}` returns the winner, the ranked fallbacks, and every skipped candidate with its
+reason.
 
 The response's `next_action` tells the frontend what to do next:
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -161,6 +161,38 @@ Cutover](operations.md#cutover-booting-against-production-credentials).
   stale intents expire/supersede. Rules:
   [operations.md → Durability model](operations.md#durability-model).
 
+### Processor routing
+
+Checkout is one processor at a time, chosen **before** the session exists. A request that
+names a PSP gets that PSP; a request that omits `payment.rail` is routed.
+
+- **Default** (no policy declared): stripe → nmi → ccbill → solana, first one that can
+  serve the price.
+- **Policy**: `checkout_routing` in the merchant manifest (mode 1) or
+  `checkout_routing` on `PUT /v1/merchant/settings` (mode 2). Ordered
+  rules, first match wins; each rule's `prefer` list is both the ranking and the
+  whitelist, so a rule can pin a product to one rail. Conditions: `currency`, `product`,
+  `price`, `mode`, `country` — all optional, all AND-ed; a rule with no conditions is the
+  catch-all and must be last.
+
+```yaml
+checkout_routing:
+  - match: { currency: eur, mode: subscription }
+    prefer: [ccbill, mobius]
+  - prefer: [mobius, ccbill, solana]
+```
+
+- **Fallback** is availability-only and evaluated pre-charge: `not_armed`,
+  `credentials_missing`, `link_missing`, `mode_unsupported`, `service_unavailable`,
+  `ambiguous_selector`, `unknown_selector`, `resolve_failed`. A **decline is not one of
+  them** — routing never retries a charge on a second processor.
+- **Why did this customer get CCBill?** `checkout_sessions.routing_reason` holds the
+  decision: policy, matched rule, winner, ranked fallbacks, and every skipped candidate
+  with its class. Written once at creation, never rewritten.
+- **Preview without charging**: `POST /v1/merchant/payment-providers/routing/dry-run`
+  with `{"price_id": "...", "country": "US"}` returns the same decision a real session
+  would make, including the exact `routing_reason` it would store.
+
 ### Observability
 
 - **Metrics / analytics API**: `GET /v1/merchant/metrics/schema` (self-describing

--- a/embed/checkout_routing_integration_test.go
+++ b/embed/checkout_routing_integration_test.go
@@ -1,0 +1,395 @@
+//go:build integration
+
+package embed_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/embed"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/pkg/billingauth"
+	"github.com/open-rails/openrails/pkg/embedded"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// or#288 processor routing, driven end to end over the REAL checkout surface:
+// the merchant's declared policy decides which PSP a session lands on before
+// the session exists, unavailable candidates are fallen through with a stated
+// reason, the decision is persisted on the row, and the dry-run endpoint
+// returns the SAME decision without creating anything.
+
+type routingFixture struct {
+	merchantID    merchant.ID
+	customerURL   string
+	merchantURL   string
+	priceID       string
+	buyerUsername string
+}
+
+// bootRoutingFixture arms the given PSPs + routing policy on a fresh mode-1
+// merchant, seeds a price linked to every PSP named, and mounts both the buyer
+// checkout surface and the merchant surface.
+func bootRoutingFixture(
+	t *testing.T,
+	ctx context.Context,
+	dsn, slug string,
+	psps map[string]embed.PSPConfig,
+	routing []embed.CheckoutRoutingRuleConfig,
+) routingFixture {
+	t.Helper()
+
+	cfg := sandboxModeConfig(dsn, config.MerchantSourceManifest)
+	rt, err := embed.New(ctx, embed.Options{Options: embedded.Options{Config: cfg, River: embedded.RiverManagedByOpenRails()}})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rt.Close(context.Background()) })
+
+	id, err := rt.UpsertMerchantConfig(ctx, slug, embed.MerchantConfig{
+		DisplayName:     slug,
+		PSPs:            psps,
+		CheckoutRouting: routing,
+	})
+	require.NoError(t, err)
+	cleanupCCBillWebhookMerchant(t, id)
+	t.Cleanup(func() {
+		appDB := dbtest.OpenMerchantDB(t, id.UUID())
+		_, _ = appDB.Pool().Exec(context.Background(),
+			`DELETE FROM openrails.merchant_configurations WHERE merchant_id = $1`, id.UUID())
+	})
+
+	// The catalog is pushed with only the ccbill link (operator-owned, so the
+	// push validates nothing remotely), then the full psp_links map is written
+	// directly. Declaring an nmi plan_id in the manifest would make the push
+	// find-or-create a recurring plan against a live gateway — routing is what
+	// is under test here, not catalog push.
+	flexID, formName := seedCCBillWebhookCatalog(t, ctx, cfg, slug)
+	appDB := dbtest.OpenMerchantDB(t, id.UUID())
+	links, err := json.Marshal(map[string]map[string]string{
+		"ccbill":   {"rail": "ccbill", "flex_id": flexID, "form_name": formName},
+		"mobius":   {"rail": "nmi", "plan_id": "plan-" + slug},
+		"paykings": {"rail": "nmi", "plan_id": "plan-old-" + slug},
+	})
+	require.NoError(t, err)
+	tag, err := appDB.Pool().Exec(ctx,
+		`UPDATE openrails.prices SET psp_links = $2::jsonb WHERE merchant_id = $1`, id.UUID(), string(links))
+	require.NoError(t, err)
+	require.EqualValues(t, 1, tag.RowsAffected(), "exactly one seeded price must be linked")
+
+	username := "routing_" + uuid.NewString()[:8]
+	userID := seedProfileUser(t, ctx, dsn, username)
+	email := username + "@test.example.com"
+	userAuthn := billingauth.AuthenticatorFunc(func(context.Context, *http.Request) (billingauth.UserContext, error) {
+		return billingauth.UserContext{UserID: userID, Email: email, EmailVerified: true}, nil
+	})
+	delegated := billingauth.DelegatedAuthenticatorFunc(func(context.Context, *http.Request) (*billingauth.DelegatedPrincipal, error) {
+		return &billingauth.DelegatedPrincipal{MerchantID: id.UUID().String(), SubjectID: userID, Email: email, EmailVerified: true, Username: username}, nil
+	})
+	buyerHandler, err := embedded.MountHandler(rt.Embedded(), embedded.MountOptions{
+		RouteSets:              []embed.RouteSet{embed.RouteSetCheckout, embed.RouteSetCustomer},
+		Authenticator:          userAuthn,
+		DelegatedAuthenticator: delegated,
+	})
+	require.NoError(t, err)
+	buyerServer := httptest.NewServer(buyerHandler)
+	t.Cleanup(buyerServer.Close)
+
+	merchantHandler, err := embedded.MountHandler(rt.Embedded(), embedded.MountOptions{
+		RouteSets: []embed.RouteSet{embed.RouteSetPaymentProviders, embed.RouteSetMerchantAPI},
+		Gate:      allowAllGate{id: id},
+	})
+	require.NoError(t, err)
+	merchantServer := httptest.NewServer(merchantHandler)
+	t.Cleanup(merchantServer.Close)
+
+	return routingFixture{
+		merchantID:    id,
+		customerURL:   buyerServer.URL,
+		merchantURL:   merchantServer.URL,
+		priceID:       fetchCCBillPriceID(t, buyerServer.URL),
+		buyerUsername: username,
+	}
+}
+
+type routingDryRunResponse struct {
+	Policy     string `json:"policy"`
+	Rule       *int   `json:"rule"`
+	Selected   string `json:"selected"`
+	Rail       string `json:"rail"`
+	Mode       string `json:"mode"`
+	Candidates []struct {
+		Selector string `json:"selector"`
+		Rail     string `json:"rail"`
+		Skip     string `json:"skip"`
+	} `json:"candidates"`
+	RoutingReason json.RawMessage `json:"routing_reason"`
+}
+
+func routingDryRun(t *testing.T, fx routingFixture, selector string) routingDryRunResponse {
+	t.Helper()
+	body := fmt.Sprintf(`{"price_id":%q,"country":"US","selector":%q}`, fx.priceID, selector)
+	req, err := http.NewRequest(http.MethodPost, fx.merchantURL+"/v1/merchant/payment-providers/routing/dry-run", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
+	var out routingDryRunResponse
+	require.NoError(t, json.Unmarshal(raw, &out), string(raw))
+	return out
+}
+
+// openRoutedCheckoutSession posts a checkout WITHOUT payment.rail — the
+// routing request — and returns the created session id.
+func openRoutedCheckoutSession(t *testing.T, fx routingFixture) string {
+	t.Helper()
+	body := fmt.Sprintf(`{"price_id":%q,"mode":"subscription","payment":{"email":%q,"first_name":"Routing","last_name":"Buyer","address1":"123 Test St","city":"Denver","state":"CO","zip":"80202","country":"US"}}`,
+		fx.priceID, fx.buyerUsername+"@test.example.com")
+	req, err := http.NewRequest(http.MethodPost, fx.customerURL+"/v1/me/checkout", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer host-credential")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
+	var session struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+		Rail   string `json:"rail"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &session), string(raw))
+	require.Equal(t, "requires_action", session.Status, string(raw))
+	return session.ID
+}
+
+func sessionRoutingReason(t *testing.T, ctx context.Context, mid merchant.ID, sessionID string) (rail string, reason json.RawMessage) {
+	t.Helper()
+	appDB := dbtest.OpenMerchantDB(t, mid.UUID())
+	require.NoError(t, appDB.Pool().QueryRow(ctx,
+		`SELECT rail, routing_reason FROM openrails.checkout_sessions WHERE merchant_id = $1`,
+		mid.UUID()).Scan(&rail, &reason))
+	return rail, reason
+}
+
+// A declared policy reorders the candidates, falls through an ARCHIVED PSP with
+// a stated reason, records the decision on the session row, and the dry-run
+// endpoint reproduces that decision exactly without creating anything.
+func TestCheckoutRoutingPolicyDecidesRecordsAndDryRuns(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+
+	nano := time.Now().UnixNano()
+	slug := fmt.Sprintf("rtpol%d", nano)
+	ccbillAccount := fmt.Sprintf("96%04d-0000", nano%10_000)
+
+	fx := bootRoutingFixture(t, ctx, dsn, slug,
+		map[string]embed.PSPConfig{
+			"ccbill": {"ccbill": {
+				AccountID: ccbillAccount,
+				Secrets:   map[string]string{"salt": "test-salt-" + slug},
+			}},
+			"mobius": {"nmi": {
+				AccountID: fmt.Sprintf("gw-%d", nano),
+				Secrets:   map[string]string{"security_key": "sk-" + slug},
+			}},
+			// Retired: declared, archived, and therefore never routable.
+			"paykings": {"nmi": {
+				AccountID: fmt.Sprintf("gw-old-%d", nano),
+				Archived:  true,
+				Secrets:   map[string]string{"security_key": "sk-old-" + slug},
+			}},
+		},
+		[]embed.CheckoutRoutingRuleConfig{
+			// Deliberately NOT the default order: the retired PSP first, then
+			// ccbill, then nmi. If the policy were ignored the default order
+			// would put nmi (mobius) ahead of ccbill.
+			{Prefer: []string{"paykings", "ccbill", "mobius"}},
+		},
+	)
+
+	// The dry run explains the decision without creating anything.
+	trace := routingDryRun(t, fx, "")
+	require.Equal(t, "merchant", trace.Policy)
+	require.NotNil(t, trace.Rule)
+	require.Equal(t, 0, *trace.Rule)
+	require.Equal(t, "ccbill", trace.Selected)
+	require.Equal(t, "ccbill", trace.Rail)
+	require.Equal(t, "subscription", trace.Mode)
+	require.Len(t, trace.Candidates, 3)
+	require.Equal(t, "paykings", trace.Candidates[0].Selector)
+	require.Equal(t, "not_armed", trace.Candidates[0].Skip, "an archived PSP is retired, not unknown")
+	require.Equal(t, "ccbill", trace.Candidates[1].Selector)
+	require.Empty(t, trace.Candidates[1].Skip)
+	require.Equal(t, "mobius", trace.Candidates[2].Selector)
+	require.Empty(t, trace.Candidates[2].Skip)
+
+	var appDB = dbtest.OpenMerchantDB(t, fx.merchantID.UUID())
+	var sessionCount int
+	require.NoError(t, appDB.Pool().QueryRow(ctx,
+		`SELECT count(*) FROM openrails.checkout_sessions WHERE merchant_id = $1`, fx.merchantID.UUID()).Scan(&sessionCount))
+	require.Zero(t, sessionCount, "a dry run must not create a session")
+
+	// The real checkout, with NO payment.rail, makes the same decision.
+	sessionID := openRoutedCheckoutSession(t, fx)
+	require.NotEmpty(t, sessionID)
+
+	rail, reason := sessionRoutingReason(t, ctx, fx.merchantID, sessionID)
+	require.Equal(t, "ccbill", rail)
+	require.NotEmpty(t, reason, "the routed session must record WHY it chose this PSP")
+	require.JSONEq(t, string(trace.RoutingReason), string(reason),
+		"the dry-run trace must be the decision a real session records")
+}
+
+// With no policy declared, routing reproduces the historical hardcoded order:
+// stripe, then nmi, then ccbill, then solana.
+func TestCheckoutRoutingDefaultOrderMatchesLegacyPreference(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+
+	nano := time.Now().UnixNano()
+	slug := fmt.Sprintf("rtdef%d", nano)
+	ccbillAccount := fmt.Sprintf("97%04d-0000", nano%10_000)
+
+	fx := bootRoutingFixture(t, ctx, dsn, slug,
+		map[string]embed.PSPConfig{
+			"ccbill": {"ccbill": {
+				AccountID: ccbillAccount,
+				Secrets:   map[string]string{"salt": "test-salt-" + slug},
+			}},
+			"mobius": {"nmi": {
+				AccountID: fmt.Sprintf("gw-%d", nano),
+				Secrets:   map[string]string{"security_key": "sk-" + slug},
+			}},
+		},
+		nil, // no policy at all
+	)
+
+	trace := routingDryRun(t, fx, "")
+	require.Equal(t, "default", trace.Policy)
+	require.Nil(t, trace.Rule)
+	// nmi outranks ccbill in the built-in order, and the bare rail kind
+	// resolves to the one armed PSP's key.
+	require.Equal(t, "mobius", trace.Selected)
+	require.Equal(t, "nmi", trace.Rail)
+
+	order := make([]string, 0, len(trace.Candidates))
+	for _, c := range trace.Candidates {
+		order = append(order, c.Rail)
+	}
+	require.Equal(t, []string{"stripe", "nmi", "ccbill", "solana"}, order,
+		"the default candidate order is the historical hardcoded one")
+	require.Equal(t, "not_armed", trace.Candidates[0].Skip)
+	require.Empty(t, trace.Candidates[1].Skip)
+	require.Empty(t, trace.Candidates[2].Skip)
+	require.Equal(t, "not_armed", trace.Candidates[3].Skip)
+
+	// MODE-2 PARITY: the same policy declared over the config API takes effect
+	// on the next decision, and reorders the very order pinned above.
+	putMerchantRoutingPolicy(t, fx, `{"checkout_routing":[{"match":{"currency":"usd"},"prefer":["ccbill","mobius"]}]}`)
+	trace = routingDryRun(t, fx, "")
+	require.Equal(t, "merchant", trace.Policy)
+	require.NotNil(t, trace.Rule)
+	require.Equal(t, 0, *trace.Rule)
+	require.Equal(t, "ccbill", trace.Selected)
+	require.Equal(t, []string{"ccbill", "mobius"}, []string{trace.Candidates[0].Selector, trace.Candidates[1].Selector})
+
+	// A rule whose conditions do not hold is not reached: EUR-only, USD price.
+	putMerchantRoutingPolicy(t, fx, `{"checkout_routing":[{"match":{"currency":"eur"},"prefer":["ccbill"]}]}`)
+	trace = routingDryRun(t, fx, "")
+	require.Equal(t, "default", trace.Policy, "no rule matched, so the built-in order decides")
+	require.Equal(t, "mobius", trace.Selected)
+
+	// A malformed policy is refused, not half-applied.
+	req, err := http.NewRequest(http.MethodPut, fx.merchantURL+"/v1/merchant/settings",
+		strings.NewReader(`{"checkout_routing":[{"prefer":["mobius"]},{"match":{"currency":"eur"},"prefer":["ccbill"]}]}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode, string(raw))
+	require.Contains(t, string(raw), "unreachable", string(raw))
+}
+
+// putMerchantRoutingPolicy installs a routing policy over the mode-2 config API.
+func putMerchantRoutingPolicy(t *testing.T, fx routingFixture, body string) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPut, fx.merchantURL+"/v1/merchant/settings", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, string(raw))
+}
+
+// #848 is untouched: a bare rail kind with two armed PSPs is still refused when
+// the CALLER names it, and routing skips it rather than picking one at random.
+func TestCheckoutRoutingKeepsAmbiguousSelectorRefusal(t *testing.T) {
+	ctx := context.Background()
+	dsn := dbtest.SharedPostgresDSN(t)
+
+	nano := time.Now().UnixNano()
+	slug := fmt.Sprintf("rtamb%d", nano)
+	ccbillAccount := fmt.Sprintf("98%04d-0000", nano%10_000)
+
+	fx := bootRoutingFixture(t, ctx, dsn, slug,
+		map[string]embed.PSPConfig{
+			"ccbill": {"ccbill": {
+				AccountID: ccbillAccount,
+				Secrets:   map[string]string{"salt": "test-salt-" + slug},
+			}},
+			"mobius": {"nmi": {
+				AccountID: fmt.Sprintf("gw-a-%d", nano),
+				Secrets:   map[string]string{"security_key": "sk-a-" + slug},
+			}},
+			"paykings": {"nmi": {
+				AccountID: fmt.Sprintf("gw-b-%d", nano),
+				Secrets:   map[string]string{"security_key": "sk-b-" + slug},
+			}},
+		},
+		nil,
+	)
+
+	// Routing: the ambiguous rail kind is SKIPPED with its class, and the
+	// decision falls through to the unambiguous ccbill PSP.
+	trace := routingDryRun(t, fx, "")
+	require.Equal(t, "default", trace.Policy)
+	require.Equal(t, "ambiguous_selector", trace.Candidates[1].Skip)
+	require.Equal(t, "ccbill", trace.Selected)
+
+	// An explicitly NAMED ambiguous rail kind is still a hard refusal —
+	// routing does not soften the #848 contract for a caller who asked.
+	body := fmt.Sprintf(`{"price_id":%q,"mode":"subscription","payment":{"rail":"nmi"}}`, fx.priceID)
+	req, err := http.NewRequest(http.MethodPost, fx.customerURL+"/v1/me/checkout", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer host-credential")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode, string(raw))
+	require.Contains(t, string(raw), "ambiguous rail", string(raw))
+}

--- a/embed/provision.go
+++ b/embed/provision.go
@@ -26,6 +26,13 @@ type MerchantConfig = boot.MerchantConfig
 type InvoiceConfig = boot.InvoiceConfig
 type MerchantProfileConfig = boot.MerchantProfileConfig
 type PSPConfig = boot.PSPConfig
+
+// CheckoutRoutingRuleConfig / CheckoutRoutingMatchConfig alias the or#288
+// processor-routing policy block so embedded hosts can declare it
+// programmatically alongside their PSPs.
+type CheckoutRoutingRuleConfig = boot.CheckoutRoutingRuleConfig
+type CheckoutRoutingMatchConfig = boot.CheckoutRoutingMatchConfig
+
 type ProviderRailAccountConfig = boot.ProviderRailAccountConfig
 type RailMerchantAccountSignerConfig = boot.RailMerchantAccountSignerConfig
 type RemoteApplicationConfig = boot.RemoteApplicationConfig
@@ -145,6 +152,7 @@ func merchantConfigDeclaresManifestTruth(m MerchantConfig) bool {
 		m.RemoteApplication != nil ||
 		m.Invoice != nil ||
 		len(m.DelegatedInvokerWastedSpendWindows) > 0 ||
+		len(m.CheckoutRouting) > 0 ||
 		strings.TrimSpace(m.Profile.DisplayName) != "" ||
 		strings.TrimSpace(m.Profile.LogoURL) != "" ||
 		strings.TrimSpace(m.Profile.FromEmail) != "" ||

--- a/internal/bootstrap/bootstrap_manifest.go
+++ b/internal/bootstrap/bootstrap_manifest.go
@@ -9,6 +9,7 @@ import (
 	"github.com/open-rails/openrails/config"
 	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/merchants"
+	"github.com/open-rails/openrails/internal/modules/merchantconfig"
 )
 
 const (
@@ -58,6 +59,12 @@ func validateMerchantManifestShape(m *BillingConfig) error {
 		}
 		if err := validateManifestWastedWindows(slug, t.DelegatedInvokerWastedSpendWindows); err != nil {
 			return err
+		}
+		// or#288: the routing policy is validated by the SAME normalizer the
+		// mode-2 config API uses, so a manifest cannot declare a policy the API
+		// would refuse.
+		if _, err := merchantconfig.NormalizeCheckoutRouting(checkoutRoutingRules(t.CheckoutRouting)); err != nil {
+			return fmt.Errorf("merchant %q %w", slug, err)
 		}
 		for key, account := range t.PSPs {
 			if err := validateManifestRailMerchantAccount(slug, key, account); err != nil {

--- a/internal/bootstrap/merchant_dump.go
+++ b/internal/bootstrap/merchant_dump.go
@@ -114,6 +114,18 @@ func DumpMerchantConfig(ctx context.Context, cfg *config.Config, cp *controlplan
 				Currency: w.Currency,
 			})
 		}
+		for _, rule := range conf.CheckoutRouting {
+			mt.CheckoutRouting = append(mt.CheckoutRouting, CheckoutRoutingRuleConfig{
+				Match: CheckoutRoutingMatchConfig{
+					Currency: rule.Match.Currency,
+					Product:  rule.Match.Product,
+					Price:    rule.Match.Price,
+					Mode:     rule.Match.Mode,
+					Country:  rule.Match.Country,
+				},
+				Prefer: rule.Prefer,
+			})
+		}
 	}
 
 	// provider accounts (identity + lifecycle + secret references).

--- a/internal/bootstrap/merchant_manifest.go
+++ b/internal/bootstrap/merchant_manifest.go
@@ -269,6 +269,9 @@ func mergeMerchantConfig(dst *MerchantConfig, src MerchantConfig) {
 	if len(src.DelegatedInvokerWastedSpendWindows) > 0 {
 		dst.DelegatedInvokerWastedSpendWindows = src.DelegatedInvokerWastedSpendWindows
 	}
+	if len(src.CheckoutRouting) > 0 {
+		dst.CheckoutRouting = src.CheckoutRouting
+	}
 	if len(src.PSPs) > 0 {
 		if dst.PSPs == nil {
 			dst.PSPs = map[string]PSPConfig{}
@@ -376,6 +379,50 @@ type MerchantConfig struct {
 	// DB table (openrails.psps) and the merchant-secret name prefix (`psps/…`)
 	// speak the same vocabulary as this key.
 	PSPs map[string]PSPConfig `yaml:"psps,omitempty" koanf:"psps"`
+	// CheckoutRouting (or#288) is the merchant's processor preference policy:
+	// ordered rules, first match wins, each naming a ranked PSP list. Omitted
+	// leaves the stored policy untouched; declared REPLACES it whole (an
+	// ordered list has no meaningful per-element merge).
+	CheckoutRouting []CheckoutRoutingRuleConfig `yaml:"checkout_routing,omitempty" koanf:"checkout_routing"`
+}
+
+// CheckoutRoutingRuleConfig is one manifest routing rule. Prefer speaks the
+// checkout selector vocabulary (#848): PSP keys, or a rail kind where exactly
+// one PSP is armed on it.
+type CheckoutRoutingRuleConfig struct {
+	Match  CheckoutRoutingMatchConfig `yaml:"match,omitempty" koanf:"match"`
+	Prefer []string                   `yaml:"prefer" koanf:"prefer"`
+}
+
+// CheckoutRoutingMatchConfig is a rule's condition; every set field must match,
+// and an all-empty match is the catch-all (which must be the last rule).
+type CheckoutRoutingMatchConfig struct {
+	Currency string `yaml:"currency,omitempty" koanf:"currency"`
+	Product  string `yaml:"product,omitempty" koanf:"product"`
+	Price    string `yaml:"price,omitempty" koanf:"price"`
+	Mode     string `yaml:"mode,omitempty" koanf:"mode"`
+	Country  string `yaml:"country,omitempty" koanf:"country"`
+}
+
+// checkoutRoutingRules projects the manifest rules onto the stored model.
+func checkoutRoutingRules(in []CheckoutRoutingRuleConfig) []models.CheckoutRoutingRule {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]models.CheckoutRoutingRule, 0, len(in))
+	for _, rule := range in {
+		out = append(out, models.CheckoutRoutingRule{
+			Match: models.CheckoutRoutingMatch{
+				Currency: rule.Match.Currency,
+				Product:  rule.Match.Product,
+				Price:    rule.Match.Price,
+				Mode:     rule.Match.Mode,
+				Country:  rule.Match.Country,
+			},
+			Prefer: rule.Prefer,
+		})
+	}
+	return out
 }
 
 // InvoiceConfig is the merchant invoice/collection policy block, mirroring
@@ -824,7 +871,7 @@ func reconcileManifestMerchantConfiguration(ctx context.Context, cfg *config.Con
 	// Apply the merchant_configurations payload (#646): profile, invoice/collection
 	// policy, and delegated-invoker abuse windows. Load once, mutate only the
 	// declared parts (omit = leave-as-is), upsert if anything changed.
-	if hasManifestProfile(mt.Profile) || mt.Invoice != nil || len(mt.DelegatedInvokerWastedSpendWindows) > 0 {
+	if hasManifestProfile(mt.Profile) || mt.Invoice != nil || len(mt.DelegatedInvokerWastedSpendWindows) > 0 || len(mt.CheckoutRouting) > 0 {
 		store := merchantconfig.NewStore(database)
 		conf, _, err := store.Get(mctx)
 		if err != nil {
@@ -874,6 +921,14 @@ func reconcileManifestMerchantConfiguration(ctx context.Context, cfg *config.Con
 				})
 			}
 			conf.DelegatedInvokerWastedSpendWindows = windows
+		}
+		if len(mt.CheckoutRouting) > 0 {
+			// or#288: the declared order IS the policy, so it replaces whole.
+			routing, err := merchantconfig.NormalizeCheckoutRouting(checkoutRoutingRules(mt.CheckoutRouting))
+			if err != nil {
+				return err
+			}
+			conf.CheckoutRouting = routing
 		}
 		if err := store.Upsert(mctx, conf); err != nil {
 			return fmt.Errorf("upsert merchant configuration: %w", err)

--- a/internal/db/gen/checkout_sessions.sql.go
+++ b/internal/db/gen/checkout_sessions.sql.go
@@ -52,17 +52,17 @@ const createCheckoutSession = `-- name: CreateCheckoutSession :execrows
 INSERT INTO openrails.checkout_sessions (
     id, merchant_id, customer_id, price_id, mode, rail, status, amount,
     currency, expires_at, reference, transaction_id, payment_id,
-    subscription_id, metadata, rail_fields, rail_state,
+    subscription_id, metadata, rail_fields, rail_state, routing_reason,
     psp_id, created_at, updated_at
 ) VALUES (
     $1, $8::uuid, $2, $3, $4, $5, $6, $7,
     $9,
     $10, $11, $12,
     $13, $14, $15,
-    $16, $17,
-    $18,
-    COALESCE(NULLIF($19::timestamptz, '0001-01-01 00:00:00+00'::timestamptz), now()),
-    COALESCE(NULLIF($20::timestamptz, '0001-01-01 00:00:00+00'::timestamptz), now())
+    $16, $17, $18,
+    $19,
+    COALESCE(NULLIF($20::timestamptz, '0001-01-01 00:00:00+00'::timestamptz), now()),
+    COALESCE(NULLIF($21::timestamptz, '0001-01-01 00:00:00+00'::timestamptz), now())
 )
 `
 
@@ -84,6 +84,7 @@ type CreateCheckoutSessionParams struct {
 	Metadata       []byte
 	RailFields     []byte
 	RailState      []byte
+	RoutingReason  []byte
 	PspID          *uuid.UUID
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
@@ -109,6 +110,7 @@ func (q *Queries) CreateCheckoutSession(ctx context.Context, arg CreateCheckoutS
 		arg.Metadata,
 		arg.RailFields,
 		arg.RailState,
+		arg.RoutingReason,
 		arg.PspID,
 		arg.CreatedAt,
 		arg.UpdatedAt,
@@ -168,7 +170,7 @@ func (q *Queries) ExpireCheckoutSessions(ctx context.Context, arg ExpireCheckout
 }
 
 const getCheckoutSessionByID = `-- name: GetCheckoutSessionByID :one
-SELECT id, price_id, mode, rail, status, amount, currency, expires_at, reference, transaction_id, payment_id, subscription_id, rail_fields, rail_state, metadata, created_at, updated_at, merchant_id, customer_id, psp_id, deleted_at, destructive_run_id FROM openrails.checkout_sessions WHERE id = $1
+SELECT id, price_id, mode, rail, status, amount, currency, expires_at, reference, transaction_id, payment_id, subscription_id, rail_fields, rail_state, metadata, created_at, updated_at, merchant_id, customer_id, psp_id, deleted_at, destructive_run_id, routing_reason FROM openrails.checkout_sessions WHERE id = $1
   AND deleted_at IS NULL
 `
 
@@ -198,12 +200,13 @@ func (q *Queries) GetCheckoutSessionByID(ctx context.Context, id uuid.UUID) (Ope
 		&i.PspID,
 		&i.DeletedAt,
 		&i.DestructiveRunID,
+		&i.RoutingReason,
 	)
 	return i, err
 }
 
 const getCheckoutSessionByReference = `-- name: GetCheckoutSessionByReference :one
-SELECT id, price_id, mode, rail, status, amount, currency, expires_at, reference, transaction_id, payment_id, subscription_id, rail_fields, rail_state, metadata, created_at, updated_at, merchant_id, customer_id, psp_id, deleted_at, destructive_run_id FROM openrails.checkout_sessions cs
+SELECT id, price_id, mode, rail, status, amount, currency, expires_at, reference, transaction_id, payment_id, subscription_id, rail_fields, rail_state, metadata, created_at, updated_at, merchant_id, customer_id, psp_id, deleted_at, destructive_run_id, routing_reason FROM openrails.checkout_sessions cs
 WHERE cs.reference = $1
   AND cs.deleted_at IS NULL
 LIMIT 1
@@ -235,12 +238,13 @@ func (q *Queries) GetCheckoutSessionByReference(ctx context.Context, reference *
 		&i.PspID,
 		&i.DeletedAt,
 		&i.DestructiveRunID,
+		&i.RoutingReason,
 	)
 	return i, err
 }
 
 const getLatestOpenCheckoutSession = `-- name: GetLatestOpenCheckoutSession :one
-SELECT id, price_id, mode, rail, status, amount, currency, expires_at, reference, transaction_id, payment_id, subscription_id, rail_fields, rail_state, metadata, created_at, updated_at, merchant_id, customer_id, psp_id, deleted_at, destructive_run_id FROM openrails.checkout_sessions cs
+SELECT id, price_id, mode, rail, status, amount, currency, expires_at, reference, transaction_id, payment_id, subscription_id, rail_fields, rail_state, metadata, created_at, updated_at, merchant_id, customer_id, psp_id, deleted_at, destructive_run_id, routing_reason FROM openrails.checkout_sessions cs
 WHERE cs.customer_id = $1
   AND cs.price_id = $2
   AND cs.rail = $3
@@ -289,6 +293,7 @@ func (q *Queries) GetLatestOpenCheckoutSession(ctx context.Context, arg GetLates
 		&i.PspID,
 		&i.DeletedAt,
 		&i.DestructiveRunID,
+		&i.RoutingReason,
 	)
 	return i, err
 }

--- a/internal/db/gen/models.go
+++ b/internal/db/gen/models.go
@@ -256,6 +256,8 @@ type OpenrailsCheckoutSession struct {
 	// or#858 soft delete: set, the row is invisible to every live read. Only `pull-provider --prune` sets it, and `openrails undo-run` clears it.
 	DeletedAt        *time.Time
 	DestructiveRunID *uuid.UUID
+	// or#288 processor-routing decision trace, written once at creation: {policy: explicit|merchant|default, rule: matched merchant-rule index, selected: PSP key, rail, fallbacks: [remaining eligible PSP keys, ranked], skipped: [{selector, reason}]}. Skip reasons are PRE-CHARGE availability classes (not_armed, credentials_missing, link_missing, mode_unsupported, service_unavailable, ambiguous_selector, unknown_selector, resolve_failed); a decline is never one of them. NULL = created before the column existed.
+	RoutingReason []byte
 }
 
 // Per-tenant custom credit units (#475): consume-only, no FX, never billed in. Referenced from money rows via the qualified code tenant-slug/name. Written by the catalog sidecar push (#706): auto-defined from catalog_credit_balances.unit; never auto-deactivated (grants may still reference a removed balance's unit).

--- a/internal/db/models/checkout_session.go
+++ b/internal/db/models/checkout_session.go
@@ -63,6 +63,12 @@ type CheckoutSession struct {
 	RailFields map[string]any `json:"rail_fields,omitempty"`
 	RailState  map[string]any `json:"rail_state,omitempty"`
 
+	// RoutingReason (or#288) is the decision trace that picked this session's
+	// PSP: which policy and rule matched, and what was skipped and why. Written
+	// once at creation and never rewritten — support answers "why did this
+	// customer get CCBill" from the row, not from a reconstruction.
+	RoutingReason *CheckoutRoutingReason `json:"routing_reason,omitempty"`
+
 	// IdempotencyKey is request-scoped only (Redis owns checkout idempotency,
 	// #702 dropped the column); never persisted or round-tripped from the DB.
 	IdempotencyKey *string `json:"idempotency_key,omitempty"`
@@ -77,4 +83,71 @@ type CheckoutSession struct {
 	LastFour   *string `json:"last_four,omitempty"`
 	CardType   *string `json:"card_type,omitempty"`
 	ExpiryDate *string `json:"expiry_date,omitempty"`
+}
+
+// Checkout routing policy sources (or#288). Recorded on every session so the
+// trace names WHO decided, not just what was decided.
+const (
+	// CheckoutRoutingPolicyExplicit: the request named the PSP. Honoured
+	// verbatim — an explicitly named processor is NEVER silently switched,
+	// because the browser has already committed to that rail's flow.
+	CheckoutRoutingPolicyExplicit = "explicit"
+	// CheckoutRoutingPolicyMerchant: a declared merchant routing rule matched.
+	CheckoutRoutingPolicyMerchant = "merchant"
+	// CheckoutRoutingPolicyDefault: no policy declared (or none matched) — the
+	// built-in preference order decided.
+	CheckoutRoutingPolicyDefault = "default"
+)
+
+// Checkout routing skip classes (or#288): why a candidate ahead of the winner
+// was passed over. These are PRE-CHARGE availability facts only. A decline is
+// deliberately absent — it is a per-charge outcome, not a routing failure, and
+// never re-routes a session.
+const (
+	// CheckoutRoutingSkipUnknownSelector: not a declared PSP key or rail kind.
+	CheckoutRoutingSkipUnknownSelector = "unknown_selector"
+	// CheckoutRoutingSkipAmbiguousSelector: a bare rail kind with more than one
+	// armed PSP — the #848 selector demands the PSP key.
+	CheckoutRoutingSkipAmbiguousSelector = "ambiguous_selector"
+	// CheckoutRoutingSkipNotArmed: no active non-archived psps row.
+	CheckoutRoutingSkipNotArmed = "not_armed"
+	// CheckoutRoutingSkipCredentialsMissing: armed, but the credentials the rail
+	// needs to charge are absent or malformed.
+	CheckoutRoutingSkipCredentialsMissing = "credentials_missing"
+	// CheckoutRoutingSkipLinkMissing: the price carries no usable psp_link for
+	// this PSP (absent, or pointing at a different remote object than execution).
+	CheckoutRoutingSkipLinkMissing = "link_missing"
+	// CheckoutRoutingSkipModeUnsupported: the rail cannot serve this checkout
+	// mode for this price (CCBill one-off, Stripe paid intro).
+	CheckoutRoutingSkipModeUnsupported = "mode_unsupported"
+	// CheckoutRoutingSkipServiceUnavailable: the runtime service backing the
+	// rail is not wired in this deployment.
+	CheckoutRoutingSkipServiceUnavailable = "service_unavailable"
+	// CheckoutRoutingSkipResolveFailed: the selector could not be resolved at
+	// all (backend error). Fail closed: skip, never guess.
+	CheckoutRoutingSkipResolveFailed = "resolve_failed"
+)
+
+// CheckoutRoutingReason is the compact decision trace persisted on
+// checkout_sessions.routing_reason.
+type CheckoutRoutingReason struct {
+	// Policy is who decided: explicit | merchant | default.
+	Policy string `json:"policy"`
+	// Rule is the matched merchant-rule index (0-based). Merchant policy only.
+	Rule *int `json:"rule,omitempty"`
+	// Selected is the winning checkout selector (the PSP key), and Rail its kind.
+	Selected string `json:"selected"`
+	Rail     string `json:"rail"`
+	// Fallbacks are the remaining ELIGIBLE selectors, still ranked — what the
+	// next session would get if the winner went away.
+	Fallbacks []string `json:"fallbacks,omitempty"`
+	// Skipped names every candidate passed over ahead of the winner, with its
+	// class.
+	Skipped []CheckoutRoutingSkip `json:"skipped,omitempty"`
+}
+
+// CheckoutRoutingSkip is one passed-over candidate and its class.
+type CheckoutRoutingSkip struct {
+	Selector string `json:"selector"`
+	Reason   string `json:"reason"`
 }

--- a/internal/db/models/genmap.go
+++ b/internal/db/models/genmap.go
@@ -322,6 +322,13 @@ func CheckoutSessionFromGen(c gen.OpenrailsCheckoutSession) (*CheckoutSession, e
 	if err := FromJSONB(c.RailState, &m.RailState, "checkout_sessions.rail_state"); err != nil {
 		return nil, err
 	}
+	if len(c.RoutingReason) > 0 {
+		var reason CheckoutRoutingReason
+		if err := FromJSONB(c.RoutingReason, &reason, "checkout_sessions.routing_reason"); err != nil {
+			return nil, err
+		}
+		m.RoutingReason = &reason
+	}
 	return m, nil
 }
 

--- a/internal/db/models/merchant_configuration.go
+++ b/internal/db/models/merchant_configuration.go
@@ -37,6 +37,39 @@ type MerchantConfiguration struct {
 	// subscribers. Decreases are exempt. Nil ⇒ DefaultRepriceNoticeWindowDays
 	// (30). Zero is a valid explicit merchant choice (no minimum enforced).
 	RepriceNoticeWindowDays *int `json:"reprice_notice_window_days,omitempty"`
+
+	// CheckoutRouting (or#288) is the merchant's deterministic processor
+	// preference policy: ordered rules, first match wins. Empty ⇒ the built-in
+	// default order.
+	CheckoutRouting []CheckoutRoutingRule `json:"checkout_routing,omitempty"`
+}
+
+// CheckoutRoutingRule is one processor-preference rule (or#288). Rules are
+// evaluated in declaration order and the FIRST whose Match accepts the routing
+// inputs wins — no scoring, no second pass. Prefer is that rule's ranked
+// candidate list AND its whitelist: a PSP the winning rule does not name is not
+// eligible, so a rule can constrain a product to one rail.
+type CheckoutRoutingRule struct {
+	Match CheckoutRoutingMatch `json:"match,omitempty"`
+	// Prefer are checkout selectors in preference order — PSP keys ("mobius"),
+	// or a rail kind where the #848 wire accepts one (exactly one armed PSP).
+	Prefer []string `json:"prefer"`
+}
+
+// CheckoutRoutingMatch is a rule's condition. Every SET field must match the
+// routing inputs; an all-empty match accepts everything (the catch-all rule).
+type CheckoutRoutingMatch struct {
+	Currency string `json:"currency,omitempty"` // ISO-4217, lowercase
+	Product  string `json:"product,omitempty"`  // product key
+	Price    string `json:"price,omitempty"`    // price key
+	Mode     string `json:"mode,omitempty"`     // one_off | subscription
+	Country  string `json:"country,omitempty"`  // payer country, ISO-3166-1 alpha-2
+}
+
+// IsCatchAll reports a match with no conditions — it accepts every input, so
+// no later rule can ever be reached.
+func (m CheckoutRoutingMatch) IsCatchAll() bool {
+	return m.Currency == "" && m.Product == "" && m.Price == "" && m.Mode == "" && m.Country == ""
 }
 
 // MerchantProfileConfiguration is merchant-owned public/communication metadata.

--- a/internal/db/queries/checkout_sessions.sql
+++ b/internal/db/queries/checkout_sessions.sql
@@ -4,14 +4,14 @@
 INSERT INTO openrails.checkout_sessions (
     id, merchant_id, customer_id, price_id, mode, rail, status, amount,
     currency, expires_at, reference, transaction_id, payment_id,
-    subscription_id, metadata, rail_fields, rail_state,
+    subscription_id, metadata, rail_fields, rail_state, routing_reason,
     psp_id, created_at, updated_at
 ) VALUES (
     $1, sqlc.arg(merchant_id)::uuid, $2, $3, $4, $5, $6, $7,
     sqlc.arg(currency),
     sqlc.narg(expires_at), sqlc.narg(reference), sqlc.narg(transaction_id),
     sqlc.narg(payment_id), sqlc.narg(subscription_id), sqlc.narg(metadata),
-    sqlc.narg(rail_fields), sqlc.narg(rail_state),
+    sqlc.narg(rail_fields), sqlc.narg(rail_state), sqlc.narg(routing_reason),
     sqlc.narg(psp_id),
     COALESCE(NULLIF(sqlc.arg(created_at)::timestamptz, '0001-01-01 00:00:00+00'::timestamptz), now()),
     COALESCE(NULLIF(sqlc.arg(updated_at)::timestamptz, '0001-01-01 00:00:00+00'::timestamptz), now())

--- a/internal/http/handlers/checkout_session.go
+++ b/internal/http/handlers/checkout_session.go
@@ -18,7 +18,9 @@ import (
 )
 
 type checkoutSessionPaymentParams struct {
-	Rail            string `json:"rail" binding:"required"`
+	// Rail is the PSP the caller wants (the #848 selector). OPTIONAL since
+	// or#288: omitting it hands the choice to the merchant's routing policy.
+	Rail            string `json:"rail,omitempty" binding:"omitempty"`
 	PaymentMethodID string `json:"payment_method_id,omitempty" binding:"omitempty"`
 	PaymentToken    string `json:"payment_token,omitempty"`
 	TokenSymbol     string `json:"token_symbol,omitempty" binding:"omitempty"`
@@ -85,9 +87,14 @@ func CreateCheckoutSession(r *httprequest.Request) {
 		r.ErrorJSON(http.StatusInternalServerError, "checkout session service unavailable")
 		return
 	}
-	if err := checkoutRailUsable(r, req.Payment.Rail); err != nil {
-		r.ErrorJSON(http.StatusBadRequest, err.Error())
-		return
+	// The pre-gate checks a NAMED PSP. An omitted selector is the routing
+	// request (or#288) — there is nothing to pre-gate, and routing itself fails
+	// closed when no PSP can serve the price.
+	if strings.TrimSpace(req.Payment.Rail) != "" {
+		if err := checkoutRailUsable(r, req.Payment.Rail); err != nil {
+			r.ErrorJSON(http.StatusBadRequest, err.Error())
+			return
+		}
 	}
 	req.IdempotencyKey = middleware.IdempotencyKeyFromRequest(r.Request)
 	e2eRunID := strings.TrimSpace(r.Header("X-E2E-Run-ID"))

--- a/internal/http/handlers/merchant_checkout_routing.go
+++ b/internal/http/handlers/merchant_checkout_routing.go
@@ -1,0 +1,90 @@
+package handlers
+
+import (
+	"net/http"
+
+	httprequest "github.com/open-rails/openrails/internal/http/request"
+	billingservice "github.com/open-rails/openrails/pkg/service"
+)
+
+// checkoutRoutingDryRunRequest is the dry-run body. Every field is a routing
+// INPUT: nothing here creates or mutates anything.
+type checkoutRoutingDryRunRequest struct {
+	// PriceID accepts a price id or a price key (#774).
+	PriceID string `json:"price_id"`
+	// Country is the payer's country when known (ISO-3166-1 alpha-2).
+	Country string `json:"country,omitempty"`
+	// Selector traces an EXPLICITLY named PSP (the checkout payment.rail value).
+	// Empty asks what the merchant's policy would pick on its own.
+	Selector string `json:"selector,omitempty"`
+}
+
+type checkoutRoutingCandidateResponse struct {
+	Selector string `json:"selector"`
+	Rail     string `json:"rail,omitempty"`
+	// Skip is absent when the candidate is eligible.
+	Skip string `json:"skip,omitempty"`
+}
+
+type checkoutRoutingDryRunResponse struct {
+	Object string `json:"object"`
+	// Policy is who decided: explicit | merchant | default.
+	Policy string `json:"policy"`
+	// Rule is the matched merchant-rule index; absent for explicit/default.
+	Rule *int `json:"rule,omitempty"`
+	// Selected is the winning PSP key, empty when nothing was eligible.
+	Selected   string                             `json:"selected,omitempty"`
+	Rail       string                             `json:"rail,omitempty"`
+	Mode       string                             `json:"mode,omitempty"`
+	Candidates []checkoutRoutingCandidateResponse `json:"candidates"`
+	// RoutingReason is the exact document a real session would persist on
+	// checkout_sessions.routing_reason for this decision.
+	RoutingReason any `json:"routing_reason,omitempty"`
+}
+
+// MerchantDryRunCheckoutRouting handles
+// POST /v1/merchant/checkout-routing/dry-run (or#288): explain which PSP a
+// checkout for this price would land on, and why every other candidate did not,
+// without creating a session.
+func MerchantDryRunCheckoutRouting(r *httprequest.Request) {
+	var req checkoutRoutingDryRunRequest
+	if !r.BindJSON(&req) {
+		return
+	}
+	svc, err := billingservice.New(r.State)
+	if err != nil {
+		r.ErrorJSON(http.StatusInternalServerError, "billing service unavailable")
+		return
+	}
+	trace, err := svc.DryRunCheckoutRouting(r.Request.Context(), billingservice.CheckoutRoutingDryRun{
+		PriceID:  req.PriceID,
+		Country:  req.Country,
+		Selector: req.Selector,
+	})
+	if err != nil {
+		// Dry run reads only price/product/PSP state the caller supplied or
+		// owns, so a failure is a bad input, not a server fault.
+		r.ErrorJSON(http.StatusBadRequest, err.Error())
+		return
+	}
+	out := checkoutRoutingDryRunResponse{
+		Object:     "checkout_routing_decision",
+		Policy:     trace.Policy,
+		Rule:       trace.Rule,
+		Selected:   trace.Selected,
+		Rail:       trace.Rail,
+		Mode:       trace.Mode,
+		Candidates: make([]checkoutRoutingCandidateResponse, 0, len(trace.Candidates)),
+	}
+	if trace.Reason != nil {
+		out.RoutingReason = trace.Reason
+	}
+	for _, candidate := range trace.Candidates {
+		out.Candidates = append(out.Candidates, checkoutRoutingCandidateResponse{
+			Selector: candidate.Selector,
+			Rail:     candidate.Rail,
+			Skip:     candidate.Skip,
+		})
+	}
+	r.SuccessJSON(out)
+}

--- a/internal/http/handlers/service_admission.go
+++ b/internal/http/handlers/service_admission.go
@@ -10,6 +10,7 @@ import (
 	"github.com/open-rails/openrails/internal/db/models"
 	httprequest "github.com/open-rails/openrails/internal/http/request"
 	"github.com/open-rails/openrails/internal/modules/abuse"
+	"github.com/open-rails/openrails/internal/modules/merchantconfig"
 	"github.com/open-rails/openrails/internal/shared/moneyutil"
 	billingidentity "github.com/open-rails/openrails/pkg/identity"
 	billingservice "github.com/open-rails/openrails/pkg/service"
@@ -351,6 +352,10 @@ type serviceMerchantSettingsRequest struct {
 	// derived from monthly_floor.
 	ArrearsGraceDays        *int   `json:"arrears_grace_days,omitempty"`
 	ArrearsDelinquencyFloor *int64 `json:"arrears_delinquency_floor,omitempty"`
+	// CheckoutRouting (or#288): the processor-routing policy. Omitted preserves
+	// the stored policy; present replaces it whole (an empty array clears it
+	// back to the built-in default order).
+	CheckoutRouting                   *[]models.CheckoutRoutingRule         `json:"checkout_routing,omitempty"`
 	TrustLevelSchedules               []serviceMerchantTrustLevelSchedule   `json:"trust_level_schedules,omitempty"`
 	TrustLevelSpendLimits             []billingservice.PayerSpendLimitInput `json:"trust_level_spend_limits,omitempty"`
 	DelegatedInvokerWastedSpendLimits []serviceMerchantConfigWindow         `json:"delegated_invoker_wasted_spend_limits,omitempty"`
@@ -390,6 +395,7 @@ func ServiceGetMerchantSettings(r *httprequest.Request) {
 		RepriceNoticeWindowDays:           cfg.RepriceNoticeWindowDays,
 		ArrearsGraceDays:                  cfg.ArrearsGraceDays,
 		ArrearsDelinquencyFloor:           cfg.ArrearsDelinquencyFloor,
+		CheckoutRouting:                   cfg.CheckoutRouting,
 		DelegatedInvokerWastedSpendLimits: serviceMerchantConfigWindows(cfg.DelegatedInvokerWastedSpendWindows),
 	})
 }
@@ -406,6 +412,16 @@ func ServiceSetMerchantSettings(r *httprequest.Request) {
 	if err != nil {
 		r.ErrorJSON(http.StatusInternalServerError, "billing service unavailable")
 		return
+	}
+
+	// or#288: a malformed routing policy is a client error, not a server one.
+	// Run the SAME normalizer the service will run, so the caller gets the
+	// exact reason instead of a bare 500.
+	if req.CheckoutRouting != nil {
+		if _, err := merchantconfig.NormalizeCheckoutRouting(*req.CheckoutRouting); err != nil {
+			r.ErrorJSON(http.StatusBadRequest, err.Error())
+			return
+		}
 	}
 
 	windows := make([]abuse.WastedWindow, 0, len(req.DelegatedInvokerWastedSpendLimits))
@@ -426,6 +442,7 @@ func ServiceSetMerchantSettings(r *httprequest.Request) {
 		RepriceNoticeWindowDays:            req.RepriceNoticeWindowDays,
 		ArrearsGraceDays:                   req.ArrearsGraceDays,
 		ArrearsDelinquencyFloor:            req.ArrearsDelinquencyFloor,
+		CheckoutRouting:                    req.CheckoutRouting,
 		DelegatedInvokerWastedSpendWindows: windows,
 	}); err != nil {
 		r.ErrorJSON(http.StatusInternalServerError, "set merchant settings failed")

--- a/internal/http/routes/merchant_action_routes_test.go
+++ b/internal/http/routes/merchant_action_routes_test.go
@@ -75,6 +75,14 @@ func TestRegisterMerchantActionRoutesPermissions(t *testing.T) {
 			perm:   controlplane.PermMerchantPaymentProvidersRead,
 		},
 		{
+			// or#288: the routing dry run reads PSP state, so it rides the
+			// payment-providers READ grant even though it is a POST.
+			name:   "checkout routing dry run",
+			method: http.MethodPost,
+			path:   "/billing/v1/merchant/payment-providers/routing/dry-run",
+			perm:   controlplane.PermMerchantPaymentProvidersRead,
+		},
+		{
 			name:   "payment providers write",
 			method: http.MethodPut,
 			path:   "/billing/v1/merchant/payment-providers/stripe",

--- a/internal/http/routes/routes.go
+++ b/internal/http/routes/routes.go
@@ -672,6 +672,11 @@ func registerPaymentProviderActionRoutes(providers router.Router, rt *app.Runtim
 	writeMW := append([]router.Middleware{manifestModeWriteGuardMW(rt), write}, dbMW...)
 
 	providers.Handle(http.MethodGet, "", h(httphandlers.MerchantListPaymentProviders), readMW...)
+	// or#288 routing dry run: read-only "which PSP would this checkout get, and
+	// why" — same permission as reading the PSP catalog, since the answer is a
+	// projection of it. Registered before "/:provider" so "routing" is never
+	// captured as a provider name.
+	providers.Handle(http.MethodPost, "/routing/dry-run", h(httphandlers.MerchantDryRunCheckoutRouting), readMW...)
 	providers.Handle(http.MethodGet, "/:provider", h(httphandlers.MerchantGetPaymentProvider), readMW...)
 	// Provider-config WRITE surface persists secrets; mount it only when OpenRails
 	// can actually write them (#661). Nil ProviderRoutes = permissive (standalone).

--- a/internal/merchants/credentials.go
+++ b/internal/merchants/credentials.go
@@ -302,6 +302,35 @@ func (s *Service) activePSPSecretScope(ctx context.Context, id merchant.ID, rail
 	return scope, true, nil
 }
 
+// PSPKeyArchived reports whether key names an ARCHIVED account for this
+// merchant/environment. It is the complement of PSPScopeByKey (which sees only
+// live rows) and exists so routing can say "retired" instead of "unknown".
+func (s *Service) PSPKeyArchived(ctx context.Context, id merchant.ID, key, environment string) (bool, error) {
+	if s == nil || s.pool == nil || id.IsZero() || strings.TrimSpace(key) == "" {
+		return false, nil
+	}
+	environment = normalizeProviderSecretEnvironment(environment)
+	if environment == "" {
+		return false, fmt.Errorf("provider account environment must be live or test")
+	}
+	archived := false
+	err := s.pool.MerchantTx(ctx, id, func(ctx context.Context, tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+				SELECT EXISTS (
+					SELECT 1 FROM openrails.psps
+					 WHERE merchant_id = $1::uuid
+					   AND lower(key) = lower($2)
+					   AND environment = $3
+					   AND archived = true
+				)
+			`, id.String(), strings.TrimSpace(key), environment).Scan(&archived)
+	})
+	if err != nil {
+		return false, fmt.Errorf("load archived provider account by key %s/%s: %w", key, environment, err)
+	}
+	return archived, nil
+}
+
 // PSPScopeByKey resolves a declared, non-archived account by
 // its manifest account key (e.g. "mobius") for the given
 // environment. This is how the payment-provider vocabulary used by the catalog

--- a/internal/merchants/secrets.go
+++ b/internal/merchants/secrets.go
@@ -212,6 +212,14 @@ type PSPRailScopesResolver interface {
 	ActivePSPScopesForRail(ctx context.Context, merchantID merchant.ID, rail, environment string) ([]PSPScope, error)
 }
 
+// ArchivedPSPKeyResolver reports whether a key names an ARCHIVED account
+// (or#288). Routing needs it to tell "you retired this PSP" (not_armed) from
+// "no such PSP was ever declared" (unknown_selector) — two very different
+// answers to "why didn't my checkout go there".
+type ArchivedPSPKeyResolver interface {
+	PSPKeyArchived(ctx context.Context, merchantID merchant.ID, key, environment string) (bool, error)
+}
+
 // MerchantSecretStore is the per-merchant secrets abstraction (issue #225). Every
 // operation is namespaced by merchant id so one merchant can never read or
 // overwrite another merchant's Stripe credentials or webhook signing secrets.

--- a/internal/modules/checkout/merchant_rail_secrets.go
+++ b/internal/modules/checkout/merchant_rail_secrets.go
@@ -385,3 +385,24 @@ func custodianHeld(target railTarget) bool {
 	custody, err := config.ParseCustodySettings(target.Scope.Settings)
 	return err == nil && custody.ThirdParty()
 }
+
+// pspKeyArchived reports whether selector names a declared-but-archived PSP
+// (or#288). Best-effort by design: it only refines a skip CLASS in the routing
+// trace, never a routing outcome, so a resolver that cannot answer leaves the
+// class as-is rather than failing the checkout.
+func (s *CheckoutService) pspKeyArchived(ctx context.Context, selector string) bool {
+	resolver, ok := s.ProviderSecrets.(merchants.ArchivedPSPKeyResolver)
+	if !ok {
+		return false
+	}
+	tid, err := merchant.Require(ctx)
+	if err != nil {
+		return false
+	}
+	archived, err := resolver.PSPKeyArchived(ctx, tid, selector, s.pspEnvironment())
+	if err != nil {
+		log.WithContext(ctx).WithError(err).Debug("checkout routing: archived-PSP lookup failed")
+		return false
+	}
+	return archived
+}

--- a/internal/modules/checkout/rail_options.go
+++ b/internal/modules/checkout/rail_options.go
@@ -9,7 +9,6 @@ import (
 	"github.com/open-rails/openrails/config"
 	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/modules/catalog"
-	"github.com/open-rails/openrails/internal/railresolve"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
 
@@ -21,17 +20,11 @@ type CheckoutRailOption struct {
 	Mode     string
 }
 
-var checkoutRailOptionOrder = []string{
-	string(models.RailStripe),
-	string(models.RailNMI),
-	string(models.RailCCBill),
-	string(models.RailSolana),
-}
-
 // ListCheckoutRailOptions returns payment providers that this runtime can use
-// for new checkout against priceRef. It performs no remote provider probes and
-// no writes; readiness means the active local account, required credentials,
-// price link, checkout mode, and runtime services are all present.
+// for new checkout against priceRef, IN THE MERCHANT'S ROUTING ORDER (or#288).
+// It performs no remote provider probes and no writes; readiness means the
+// active local account, required credentials, price link, checkout mode, and
+// runtime services are all present.
 func (s *CheckoutSessionService) ListCheckoutRailOptions(ctx context.Context, priceRef string) ([]CheckoutRailOption, error) {
 	priceRef = strings.TrimSpace(priceRef)
 	if priceRef == "" {
@@ -72,43 +65,39 @@ func (s *CheckoutSessionService) ListCheckoutRailOptions(ctx context.Context, pr
 	if !product.IsPurchasable() {
 		return []CheckoutRailOption{}, nil
 	}
-	return s.listCheckoutRailOptionsForPrice(ctx, checkoutService, price)
+	return s.listCheckoutRailOptionsForPrice(ctx, price, product)
 }
 
-func (s *CheckoutSessionService) listCheckoutRailOptionsForPrice(ctx context.Context, checkoutService *CheckoutService, price *models.Price) ([]CheckoutRailOption, error) {
-	options := make([]CheckoutRailOption, 0, len(checkoutRailOptionOrder))
-	var resolutionErr error
-	for _, requestedRail := range checkoutRailOptionOrder {
-		target, err := checkoutService.resolveRailTarget(ctx, requestedRail)
-		if err != nil {
-			resolutionErr = errors.Join(resolutionErr, fmt.Errorf("resolve checkout rail %s: %w", requestedRail, err))
-			continue
-		}
-		accountID := ""
-		if target.Scope != nil {
-			accountID = target.Scope.AccountID
-		}
-		providerConfig, err := checkoutService.Rails.RailConfig(ctx, target.Rail, accountID)
-		if err != nil {
-			if errors.Is(err, railresolve.ErrRailNotArmed) {
-				continue
+// listCheckoutRailOptionsForPrice is a projection of the routing decision: the
+// options a frontend may offer are exactly the candidates routing found
+// eligible, in the order routing would pick them.
+func (s *CheckoutSessionService) listCheckoutRailOptionsForPrice(ctx context.Context, price *models.Price, product *models.Product) ([]CheckoutRailOption, error) {
+	mode := checkoutModeForRail(price, "")
+	decision, err := s.Route(ctx, RoutingInput{Price: price, Product: product, Mode: mode})
+	if err != nil && !errors.Is(err, ErrNoRoutableProcessor) {
+		return nil, err
+	}
+	eligible := decision.Eligible()
+	if len(eligible) == 0 {
+		// Nothing eligible AND something failed to resolve: report the failure
+		// rather than an empty list that reads like "this merchant is unarmed".
+		for _, candidate := range decision.Candidates {
+			if candidate.Skip == models.CheckoutRoutingSkipResolveFailed {
+				return nil, fmt.Errorf("resolve checkout rail %s: resolution failed", candidate.Selector)
 			}
-			resolutionErr = errors.Join(resolutionErr, fmt.Errorf("resolve checkout rail config %s: %w", requestedRail, err))
-			continue
 		}
-
-		mode := checkoutModeForRail(price, target.Rail)
-		if !s.checkoutRailOptionReady(price, target, providerConfig, mode) {
+		return []CheckoutRailOption{}, nil
+	}
+	options := make([]CheckoutRailOption, 0, len(eligible))
+	for _, candidate := range decision.Candidates {
+		if candidate.Skip != "" {
 			continue
 		}
 		options = append(options, CheckoutRailOption{
-			Selector: target.Rail,
-			Rail:     target.Rail,
+			Selector: candidate.Selector,
+			Rail:     candidate.Rail,
 			Mode:     string(mode),
 		})
-	}
-	if len(options) == 0 && resolutionErr != nil {
-		return nil, resolutionErr
 	}
 	return options, nil
 }
@@ -121,61 +110,86 @@ func checkoutModeForRail(price *models.Price, rail string) models.CheckoutSessio
 	return models.CheckoutSessionModeOneOff
 }
 
-func (s *CheckoutSessionService) checkoutRailOptionReady(price *models.Price, target railTarget, providerConfig *config.PSPConfig, mode models.CheckoutSessionMode) bool {
+// checkoutRailSkipReason reports why this PSP cannot serve the price under mode,
+// or "" when it can. It is the single readiness verdict behind both the option
+// list and routing's fallback classes (or#288) — one place decides, so the
+// advertised list and the routed choice can never disagree.
+func (s *CheckoutSessionService) checkoutRailSkipReason(price *models.Price, target railTarget, providerConfig *config.PSPConfig, mode models.CheckoutSessionMode) string {
 	if price == nil || providerConfig == nil {
-		return false
+		return models.CheckoutRoutingSkipNotArmed
 	}
 	switch target.Rail {
 	case string(models.RailStripe):
-		if providerConfig.Stripe == nil || strings.TrimSpace(providerConfig.Stripe.SecretKey) == "" || stripePaidIntroUnsupported(price) {
-			return false
+		if providerConfig.Stripe == nil || strings.TrimSpace(providerConfig.Stripe.SecretKey) == "" {
+			return models.CheckoutRoutingSkipCredentialsMissing
+		}
+		if stripePaidIntroUnsupported(price) {
+			return models.CheckoutRoutingSkipModeUnsupported
 		}
 		targetPriceID := strings.TrimSpace(checkoutPSPLinkForTarget(price, target)[models.RailKeyStripePriceID])
 		executionPriceID, err := getStripePriceID(price)
-		return err == nil && targetPriceID != "" && targetPriceID == executionPriceID
+		if err != nil || targetPriceID == "" || targetPriceID != executionPriceID {
+			return models.CheckoutRoutingSkipLinkMissing
+		}
+		return ""
 	case string(models.RailNMI):
 		if providerConfig.NMI == nil || strings.TrimSpace(providerConfig.NMI.SecurityKey) == "" {
-			return false
+			return models.CheckoutRoutingSkipCredentialsMissing
 		}
 		if checkoutPSPLinkForTarget(price, target) == nil {
-			return false
+			return models.CheckoutRoutingSkipLinkMissing
 		}
 		if mode == models.CheckoutSessionModeSubscription {
-			_, err := requireNMIPlanForTarget(price, target)
-			return err == nil
+			if _, err := requireNMIPlanForTarget(price, target); err != nil {
+				return models.CheckoutRoutingSkipLinkMissing
+			}
 		}
-		return true
+		return ""
 	case string(models.RailCCBill):
-		if mode != models.CheckoutSessionModeSubscription || providerConfig.CCBill == nil {
-			return false
+		if mode != models.CheckoutSessionModeSubscription {
+			return models.CheckoutRoutingSkipModeUnsupported
+		}
+		// The dash-joined composite account id (#697) is CCBill's identity, so a
+		// malformed one is a credential fault, not a link fault.
+		if providerConfig.CCBill == nil {
+			return models.CheckoutRoutingSkipCredentialsMissing
 		}
 		if _, _, err := config.SplitCCBillAccountID(providerConfig.EffectiveAccountID()); err != nil {
-			return false
+			return models.CheckoutRoutingSkipCredentialsMissing
 		}
 		link := checkoutPSPLinkForTarget(price, target)
 		targetForm := strings.TrimSpace(link[models.RailKeyCCBillFormName])
 		targetFlexID := strings.TrimSpace(link[models.RailKeyCCBillFlexID])
 		executionForm, executionFlexID, ok := price.GetCCBillFlexForm()
-		return ok && targetForm != "" && targetFlexID != "" &&
-			targetForm == executionForm && targetFlexID == executionFlexID
+		if !ok || targetForm == "" || targetFlexID == "" ||
+			targetForm != executionForm || targetFlexID != executionFlexID {
+			return models.CheckoutRoutingSkipLinkMissing
+		}
+		return ""
 	case string(models.RailSolana):
 		if providerConfig.Solana == nil || len(providerConfig.Solana.Tokens) == 0 {
-			return false
+			return models.CheckoutRoutingSkipCredentialsMissing
 		}
 		if checkoutPSPLinkForTarget(price, target) == nil {
-			return false
+			return models.CheckoutRoutingSkipLinkMissing
 		}
 		if mode == models.CheckoutSessionModeSubscription {
 			if s.solanaPrepareSubscribe == nil || s.solanaEnroll == nil {
-				return false
+				return models.CheckoutRoutingSkipServiceUnavailable
 			}
 			targetTerms, targetErr := parseSolanaPlanTerms(checkoutPSPLinkForTarget(price, target))
 			executionTerms, executionErr := parseSolanaPlanTerms(price.PSPLinkForRail(models.RailSolana))
-			return targetErr == nil && executionErr == nil && targetTerms == executionTerms
+			if targetErr != nil || executionErr != nil || targetTerms != executionTerms {
+				return models.CheckoutRoutingSkipLinkMissing
+			}
+			return ""
 		}
-		return s.solanaPayService != nil || s.solanaTransactionService != nil
+		if s.solanaPayService == nil && s.solanaTransactionService == nil {
+			return models.CheckoutRoutingSkipServiceUnavailable
+		}
+		return ""
 	default:
-		return false
+		return models.CheckoutRoutingSkipUnknownSelector
 	}
 }
 

--- a/internal/modules/checkout/rail_options_test.go
+++ b/internal/modules/checkout/rail_options_test.go
@@ -50,7 +50,7 @@ func TestCheckoutModeForRail(t *testing.T) {
 	}
 }
 
-func TestCheckoutRailOptionReady(t *testing.T) {
+func TestCheckoutRailSkipReason(t *testing.T) {
 	t.Parallel()
 
 	stripePrice := railOptionPrice(true, "stripe", map[string]string{
@@ -83,7 +83,8 @@ func TestCheckoutRailOptionReady(t *testing.T) {
 		target         railTarget
 		providerConfig *config.PSPConfig
 		mode           models.CheckoutSessionMode
-		expected       bool
+		// wantSkip is the or#288 skip class, "" when the PSP is ready.
+		wantSkip string
 	}{
 		{
 			name:    "stripe recurring ready",
@@ -94,8 +95,7 @@ func TestCheckoutRailOptionReady(t *testing.T) {
 				Rail:   models.RailStripe,
 				Stripe: &config.StripeRailConfig{SecretKey: "sk_test_value"},
 			},
-			mode:     models.CheckoutSessionModeSubscription,
-			expected: true,
+			mode: models.CheckoutSessionModeSubscription,
 		},
 		{
 			name:    "stripe missing price link",
@@ -106,7 +106,8 @@ func TestCheckoutRailOptionReady(t *testing.T) {
 				Rail:   models.RailStripe,
 				Stripe: &config.StripeRailConfig{SecretKey: "sk_test_value"},
 			},
-			mode: models.CheckoutSessionModeSubscription,
+			mode:     models.CheckoutSessionModeSubscription,
+			wantSkip: models.CheckoutRoutingSkipLinkMissing,
 		},
 		{
 			name:    "stripe ambiguous account links",
@@ -120,7 +121,8 @@ func TestCheckoutRailOptionReady(t *testing.T) {
 				Rail:   models.RailStripe,
 				Stripe: &config.StripeRailConfig{SecretKey: "sk_test_value"},
 			},
-			mode: models.CheckoutSessionModeSubscription,
+			mode:     models.CheckoutSessionModeSubscription,
+			wantSkip: models.CheckoutRoutingSkipLinkMissing,
 		},
 		{
 			name:    "nmi recurring ready for exact provider",
@@ -131,8 +133,7 @@ func TestCheckoutRailOptionReady(t *testing.T) {
 				Rail: models.RailNMI,
 				NMI:  &config.NMIRailConfig{SecurityKey: "security_test"},
 			},
-			mode:     models.CheckoutSessionModeSubscription,
-			expected: true,
+			mode: models.CheckoutSessionModeSubscription,
 		},
 		{
 			name:    "nmi recurring missing exact provider plan",
@@ -143,7 +144,8 @@ func TestCheckoutRailOptionReady(t *testing.T) {
 				Rail: models.RailNMI,
 				NMI:  &config.NMIRailConfig{SecurityKey: "security_test"},
 			},
-			mode: models.CheckoutSessionModeSubscription,
+			mode:     models.CheckoutSessionModeSubscription,
+			wantSkip: models.CheckoutRoutingSkipLinkMissing,
 		},
 		{
 			name:    "ccbill recurring ready",
@@ -155,8 +157,7 @@ func TestCheckoutRailOptionReady(t *testing.T) {
 				AccountID: "945280-0000",
 				CCBill:    &config.CCBillRailConfig{},
 			},
-			mode:     models.CheckoutSessionModeSubscription,
-			expected: true,
+			mode: models.CheckoutSessionModeSubscription,
 		},
 		{
 			name:    "ccbill one off unsupported",
@@ -168,7 +169,8 @@ func TestCheckoutRailOptionReady(t *testing.T) {
 				AccountID: "945280-0000",
 				CCBill:    &config.CCBillRailConfig{},
 			},
-			mode: models.CheckoutSessionModeOneOff,
+			mode:     models.CheckoutSessionModeOneOff,
+			wantSkip: models.CheckoutRoutingSkipModeUnsupported,
 		},
 		{
 			name:    "solana recurring ready",
@@ -181,8 +183,7 @@ func TestCheckoutRailOptionReady(t *testing.T) {
 					"USDC": {Mint: "mint_test"},
 				}},
 			},
-			mode:     models.CheckoutSessionModeSubscription,
-			expected: true,
+			mode: models.CheckoutSessionModeSubscription,
 		},
 		{
 			name:    "solana recurring services unavailable",
@@ -195,14 +196,15 @@ func TestCheckoutRailOptionReady(t *testing.T) {
 					"USDC": {Mint: "mint_test"},
 				}},
 			},
-			mode: models.CheckoutSessionModeSubscription,
+			mode:     models.CheckoutSessionModeSubscription,
+			wantSkip: models.CheckoutRoutingSkipServiceUnavailable,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tt.expected, tt.service.checkoutRailOptionReady(tt.price, tt.target, tt.providerConfig, tt.mode))
+			assert.Equal(t, tt.wantSkip, tt.service.checkoutRailSkipReason(tt.price, tt.target, tt.providerConfig, tt.mode))
 		})
 	}
 }
@@ -255,7 +257,7 @@ func TestListCheckoutRailOptionsForPrice_ReturnsExecutableSelectors(t *testing.T
 		checkoutService: checkoutService,
 	}
 
-	options, err := svc.listCheckoutRailOptionsForPrice(context.Background(), checkoutService, price)
+	options, err := svc.listCheckoutRailOptionsForPrice(context.Background(), price, &models.Product{})
 	require.NoError(t, err)
 	require.Equal(t, []CheckoutRailOption{
 		{Selector: "stripe", Rail: "stripe", Mode: "subscription"},

--- a/internal/modules/checkout/routing.go
+++ b/internal/modules/checkout/routing.go
@@ -1,0 +1,304 @@
+package checkout
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/modules/catalog"
+	"github.com/open-rails/openrails/internal/modules/merchantconfig"
+	"github.com/open-rails/openrails/internal/railresolve"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// Deterministic processor routing (or#288).
+//
+// One function decides which PSP a checkout lands on, and the SAME function
+// backs the option list, session creation and the dry-run trace — there is no
+// second implementation to drift. Routing is a pre-session act: it ranks
+// declared candidates, drops the ones that cannot serve this price right now,
+// and takes the first survivor. It never retries after a charge — a decline is
+// a per-charge outcome, not a routing failure.
+
+// defaultRoutingOrder is the built-in preference order used when the merchant
+// declares no policy. Rail kinds, not PSP keys: it must hold for merchants
+// whose PSPs it has never seen.
+var defaultRoutingOrder = []string{
+	string(models.RailStripe),
+	string(models.RailNMI),
+	string(models.RailCCBill),
+	string(models.RailSolana),
+}
+
+// RoutingInput is everything routing is allowed to look at. Price and Product
+// are already resolved and ownership-checked by the caller.
+type RoutingInput struct {
+	Price   *models.Price
+	Product *models.Product
+	// Mode is the checkout mode this price implies (one_off | subscription).
+	Mode models.CheckoutSessionMode
+	// Country is the payer's country when the request carries one, else "".
+	Country string
+	// Selector is an EXPLICIT client preference (the wire payment.rail). When
+	// set it wins outright and no fallback applies: the browser has already
+	// committed to that rail's flow, so silently switching would break it.
+	Selector string
+}
+
+// RoutingCandidate is one evaluated candidate in preference order.
+type RoutingCandidate struct {
+	Selector string `json:"selector"`
+	Rail     string `json:"rail,omitempty"`
+	// Skip is "" when the candidate is eligible, else its skip class.
+	Skip string `json:"skip,omitempty"`
+}
+
+// RoutingDecision is the full trace: the winner, the ranked remainder, and
+// every candidate with its verdict.
+type RoutingDecision struct {
+	Target     railTarget
+	Policy     string
+	Rule       *int
+	Candidates []RoutingCandidate
+}
+
+// Selected is the winning selector, or "" when nothing was eligible.
+func (d *RoutingDecision) Selected() string {
+	if d == nil {
+		return ""
+	}
+	return d.Target.PSP
+}
+
+// Eligible returns the eligible selectors in preference order.
+func (d *RoutingDecision) Eligible() []string {
+	if d == nil {
+		return nil
+	}
+	out := make([]string, 0, len(d.Candidates))
+	for _, c := range d.Candidates {
+		if c.Skip == "" {
+			out = append(out, c.Selector)
+		}
+	}
+	return out
+}
+
+// Reason projects the decision onto the persisted trace.
+func (d *RoutingDecision) Reason() *models.CheckoutRoutingReason {
+	if d == nil || d.Target.PSP == "" {
+		return nil
+	}
+	reason := &models.CheckoutRoutingReason{
+		Policy:   d.Policy,
+		Rule:     d.Rule,
+		Selected: d.Target.PSP,
+		Rail:     d.Target.Rail,
+	}
+	for _, c := range d.Candidates {
+		switch {
+		case c.Skip != "":
+			reason.Skipped = append(reason.Skipped, models.CheckoutRoutingSkip{Selector: c.Selector, Reason: c.Skip})
+		case c.Selector != reason.Selected:
+			reason.Fallbacks = append(reason.Fallbacks, c.Selector)
+		}
+	}
+	return reason
+}
+
+// ErrNoRoutableProcessor is returned when no declared candidate can serve the
+// price. Fail closed: routing never invents a processor.
+var ErrNoRoutableProcessor = errors.New("no payment provider is available for this price")
+
+// Route picks the PSP for a checkout. The returned decision always carries the
+// full candidate trace, including on the no-winner error path.
+func (s *CheckoutSessionService) Route(ctx context.Context, in RoutingInput) (*RoutingDecision, error) {
+	checkoutService, ok := s.checkoutService.(*CheckoutService)
+	if !ok || checkoutService == nil || checkoutService.Rails == nil {
+		return nil, fmt.Errorf("checkout routing unavailable")
+	}
+	if in.Price == nil {
+		return nil, fmt.Errorf("checkout routing requires a price")
+	}
+
+	// An explicitly named PSP is resolved and used as named — no eligibility
+	// sweep, no fallback. The caller asked for this processor.
+	if selector := strings.ToLower(strings.TrimSpace(in.Selector)); selector != "" {
+		target, err := checkoutService.resolveRailTarget(ctx, selector)
+		if err != nil {
+			return nil, err
+		}
+		return &RoutingDecision{
+			Target:     target,
+			Policy:     models.CheckoutRoutingPolicyExplicit,
+			Candidates: []RoutingCandidate{{Selector: target.PSP, Rail: target.Rail}},
+		}, nil
+	}
+
+	order, policy, rule, err := s.routingOrder(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	decision := &RoutingDecision{Policy: policy, Rule: rule, Candidates: make([]RoutingCandidate, 0, len(order))}
+	for _, selector := range order {
+		target, skip := s.evaluateCandidate(ctx, checkoutService, in, selector)
+		candidate := RoutingCandidate{Selector: selector, Rail: target.Rail, Skip: skip}
+		if skip == "" {
+			// The resolved PSP key is the answer, not the requested selector: a
+			// rail kind resolves to the armed account's key (#848).
+			candidate.Selector = target.PSP
+			if decision.Target.PSP == "" {
+				decision.Target = target
+			}
+		}
+		decision.Candidates = append(decision.Candidates, candidate)
+	}
+	if decision.Target.PSP == "" {
+		return decision, ErrNoRoutableProcessor
+	}
+	return decision, nil
+}
+
+// routingOrder resolves the candidate order for these inputs: the first
+// matching merchant rule, else the built-in default.
+func (s *CheckoutSessionService) routingOrder(ctx context.Context, in RoutingInput) ([]string, string, *int, error) {
+	rules, err := s.routingRules(ctx)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	for i, rule := range rules {
+		if !routingRuleMatches(rule.Match, in) {
+			continue
+		}
+		idx := i
+		order := make([]string, 0, len(rule.Prefer))
+		for _, selector := range rule.Prefer {
+			if selector = strings.ToLower(strings.TrimSpace(selector)); selector != "" {
+				order = append(order, selector)
+			}
+		}
+		return order, models.CheckoutRoutingPolicyMerchant, &idx, nil
+	}
+	return defaultRoutingOrder, models.CheckoutRoutingPolicyDefault, nil, nil
+}
+
+// routingRules loads the merchant's declared policy. No stored config (or no
+// DB, as in unit fixtures) means no policy, which means the default order.
+func (s *CheckoutSessionService) routingRules(ctx context.Context) ([]models.CheckoutRoutingRule, error) {
+	if s.db == nil {
+		return nil, nil
+	}
+	conf, found, err := merchantconfig.NewStore(s.db).Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load checkout routing policy: %w", err)
+	}
+	if !found {
+		return nil, nil
+	}
+	return conf.CheckoutRouting, nil
+}
+
+// routingRuleMatches reports whether every SET condition holds. An all-empty
+// match is the catch-all.
+func routingRuleMatches(m models.CheckoutRoutingMatch, in RoutingInput) bool {
+	eq := func(want, got string) bool {
+		return want == "" || strings.EqualFold(strings.TrimSpace(want), strings.TrimSpace(got))
+	}
+	priceKey, productKey := "", ""
+	if in.Price != nil {
+		priceKey = in.Price.Key
+	}
+	if in.Product != nil {
+		productKey = in.Product.Key
+	}
+	currency := ""
+	if in.Price != nil {
+		currency = in.Price.Currency
+	}
+	return eq(m.Currency, currency) &&
+		eq(m.Product, productKey) &&
+		eq(m.Price, priceKey) &&
+		eq(m.Mode, string(in.Mode)) &&
+		eq(m.Country, in.Country)
+}
+
+// evaluateCandidate resolves one selector and reports whether it can serve this
+// price now. The empty skip class means eligible.
+func (s *CheckoutSessionService) evaluateCandidate(ctx context.Context, checkoutService *CheckoutService, in RoutingInput, selector string) (railTarget, string) {
+	target, err := checkoutService.resolveRailTarget(ctx, selector)
+	if err != nil {
+		var ambiguous *AmbiguousRailError
+		var unknown *UnknownRailError
+		switch {
+		case errors.As(err, &ambiguous):
+			return railTarget{}, models.CheckoutRoutingSkipAmbiguousSelector
+		case errors.As(err, &unknown):
+			// A key that resolves to nothing may still be DECLARED and archived.
+			// Say "retired", not "never heard of it" — support reads this.
+			if checkoutService.pspKeyArchived(ctx, selector) {
+				return railTarget{}, models.CheckoutRoutingSkipNotArmed
+			}
+			return railTarget{}, models.CheckoutRoutingSkipUnknownSelector
+		default:
+			return railTarget{}, models.CheckoutRoutingSkipResolveFailed
+		}
+	}
+	accountID := ""
+	if target.Scope != nil {
+		accountID = target.Scope.AccountID
+	}
+	providerConfig, err := checkoutService.Rails.RailConfig(ctx, target.Rail, accountID)
+	if err != nil {
+		if errors.Is(err, railresolve.ErrRailNotArmed) {
+			return target, models.CheckoutRoutingSkipNotArmed
+		}
+		return target, models.CheckoutRoutingSkipResolveFailed
+	}
+	return target, s.checkoutRailSkipReason(in.Price, target, providerConfig, in.Mode)
+}
+
+// DryRunRouting answers "which PSP would this checkout get, and why" without
+// creating anything. It resolves the price/product exactly as checkout does and
+// runs the SAME Route call, so the trace it returns is the decision a real
+// session would record — not a re-implementation that can drift.
+func (s *CheckoutSessionService) DryRunRouting(ctx context.Context, priceRef, country, selector string) (*RoutingDecision, models.CheckoutSessionMode, error) {
+	priceRef = strings.TrimSpace(priceRef)
+	if priceRef == "" {
+		return nil, "", fmt.Errorf("price reference is required")
+	}
+	if s == nil || s.priceService == nil || s.productService == nil {
+		return nil, "", fmt.Errorf("checkout routing unavailable")
+	}
+	merchantID, err := merchant.Require(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolve checkout merchant: %w", err)
+	}
+	price, err := catalog.ResolveReference(ctx, s.priceService, priceRef)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolve checkout price: %w", err)
+	}
+	if price.MerchantID != merchantID.UUID() {
+		return nil, "", fmt.Errorf("resolve checkout price: price not found")
+	}
+	product, err := s.productService.GetByID(ctx, price.ProductID)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolve checkout product: %w", err)
+	}
+	if product.MerchantID != merchantID.UUID() {
+		return nil, "", fmt.Errorf("resolve checkout product: product not found")
+	}
+	mode := checkoutModeForRail(price, "")
+	decision, err := s.Route(ctx, RoutingInput{
+		Price:    price,
+		Product:  product,
+		Mode:     mode,
+		Country:  strings.TrimSpace(country),
+		Selector: strings.TrimSpace(selector),
+	})
+	if err != nil && !errors.Is(err, ErrNoRoutableProcessor) {
+		return nil, mode, err
+	}
+	return decision, mode, nil
+}

--- a/internal/modules/checkout/routing_test.go
+++ b/internal/modules/checkout/routing_test.go
@@ -1,0 +1,200 @@
+package checkout
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/railresolve"
+)
+
+// routingFixturePrice is a recurring price linked on all four rails.
+func routingFixturePrice() *models.Price {
+	return &models.Price{
+		ID:        uuid.New(),
+		Key:       "pro-monthly",
+		Currency:  "usd",
+		AutoRenew: true,
+		PSPLinks: map[string]map[string]string{
+			"stripe": {models.RailKeyRail: "stripe", models.RailKeyStripePriceID: "price_test"},
+			"nmi":    {models.RailKeyRail: "nmi", models.RailKeyPlanID: "plan_test"},
+			"ccbill": {
+				models.RailKeyRail:           "ccbill",
+				models.RailKeyCCBillFormName: "form_test",
+				models.RailKeyCCBillFlexID:   "flex_test",
+			},
+		},
+	}
+}
+
+func routingFixtureService(armed railresolve.FixedSet) *CheckoutSessionService {
+	checkoutService := &CheckoutService{Config: fullModeConfigUnit(), Rails: armed}
+	return &CheckoutSessionService{config: fullModeConfigUnit(), checkoutService: checkoutService}
+}
+
+func fullModeConfigUnit() *config.Config {
+	return &config.Config{ProviderWriteMode: config.ProviderWriteModeFull}
+}
+
+func routingArmedAll() railresolve.FixedSet {
+	return railresolve.FixedSet{
+		"stripe": {Rail: models.RailStripe, AccountID: "acct_stripe", Stripe: &config.StripeRailConfig{SecretKey: "sk_test_value"}},
+		"nmi":    {Rail: models.RailNMI, AccountID: "acct_nmi", NMI: &config.NMIRailConfig{SecurityKey: "security_test"}},
+		"ccbill": {Rail: models.RailCCBill, AccountID: "945280-0000", CCBill: &config.CCBillRailConfig{}},
+	}
+}
+
+// The default policy IS today's hardcoded order. Pin it: a merchant that
+// declares nothing must keep getting stripe, then nmi, then ccbill, then
+// solana — no reordering may sneak in through a refactor.
+func TestRouteDefaultOrderIsTodaysHardcodedOrder(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, []string{"stripe", "nmi", "ccbill", "solana"}, defaultRoutingOrder)
+
+	svc := routingFixtureService(routingArmedAll())
+	decision, err := svc.Route(context.Background(), RoutingInput{
+		Price: routingFixturePrice(),
+		Mode:  models.CheckoutSessionModeSubscription,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, models.CheckoutRoutingPolicyDefault, decision.Policy)
+	assert.Nil(t, decision.Rule)
+	assert.Equal(t, "stripe", decision.Selected())
+	assert.Equal(t, "stripe", decision.Target.Rail)
+	assert.Equal(t, []string{"stripe", "nmi", "ccbill"}, decision.Eligible())
+}
+
+// The first eligible candidate wins; the unavailable ones ahead of it are
+// skipped WITH their class, not silently dropped.
+func TestRouteFallsThroughUnavailableCandidates(t *testing.T) {
+	t.Parallel()
+
+	armed := routingArmedAll()
+	delete(armed, "stripe") // stripe not armed at all
+
+	svc := routingFixtureService(armed)
+	decision, err := svc.Route(context.Background(), RoutingInput{
+		Price: routingFixturePrice(),
+		Mode:  models.CheckoutSessionModeSubscription,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "nmi", decision.Selected())
+
+	reason := decision.Reason()
+	require.NotNil(t, reason)
+	assert.Equal(t, models.CheckoutRoutingPolicyDefault, reason.Policy)
+	assert.Equal(t, "nmi", reason.Selected)
+	assert.Equal(t, []string{"ccbill"}, reason.Fallbacks)
+	assert.Equal(t, []models.CheckoutRoutingSkip{
+		{Selector: "stripe", Reason: models.CheckoutRoutingSkipNotArmed},
+		{Selector: "solana", Reason: models.CheckoutRoutingSkipNotArmed},
+	}, reason.Skipped)
+}
+
+// A one-off price cannot go to CCBill (subscription-only) — the skip class says
+// so rather than reporting a generic unavailability.
+func TestRouteSkipsModeUnsupported(t *testing.T) {
+	t.Parallel()
+
+	price := routingFixturePrice()
+	price.AutoRenew = false
+
+	armed := railresolve.FixedSet{
+		"ccbill": {Rail: models.RailCCBill, AccountID: "945280-0000", CCBill: &config.CCBillRailConfig{}},
+		"nmi":    {Rail: models.RailNMI, AccountID: "acct_nmi", NMI: &config.NMIRailConfig{SecurityKey: "security_test"}},
+	}
+	svc := routingFixtureService(armed)
+	decision, err := svc.Route(context.Background(), RoutingInput{
+		Price: price,
+		Mode:  models.CheckoutSessionModeOneOff,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "nmi", decision.Selected())
+	assert.Equal(t, []models.CheckoutRoutingSkip{
+		{Selector: "stripe", Reason: models.CheckoutRoutingSkipNotArmed},
+		{Selector: "ccbill", Reason: models.CheckoutRoutingSkipModeUnsupported},
+		{Selector: "solana", Reason: models.CheckoutRoutingSkipNotArmed},
+	}, decision.Reason().Skipped)
+}
+
+// Nothing eligible must fail closed, and still hand back the full trace so the
+// operator can see WHY nothing was routable.
+func TestRouteFailsClosedWithNoEligibleProcessor(t *testing.T) {
+	t.Parallel()
+
+	svc := routingFixtureService(railresolve.FixedSet{})
+	decision, err := svc.Route(context.Background(), RoutingInput{
+		Price: routingFixturePrice(),
+		Mode:  models.CheckoutSessionModeSubscription,
+	})
+	require.ErrorIs(t, err, ErrNoRoutableProcessor)
+	require.NotNil(t, decision)
+	assert.Empty(t, decision.Selected())
+	assert.Len(t, decision.Candidates, 4)
+	assert.Nil(t, decision.Reason(), "no winner means no decision to record")
+}
+
+// An explicitly named PSP is used as named, with no eligibility sweep and no
+// fallback: the browser has already committed to that PSP's flow.
+func TestRouteExplicitSelectorNeverFallsBack(t *testing.T) {
+	t.Parallel()
+
+	armed := routingArmedAll()
+	delete(armed, "ccbill")
+
+	svc := routingFixtureService(armed)
+	decision, err := svc.Route(context.Background(), RoutingInput{
+		Price:    routingFixturePrice(),
+		Mode:     models.CheckoutSessionModeSubscription,
+		Selector: "ccbill",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, models.CheckoutRoutingPolicyExplicit, decision.Policy)
+	assert.Equal(t, "ccbill", decision.Selected())
+	assert.Empty(t, decision.Reason().Fallbacks)
+	assert.Empty(t, decision.Reason().Skipped)
+}
+
+func TestRoutingRuleMatches(t *testing.T) {
+	t.Parallel()
+
+	price := routingFixturePrice()
+	product := &models.Product{Key: "pro"}
+	in := RoutingInput{
+		Price:   price,
+		Product: product,
+		Mode:    models.CheckoutSessionModeSubscription,
+		Country: "US",
+	}
+
+	tests := []struct {
+		name  string
+		match models.CheckoutRoutingMatch
+		want  bool
+	}{
+		{name: "catch-all", match: models.CheckoutRoutingMatch{}, want: true},
+		{name: "currency hit", match: models.CheckoutRoutingMatch{Currency: "usd"}, want: true},
+		{name: "currency miss", match: models.CheckoutRoutingMatch{Currency: "eur"}},
+		{name: "product hit", match: models.CheckoutRoutingMatch{Product: "pro"}, want: true},
+		{name: "product miss", match: models.CheckoutRoutingMatch{Product: "enterprise"}},
+		{name: "price hit", match: models.CheckoutRoutingMatch{Price: "pro-monthly"}, want: true},
+		{name: "mode hit", match: models.CheckoutRoutingMatch{Mode: "subscription"}, want: true},
+		{name: "mode miss", match: models.CheckoutRoutingMatch{Mode: "one_off"}},
+		{name: "country hit", match: models.CheckoutRoutingMatch{Country: "US"}, want: true},
+		{name: "country miss", match: models.CheckoutRoutingMatch{Country: "DE"}},
+		{name: "all conditions AND", match: models.CheckoutRoutingMatch{Currency: "usd", Product: "pro", Mode: "subscription"}, want: true},
+		{name: "one condition fails the whole rule", match: models.CheckoutRoutingMatch{Currency: "usd", Product: "enterprise"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, routingRuleMatches(tt.match, in))
+		})
+	}
+}

--- a/internal/modules/checkout/session_repo.go
+++ b/internal/modules/checkout/session_repo.go
@@ -2,6 +2,7 @@ package checkout
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -47,6 +48,12 @@ func (r *CheckoutSessionRepo) Create(ctx context.Context, session *models.Checko
 	if err != nil {
 		return err
 	}
+	var routingReason []byte
+	if session.RoutingReason != nil {
+		if routingReason, err = json.Marshal(session.RoutingReason); err != nil {
+			return fmt.Errorf("encode checkout session routing reason: %w", err)
+		}
+	}
 	tid, err := merchant.Require(ctx)
 	if err != nil {
 		return err
@@ -69,6 +76,7 @@ func (r *CheckoutSessionRepo) Create(ctx context.Context, session *models.Checko
 		Metadata:       meta,
 		RailFields:     fields,
 		RailState:      state,
+		RoutingReason:  routingReason,
 		PspID:          session.PspID,
 		CreatedAt:      session.CreatedAt,
 		UpdatedAt:      session.UpdatedAt,

--- a/internal/modules/checkout/session_service.go
+++ b/internal/modules/checkout/session_service.go
@@ -93,14 +93,6 @@ type railMerchantAccountIDResolver interface {
 	ResolvePSPID(ctx context.Context, rail string) *uuid.UUID
 }
 
-// railTargetResolver is the OPTIONAL executor capability (#848): resolve the
-// wire payment.rail selector (PSP key first, unambiguous rail-kind fallback)
-// into the target PSP + rail kind. Satisfied by *CheckoutService; test fakes
-// may omit it (the wire value is then treated as the rail kind directly).
-type railTargetResolver interface {
-	resolveRailTarget(ctx context.Context, requested string) (railTarget, error)
-}
-
 type solanaPaymentService interface {
 	GeneratePayment(ctx context.Context, userID string, priceID uuid.UUID, tokenSymbol string, sessionID *uuid.UUID) (*solanamodule.PayResult, error)
 	ConsumeAndRemovePending(ctx context.Context, reference, transactionID string) error
@@ -430,9 +422,6 @@ func (s *CheckoutSessionService) createSessionWithValidation(ctx context.Context
 	if strings.TrimSpace(req.PriceID) == "" {
 		return nil, fmt.Errorf("%w: price_id is required", ErrCheckoutSessionValidation)
 	}
-	if strings.TrimSpace(req.Payment.Rail) == "" {
-		return nil, fmt.Errorf("%w: payment.rail is required", ErrCheckoutSessionValidation)
-	}
 
 	// #774: price_id accepts a price_key too.
 	price, err := catalog.ResolveReference(ctx, s.priceService, req.PriceID)
@@ -450,32 +439,51 @@ func (s *CheckoutSessionService) createSessionWithValidation(ctx context.Context
 		return nil, fmt.Errorf("%w: product is not active", ErrCheckoutSessionValidation)
 	}
 
-	// #848: the wire payment.rail value speaks PSP vocabulary. Resolve it ONCE
-	// (PSP key first, unambiguous rail-kind fallback) into the rail KIND — used
-	// for dispatch and row vocabulary — plus the PSP the charge must land on.
+	// or#288 + #848: resolve the processor ONCE, before the session exists.
+	// A request that NAMES a PSP gets that PSP (the #848 wire value: PSP key
+	// first, unambiguous rail-kind fallback); a request that names none is
+	// routed by the merchant's policy, falling through unavailable candidates.
+	// Either way this yields the rail KIND — used for dispatch and row
+	// vocabulary — plus the PSP the charge must land on, and the trace that
+	// explains the choice.
 	rail := strings.ToLower(strings.TrimSpace(req.Payment.Rail))
 	pspSelector := rail
 	var pspID *uuid.UUID
-	if resolver, ok := s.checkoutService.(railTargetResolver); ok {
-		target, err := resolver.resolveRailTarget(ctx, rail)
+	var routingReason *models.CheckoutRoutingReason
+	if _, ok := s.checkoutService.(*CheckoutService); ok {
+		decision, err := s.Route(ctx, RoutingInput{
+			Price:    price,
+			Product:  product,
+			Mode:     checkoutModeForRail(price, ""),
+			Country:  strings.TrimSpace(req.Payment.Country),
+			Selector: rail,
+		})
 		if err != nil {
 			var ambiguous *AmbiguousRailError
 			var unknown *UnknownRailError
-			if errors.As(err, &ambiguous) || errors.As(err, &unknown) {
+			if errors.As(err, &ambiguous) || errors.As(err, &unknown) || errors.Is(err, ErrNoRoutableProcessor) {
 				return nil, fmt.Errorf("%w: %v", ErrCheckoutSessionValidation, err)
 			}
 			return nil, err
 		}
-		rail = target.Rail
-		pspSelector = target.PSP
+		rail = decision.Target.Rail
+		pspSelector = decision.Target.PSP
+		routingReason = decision.Reason()
 		// #704: pin provenance with the REAL resolved account — never invented.
-		if target.Scope != nil && target.Scope.ID != uuid.Nil {
-			id := target.Scope.ID
+		if decision.Target.Scope != nil && decision.Target.Scope.ID != uuid.Nil {
+			id := decision.Target.Scope.ID
 			pspID = &id
 		}
-	} else if resolver, ok := s.checkoutService.(railMerchantAccountIDResolver); ok {
-		// #704 fallback for executors without target resolution (test fakes).
-		pspID = resolver.ResolvePSPID(ctx, rail)
+	} else {
+		// Executors without the concrete checkout service (test fakes) cannot
+		// route: the wire value is the rail kind directly.
+		if rail == "" {
+			return nil, fmt.Errorf("%w: payment.rail is required", ErrCheckoutSessionValidation)
+		}
+		if resolver, ok := s.checkoutService.(railMerchantAccountIDResolver); ok {
+			// #704 fallback for executors without target resolution.
+			pspID = resolver.ResolvePSPID(ctx, rail)
+		}
 	}
 	if pspID != nil {
 		ctx = db.WithPSPID(ctx, *pspID)
@@ -526,12 +534,15 @@ func (s *CheckoutSessionService) createSessionWithValidation(ctx context.Context
 		Metadata:   normalizeMetadata(req.Metadata),
 		RailFields: railFields,
 		RailState:  railState,
-		CreatedAt:  now,
-		UpdatedAt:  now,
-		PspID:      pspID,
-		LastFour:   &req.Payment.LastFour,
-		CardType:   &req.Payment.CardType,
-		ExpiryDate: &req.Payment.ExpiryDate,
+		// or#288: the decision trace is written with the row and never rewritten
+		// (UpdateCheckoutSession does not name the column).
+		RoutingReason: routingReason,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+		PspID:         pspID,
+		LastFour:      &req.Payment.LastFour,
+		CardType:      &req.Payment.CardType,
+		ExpiryDate:    &req.Payment.ExpiryDate,
 	}
 
 	if idempotencyKey != "" {
@@ -583,6 +594,9 @@ func (s *CheckoutSessionService) resumeIdempotentSession(
 	if existing == nil || requested == nil {
 		return nil, fmt.Errorf("%w: idempotent checkout session unavailable", ErrCheckoutSessionConflict)
 	}
+	// or#288: Rail and PspID are part of the match, so a retry whose routing
+	// would now resolve elsewhere (arming or policy moved between attempts)
+	// CONFLICTS rather than quietly switching processors mid-idempotency.
 	storedFingerprint, _ := existing.RailState[checkoutSessionFingerprintKey].(string)
 	requestedFingerprint, _ := requested.RailState[checkoutSessionFingerprintKey].(string)
 	parametersMatch := existing.CustomerID == requested.CustomerID &&

--- a/internal/modules/merchantconfig/checkout_routing.go
+++ b/internal/modules/merchantconfig/checkout_routing.go
@@ -1,0 +1,95 @@
+package merchantconfig
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/open-rails/openrails/internal/db/models"
+)
+
+// Checkout routing policy shape (or#288). ONE validator serves both declaration
+// paths — the mode-1 manifest and the mode-2 config API — so a policy that
+// boots cannot be a policy the API would have refused.
+
+var validRoutingModes = map[string]struct{}{
+	string(models.CheckoutSessionModeOneOff):       {},
+	string(models.CheckoutSessionModeSubscription): {},
+}
+
+// NormalizeCheckoutRouting validates a declared policy and returns it in
+// canonical form (lowercased selectors and conditions). It rejects rather than
+// repairs: a rule that cannot mean what it says is an operator error, and
+// silently dropping it would route money somewhere nobody chose.
+func NormalizeCheckoutRouting(rules []models.CheckoutRoutingRule) ([]models.CheckoutRoutingRule, error) {
+	if len(rules) == 0 {
+		return nil, nil
+	}
+	out := make([]models.CheckoutRoutingRule, 0, len(rules))
+	catchAll := -1
+	for i, rule := range rules {
+		if catchAll >= 0 {
+			return nil, fmt.Errorf("checkout_routing[%d] is unreachable: rule %d matches everything", i, catchAll)
+		}
+		match, err := normalizeRoutingMatch(i, rule.Match)
+		if err != nil {
+			return nil, err
+		}
+		prefer := make([]string, 0, len(rule.Prefer))
+		seen := make(map[string]struct{}, len(rule.Prefer))
+		for _, selector := range rule.Prefer {
+			selector = strings.ToLower(strings.TrimSpace(selector))
+			if selector == "" {
+				return nil, fmt.Errorf("checkout_routing[%d].prefer contains an empty selector", i)
+			}
+			if _, dup := seen[selector]; dup {
+				return nil, fmt.Errorf("checkout_routing[%d].prefer repeats %q", i, selector)
+			}
+			seen[selector] = struct{}{}
+			prefer = append(prefer, selector)
+		}
+		if len(prefer) == 0 {
+			// An empty prefer list would route nothing at all. A merchant that
+			// wants a rail off archives the PSP; it does not declare a dead rule.
+			return nil, fmt.Errorf("checkout_routing[%d].prefer must name at least one PSP", i)
+		}
+		if match.IsCatchAll() {
+			catchAll = i
+		}
+		out = append(out, models.CheckoutRoutingRule{Match: match, Prefer: prefer})
+	}
+	return out, nil
+}
+
+func normalizeRoutingMatch(i int, m models.CheckoutRoutingMatch) (models.CheckoutRoutingMatch, error) {
+	out := models.CheckoutRoutingMatch{
+		Currency: strings.ToLower(strings.TrimSpace(m.Currency)),
+		Product:  strings.TrimSpace(m.Product),
+		Price:    strings.TrimSpace(m.Price),
+		Mode:     strings.ToLower(strings.TrimSpace(m.Mode)),
+		Country:  strings.ToUpper(strings.TrimSpace(m.Country)),
+	}
+	if out.Currency != "" && !isAlpha(out.Currency, 3) {
+		return out, fmt.Errorf("checkout_routing[%d].match.currency must be a 3-letter ISO-4217 code", i)
+	}
+	if out.Country != "" && !isAlpha(out.Country, 2) {
+		return out, fmt.Errorf("checkout_routing[%d].match.country must be a 2-letter ISO-3166-1 code", i)
+	}
+	if out.Mode != "" {
+		if _, ok := validRoutingModes[out.Mode]; !ok {
+			return out, fmt.Errorf("checkout_routing[%d].match.mode must be one_off or subscription", i)
+		}
+	}
+	return out, nil
+}
+
+func isAlpha(s string, n int) bool {
+	if len(s) != n {
+		return false
+	}
+	for _, r := range s {
+		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/modules/merchantconfig/checkout_routing_test.go
+++ b/internal/modules/merchantconfig/checkout_routing_test.go
@@ -1,0 +1,89 @@
+package merchantconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/db/models"
+)
+
+func TestNormalizeCheckoutRoutingCanonicalises(t *testing.T) {
+	t.Parallel()
+
+	out, err := NormalizeCheckoutRouting([]models.CheckoutRoutingRule{
+		{
+			Match:  models.CheckoutRoutingMatch{Currency: " USD ", Country: "us", Mode: " Subscription "},
+			Prefer: []string{" Mobius ", "CCBill"},
+		},
+		{Prefer: []string{"stripe"}},
+	})
+	require.NoError(t, err)
+	require.Len(t, out, 2)
+	assert.Equal(t, "usd", out[0].Match.Currency)
+	assert.Equal(t, "US", out[0].Match.Country)
+	assert.Equal(t, "subscription", out[0].Match.Mode)
+	assert.Equal(t, []string{"mobius", "ccbill"}, out[0].Prefer)
+	assert.True(t, out[1].Match.IsCatchAll())
+}
+
+func TestNormalizeCheckoutRoutingRejects(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		rules []models.CheckoutRoutingRule
+		want  string
+	}{
+		{
+			name:  "empty prefer routes nothing",
+			rules: []models.CheckoutRoutingRule{{Prefer: nil}},
+			want:  "must name at least one PSP",
+		},
+		{
+			name:  "repeated selector is a paste error",
+			rules: []models.CheckoutRoutingRule{{Prefer: []string{"mobius", "mobius"}}},
+			want:  `repeats "mobius"`,
+		},
+		{
+			name: "a rule after the catch-all can never match",
+			rules: []models.CheckoutRoutingRule{
+				{Prefer: []string{"mobius"}},
+				{Match: models.CheckoutRoutingMatch{Currency: "eur"}, Prefer: []string{"ccbill"}},
+			},
+			want: "unreachable",
+		},
+		{
+			name:  "bad currency",
+			rules: []models.CheckoutRoutingRule{{Match: models.CheckoutRoutingMatch{Currency: "dollars"}, Prefer: []string{"mobius"}}},
+			want:  "ISO-4217",
+		},
+		{
+			name:  "bad country",
+			rules: []models.CheckoutRoutingRule{{Match: models.CheckoutRoutingMatch{Country: "USA"}, Prefer: []string{"mobius"}}},
+			want:  "ISO-3166-1",
+		},
+		{
+			name:  "bad mode",
+			rules: []models.CheckoutRoutingRule{{Match: models.CheckoutRoutingMatch{Mode: "recurring"}, Prefer: []string{"mobius"}}},
+			want:  "one_off or subscription",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NormalizeCheckoutRouting(tt.rules)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestNormalizeCheckoutRoutingEmptyIsNoPolicy(t *testing.T) {
+	t.Parallel()
+
+	out, err := NormalizeCheckoutRouting(nil)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+}

--- a/migrations/postgres/0041_checkout_session_routing_reason.down.sql
+++ b/migrations/postgres/0041_checkout_session_routing_reason.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE openrails.checkout_sessions DROP COLUMN IF EXISTS routing_reason;

--- a/migrations/postgres/0041_checkout_session_routing_reason.up.sql
+++ b/migrations/postgres/0041_checkout_session_routing_reason.up.sql
@@ -1,0 +1,23 @@
+-- or#288: record WHY a checkout session landed on the PSP it landed on.
+--
+-- Until now the row stated the outcome (rail, psp_id) and nothing about the
+-- decision, so "why did this customer get CCBill instead of Stripe" was only
+-- answerable by re-deriving arming, credentials and price links as they were at
+-- the time — which is to say, not answerable at all once anything moved.
+--
+-- One compact jsonb column holds the whole trace: which policy and rule
+-- matched, the winner, the still-eligible fallbacks, and every candidate passed
+-- over with its skip class. Written once at creation and never rewritten
+-- (UpdateCheckoutSession does not name it), so the row keeps the decision as it
+-- was made.
+--
+-- Nullable rather than defaulted: sessions created before this column existed
+-- had no trace, and inventing an empty one would assert a decision nobody
+-- recorded (#651).
+
+SET LOCAL statement_timeout = '60s';
+SET LOCAL lock_timeout = '10s';
+
+ALTER TABLE openrails.checkout_sessions ADD COLUMN IF NOT EXISTS routing_reason jsonb;
+
+COMMENT ON COLUMN openrails.checkout_sessions.routing_reason IS 'or#288 processor-routing decision trace, written once at creation: {policy: explicit|merchant|default, rule: matched merchant-rule index, selected: PSP key, rail, fallbacks: [remaining eligible PSP keys, ranked], skipped: [{selector, reason}]}. Skip reasons are PRE-CHARGE availability classes (not_armed, credentials_missing, link_missing, mode_unsupported, service_unavailable, ambiguous_selector, unknown_selector, resolve_failed); a decline is never one of them. NULL = created before the column existed.';

--- a/pkg/service/admission.go
+++ b/pkg/service/admission.go
@@ -372,6 +372,11 @@ type MerchantConfiguration struct {
 	// merchant's InvoiceMonthlyFloor respectively.
 	ArrearsGraceDays        *int
 	ArrearsDelinquencyFloor *int64
+	// CheckoutRouting (or#288) is the processor-routing policy — the mode-2
+	// twin of the manifest's checkout_routing block. A nil pointer preserves
+	// the stored policy; a non-nil pointer replaces it whole (an empty slice
+	// clears it back to the built-in default order).
+	CheckoutRouting *[]models.CheckoutRoutingRule
 }
 
 // GetMerchantConfiguration returns the stored merchant-scoped configuration row.
@@ -384,6 +389,13 @@ func (s *Service) GetMerchantConfiguration(ctx context.Context) (MerchantConfigu
 		return MerchantConfiguration{}, false, err
 	}
 	alertEmail := cfg.AlertEmail
+	// A nil pointer means "no policy declared" — distinct from a pointer to an
+	// empty list, which a writer uses to CLEAR one.
+	var routing *[]models.CheckoutRoutingRule
+	if len(cfg.CheckoutRouting) > 0 {
+		rules := cfg.CheckoutRouting
+		routing = &rules
+	}
 	out := MerchantConfiguration{
 		Profile:                            &cfg.Profile,
 		InvoiceCollectionThreshold:         cfg.InvoiceCollectionThreshold,
@@ -393,6 +405,7 @@ func (s *Service) GetMerchantConfiguration(ctx context.Context) (MerchantConfigu
 		RepriceNoticeWindowDays:            cfg.RepriceNoticeWindowDays,
 		ArrearsGraceDays:                   cfg.ArrearsGraceDays,
 		ArrearsDelinquencyFloor:            cfg.ArrearsDelinquencyFloor,
+		CheckoutRouting:                    routing,
 		DelegatedInvokerWastedSpendWindows: make([]abuse.WastedWindow, 0, len(cfg.DelegatedInvokerWastedSpendWindows)),
 	}
 	for _, w := range cfg.DelegatedInvokerWastedSpendWindows {
@@ -462,6 +475,13 @@ func (s *Service) SetMerchantConfiguration(ctx context.Context, in MerchantConfi
 			return fmt.Errorf("arrears_delinquency_floor must be >= 0")
 		}
 		cfg.ArrearsDelinquencyFloor = in.ArrearsDelinquencyFloor
+	}
+	if in.CheckoutRouting != nil {
+		routing, err := merchantconfig.NormalizeCheckoutRouting(*in.CheckoutRouting)
+		if err != nil {
+			return err
+		}
+		cfg.CheckoutRouting = routing
 	}
 	cfg.DelegatedInvokerWastedSpendWindows = make([]models.BudgetWindowPolicy, 0, len(in.DelegatedInvokerWastedSpendWindows))
 	for _, w := range in.DelegatedInvokerWastedSpendWindows {

--- a/pkg/service/checkout_routing.go
+++ b/pkg/service/checkout_routing.go
@@ -1,0 +1,85 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/modules/checkout"
+)
+
+// CheckoutRoutingDryRun asks which PSP a checkout WOULD get (or#288). Selector
+// mirrors CheckoutPayment.Rail: set it to trace an explicitly named PSP, leave
+// it empty to trace what the merchant's routing policy would pick.
+type CheckoutRoutingDryRun struct {
+	PriceID  string
+	Country  string
+	Selector string
+}
+
+// CheckoutRoutingCandidate is one evaluated candidate. Skip is "" when the
+// candidate is eligible, else the class that disqualified it.
+type CheckoutRoutingCandidate struct {
+	Selector string
+	Rail     string
+	Skip     string
+}
+
+// CheckoutRoutingTrace is a dry run's full decision: what a real session would
+// choose, plus the exact trace it would persist on checkout_sessions.
+type CheckoutRoutingTrace struct {
+	Policy     string
+	Rule       *int
+	Selected   string
+	Rail       string
+	Mode       string
+	Candidates []CheckoutRoutingCandidate
+	Reason     *models.CheckoutRoutingReason
+}
+
+// DryRunCheckoutRouting explains routing for a price without creating a
+// session. It runs the production decision path, so the answer is what checkout
+// would actually do — not a prediction of it.
+func (s *Service) DryRunCheckoutRouting(ctx context.Context, in CheckoutRoutingDryRun) (*CheckoutRoutingTrace, error) {
+	checkoutSessions, err := s.requireCheckoutSessionService()
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(in.PriceID) == "" {
+		return nil, fmt.Errorf("price reference is required")
+	}
+	rt, err := s.runtime()
+	if err != nil {
+		return nil, err
+	}
+	if rt.DB == nil {
+		return nil, fmt.Errorf("billing service: database unavailable")
+	}
+	var decision *checkout.RoutingDecision
+	var mode models.CheckoutSessionMode
+	if err := rt.DB.RunInMerchantConn(ctx, func(scopedCtx context.Context) error {
+		var runErr error
+		decision, mode, runErr = checkoutSessions.DryRunRouting(scopedCtx, in.PriceID, in.Country, in.Selector)
+		return runErr
+	}); err != nil {
+		return nil, fmt.Errorf("dry run checkout routing: %w", err)
+	}
+	trace := &CheckoutRoutingTrace{
+		Policy:     decision.Policy,
+		Rule:       decision.Rule,
+		Selected:   decision.Selected(),
+		Rail:       decision.Target.Rail,
+		Mode:       string(mode),
+		Candidates: make([]CheckoutRoutingCandidate, 0, len(decision.Candidates)),
+		Reason:     decision.Reason(),
+	}
+	for _, candidate := range decision.Candidates {
+		trace.Candidates = append(trace.Candidates, CheckoutRoutingCandidate{
+			Selector: candidate.Selector,
+			Rail:     candidate.Rail,
+			Skip:     candidate.Skip,
+		})
+	}
+	return trace, nil
+}


### PR DESCRIPTION
Closes the routing half of or#288: checkout can now express a merchant's processor preference, fall through unavailable PSPs deterministically, and explain the choice afterwards.

## What was wrong

Checkout picked its PSP from a hardcoded rail order (`stripe, nmi, ccbill, solana`) inside the readiness lister, and recorded nothing about the choice. A merchant could not state a preference at all, and "why did this customer get CCBill instead of Stripe" was only answerable by re-deriving arming, credentials and price links as they were at the time — which is to say, not answerable.

## The shape

One function (`checkout.Route`) decides, and the same function backs the option list, session creation and the dry run — there is no second implementation to drift.

### Policy

`checkout_routing`, declared in the merchant manifest (mode 1) or on `PUT /v1/merchant/settings` (mode 2), through **one shared validator** so a manifest cannot declare a policy the API would refuse.

```yaml
checkout_routing:
  # EU subscriptions prefer CCBill, then NMI.
  - match: { currency: eur, mode: subscription }
    prefer: [ccbill, mobius]
  # This product is card-only; solana must never be offered for it.
  - match: { product: enterprise }
    prefer: [stripe, mobius]
  # Catch-all (must be last).
  - prefer: [mobius, ccbill, solana]
```

Ordered rules, **first match wins**. Conditions (`currency`, `product`, `price`, `mode`, `country`) are all optional and AND-ed; an empty match is the catch-all and any rule after it is rejected as unreachable. `prefer` is both the ranking **and** the whitelist — a PSP the winning rule does not name is not eligible, which is how a rule pins a product to one rail. Entries speak the #848 selector vocabulary (PSP keys; a rail kind where exactly one PSP is armed).

**Omitting the block entirely reproduces today's order exactly**, pinned by test in both the unit and integration suites.

### Fallback classes

Pre-charge availability only: `not_armed`, `credentials_missing`, `link_missing`, `mode_unsupported`, `service_unavailable`, `ambiguous_selector`, `unknown_selector`, `resolve_failed`. A **decline is deliberately absent** — it is a per-charge outcome, not a routing failure, and never re-routes a session. An archived PSP reports `not_armed`, not `unknown_selector` (new `merchants.PSPKeyArchived`), because "you retired this" and "no such PSP" are different answers.

The single readiness verdict (`checkoutRailSkipReason`, refactored from the old bool) now serves both the advertised option list and routing's skip classes, so the two can never disagree.

### `payment.rail` becomes optional

Naming a PSP still pins it and **never falls back** — the browser has already committed to that PSP's flow, so a silent switch would break the page. Omitting it is the routing request. #848's ambiguity refusal is untouched for a named selector; routing *skips* an ambiguous rail kind rather than guessing.

### The trace

Migration **0041** adds `checkout_sessions.routing_reason jsonb`:

```json
{"policy":"merchant","rule":0,"selected":"ccbill","rail":"ccbill",
 "fallbacks":["mobius"],"skipped":[{"selector":"paykings","reason":"not_armed"}]}
```

Written once at creation and never rewritten (`UpdateCheckoutSession` does not name the column). Nullable rather than defaulted: sessions created before the column existed had no trace, and inventing an empty one would assert a decision nobody recorded.

### Dry run

`POST /v1/merchant/payment-providers/routing/dry-run` (payment-providers **read** permission — the answer is a projection of the PSP catalog) returns the winner, the ranked fallbacks, every skipped candidate with its class, and the exact `routing_reason` a real session would store. It runs the production decision path, so it is what checkout would do, not a prediction of it.

Retries stay bound to the resolved processor: `rail` and `psp_id` are already part of the idempotent-resume match, so a retry whose routing moved conflicts instead of switching rails silently.

## Tests

Unit (`internal/modules/checkout/routing_test.go`, `internal/modules/merchantconfig/checkout_routing_test.go`): default-order pin, fallback with skip classes, mode-unsupported class, fail-closed with no eligible PSP, explicit selector never falls back, rule matching, and policy validation/normalisation.

Integration against the real checkout surface (`embed/checkout_routing_integration_test.go`, real Postgres, real HTTP):

- a manifest policy reorders past an **archived** PSP (`not_armed`), the routed session is created on the chosen PSP, and its stored `routing_reason` is `JSONEq` to the dry-run trace;
- a dry run creates no session row;
- with no policy, the candidate order is exactly `stripe, nmi, ccbill, solana` and a bare rail kind resolves to the armed PSP's key;
- **mode-2 parity**: the same policy over `PUT /v1/merchant/settings` reorders the next decision, a non-matching rule falls back to the default, and an unreachable-rule policy is refused 400;
- two armed NMI PSPs: routing skips the ambiguous kind and falls through, while an explicitly named `nmi` still 400s naming both keys.

**Results** (testcontainers, `-p 1`): `embed`, `internal/modules/checkout`, `internal/bootstrap`, `internal/http/...`, `internal/merchants`, `pkg/service` integration suites green; full unit suite green.

**Gates**: `golangci-lint` 0 issues, `sql-lint` clean, `migration-lint` clean (squawk, 25 files), `sqlc generate` + `sqlc vet` clean, query audit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)