### PR TITLE
or#877: reconcile engine tests get their own merchant — full integration sweep green (47/47)

### DIFF
--- a/internal/dbtest/customer.go
+++ b/internal/dbtest/customer.go
@@ -28,10 +28,29 @@ func EnsureCustomerIDPgx(ctx context.Context, t testing.TB, qx gen.DBTX, userID 
 	// No default merchant (#336): materialize the canonical test merchant first so
 	// the customers FK resolves, then pin the customer under it.
 	EnsureTestMerchant(ctx, t, qx)
+	return ensureCustomerUnder(ctx, t, qx, TestMerchantID.UUID(), uid, userID)
+}
+
+// EnsureCustomerIDPgxFor is EnsureCustomerIDPgx under an EXPLICIT merchant, for
+// tests that own a merchant of their own rather than sharing the canonical one.
+// customers is RLS-forced, so a handle pinned to merchant X cannot materialize a
+// customer under the canonical test merchant — the WITH CHECK refuses it. The
+// caller is expected to have created the merchant row already.
+func EnsureCustomerIDPgxFor(ctx context.Context, t testing.TB, qx gen.DBTX, merchantID uuid.UUID, userID string) uuid.UUID {
+	t.Helper()
+	userID = strings.TrimSpace(userID)
+	require.NotEmpty(t, userID, "test user id must be set")
+	uid, err := uuid.Parse(userID)
+	require.NoError(t, err, "test user id must be a UUID (#364): %q", userID)
+	return ensureCustomerUnder(ctx, t, qx, merchantID, uid, userID)
+}
+
+func ensureCustomerUnder(ctx context.Context, t testing.TB, qx gen.DBTX, merchantID, uid uuid.UUID, subject string) uuid.UUID {
+	t.Helper()
 	id, err := gen.New(qx).EnsureCustomer(ctx, gen.EnsureCustomerParams{
 		ID:         uid,
-		MerchantID: TestMerchantID.UUID(),
-		Subject:    &userID,
+		MerchantID: merchantID,
+		Subject:    &subject,
 	})
 	require.NoError(t, err, "ensure customer")
 	return id

--- a/internal/reconcile/account_updater_integration_test.go
+++ b/internal/reconcile/account_updater_integration_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/open-rails/openrails/internal/dbtest"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
 
@@ -28,7 +27,10 @@ import (
 //   - and the next pass does not re-raise it as a discrepancy needing repair.
 func TestReconcileAdoptsAccountUpdaterRefreshedCard(t *testing.T) {
 	appDB := startReconcilePostgres(t)
-	baseCtx := merchant.WithID(context.Background(), dbtest.TestMerchantID)
+	// Own merchant: this test runs an ENFORCE pass, which is a real mutation —
+	// on a shared merchant it would act on other tests' subscriptions.
+	mid := newReconcileMerchant(t, appDB)
+	baseCtx := merchant.WithID(context.Background(), mid)
 
 	var (
 		seeded   seededState
@@ -36,13 +38,13 @@ func TestReconcileAdoptsAccountUpdaterRefreshedCard(t *testing.T) {
 		methodID = uuid.New()
 	)
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
-		seeded = seedReconcileFixtures(t, ctx, appDB)
+		seeded = seedReconcileFixtures(t, ctx, appDB, mid.UUID())
 		_, err := appDB.Qx(ctx).Exec(ctx, `
 			INSERT INTO openrails.payment_methods
 			  (id, merchant_id, customer_id, rail, rail_customer_ref, rail_method_ref,
 			   initial_transaction_id, last_four, card_type, expiry_date)
 			VALUES ($1, $2, $3, 'nmi', $4, '', '', '1111', 'visa', '1226')`,
-			methodID, dbtest.TestMerchantID.UUID(), seeded.subjectID, vaultID)
+			methodID, mid.UUID(), seeded.subjectID, vaultID)
 		return err
 	}))
 	t.Cleanup(func() {

--- a/internal/reconcile/integration_test.go
+++ b/internal/reconcile/integration_test.go
@@ -36,6 +36,27 @@ func startReconcilePostgres(t *testing.T) *db.DB {
 	return appDB
 }
 
+// newReconcileMerchant creates a merchant owned by ONE test.
+//
+// The engine diffs the provider roster against every local subscription the
+// merchant has, so a test that exact-counts findings cannot share a merchant:
+// any active NMI subscription another test left behind is absent from this
+// test's snapshot and is CORRECTLY reported as local-active/remote-dead. That
+// is what made TestReconcileEngineIntegration order-dependent (PS-2 expected 1,
+// got 3 — passing alone, failing in a full-package run).
+//
+// It also keeps enforce passes honest: an enforce run is a real mutation, and
+// on a shared merchant it would act on rows belonging to other tests.
+func newReconcileMerchant(t *testing.T, appDB *db.DB) merchant.ID {
+	t.Helper()
+	id := merchant.ID(uuid.New())
+	_, err := appDB.Pool().Exec(context.Background(),
+		`INSERT INTO openrails.merchants (id, slug, status) VALUES ($1,$2,'active')`,
+		id.UUID(), "reconcile-"+id.UUID().String()[:8])
+	require.NoError(t, err)
+	return id
+}
+
 type seededState struct {
 	subjectID uuid.UUID
 	productID uuid.UUID
@@ -48,7 +69,7 @@ type seededState struct {
 // seedReconcileFixtures inserts a product, price, tenant subject, and two NMI
 // subscriptions (one that the fake snapshot will keep alive, one that it
 // drops), plus a live subscription-sourced entitlement on each.
-func seedReconcileFixtures(t *testing.T, ctx context.Context, appDB *db.DB) seededState {
+func seedReconcileFixtures(t *testing.T, ctx context.Context, appDB *db.DB, merchantID uuid.UUID) seededState {
 	t.Helper()
 	s := seededState{
 		productID: uuid.New(),
@@ -57,7 +78,7 @@ func seedReconcileFixtures(t *testing.T, ctx context.Context, appDB *db.DB) seed
 		subDead:   uuid.New(),
 		entDeadID: uuid.New(),
 	}
-	s.subjectID = dbtest.EnsureCustomerIDPgx(ctx, t, appDB.Qx(ctx), uuid.NewString())
+	s.subjectID = dbtest.EnsureCustomerIDPgxFor(ctx, t, appDB.Qx(ctx), merchantID, uuid.NewString())
 
 	suffix := uuid.NewString()[:8]
 	now := time.Now().UTC()
@@ -85,23 +106,23 @@ func seedReconcileFixtures(t *testing.T, ctx context.Context, appDB *db.DB) seed
 		entName := fmt.Sprintf("premium-%d", i)
 		exec(`INSERT INTO openrails.products (id, key, display_name, tier_group, entitlements_spec, merchant_id)
 		      VALUES ($1, $2, $2, $3, jsonb_build_object($4::text, null), $5)`,
-			productID, fmt.Sprintf("reconcile-prod-%d-%s", i, suffix), fmt.Sprintf("reconcile-tier-%d-%s", i, suffix), entName, dbtest.TestMerchantID.UUID())
+			productID, fmt.Sprintf("reconcile-prod-%d-%s", i, suffix), fmt.Sprintf("reconcile-tier-%d-%s", i, suffix), entName, merchantID)
 		exec(`INSERT INTO openrails.prices (id, product_id, amount, currency, access_duration_hours, auto_renew, merchant_id)
-		      VALUES ($1, $2, 9990000, 'USD', 720, true, $3)`, priceID, productID, dbtest.TestMerchantID.UUID())
+		      VALUES ($1, $2, 9990000, 'USD', 720, true, $3)`, priceID, productID, merchantID)
 		exec(`INSERT INTO openrails.subscriptions
 		        (id, price_id, product_id, status, rail, rail_subscription_id,
 		         current_period_starts_at, current_period_ends_at, started_at,
 		         entitlements_spec_snapshot, customer_id, merchant_id)
 		      VALUES ($1, $2, $3, 'active', 'nmi', $4, $5, $6, $5, jsonb_build_object($8::text, null), $7, $9)`,
 			subID, priceID, productID, fmt.Sprintf("it-%d-%s", i, suffix),
-			periodStart, periodEnd, s.subjectID, entName, dbtest.TestMerchantID.UUID())
+			periodStart, periodEnd, s.subjectID, entName, merchantID)
 		entID := uuid.New()
 		if subID == s.subDead {
 			entID = s.entDeadID
 		}
 		exec(`INSERT INTO openrails.entitlements (id, customer_id, entitlement, start_at, end_at, source_id, source_type, merchant_id)
 		      VALUES ($1, $2, $3, $4, $5, $6, 'subscription', $7)`,
-			entID, s.subjectID, entName, periodStart, periodEnd, subID, dbtest.TestMerchantID.UUID())
+			entID, s.subjectID, entName, periodStart, periodEnd, subID, merchantID)
 	}
 	return s
 }
@@ -147,11 +168,14 @@ func reconcileSnapshot(t *testing.T, ctx context.Context, appDB *db.DB, seeded s
 
 func TestReconcileEngineIntegration(t *testing.T) {
 	appDB := startReconcilePostgres(t)
-	baseCtx := merchant.WithID(context.Background(), dbtest.TestMerchantID)
+	// Own merchant: the finding counts below are exact, so nothing another test
+	// seeded may be in scope (see newReconcileMerchant).
+	mid := newReconcileMerchant(t, appDB)
+	baseCtx := merchant.WithID(context.Background(), mid)
 
 	var seeded seededState
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
-		seeded = seedReconcileFixtures(t, ctx, appDB)
+		seeded = seedReconcileFixtures(t, ctx, appDB, mid.UUID())
 		return nil
 	}))
 


### PR DESCRIPTION
Closing verification of the night's work. One fix, then the full sequential
integration sweep: **47 packages ok, 0 failures, exit 0.**

## The fix: reconcile engine tests get their own merchant

`TestReconcileEngineIntegration` exact-counts findings by type but seeded into the
shared `dbtest.TestMerchantID`. The engine diffs the provider roster against **every
local subscription that merchant has**, so any active NMI subscription an earlier
test left behind is absent from this test's snapshot and is *correctly* reported as
local-active/remote-dead:

    integration_test.go:192: expected: 1, actual: 3   ("PS-2 absent subscription")

Passed alone, failed in a full-package run. The engine was right; the fixture was
sharing a merchant with an exact-count assertion.

Fixed by giving the test its own merchant (`newReconcileMerchant`), following the
package's existing precedent in `history_integration_test.go`. This makes **all
four** PS-1/PS-2/PS-4/PS-8 exact counts meaningful, not just the one that happened
to break.

`TestReconcileAdoptsAccountUpdaterRefreshedCard` moves with it, for a stronger
reason: it runs an **enforce** pass, which is a real mutation. On a shared merchant
that pass acts on other tests' subscriptions — a latent cross-test hazard even while
it happened to be passing.

### One dependency this exposed

`customers` is RLS-forced, so a handle pinned to the new merchant cannot use
`dbtest.EnsureCustomerIDPgx` — it hardcodes the canonical test merchant and the
`WITH CHECK` refuses the insert. Added `EnsureCustomerIDPgxFor` (explicit merchant)
next to it; the existing helper delegates to the same internal and is byte-for-byte
unchanged for its callers.

## Full sweep — every integration-tagged package, `-p 1`, `-count=1`, `nice -n 10`

Run against dev tip (`877e201a`) **plus** the commit in this PR, on a dedicated
Postgres+Redis stack (no shared DB with other agents). 627.6s cumulative.

| result | count |
|---|---|
| ok | **47** |
| FAIL | **0** |
| no test files | 2 (`internal/dbtest`, `internal/integrations/vault/vaulttest` — helper packages) |

Notable timings: `internal/bootstrap` 72.7s · `internal/merchants` 66.8s ·
`internal/modules/solana/recurring` 59.6s · `internal/controlplane` 51.7s ·
`pkg/service` 90.0s · `internal/db/querytest` 41.5s · `internal/river` 33.5s ·
`tests` 11.0s.

Both packages I was asked to watch came back green:
- `internal/reconcile` 8.6s (was the order-dependent failure above).
- **`internal/db` 33.6s** — the reported ~6-minute timeout did **not** recur.
  Recorded as not-reproducible post-#224; it was load-sensitive (I first saw it with
  the box at load ~21; this sweep ran at load ~3).

Expected skip present and correct: the admit-cap pin in
`pkg/service/delinquency_admission_integration_test.go`, skipped pending the owner
ruling on the authoritative exposure model (PR #224 body). No other skips.

Also verified: migration numbering has no duplicates after the parallel lanes landed
— or#892's `0042`/`0043` and my `0044` coexist cleanly.
