### PR TITLE
or#889 + gosec G115: make the customer claim tests self-scoping, bounds-check three narrowings

### DIFF
--- a/cmd/openrails/converge_runs.go
+++ b/cmd/openrails/converge_runs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -75,6 +76,12 @@ func runConvergeList(cmd *cobra.Command, merchantSlug string, limit int, format 
 	if limit <= 0 {
 		limit = 20
 	}
+	// Clamp AT the int32 narrowing: --limit is an operator-supplied flag and a
+	// wrapped value would reach SQL as a negative LIMIT.
+	if limit > math.MaxInt32 {
+		limit = math.MaxInt32
+	}
+	lim := int32(limit)
 	database, mid, err := convergeOpenDB(cmd, merchantSlug)
 	if err != nil {
 		return err
@@ -87,7 +94,7 @@ func runConvergeList(cmd *cobra.Command, merchantSlug string, limit int, format 
 	if err := database.RunInMerchantConn(ctx, func(ctx context.Context) error {
 		var e error
 		runs, e = database.Gen(ctx).ListDestructiveRuns(ctx, gen.ListDestructiveRunsParams{
-			MerchantID: mid.UUID(), Kind: &kind, Lim: int32(limit),
+			MerchantID: mid.UUID(), Kind: &kind, Lim: lim,
 		})
 		return e
 	}); err != nil {

--- a/internal/crypto/envelope.go
+++ b/internal/crypto/envelope.go
@@ -28,6 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"sync"
 
 	"github.com/open-rails/openrails/pkg/merchant"
@@ -112,7 +113,16 @@ func SecretAAD(merchantID merchant.ID, name string) AAD {
 	out = append(out, "openrails/secret/v1\x00"...)
 	out = binary.BigEndian.AppendUint32(out, uint32(len(id)))
 	out = append(out, id[:]...)
-	out = binary.BigEndian.AppendUint32(out, uint32(len(name)))
+	// Bounds-checked narrowing: a name at the uint32 ceiling is a bug, not an
+	// input (names are addressing keys like psps/<key>/<field>). The clamp
+	// cannot create the collision the prefix exists to prevent — merchantID is
+	// fixed-width, so name is the only variable-length field AND it is last, and
+	// its bytes are appended in full below.
+	nameLen := len(name)
+	if nameLen > math.MaxUint32 {
+		nameLen = math.MaxUint32
+	}
+	out = binary.BigEndian.AppendUint32(out, uint32(nameLen))
 	out = append(out, name...)
 	return out
 }

--- a/internal/db/customer_integration_test.go
+++ b/internal/db/customer_integration_test.go
@@ -53,6 +53,8 @@ func TestEnsureCustomerID_UUIDReusesExistingPayableID(t *testing.T) {
 
 // seedForeignCustomer creates a second merchant plus a customer row owned by it,
 // returning that merchant's id and the customer id.
+// It requires a handle that spans merchants (the privileged pool): the foreign
+// customer row is by definition outside the test merchant's RLS scope.
 func seedForeignCustomer(ctx context.Context, t *testing.T, pool gen.DBTX) (uuid.UUID, uuid.UUID) {
 	t.Helper()
 	otherMerchantID := uuid.New()
@@ -79,7 +81,10 @@ func seedForeignCustomer(ctx context.Context, t *testing.T, pool gen.DBTX) (uuid
 // and hand the caller an id it does not own.
 func TestEnsureCustomerID_RefusesCrossMerchantClaim(t *testing.T) {
 	ctx := context.Background()
-	pool := dbtest.SharedPGXPool(t)
+	// The privileged handle IS the subject of this test: the guard has to hold
+	// where RLS does not. A bare SharedPGXPool is RLS-enforcing with no
+	// app.merchant_id, so seeding customers on it fails WITH CHECK (42501).
+	pool := dbtest.SharedSuperuserPGXPool(t)
 
 	dbtest.EnsureTestMerchant(ctx, t, pool)
 	otherMerchantID, customerID := seedForeignCustomer(ctx, t, pool)
@@ -100,7 +105,9 @@ func TestEnsureCustomerID_RefusesCrossMerchantClaim(t *testing.T) {
 // bypass RLS).
 func TestEnsureCustomerRow_RefusesCrossMerchantClaim(t *testing.T) {
 	ctx := context.Background()
-	pool := dbtest.SharedPGXPool(t)
+	// Privileged for the same reason as the sibling above: FK checks bypass RLS,
+	// so the silent-no-op corruption this guards is reachable precisely here.
+	pool := dbtest.SharedSuperuserPGXPool(t)
 
 	dbtest.EnsureTestMerchant(ctx, t, pool)
 	otherMerchantID, customerID := seedForeignCustomer(ctx, t, pool)
@@ -118,7 +125,9 @@ func TestEnsureCustomerRow_RefusesCrossMerchantClaim(t *testing.T) {
 // The same id under the SAME merchant stays a plain idempotent no-op.
 func TestEnsureCustomerRow_RepeatIsIdempotent(t *testing.T) {
 	ctx := context.Background()
-	pool := dbtest.SharedPGXPool(t)
+	// One merchant's own rows: the RLS-enforcing pinned pool, so the policies
+	// stay live and the fixture proves the merchant can write its own customer.
+	pool := dbtest.SharedMerchantPool(t, dbtest.TestMerchantID.UUID())
 
 	dbtest.EnsureTestMerchant(ctx, t, pool)
 	tenantID := dbtest.TestMerchantID.UUID()
@@ -144,7 +153,7 @@ func TestEnsureCustomerRow_RepeatIsIdempotent(t *testing.T) {
 // it once that writer commits (#889).
 func TestEnsureCustomerRow_ConcurrentFirstTouchConverges(t *testing.T) {
 	ctx := context.Background()
-	pool := dbtest.SharedPGXPool(t)
+	pool := dbtest.SharedMerchantPool(t, dbtest.TestMerchantID.UUID())
 
 	dbtest.EnsureTestMerchant(ctx, t, pool)
 	tenantID := dbtest.TestMerchantID.UUID()
@@ -155,6 +164,11 @@ func TestEnsureCustomerRow_ConcurrentFirstTouchConverges(t *testing.T) {
 
 	tx, err := pool.Begin(ctx)
 	require.NoError(t, err)
+	// The committing goroutine below is only reached if every assertion between
+	// here and it passes. Without this, ANY failure in between abandons a
+	// checked-out connection and the pool's Close cleanup blocks forever —
+	// turning a one-line assertion failure into a whole-package hang.
+	defer func() { _ = tx.Rollback(ctx) }()
 	_, err = tx.Exec(ctx,
 		`INSERT INTO openrails.customers (id, merchant_id, subject) VALUES ($1, $2, $3)`,
 		customerID, tenantID, customerID.String())

--- a/pkg/embedded/prune_list.go
+++ b/pkg/embedded/prune_list.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -38,6 +39,12 @@ func PruneList(ctx context.Context, opts PruneListOptions) error {
 	if limit <= 0 {
 		limit = 20
 	}
+	// Host-supplied page size: clamp AT the narrowing so a caller's huge value
+	// cannot wrap to a negative LIMIT.
+	if limit > math.MaxInt32 {
+		limit = math.MaxInt32
+	}
+	lim := int32(limit)
 	database, err := openEmbeddedDB(ctx, opts.Config, opts.PGXPool)
 	if err != nil {
 		return err
@@ -54,7 +61,7 @@ func PruneList(ctx context.Context, opts PruneListOptions) error {
 	if err := database.RunInMerchantConn(ctx, func(ctx context.Context) error {
 		var e error
 		runs, e = database.Gen(ctx).ListDestructiveRuns(ctx, gen.ListDestructiveRunsParams{
-			MerchantID: merchantID.UUID(), Lim: int32(limit),
+			MerchantID: merchantID.UUID(), Lim: lim,
 		})
 		return e
 	}); err != nil {


### PR DESCRIPTION
Two landed fixes, and two findings handed back rather than guessed at.

## 1. or#889 — the four new customer claim tests could never pass on a fresh DB

`internal/db/customer_integration_test.go` (PR #212). All four do their first
`INSERT INTO openrails.customers` on `dbtest.SharedPGXPool(t)` — the bare
RLS-**enforcing** app-role pool with no `app.merchant_id`. `customers` is
RLS-forced, so `WITH CHECK` refuses with **42501** every time.

**Failing before** (`-run TestEnsureCustomer ./internal/db/`, fresh testcontainer DB):
all four fail; **after**: `ok ... 34.9s`. Full `./internal/db/...` is green.

Fix follows the handle doctrine already written in `SharedMerchantPool`'s own doc
("this, not a superuser pool, is what a test wants when it seeds or asserts on ONE
merchant's own rows; superuser is for fixtures spanning merchants"):

- the two `RefusesCrossMerchantClaim` tests → `SharedSuperuserPGXPool`. The
  privileged handle *is* the subject: these exist to prove the guard holds where
  RLS does not, and `seedForeignCustomer` spans merchants by definition.
- the two same-merchant tests → `SharedMerchantPool(TestMerchantID)`, policies live.

### The reported 9-minute hang is a test artifact, not an or#889 design defect

`EnsureCustomerRowQ` never runs, `LockCustomerForMerchant` never runs, and there is
no infinite wait in the claim guard. The goroutine dump shows the test goroutine at
**line 161** — `require.NoError` on the test's **own** `tx.Exec` insert (the
`EnsureCustomerRow` call is line 169, never reached) — in
`FailNow → Goexit → t.Cleanup → pgxpool.Pool.Close → puddle WaitGroup.Wait`.

The failure at 161 abandons a checked-out connection: the goroutine that would
commit that tx is launched at line 164, *after* the failure point, so it never
starts and the pool's Close cleanup blocks forever. A one-line assertion failure
therefore read as a whole-package hang. Production has no analogue — it requires an
abandoned `pgx.Tx` whose commit is unreachable because a test assertion `Goexit`'d.
Added `defer tx.Rollback(ctx)` so this can never wedge the package again.

## 2. gosec G115 — three narrowings, bounds-checked (0 HIGH findings now)

Verified with the CI-pinned binary (`scripts/ci-install-tool.sh gosec` → 2.28.0,
`-severity high -confidence medium`). No `#nosec` used.

- `pkg/embedded/prune_list.go`, `cmd/openrails/converge_runs.go`: an
  operator-supplied page size narrowed to `int32` **inside a closure**, which is
  why a clamp earlier in the function did not satisfy the checker — clamp and
  narrow at the same site. A wrapped value would reach SQL as a negative `LIMIT`.
- `internal/crypto/envelope.go`: `SecretAAD` narrowed `len(name)` for its length
  prefix. Clamping cannot create the collision the prefix exists to prevent —
  `merchant_id` is fixed-width, so `name` is the only variable-length field *and*
  it is last, appended in full.

## 3. NOT FIXED — `TestAdmitRefusesWhenOverdueExposureEatsTheCreditLine`

Reproduced alone in 4.4s: fails at line 180, `Admit` allows the over-the-line payer.
Note the *preceding* assertion passes — `GetOutstandingOwed` correctly returns
5,000,000, so exposure is visible. The cap simply does not consult it.

**Root cause: two different, both-deliberate exposure models.**

- `AuthorizeAndHold` — `internal/modules/money/authorize.go:125`:
  `remainingCredit = CreditLimitAmount - arrearsExposureTx(...)`, where exposure is
  **invoice-derived** (`SumOpenInvoiceAmountDue + SumPendingInvoiceItemAmount`).
- `Admit` — `admission/spendgate_policy.go:189` `payerCapacity` →
  `money_service.go:250` `GetAdmissionCapacity`, whose doc says explicitly:
  *"It deliberately does not subtract outstanding owed; under the Phase-H model
  used credit is already represented by a negative customer_balance."*
  So `creditLine = CreditLimitAmount` raw.

The test inserts an invoice with raw SQL and **never moves the ledger**, so
`customer_balance` stays 0: `available` 0, `creditLine` 2,000,000, estimate
1,000,000 → allowed. Only the invoice-derived model sees that fixture.

This is neither a clean (a) nor (b). Deciding it is an owner-level call I did not
want to make unilaterally, because both directions carry real money risk:
- subtract exposure in `payerCapacity` → **double-counts** credit whenever usage
  has already driven `customer_balance` negative *and* been invoiced, refusing
  legitimate spend;
- leave it → an unpaid-invoice payer keeps being admitted, i.e. exactly the "cap
  never bites" the or#878 test was written to disprove.

The real question is which is authoritative for admission under Phase-H, and
whether the ledger-negative and invoice-derived views can diverge in production the
way this fixture forces. If they cannot, the fixture is unrealistic and the test
should drive the ledger (or pin `AuthorizeAndHold`, which *does* refuse here). If
they can, `payerCapacity` is the defect and Phase-H's premise needs revisiting.
Not a merge interaction: the divergence predates PRs #211-#222 — both models are
long-standing and independently documented.

## 4. NOT DONE — 4 HIGH npm CVEs

Not attempted; out of remaining budget rather than blocked. `.trivyignore`'s
procedure is explicit and should be followed literally: compare
`registry.npmjs.org/<pkg>/<version>` `.dist.attestations` for the pinned *and* the
fixed version before believing any provenance-based suppression — the or#853
re-check found 3 of 4 prior suppression reasons were simply false.

## Not reproducible

`TestMerchantConn_LazyConnNotAcquiredWithoutUse` and `TestRLSEnforcement_PgxSide`
failed once in a heavily-loaded `./internal/db/...` run and passed in two
subsequent runs (alone and in-package). Load-sensitive, not order-dependent, and
not touched by this branch — recording rather than claiming a fix.
