### PR TITLE
or#881: select-and-restrict Solana tokens — declared set is the accepted set, default USDC only

### DIFF
--- a/config/merchants_config.example.yaml
+++ b/config/merchants_config.example.yaml
@@ -158,10 +158,12 @@ merchants:
             # embedded boot plane also sets them, these settings win (#699).
             rpc_provider: helius # helius | public; empty defaults to helius
             rpc_api_key: replace-with-helius-api-key
-            # `tokens` is OPTIONAL and additive (or#881). The built-in registry
-            # (SOL, USDC, USDT, PYUSD, USD1, USDG on mainnet; SOL, USDC, PYUSD
-            # on devnet) is always available, so there is normally nothing to
-            # declare here at all.
+            # `tokens` is OPTIONAL and it is the ACCEPTED SET (or#881): what you
+            # declare is what buyers can pay in, nothing more. Omit it and you
+            # accept USDC only — the one token on every network that also
+            # rebills. The built-in registry (SOL, USDC, USDT, PYUSD, USD1, USDG
+            # on mainnet; SOL, USDC, PYUSD on devnet) is a mint lookup table,
+            # not an acceptance list.
             #   - built-in symbol: SELECT it (`USDC: {}`) — its mint comes from
             #     the registry. Declaring `mint:` for a built-in symbol is an
             #     ERROR, even when the address agrees: a mint you can type is a
@@ -176,6 +178,8 @@ merchants:
             # any other ad-hoc devnet token, with an explicit mint.
             #
             # tokens:
+            #   USDC: {}                    # built-in: mint from the registry
+            #   SOL:  {}
             #   MYTK: { name: My Token, mint: replace-with-spl-mint-address }
           secrets:
             private_key: replace-with-base58-ed25519-keypair

--- a/docs/rails/solana.md
+++ b/docs/rails/solana.md
@@ -42,7 +42,7 @@ psps:
         recipient_wallet: 9hSR6S7WPtxmTojgo6GG3k4yDPecgJY292j7xrsUGWBu
         rpc_provider: helius     # helius | public; empty defaults to helius
         rpc_api_key: replace-with-helius-api-key   # forbidden with rpc_provider: public
-        # tokens is OPTIONAL — the built-in registry below is always accepted.
+        # tokens is OPTIONAL and IS the accepted set; omit it to accept USDC only.
         tokens:
           USDC: {}               # built-in symbol: SELECTED, mint from the registry.
                                  # Declaring `mint:` here is an ERROR.
@@ -71,9 +71,12 @@ well-known token's on-chain identity:
 | mainnet | `SOL`, `USDC`, `USDT`, `PYUSD`, `USD1`, `USDG` |
 | devnet (`test_mode`) | `SOL`, `USDC`, `PYUSD` |
 
-Every symbol in the registry is accepted without declaring anything. A `tokens`
-declaration is **additive** — it extends the registry per symbol, it never
-replaces it, so adding one custom token cannot drop the canonical set.
+The registry is a mint lookup table, **not** an acceptance list. `tokens` is the
+accepted set: declare `{USDC: {}, SOL: {}}` and buyers can pay in exactly those
+two. Declare nothing and you accept **USDC only** — the one token present on
+every network that is also recurring-eligible, so a zero-configuration merchant
+can take one-off payments and rebill. `GET /v1/solana/tokens` advertises exactly
+this set, never more.
 
 - **Built-in symbol** — select it (`USDC: {}`); `name:` may be overridden.
   Declaring `mint:` is an error *even when the address is correct*: a mint you

