### PR TITLE
or#878: host_lifecycle_events.currency NOT NULL (CUR-1), migration 0044

### DIFF
--- a/internal/controlplane/host_lifecycle_events.go
+++ b/internal/controlplane/host_lifecycle_events.go
@@ -81,9 +81,7 @@ func (c *ControlPlane) ListPendingHostLifecycleEvents(ctx context.Context, merch
 			SubjectType: row.SubjectType,
 			SubjectID:   row.SubjectID,
 			OccurredAt:  row.OccurredAt,
-		}
-		if row.Currency != nil {
-			event.Currency = *row.Currency
+			Currency:    row.Currency,
 		}
 		if len(row.Data) > 0 {
 			if err := json.Unmarshal(row.Data, &event.Data); err != nil {

--- a/internal/db/gen/host_lifecycle_events.sql.go
+++ b/internal/db/gen/host_lifecycle_events.sql.go
@@ -69,7 +69,7 @@ type EnqueueHostLifecycleEventParams struct {
 	EventType   string
 	SubjectType string
 	SubjectID   uuid.UUID
-	Currency    *string
+	Currency    string
 	OccurredAt  time.Time
 	Data        []byte
 	DedupeKey   string
@@ -118,7 +118,7 @@ type ListPendingHostLifecycleEventsRow struct {
 	EventType   string
 	SubjectType string
 	SubjectID   uuid.UUID
-	Currency    *string
+	Currency    string
 	OccurredAt  time.Time
 	Data        []byte
 }

--- a/internal/db/gen/models.go
+++ b/internal/db/gen/models.go
@@ -452,7 +452,8 @@ type OpenrailsHostLifecycleEvent struct {
 	EventType   string
 	SubjectType string
 	SubjectID   uuid.UUID
-	Currency    *string
+	// The transition's currency. NOT NULL (CUR-1): every lifecycle event is per-(merchant, payer, currency) and the currency is part of its dedupe key, so an event without one is not a well-formed event.
+	Currency    string
 	OccurredAt  time.Time
 	Data        []byte
 	DeliveredAt *time.Time

--- a/internal/db/queries/EXEMPTIONS.md
+++ b/internal/db/queries/EXEMPTIONS.md
@@ -196,6 +196,7 @@ ran. The rules stay armed for new migrations.
 | `0027` merchant_exports→merchant_purge_inventories | `renaming-table`, `renaming-column` | Same hard-cut rationale as `0025`; breaking a client that still names `merchant_exports` is the point of or#858. |
 | `0031` vault_fingerprint→fingerprint | `renaming-column` | Same hard-cut rationale as `0025` (or#871): `vault` is reserved for HashiCorp Vault, and a caller still naming `vault_fingerprint` must fail loudly rather than read a stale alias. |
 | `0031` payments token_type CHECK | `constraint-missing-not-valid` | The two `UPDATE`s immediately above rewrite every row the re-added CHECK then validates, in the same transaction — the constraint is dropped and restored only to move `provider_vault`/`pan_via_vault` to their new names. |
+| `0044` host_lifecycle_events.currency | `adding-not-nullable-field` | The rule's own suggested fix — stay nullable, add a `CHECK` — provably cannot satisfy the invariant it exists for: CUR-1 reads `information_schema.columns.is_nullable`, so only the column attribute counts. The scan is inherent to `SET NOT NULL`, not the constraint two-step the sibling rule covers, so no file split reduces it. The table is a delivery feed created in `0037` and pruned after delivery, so the scan is over a small, short-lived table. |
 
 A new migration that genuinely needs one of these must add the constraint
 `NOT VALID` and `VALIDATE CONSTRAINT` it in a *later* file — one transaction

--- a/internal/db/queries/host_lifecycle_events.sql
+++ b/internal/db/queries/host_lifecycle_events.sql
@@ -10,7 +10,7 @@ INSERT INTO openrails.host_lifecycle_events
     (merchant_id, event_type, subject_type, subject_id, currency, occurred_at, data, dedupe_key)
 VALUES (
     sqlc.arg(merchant_id), sqlc.arg(event_type)::text, sqlc.arg(subject_type)::text,
-    sqlc.arg(subject_id), sqlc.narg(currency)::text, sqlc.arg(occurred_at)::timestamptz,
+    sqlc.arg(subject_id), sqlc.arg(currency)::text, sqlc.arg(occurred_at)::timestamptz,
     sqlc.arg(data)::jsonb, sqlc.arg(dedupe_key)::text)
 ON CONFLICT (merchant_id, dedupe_key) DO NOTHING;
 

--- a/internal/modules/delinquency/delinquency_integration_test.go
+++ b/internal/modules/delinquency/delinquency_integration_test.go
@@ -306,8 +306,7 @@ func TestDelinquencyLifecycle(t *testing.T) {
 	for _, ev := range events {
 		require.Equal(t, "customer", ev.SubjectType)
 		require.Equal(t, e.payer.UUID(), ev.SubjectID)
-		require.NotNil(t, ev.Currency)
-		require.Equal(t, e.currency, *ev.Currency)
+		require.Equal(t, e.currency, ev.Currency)
 	}
 	var payload map[string]any
 	require.NoError(t, json.Unmarshal(events[1].Data, &payload))

--- a/internal/modules/delinquency/service.go
+++ b/internal/modules/delinquency/service.go
@@ -284,7 +284,6 @@ func (s *Service) apply(ctx context.Context, tid merchant.ID, policy Policy, cus
 		if err != nil {
 			return fmt.Errorf("encode delinquency event: %w", err)
 		}
-		cur := currency
 		// transition_seq is the idempotency coordinate: two evaluators racing
 		// the same transition compute the same sequence, so the unique index
 		// collapses them into one instruction to the host.
@@ -294,7 +293,7 @@ func (s *Service) apply(ctx context.Context, tid merchant.ID, policy Policy, cus
 			EventType:   eventTypeFor(ParseState(row.State)),
 			SubjectType: subjectCustomer,
 			SubjectID:   customerID,
-			Currency:    &cur,
+			Currency:    currency,
 			OccurredAt:  now,
 			Data:        data,
 			DedupeKey:   dedupe,

--- a/migrations/postgres/0044_host_lifecycle_events_currency_not_null.down.sql
+++ b/migrations/postgres/0044_host_lifecycle_events_currency_not_null.down.sql
@@ -1,0 +1,7 @@
+SET LOCAL statement_timeout = '60s';
+SET LOCAL lock_timeout = '10s';
+
+ALTER TABLE openrails.host_lifecycle_events
+    ALTER COLUMN currency DROP NOT NULL;
+
+COMMENT ON COLUMN openrails.host_lifecycle_events.currency IS NULL;

--- a/migrations/postgres/0044_host_lifecycle_events_currency_not_null.up.sql
+++ b/migrations/postgres/0044_host_lifecycle_events_currency_not_null.up.sql
@@ -1,0 +1,33 @@
+-- CUR-1: host_lifecycle_events.currency must be NOT NULL.
+--
+-- or#878's 0037 created the column nullable. CUR-1 (pinned by
+-- TestCUR1_CurrencyColumnsAreNotNull) allows exactly ONE nullable currency
+-- column in the schema — grants.currency, which CUR-2 makes conditionally
+-- required — so this one was an unintended second.
+--
+-- Nothing writes NULL. The only producer is delinquency.Service's transition
+-- emit (EnqueueHostLifecycleEvent), which always passes the transition's
+-- currency; every event is per-(merchant, payer, currency) by construction, and
+-- the currency is already part of its dedupe key, so a NULL-currency row could
+-- never have been a well-formed event. The query's sqlc.narg is what left the
+-- door open, not any caller — tightened to sqlc.arg alongside this migration.
+--
+-- A bare SET NOT NULL rather than the NOT VALID / VALIDATE two-step: per
+-- EXEMPTIONS.md, splitting only pays off across two transactions (two files),
+-- and this table does not need it — it is a delivery feed created two
+-- migrations ago and pruned after delivery, so the validating scan is over a
+-- small, short-lived table.
+
+SET LOCAL statement_timeout = '60s';
+SET LOCAL lock_timeout = '10s';
+
+-- squawk's suggested alternative (leave it nullable, add a CHECK) cannot
+-- satisfy the invariant: CUR-1 reads information_schema.columns.is_nullable, so
+-- only the column attribute counts. The scan is inherent to SET NOT NULL and is
+-- not the constraint two-step this rule's sibling covers.
+ALTER TABLE openrails.host_lifecycle_events
+    -- squawk-ignore adding-not-nullable-field
+    ALTER COLUMN currency SET NOT NULL;
+
+COMMENT ON COLUMN openrails.host_lifecycle_events.currency IS
+    'The transition''s currency. NOT NULL (CUR-1): every lifecycle event is per-(merchant, payer, currency) and the currency is part of its dedupe key, so an event without one is not a well-formed event.';


### PR DESCRIPTION
Fixes `TestCUR1_CurrencyColumnsAreNotNull` on dev. (The route-surface golden was
dropped from my list — or#288 owns it on `or/288-route-surface-golden`.)

## The fix

or#878's `0037` created `host_lifecycle_events.currency` nullable, making it a
second nullable currency column; CUR-1 allows only `grants.currency` (which CUR-2
makes conditionally required). Migration **0044** sets it `NOT NULL`.

**Checked for a NULL-writing path first — there is none.** The sole producer is
`delinquency.Service`'s transition emit (`EnqueueHostLifecycleEvent`), which always
passes the transition's currency. Every event is per-(merchant, payer, currency) by
construction and the currency is part of its `dedupe_key`, so a NULL-currency row
could never have been a well-formed event in the first place. What left the door
open was the *query*, not any caller: `sqlc.narg(currency)`.

So the tightening goes with it — `sqlc.narg` → `sqlc.arg`, which makes the column
non-nullable in Go too. Regenerated with the pinned sqlc 1.31.1 via `task sqlc`
(generate + vet both clean); the diff is 3 fields `*string` → `string`, and
`models.go` picked up the new column comment, which independently confirms the
migration applied. Two readers stop unwrapping a pointer
(`internal/controlplane/host_lifecycle_events.go`, and the delinquency integration
test's `require.NotNil` + deref).

## Why a bare SET NOT NULL, with a squawk exemption

First attempt used the `NOT VALID` / `VALIDATE` two-step; squawk correctly rejected
it (both in one transaction blocks reads anyway), and `EXEMPTIONS.md` already states
the rule: *"`NOT VALID` buys nothing inside a single-transaction migrator... The
two-step only pays off across two transactions, i.e. two migration files."*

The bare form then trips `adding-not-nullable-field`, whose suggested alternative —
stay nullable, add a `CHECK` — **provably cannot satisfy this invariant**: CUR-1
reads `information_schema.columns.is_nullable`, so only the column attribute counts.
The scan is inherent to `SET NOT NULL`, not the constraint two-step a file split
would help, so splitting buys nothing here either. Exemption taken with that
reasoning and recorded in `internal/db/queries/EXEMPTIONS.md`.
`scripts/migration-lint.sh`: **clean (30 files checked)**.

## Verified

- `TestCUR1_CurrencyColumnsAreNotNull` — was failing (`["grants","host_lifecycle_events"]`), now `ok`.
- `internal/modules/delinquency` — `ok`.
- `internal/controlplane` — `ok`.
- `go build ./...`, `go vet` on both touched packages — clean.

## Pre-existing dev failures found during this pass (NOT mine, NOT fixed)

Each verified on **unmodified `origin/dev` @ e89a3f24** by stashing my work.

**1. `internal/reconcile` — `TestReconcileEngineIntegration` is order-dependent.**
Passes ALONE (`ok 1.2s`); fails in the full-package run, on pristine dev, identically:

    integration_test.go:192: expected: 1, actual: 3
    Messages: PS-2 absent subscription

`FindingLocalActiveRemoteDead` picks up 2 extra findings. The engine scans every
local subscription for the merchant, so active subscriptions left behind by earlier
tests in the package — absent from this test's NMI snapshot — are correctly
classified as local-active/remote-dead. A shared-fixture leak, not an engine bug:
the assertion is exact-count against a shared merchant.

**2. `internal/invariantaudit` — three ledger invariants fail, alone and together.**
Also reproduced on pristine dev:

- `TestMONEY8_TransferAmountAndFloorChecks` — "a well-formed transfer must be accepted"
- `TestLED3_InsufficientFundsFloorRaises` — "a debit within the declared floor must be allowed"
- `TestLED7_CreditLotTerminatesOnce`

All three are `Received unexpected error` on operations the test asserts must
SUCCEED, which points at the ledger fixture/schema rather than the invariants —
plausibly fallout from the or#894 ledger-coordinate merge. Not investigated further;
flagging for whoever owns that lane.

I did **not** reproduce the reported `internal/db` 6-minute timeout in this pass —
`./internal/db/...` ran fully green for me earlier today (PR #224). It was
load-sensitive when I saw it before, so I will re-check it under the full sweep.
