### PR TITLE
or#288: re-pin the route-surface golden, and gate-test the routes it gained

### DIFF
--- a/internal/http/routes/merchant_action_routes_test.go
+++ b/internal/http/routes/merchant_action_routes_test.go
@@ -83,6 +83,22 @@ func TestRegisterMerchantActionRoutesPermissions(t *testing.T) {
 			perm:   controlplane.PermMerchantPaymentProvidersRead,
 		},
 		{
+			// or#878 delinquency reads. Pinned here alongside the or#288 dry
+			// run because the route-surface golden only proves a route EXISTS —
+			// it says nothing about what guards it. A new read route silently
+			// mounted ungated would pass that snapshot.
+			name:   "merchant delinquency roster",
+			method: http.MethodGet,
+			path:   "/billing/v1/merchant/delinquency",
+			perm:   controlplane.PermMerchantCustomerSettingsRead,
+		},
+		{
+			name:   "customer delinquency state",
+			method: http.MethodGet,
+			path:   "/billing/v1/merchant/customers/11111111-1111-1111-1111-111111111111/delinquency",
+			perm:   controlplane.PermMerchantCustomerSettingsRead,
+		},
+		{
 			name:   "payment providers write",
 			method: http.MethodPut,
 			path:   "/billing/v1/merchant/payment-providers/stripe",

--- a/internal/integrationharness/testdata/standalone_route_surface.txt
+++ b/internal/integrationharness/testdata/standalone_route_surface.txt
@@ -62,10 +62,12 @@ GET /v1/merchant/credit-limit
 GET /v1/merchant/credits/balance
 GET /v1/merchant/customers
 GET /v1/merchant/customers/{customer_id}
+GET /v1/merchant/customers/{customer_id}/delinquency
 GET /v1/merchant/customers/{customer_id}/entitlements
 GET /v1/merchant/customers/{customer_id}/payment-methods
 GET /v1/merchant/customers/{customer_id}/payments
 GET /v1/merchant/dashboard
+GET /v1/merchant/delinquency
 GET /v1/merchant/entitlements/{entitlement}/customers
 GET /v1/merchant/findings
 GET /v1/merchant/findings/{id}
@@ -152,6 +154,7 @@ POST /v1/merchant/findings/{id}/resolve
 POST /v1/merchant/metrics/ask
 POST /v1/merchant/metrics/query
 POST /v1/merchant/notifications/{id}/read
+POST /v1/merchant/payment-providers/routing/dry-run
 POST /v1/merchant/payments/{id}/refunds
 POST /v1/merchant/plan-migrations
 POST /v1/merchant/plan-migrations/preview


### PR DESCRIPTION
`TestStandaloneRouteSurface` (the #670 golden) is red on `dev`. The golden is a whole-list snapshot, so it fails on the *set*, not on one line — three routes reached `dev` without it being regenerated.

## Provenance, line by line

| Line added to the golden | Owner | Why it exists |
|---|---|---|
| `POST /v1/merchant/payment-providers/routing/dry-run` | **or#288 — mine** | The routing dry-run endpoint from #223 |
| `GET /v1/merchant/delinquency` | or#878 | Delinquency roster |
| `GET /v1/merchant/customers/{customer_id}/delinquency` | or#878 | Per-customer delinquency state |

I picked up or#878's two lines only because the assertion compares the whole list — the test cannot go green with just my line, and both routes demonstrably exist on `dev` today. Neither is my design call to make; if or#878's owner wants either route reshaped, this snapshot follows it rather than the reverse.

**My miss, stated plainly:** I added the dry-run route in #223 and verified `embed`, `internal/modules/checkout`, `internal/bootstrap`, `internal/http/...`, `internal/merchants` and `pkg/service` — but not `internal/integrationharness`, which is the package that owns the route surface. Adding a route without re-running the test that pins routes is a gap in my pre-merge check, not bad luck.

## A snapshot is not a gate

Regenerating alone would be the wrong fix on its own: the golden proves a route **exists** and says nothing about what guards it, so an ungated route would sail through it. Each new route is therefore also pinned in the route-permission table test:

- `POST …/payment-providers/routing/dry-run` → `merchant:payment-providers:read` (already pinned in #223)
- `GET /v1/merchant/delinquency` → `merchant:customer-settings:read` (**new assertion**)
- `GET …/customers/{customer_id}/delinquency` → `merchant:customer-settings:read` (**new assertion**)

Verified at the registration site as well: all three are read-only, mounted behind `merchantActionPermissionMW`, and carry `MerchantDBConnMW`, so RLS scopes them. No mutation, nothing unauthenticated.

## How the golden was produced

Via the test's own `UPDATE_ROUTE_GOLDEN=1` path, then **re-run without it** so the committed file is what actually passes rather than what the regenerator happened to emit.

- `internal/integrationharness` (clean, no env override): `ok` 43.4s
- `internal/http/routes` unit: `ok`
- `internal/http/...` unit + `go build ./...`: green

Diff is exactly the three lines above, +2 permission assertions.