--- a/internal/app/solana_recurring_wiring.go
+++ b/internal/app/solana_recurring_wiring.go
@@ -32,6 +32,10 @@ func (r *Runtime) ArmSolanaRecurringServices(
 	if r.Config.IsTestMode() {
 		network = "devnet"
 	}
+	// or#881: a mint LOOKUP table for the recurring plan services, NOT an
+	// acceptance list. What a merchant accepts is per-merchant and resolved by
+	// tokens.ResolveDeclared; plan publishing is separately gated by the
+	// recurring allowlist (recurring.RecurringStablecoins).
 	tokens := solanatokens.ForNetwork(network)
 	r.SetSolanaCranker(recurring.NewCrankService(submitter))
 

--- a/internal/http/handlers/solana_supported_tokens.go
+++ b/internal/http/handlers/solana_supported_tokens.go
@@ -125,10 +125,10 @@ func GetSupportedTokens(r *httprequest.Request) {
 		return
 	}
 
+	// or#881: the advertised set IS the accepted set. There is no registry
+	// fallback — falling back would advertise tokens this merchant does not
+	// accept, and a buyer would pay in one of them.
 	tokenMap := normalizeTokenMap(solanaConf.Tokens)
-	if len(tokenMap) == 0 {
-		tokenMap = normalizeTokenMap(solanatokens.ForNetwork(solanaConf.Network))
-	}
 
 	mintSet := make(map[string]struct{})
 	symbols := make([]string, 0, len(tokenMap))
@@ -248,10 +248,8 @@ func GetSolanaConfig(r *httprequest.Request) {
 	}
 
 	network := normalizeSolanaNetwork(solanaConf.Network)
+	// or#881: advertise exactly what the merchant accepts; no registry fallback.
 	tokenMap := normalizeTokenMap(solanaConf.Tokens)
-	if len(tokenMap) == 0 {
-		tokenMap = normalizeTokenMap(solanatokens.ForNetwork(network))
-	}
 
 	symbols := make([]string, 0, len(tokenMap))
 	for symbol := range tokenMap {

--- a/internal/modules/solana/recurring/allowlist_test.go
+++ b/internal/modules/solana/recurring/allowlist_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/open-rails/openrails/config"
+	solanatokens "github.com/open-rails/openrails/internal/modules/solana/tokens"
 )
 
 func TestIsRecurringStablecoinSymbol(t *testing.T) {
@@ -69,5 +70,15 @@ func TestResolveRecurringMintFromTokensUsesConfiguredMint(t *testing.T) {
 	}
 	if mint != configuredMint {
 		t.Fatalf("mint = %s, want configured mint %s", mint, configuredMint)
+	}
+}
+
+// or#881: a merchant who declares no tokens accepts tokens.DefaultAcceptedSymbol
+// alone. That default is only defensible if it can also REBILL — otherwise the
+// zero-configuration merchant silently loses subscriptions.
+func TestDefaultAcceptedSymbolIsRecurringEligible(t *testing.T) {
+	t.Parallel()
+	if !IsRecurringStablecoinSymbol(solanatokens.DefaultAcceptedSymbol) {
+		t.Fatalf("the zero-config accepted token %s must be recurring-eligible", solanatokens.DefaultAcceptedSymbol)
 	}
 }

--- a/internal/modules/solana/tokens/registry_test.go
+++ b/internal/modules/solana/tokens/registry_test.go
@@ -95,3 +95,18 @@ func TestDevnetRegistryDoesNotReuseMainnetMints(t *testing.T) {
 		require.NotEqualf(t, mainnet[symbol].Mint, token.Mint, "%s devnet mint must not be the mainnet address", symbol)
 	}
 }
+
+// The zero-configuration default (or#881) must exist on every network, or a
+// merchant who declares nothing arms with an empty accepted set.
+func TestDefaultAcceptedSymbolExistsOnEveryNetwork(t *testing.T) {
+	t.Parallel()
+	for _, network := range []string{"mainnet", "devnet"} {
+		token, ok := ForNetwork(network)[DefaultAcceptedSymbol]
+		require.Truef(t, ok, "%s has no %s entry", network, DefaultAcceptedSymbol)
+		require.NotEmptyf(t, token.Mint, "%s %s has no mint", network, DefaultAcceptedSymbol)
+	}
+	// It must also be a stablecoin — recurring plans hold an immutable on-chain
+	// amount. Recurring-allowlist membership is pinned in the recurring package,
+	// which cannot be imported from here.
+	require.True(t, IsStablecoin(DefaultAcceptedSymbol))
+}

