### PR TITLE
or#853: bump the four HIGH transitive npm CVEs (no suppressions warranted)

### DIFF
--- a/web/admin/pnpm-lock.yaml
+++ b/web/admin/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  undici: ^7.29.0
+  fast-uri: ^3.1.5
+  ip-address: ^10.3.1
+  brace-expansion: ^5.0.9
+
 importers:
 
   .:
@@ -1504,8 +1510,8 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -1905,8 +1911,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2085,8 +2091,8 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -3006,8 +3012,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.3.0:
@@ -3369,7 +3375,7 @@ snapshots:
       open: 8.4.2
       picomatch: 4.0.5
       systeminformation: 5.31.12
-      undici: 7.28.0
+      undici: 7.29.0
       which: 4.0.0
       yocto-spinner: 1.2.0
 
@@ -4599,7 +4605,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4639,7 +4645,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4994,7 +5000,7 @@ snapshots:
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.4.0
 
   express@5.2.1:
     dependencies:
@@ -5045,7 +5051,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -5205,7 +5211,7 @@ snapshots:
 
   internmap@2.0.3: {}
 
-  ip-address@10.2.0: {}
+  ip-address@10.4.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -5418,7 +5424,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -5915,7 +5921,7 @@ snapshots:
       tailwind-merge: 3.6.0
       ts-morph: 26.0.0
       tsconfig-paths: 4.2.0
-      undici: 7.28.0
+      undici: 7.29.0
       validate-npm-package-name: 7.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
@@ -6069,7 +6075,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicorn-magic@0.3.0: {}
 

--- a/web/admin/pnpm-workspace.yaml
+++ b/web/admin/pnpm-workspace.yaml
@@ -1,6 +1,17 @@
 packages:
   - '.'
 
+# Transitive security bumps. Every one was checked against the .trivyignore
+# procedure (compare registry .dist.attestations for pinned vs fixed) before
+# being applied: none is a provenance downgrade, and ip-address 10.2.0 ->
+# 10.3.1 actually GAINS attestation. Drop an entry once the direct dependency
+# that drags it in (shadcn, eslint) ships the fixed range itself.
+overrides:
+  undici: ^7.29.0 # GHSA-4cwx-7wf7-3272
+  fast-uri: ^3.1.5 # GHSA-7p8r-x3mc-p8w7
+  ip-address: ^10.3.1 # GHSA-mwp4-54f8-5fhr
+  brace-expansion: ^5.0.9 # GHSA-rgw5-rvv9-x895
+
 pmOnFail: error
 ignoreScripts: true
 ignorePnpmfile: true


### PR DESCRIPTION
All four HIGH transitive npm CVEs are **bumped, not suppressed** — the attestation
evidence refused every provenance-based excuse. No new `.trivyignore` entries.

## Attestation evidence (ran `.trivyignore`'s procedure literally, before touching anything)

Compared `registry.npmjs.org` `.dist.attestations` for pinned vs fixed:

| package | pinned | fixed | verdict |
|---|---|---|---|
| undici | 7.28.0 **attested** | 7.29.0 **attested** | no downgrade |
| ip-address | 10.2.0 unattested | 10.4.0 **attested** | bump *gains* provenance |
| fast-uri | 3.1.4 unattested | 3.1.5 unattested | **0 of 32** versions ever attested |
| brace-expansion | 5.0.8 unattested | 5.0.9 unattested | **0 of 48** versions ever attested |

Same pattern or#853 found: the provenance story never survives being checked.
fast-uri and brace-expansion are the *same two packages* whose suppression or#853
already retired for exactly this reason — nothing exists to downgrade to.

| CVE | package | bump |
|---|---|---|
| GHSA-4cwx-7wf7-3272 | undici | 7.28.0 → 7.29.0 |
| GHSA-7p8r-x3mc-p8w7 | fast-uri | 3.1.4 → 3.1.5 |
| GHSA-mwp4-54f8-5fhr | ip-address | 10.2.0 → 10.4.0 |
| GHSA-rgw5-rvv9-x895 | brace-expansion | 5.0.8 → 5.0.9 |

All four are transitive (3 of 4 via `shadcn`; brace-expansion mostly via eslint), so
they are `overrides`, with a note to drop each entry once the direct dependency
ships the fixed range itself.

## Two traps worth recording

**1. `pnpm.overrides` in package.json is silently ignored by pnpm 11.** First attempt
put the block there and got `[WARN] The "pnpm" field in package.json is no longer
read by pnpm ... "pnpm.overrides"` — it resolved nothing. Settings now live in
`pnpm-workspace.yaml` (which is already where this repo keeps `trustPolicy`,
`minimumReleaseAge`, etc.), so the overrides go there.

**2. The semver@6.3.1 trip is a local-pnpm artifact, NOT a lockfile defect — do not
"fix" it.** `pnpm 11.15.1` (my box) rejects the *existing committed* lockfile before
any change:

    [ERR_PNPM_TRUST_DOWNGRADE] semver@6.3.1 High-risk trust downgrade (possible package takeover)

CI does not hit this: `pnpm/action-setup@v4` reads `package_json_file:
web/admin/package.json` → `packageManager: "pnpm@11.0.0"`. I fetched pnpm 11.0.0
from the registry directly (corepack's download host is unreachable from this box)
and ran the whole flow under the **exact CI version**, where it succeeds with no
policy error — matching `.trivyignore`'s own recorded finding that
`pnpm@11.0.0 install --frozen-lockfile` succeeds against the committed lockfile
as-is. So this lockfile was generated by the pinned pnpm, not by bypassing policy.
Anyone reproducing on a newer pnpm should expect the semver error and ignore it.

## Verification (all under pnpm 11.0.0)

- `pnpm install --lockfile-only` → clean, `lockfileVersion: '9.0'` unchanged, diff is
  40 lines confined to the four packages.
- `pnpm install --frozen-lockfile` → passes the supply-chain policy gate.
- `tsc -b && vite build` → **exit 0**, 2529 modules (only the pre-existing >500 kB
  chunk-size advisory).
- `pnpm run lint` → **0 errors** (1 pre-existing TanStack Table warning, untouched).
- `pnpm audit --audit-level high` → **only** GHSA-qwww-vcr4-c8h2 (react-router),
  which keeps its existing `.trivyignore` suppression; its reasoning still holds
  (RSC-only bypass, this is a Vite SPA) and no react-router 7.x backport has appeared.