--- a/internal/modules/solana/tokens/resolve.go
+++ b/internal/modules/solana/tokens/resolve.go
@@ -6,10 +6,20 @@ import (
 	"github.com/open-rails/openrails/config"
 )
 
+// DefaultAcceptedSymbol is the token a merchant accepts when they declare
+// nothing (or#881). USDC only — deliberately not the whole registry: it is the
+// one token present on every network AND on the recurring allowlist, so the
+// zero-configuration merchant can take one-off payments and rebill. Accepting
+// more than that is a decision a merchant makes explicitly.
+const DefaultAcceptedSymbol = PreferredStablecoin
+
 // ResolveDeclared turns a merchant's DECLARED token map into the accepted token
 // set for network (or#881).
 //
-// Select-and-restrict, not restate:
+// SELECT AND RESTRICT: the declared set IS the accepted set. Declaring
+// `{USDC: {}, SOL: {}}` accepts exactly those two. Declaring nothing accepts
+// DefaultAcceptedSymbol. The registry's only job is resolving a known symbol's
+// on-chain identity — it is a lookup table, never an acceptance list.
 //
 //   - A registry symbol is SELECTED by name — `tokens: {USDC: {}}`. Its mint
 //     comes from ForNetwork(network). Declaring `mint:` for it is an ERROR even
@@ -18,8 +28,6 @@ import (
 //     the one that was priced.
 //   - A custom symbol still REQUIRES `mint:` — there the mint IS the token's
 //     identity, so it is genuinely declared rather than restated.
-//   - Declarations EXTEND the registry per symbol; they never replace it, so
-//     adding one custom token cannot silently drop the canonical set.
 //
 // TEST MODE (devnet): the registry has its own devnet column, so USDC/SOL/PYUSD
 // select identically there. Registry symbols with no devnet entry are not
@@ -30,10 +38,10 @@ import (
 // there), so the restatement hazard the rule exists to prevent does not apply.
 func ResolveDeclared(network string, declared map[string]config.TokenConfig) (map[string]config.TokenConfig, error) {
 	registry := ForNetwork(network)
-	out := make(map[string]config.TokenConfig, len(registry)+len(declared))
-	for symbol, token := range registry {
-		out[symbol] = token
+	if len(declared) == 0 {
+		return map[string]config.TokenConfig{DefaultAcceptedSymbol: registry[DefaultAcceptedSymbol]}, nil
 	}
+	out := make(map[string]config.TokenConfig, len(declared))
 	for rawSymbol, token := range declared {
 		symbol := strings.ToUpper(strings.TrimSpace(rawSymbol))
 		if symbol == "" {

--- a/internal/modules/solana/tokens/resolve_test.go
+++ b/internal/modules/solana/tokens/resolve_test.go
@@ -8,8 +8,9 @@ import (
 	"github.com/open-rails/openrails/config"
 )
 
-// or#881: the mint of a well-known token comes from the registry. A merchant
-// selects the symbol; they never re-type the address.
+// or#881 select-and-restrict: the declared set IS the accepted set, and a
+// well-known token's mint comes from the registry — a merchant selects the
+// symbol, they never re-type the address.
 
 func TestResolveDeclared_RegistrySymbolSelectsWithoutAMint(t *testing.T) {
 	t.Parallel()
@@ -61,11 +62,8 @@ func TestResolveDeclared_CustomSymbolRequiresMint(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, customMint, out["MYTK"].Mint)
-
-	// Additive: one custom token never costs the merchant the registry.
-	for symbol, want := range DefaultSupportedTokens() {
-		require.Equalf(t, want.Mint, out[symbol].Mint, "registry token %s was dropped or changed", symbol)
-	}
+	// Restrict: declaring a custom token accepts THAT token, not the registry too.
+	require.Len(t, out, 1)
 }
 
 // Test mode: the registry's devnet column is the built-in set there. A mainnet
@@ -90,16 +88,37 @@ func TestResolveDeclared_DevnetOnlyBuiltInWhereTheRegistryHasAMint(t *testing.T)
 	require.ErrorContains(t, err, "built-in token")
 }
 
-func TestResolveDeclared_NoDeclarationIsTheRegistry(t *testing.T) {
+// The declared set IS the accepted set: everything not named is refused.
+func TestResolveDeclared_DeclaredSetIsTheAcceptedSet(t *testing.T) {
+	t.Parallel()
+
+	out, err := ResolveDeclared("mainnet", map[string]config.TokenConfig{
+		"USDC": {},
+		"SOL":  {},
+	})
+	require.NoError(t, err)
+	require.Equal(t, map[string]config.TokenConfig{
+		"USDC": DefaultSupportedTokens()["USDC"],
+		"SOL":  DefaultSupportedTokens()["SOL"],
+	}, out)
+	for _, refused := range []string{"USDT", "PYUSD", "USD1", "USDG"} {
+		require.NotContainsf(t, out, refused, "%s was never declared and must not be accepted", refused)
+	}
+}
+
+// Declaring nothing accepts USDC alone — not the whole registry. USDC is the one
+// token on every network that also rebills, so the zero-config merchant can do
+// both.
+func TestResolveDeclared_DefaultIsUSDCOnly(t *testing.T) {
 	t.Parallel()
 
 	out, err := ResolveDeclared("mainnet", nil)
 	require.NoError(t, err)
-	require.Equal(t, DefaultSupportedTokens(), out)
+	require.Equal(t, map[string]config.TokenConfig{"USDC": DefaultSupportedTokens()["USDC"]}, out)
 
 	out, err = ResolveDeclared("devnet", map[string]config.TokenConfig{})
 	require.NoError(t, err)
-	require.Equal(t, DefaultDevnetTokens(), out)
+	require.Equal(t, map[string]config.TokenConfig{"USDC": DefaultDevnetTokens()["USDC"]}, out)
 
 	_, err = ResolveDeclared("mainnet", map[string]config.TokenConfig{"  ": {Mint: "x"}})
 	require.ErrorContains(t, err, "empty symbol")

--- a/internal/railresolve/railresolve.go
+++ b/internal/railresolve/railresolve.go
@@ -270,11 +270,12 @@ func (s *MerchantsSource) resolveCustody(ctx context.Context, mid merchant.ID, s
 
 // SolanaRailConfigFromSettings materializes the runtime Solana config from a
 // rail account's declared settings: network derives from test_mode alone
-// (#349), the token set is the network's built-in registry extended by the
-// merchant's declarations (or#881 — a built-in symbol is SELECTED, its mint is
-// never restated), and the #360 pricing policy then drops tokens that cannot
-// function (degrade-not-die). A misdeclared token set is fail-closed: the PSP
-// does not arm rather than arming against a mint nobody vouched for.
+// (#349), the token set is exactly what the merchant declared — USDC alone when
+// they declared nothing (or#881 select-and-restrict; a built-in symbol is
+// SELECTED and its mint is never restated) — and the #360 pricing policy then
+// drops tokens that cannot function (degrade-not-die). A misdeclared token set
+// is fail-closed: the PSP does not arm rather than arming against a mint nobody
+// vouched for.
 func SolanaRailConfigFromSettings(settings config.SolanaAccountSettings, testMode bool) (*config.SolanaRailConfig, error) {
 	network := "mainnet"
 	if testMode {

--- a/internal/railresolve/solana_tokens_test.go
+++ b/internal/railresolve/solana_tokens_test.go
@@ -9,49 +9,44 @@ import (
 	solanatokens "github.com/open-rails/openrails/internal/modules/solana/tokens"
 )
 
-// or#881: a declared `tokens` map used to REPLACE the built-in registry
-// wholesale, so adding one custom token forced the merchant to re-type every
-// canonical mint they still wanted. Every re-typed mint is a chance to paste a
-// wrong address on a money path. A declaration now extends the registry per
-// symbol, and a built-in symbol's mint cannot be declared at all.
+// or#881 select-and-restrict: the merchant's declared `tokens` map IS the
+// accepted set, and a built-in symbol's mint comes from the registry rather than
+// being re-typed (every re-typed mint is a chance to paste a wrong address on a
+// money path). Declaring nothing accepts USDC alone.
 
-func TestSolanaRailConfigFromSettings_CustomTokenExtendsRegistry(t *testing.T) {
+func TestSolanaRailConfigFromSettings_DeclaredSetIsTheAcceptedSet(t *testing.T) {
 	const customMint = "MyTk1111111111111111111111111111111111111111"
 
 	out, err := SolanaRailConfigFromSettings(config.SolanaAccountSettings{
 		Tokens: map[string]config.TokenConfig{
+			"USDC": {},
 			"MYTK": {Name: "My Token", Mint: customMint},
 		},
 	}, true) // devnet: no pricing requirements, so nothing is dropped for price reasons
 	require.NoError(t, err)
 
-	registry := solanatokens.ForNetwork("devnet")
-	require.NotEmpty(t, registry)
-	for symbol, want := range registry {
-		got, ok := out.Tokens[symbol]
-		require.Truef(t, ok, "registry token %s was dropped by declaring one custom token", symbol)
-		require.Equalf(t, want.Mint, got.Mint, "registry token %s mint changed", symbol)
-	}
+	require.Equal(t, solanatokens.ForNetwork("devnet")["USDC"].Mint, out.Tokens["USDC"].Mint)
 	require.Equal(t, customMint, out.Tokens["MYTK"].Mint)
-	require.Len(t, out.Tokens, len(registry)+1)
+	require.Len(t, out.Tokens, 2, "undeclared registry tokens must not be accepted")
+	for _, refused := range []string{"SOL", "PYUSD"} {
+		require.NotContainsf(t, out.Tokens, refused, "%s was never declared", refused)
+	}
 }
 
-func TestSolanaRailConfigFromSettings_MainnetCustomTokenKeepsRegistryMints(t *testing.T) {
+// The #360 pricing policy still applies on top of the restriction, and it can
+// only ever REMOVE a declared token — never add an undeclared one.
+func TestSolanaRailConfigFromSettings_MainnetPricingPolicyOnlySubtracts(t *testing.T) {
 	out, err := SolanaRailConfigFromSettings(config.SolanaAccountSettings{
 		Tokens: map[string]config.TokenConfig{
-			// A custom token with no Pyth feed is disabled by the #360 pricing
-			// policy — but that must never take the registry with it.
+			"USDC": {},
 			"MYTK": {Mint: "MyTk1111111111111111111111111111111111111111"},
 		},
 	}, false)
 	require.NoError(t, err)
 
-	for symbol, want := range solanatokens.ForNetwork("mainnet") {
-		got, ok := out.Tokens[symbol]
-		require.Truef(t, ok, "registry mainnet token %s was dropped", symbol)
-		require.Equalf(t, want.Mint, got.Mint, "registry mainnet token %s mint changed", symbol)
-	}
-	require.NotContains(t, out.Tokens, "MYTK", "feedless non-stablecoin should still be disabled")
+	require.Equal(t, solanatokens.ForNetwork("mainnet")["USDC"].Mint, out.Tokens["USDC"].Mint)
+	require.NotContains(t, out.Tokens, "MYTK", "feedless non-stablecoin is disabled by the pricing policy")
+	require.Len(t, out.Tokens, 1)
 }
 
 // Selecting a built-in symbol takes its mint from the registry; restating that
@@ -70,9 +65,18 @@ func TestSolanaRailConfigFromSettings_BuiltInSymbolIsSelectedNotRestated(t *test
 	require.ErrorContains(t, err, "USDC is a built-in token")
 }
 
-// Declaring nothing still yields exactly the registry set.
-func TestSolanaRailConfigFromSettings_NoDeclarationIsTheRegistry(t *testing.T) {
-	out, err := SolanaRailConfigFromSettings(config.SolanaAccountSettings{}, true)
-	require.NoError(t, err)
-	require.Equal(t, solanatokens.NormalizeForNetwork("devnet", solanatokens.ForNetwork("devnet")), out.Tokens)
+// Declaring nothing accepts USDC alone — the zero-configuration default, chosen
+// because it is the one token on every network that also rebills.
+func TestSolanaRailConfigFromSettings_NoDeclarationIsUSDCOnly(t *testing.T) {
+	for _, testMode := range []bool{true, false} {
+		network := "mainnet"
+		if testMode {
+			network = "devnet"
+		}
+		out, err := SolanaRailConfigFromSettings(config.SolanaAccountSettings{}, testMode)
+		require.NoError(t, err)
+		require.Equalf(t, map[string]config.TokenConfig{
+			"USDC": solanatokens.ForNetwork(network)["USDC"],
+		}, out.Tokens, "%s default accepted set", network)
+	}
 }

--- a/tests/checkout_session_test.go
+++ b/tests/checkout_session_test.go
@@ -99,7 +99,11 @@ func TestCheckoutSessionSolanaTransferRequest(t *testing.T) {
 		"solana",
 		config.ExpectedProviderEnvironment(suite.Config.IsTestMode()),
 		"DzGLHdTfgHCYh8v3qNGJHn85CyX7aeFmqoUdVRBYkWMh",
-		`{"source":"test","settings":{"recipient_wallet":"`+recipientWallet+`"}}`,
+		// or#881: these rewrite the SHARED suite's solana PSP row, so they must
+		// carry the same token declaration the fixture seeds — the declared set
+		// IS the accepted set, and dropping it would leave later tests with the
+		// USDC-only default.
+		`{"source":"test","settings":{"recipient_wallet":"`+recipientWallet+`","tokens":`+suiteSolanaTokensJSON+`}}`,
 	)
 	products := suite.SeedProducts()
 	priceID := products[2].Prices[0].ID
@@ -146,7 +150,7 @@ func TestCheckoutSessionSolanaTransferRequestDefaultsRecipientToAccountID(t *tes
 		"solana",
 		config.ExpectedProviderEnvironment(suite.Config.IsTestMode()),
 		accountID,
-		`{"source":"test"}`,
+		`{"source":"test","settings":{"tokens":`+suiteSolanaTokensJSON+`}}`,
 	)
 	products := suite.SeedProducts()
 	priceID := products[2].Prices[0].ID

--- a/tests/testcontainer_suite.go
+++ b/tests/testcontainer_suite.go
@@ -292,6 +292,13 @@ func (suite *TestContainerSuite) MintUserToken(userID, email string) string {
 	return suite.minter.Mint(userID, email, "", nil)
 }
 
+// suiteSolanaTokensJSON is the suite's declared Solana token set. or#881 made
+// the declared set the ACCEPTED set (undeclared = refused, default = USDC
+// alone), so every fixture that writes this PSP's evidence must carry it —
+// otherwise the last writer silently narrows what later tests can pay in.
+// Built-in symbols carry no mint: it comes from the registry.
+const suiteSolanaTokensJSON = `{"SOL":{},"USDC":{},"PYUSD":{}}`
+
 func (suite *TestContainerSuite) seedRailMerchantAccountFixtures() {
 	suite.t.Helper()
 	ctx := dbtest.WithTestMerchant(context.Background())
@@ -311,7 +318,8 @@ func (suite *TestContainerSuite) seedRailMerchantAccountFixtures() {
 	_, err = suite.App.Runtime.Merchants.PutCredential(ctx, dbtest.TestMerchantID, ccbillSecret, "test-salt")
 	require.NoError(suite.t, err)
 
-	suite.seedRailMerchantAccountWithEvidence(ctx, "solana", config.ExpectedProviderEnvironment(suite.Config.IsTestMode()), "DzGLHdTfgHCYh8v3qNGJHn85CyX7aeFmqoUdVRBYkWMh", `{"source":"test_fixture"}`)
+	suite.seedRailMerchantAccountWithEvidence(ctx, "solana", config.ExpectedProviderEnvironment(suite.Config.IsTestMode()), "DzGLHdTfgHCYh8v3qNGJHn85CyX7aeFmqoUdVRBYkWMh",
+		`{"source":"test_fixture","settings":{"tokens":`+suiteSolanaTokensJSON+`}}`)
 }
 
 func (suite *TestContainerSuite) seedRailMerchantAccountWithEvidence(ctx context.Context, rail, environment, accountID, evidence string) {


### PR DESCRIPTION
Paul's ruling on the design point left open by #222.

## What changed

Declarations were **additive** onto the built-in registry, so there was no way to
NARROW what a merchant accepts: declaring `{USDC: {}}` still accepted
SOL/USDT/PYUSD/USD1/USDG, and a buyer could pay in a token the merchant never chose.

**Select-and-restrict.** `ResolveDeclared` no longer seeds from the registry:

- `tokens: {USDC: {}, SOL: {}}` accepts **exactly** those two.
- **Declaring nothing accepts USDC alone** — not the whole registry. USDC is the one
  token present on every network that is also recurring-eligible, so the
  zero-configuration merchant can take one-off payments *and* rebill.
- The registry keeps its one job: resolving a known symbol's on-chain identity. It is
  a mint lookup table, never an acceptance list.

Everything from #222 stays as built: a built-in symbol is SELECTED (`USDC: {}`),
declaring `mint:` for one is an error even when the address agrees, a custom symbol
still requires `mint:`, and the devnet rules (registry's devnet column; a built-in
symbol with no devnet entry is declared there like any ad-hoc token) are unchanged.
Misdeclaration stays fail-closed at manifest push and at arm time.

## Knock-ons checked

- **Discovery must not out-advertise acceptance.** `GET /v1/solana/tokens` and the
  runtime-config route both fell back to the full registry when the resolved token map
  was empty. Under restrict that would advertise tokens the merchant does not accept
  — and a buyer would pay in one of them. Both fallbacks deleted; advertised set ==
  accepted set.
- **Recurring plan publish.** The plan/enroll services take a boot-wide token map,
  which is a mint LOOKUP table, not an acceptance list — now documented as such. Plan
  publishing remains gated by the recurring allowlist (`USDC`, `USD1`).
  *Residual, deliberately not fixed here:* a merchant accepting USDC only can still
  have a `psp_links.solana.token: USD1` plan published, because the catalog adapter
  resolves mints from that boot-wide map rather than the merchant's accepted set.
  Both sides are operator-declared in the same manifest, so it is a coherence wart,
  not a trust boundary — making it merchant-aware means plumbing per-merchant token
  sets into a boot singleton, which is not "as simple as possible". Flagging rather
  than expanding scope.
- **Peg registry** untouched: `knownStablecoins` is the mint-anchored trust anchor for
  the $1.00 parity grant, independent of what any merchant accepts. The drift test
  from #222 still pins it against the registry.
- **Fixtures that relied on undeclared tokens being accepted.** The `tests` suite
  seeded its Solana PSP with evidence carrying no `tokens`, so `/v1/solana/tokens`
  previously returned SOL only via the handler fallback. It now declares
  `SOL/USDC/PYUSD` — and, importantly, the two `checkout_session_test.go` cases that
  rewrite the **same shared PSP row** carry the same declaration, or the last writer
  silently narrows every later test in the package to the USDC-only default. Hoisted
  to one `suiteSolanaTokensJSON` const so it cannot drift again.

## Tests

- New/updated pins: declared-set-is-accepted-set, default-is-USDC-only (both
  networks), custom token does not drag in the registry, pricing policy can only
  subtract from the declared set, `DefaultAcceptedSymbol` exists on every network and
  is recurring-eligible (pinned in the `recurring` package, which owns the allowlist).
- `go test ./...` green. Integration (`-p 1`, testcontainers): `tests`,
  `integrationharness`, `bootstrap`, `pkg/service`, `internal/http/...`,
  `modules/checkout`, `modules/solana{,/recurring,/tokens}`, `railresolve`, `config` —
  all green.
- Gates: `sql-lint` clean, `migration-lint` clean (no migration), `golangci-lint run
  ./...` 0 issues.