### PR TITLE
or#896: close the rail-support gaps the certification matrix exposed

### DIFF
--- a/docs/rails/certification-matrix.md
+++ b/docs/rails/certification-matrix.md
@@ -50,7 +50,11 @@ Each live-gated test `t.Skip`s when its credential secret is absent, so a green
 run is not by itself proof the lane executed. Several provider-reaching tests
 exist outside these lanes (the Stripe catalog `TestLive*` pair, the Solana
 devnet tier-change and failure-path tests, `TestSolanaDevnetMoneyMovementProof`)
-— no workflow runs them, so they back no cell.
+— no workflow runs them, so they back no cell. The Stripe pair is at least no
+longer invisible: or#896 put both behind the `stripelive` build tag (the
+convention `internal/modules/catalog`'s live Stripe tests already used), so they
+are compiled only when a lane asks for them instead of riding a default
+`go test ./...` held back by an env check.
 
 **CCBill has no automated lane.** Every CCBill cell below is either hermetic or
 rests on a single dated manual probe.
@@ -61,8 +65,8 @@ rests on a single dated manual probe.
 |---|---|---|---|---|
 | One-off purchase | `sandbox-verified` | `unsupported` (guarded) — rail is subscription-only | `modeled` | `modeled` |
 | Subscription enrollment | `sandbox-verified` | `modeled` | `modeled` | `sandbox-verified` (devnet) |
-| Free trial (zero-amount first phase) | `unsupported` (silent) | `limited` — validated inbound, never originated | `modeled` | `unsupported` (silent) |
-| Paid introductory first phase | `unsupported` (silent) | `limited` — validated inbound, never originated | `unsupported` (guarded) | `unsupported` (silent) |
+| Free trial (zero-amount first phase) | `unsupported` (guarded) | `limited` — validated inbound, never originated | `modeled` | `unsupported` (guarded) |
+| Paid introductory first phase | `unsupported` (guarded) | `limited` — validated inbound, never originated | `unsupported` (guarded) | `unsupported` (guarded) |
 
 - **One-off, NMI** — `internal/integrations/nmi/payments.go:59` (v5 `payments/sale`). last-verified: weekly / env: sandbox / how: `TestNMILiveLifecycleE2E` step 5.
 - **One-off, CCBill** — refused at `internal/modules/checkout/service.go:485`. Subscription-only rail.
@@ -72,7 +76,7 @@ rests on a single dated manual probe.
 - **Enrollment, CCBill** — FlexForm redirect; the subscription exists only once `NewSaleSuccess` arrives. No CCBill lane exists, so the outbound URL and the inbound payload are both pinned against hand-authored fixtures.
 - **Enrollment, Stripe** — hosted Checkout `mode=subscription`; membership is created by fetch-and-converge, not from the webhook payload.
 - **Enrollment, Solana** — `init_subscription_authority` + `subscribe`, period 1 pulled atomically. last-verified: daily / env: devnet / how: `TestDevnetLifecycle/FastPlan`.
-- **Trials** — the catalog's first-phase (`Price.GetTrial`) has exactly two readers: Stripe checkout and CCBill webhook amount validation. NMI and Solana enrollment never read it, and nothing rejects the combination, so **a trial declared on an NMI or Solana price is silently dropped and the subscriber is charged the full amount immediately**. Stripe refuses a *paid* intro explicitly (`service.go:1211`); a zero-amount trial becomes `subscription_data[trial_end]`. CCBill trial terms live in the FlexForm — OpenRails only validates the billed amount against the catalog trial.
+- **Trials** — the catalog's first-phase (`Price.GetTrial`) has exactly two readers: Stripe checkout and CCBill webhook amount validation. NMI and Solana enrolment never read it, so a trial declared against either is now **refused at catalog push** (or#896): `resolveProviders` consults the rail registry's `SupportsCatalogTrial` and fails the price create with an error naming the limitation, so the price never reaches the DB (`pkg/service/catalog_providers.go`; `TestCatalogPublishRefusesTrialOnRailsWithoutFirstPhase`). It used to be accepted and dropped, and the subscriber was charged the full amount immediately. Stripe refuses a *paid* intro explicitly (`service.go:1211`); a zero-amount trial becomes `subscription_data[trial_end]`. CCBill trial terms live in the FlexForm — OpenRails only validates the billed amount against the catalog trial.
 
 ## Billing lifecycle
 
@@ -80,8 +84,8 @@ rests on a single dated manual probe.
 |---|---|---|---|---|
 | Rebill / recurring charge | `modeled` | `modeled` | `limited` — provider-driven, ingest only | `modeled` |
 | Dunning / retry | `modeled` | `limited` — provider owns cadence | `unsupported` (by design) | `modeled` |
-| Cancel — user | `sandbox-verified` | `live-verified` | `modeled` | `limited` — dedicated endpoints only |
-| Cancel — merchant/admin | `limited` — see caveat | `limited` — split-brain | `modeled` | `unsupported` (guarded) |
+| Cancel — user | `sandbox-verified` | `live-verified` | `modeled` | `limited` — dedicated endpoints only (guarded elsewhere) |
+| Cancel — merchant/admin | `modeled` — durable intent, verify-not-decline | `live-verified` (wire, 2026-07-03) — same intent as the user cancel | `modeled` | `unsupported` (guarded) |
 | Cancel — provider-initiated | `modeled` | `modeled` | `modeled` | `modeled` |
 | Tier change — upgrade | `modeled` | `modeled` | `modeled` | `modeled` |
 | Tier change — downgrade | `modeled` | `unsupported` (guarded) | `modeled` | `modeled` |
@@ -93,9 +97,9 @@ rests on a single dated manual probe.
 - **Rebill, Solana** — `transfer_subscription` pull, driven by an hourly cranker. The daily devnet lane exercises the instruction only as part of the atomic subscribe bundle (period 1), so it proves the on-chain instruction lands — **not** that the cranker bills a second period. Recurrence across a real period rollover is covered only by `TestDevnetSustainedRebill` and `TestDevnetFailurePaths`, and **no scheduled lane runs either** (see findings). Missed periods are never back-billed by design; a delegate revocation is terminal and skips dunning.
 - **Cancel (user), NMI** — deferred delete with an undo window, else immediate `DELETE /v5/subscriptions/{id}`. last-verified: weekly / env: sandbox / how: `TestNMILiveLifecycleE2E` step 9.
 - **Cancel (user), CCBill** — DataLink `cancelSubscription`. last-verified: 2026-07-03 / env: **live production account** / how: manual probe, success envelope `<results>1</results>` confirmed on a long-dead subscription; pinned by `TestCancelSubscription_SuccessShapes`.
-- **Cancel (user), Solana** — `limited`: the on-chain `cancel_subscription` path works and is covered by the daily devnet lane (`TestDevnetLifecycle/FastPlan`), but it is reachable **only** through the dedicated `solana-cancel-tx` / `solana-cancel` endpoints. The rail-agnostic `POST /subscriptions/:id/cancel` falls through the cancel worker's default branch into a facade with no Solana case and errors permanently (`user_service.go:538`).
-- **Cancel (merchant), NMI** — `limited`: `internal/modules/subscriptions/admin_service.go:176` calls the gateway **synchronously with no durable intent and no verify leg**, unlike the user path. An unresolvable PSP logs a warning and returns nil, so the local row flips to cancelled while NMI keeps rebilling.
-- **Cancel (merchant), CCBill** — `limited`: the admin subscriptions API refuses CCBill (`admin_service.go:215`), while the findings-queue `cancel_and_refund` action supports it (`admin_findings_actions.go:319`). Same operation, two answers depending on entry point.
+- **Cancel (user), Solana** — `limited`: the on-chain `cancel_subscription` path works and is covered by the daily devnet lane (`TestDevnetLifecycle/FastPlan`), but it is reachable **only** through the dedicated `solana-cancel-tx` / `solana-cancel` endpoints — a cancel is a transaction the subscriber's wallet signs. The rail-agnostic `POST /subscriptions/:id/cancel` used to queue a job that fell through the worker's default branch and failed permanently; since or#896 it is **refused synchronously (400) naming those two endpoints**, the service refuses it for any other producer, and an already-queued job is cancelled rather than retried forever (`TestCancelSubscriptionSolanaNamesDedicatedEndpoints`).
+- **Cancel (merchant), NMI** — the admin path now rides the SAME `nmi_delete_subscription` intent as the user path (or#896, admin-origin): the local cancellation and the intent commit in one transaction, the `deletion_scheduled_at` marker holds while the rail side is unconfirmed, and an ambiguous provider outcome parks as `unknown_needs_verify` for the verifier instead of reporting a delete that may not have happened. It used to call the gateway synchronously with no intent and no verify leg, and an unresolvable PSP logged a warning and returned nil — the local row went terminal while NMI kept rebilling. `modeled`: hermetic fake gateway (`TestMerchantCancelNMIRidesDurableIntent`, `TestMerchantCancelNMIAmbiguousOutcomeParksForVerification`); the delete WIRE itself is the sandbox-verified one from the user path.
+- **Cancel (merchant), CCBill** — the split-brain is closed (or#896): the admin subscriptions API used to refuse CCBill while the findings-queue `cancel_and_refund` action cancelled it. Both surfaces now queue the same admin-origin `ccbill_cancel_subscription` intent, drained through the DataLink SMS choke point. The cancel wire is the one confirmed live on 2026-07-03 (see *Cancel (user), CCBill*); the admin ENTRY POINT is pinned hermetically by `TestMerchantCancelCCBillDrivesTheLiveVerifiedCancel` alongside `TestFindingsQueueApproveCCBillCancelAndRefund`.
 - **Cancel (merchant), Solana** — refused; a cancel is a transaction the subscriber's wallet must sign.
 - **Cancel (provider-initiated)** — all rails converge from *fetched* provider truth rather than trusting the payload. NMI and Stripe treat a 404 as provider-confirmed-gone; CCBill consumes `Cancellation`/`Expiration`; Solana reads the chain.
 - **Tier change** — NMI: immediate proration charge + new subscription, downgrade deferred to period end. CCBill: upgrade is an `originalSubscriptionId` FlexForm redirect, downgrade refused (`service.go:2229`). Stripe: Model-B anchor reset with `always_invoice`; **carries an explicit `TODO(#268)` saying the live invoice amount must be verified on a real Stripe test upgrade** — the `stripe-model-b` lane exists for exactly this. Solana: a single atomic on-chain transaction via the dedicated `solana-tier-change` endpoints.
@@ -119,19 +123,19 @@ rests on a single dated manual probe.
 
 | Flow | NMI | CCBill | Stripe | Solana |
 |---|---|---|---|---|
-| Add / vault a payment method | `sandbox-verified` | `unsupported` — provider owns the vault | `limited` — portal-delegated | `unsupported` — wallet, not an instrument |
-| Update / delete a payment method | `modeled` | `unsupported` (guarded) | `limited` — portal-delegated | n/a |
+| Add / vault a payment method | `sandbox-verified` | `unsupported` (guarded) — provider owns the vault | `unsupported` (guarded) — portal-delegated | `unsupported` (guarded) — wallet, not an instrument |
+| Update / delete a payment method | `modeled` | `unsupported` (guarded) | `unsupported` (guarded) — portal-delegated | n/a |
 | Swap a subscription's payment source | `modeled` | `unsupported` (guarded) | `unsupported` | n/a |
 | Account Updater | `unsupported` — events logged, no action | `unsupported` — invisible to us | `unsupported` — nothing consumed | n/a |
 | Charge a saved method (arrears settlement, auto top-up) | `sandbox-verified` | `unsupported` — no adapter | `sandbox-verified` | `unsupported` — no adapter |
 | Credits bundled with a purchase or renewal | `modeled` | `modeled` | `modeled` | `modeled` |
-| Standalone credit-purchase price | `unsupported` — not wired on any rail | `unsupported` | `unsupported` | `unsupported` |
+| Standalone credit-purchase price | `unsupported` — priced, never checkout-able | `unsupported` | `unsupported` | `unsupported` |
 
 - **Vaulting, NMI** — Collect.js tokenization → customer vault. last-verified: weekly / env: sandbox / how: `TestLiveCollectJSTokenVaultCreate`, `TestLiveSandboxStoredCredentialCITThenMIT`. Note the lifecycle E2E vaults **directly at NMI**, so the OpenRails payment-method API surface is not itself live-exercised.
-- **Payment methods, Stripe** — `limited`: there is no first-party CRUD. `RailPaymentMethodService` is NMI-only, so a Stripe request fails with **`PSP 'stripe' is not configured`** — which reads as a misconfiguration rather than an unsupported rail. Mutation is delegated to Stripe's Billing Portal (`stripe_portal.go:23`), and `payment_method.attached` is recorded passively.
+- **Payment methods, Stripe** — `unsupported` (guarded): there is no first-party CRUD, and since or#896 the refusal is honest. `RailPaymentMethodService` is NMI-only (`rails.SupportsPaymentMethodCRUD`), and a Stripe/CCBill/Solana request now fails with *"payment methods are not managed by OpenRails on this rail"* plus where the instrument actually lives, instead of the old **`PSP 'stripe' is not configured`** — which read as a misconfiguration. Mutation is delegated to Stripe's Billing Portal (`stripe_portal.go:23`), and `payment_method.attached` is recorded passively. Pinned by `TestCreatePaymentMethodUnsupportedRailIsHonest`.
 - **Account Updater** — no rail consumes it. NMI receives `acu.summary.*` and logs them without touching the vault or the local card record (`internal/modules/webhooks/nmi.go:383`). Stripe's card updater is not subscribed to at all. The only working Account Updater in the repo belongs to the Basis Theory custodian, which is a different rail — do not read it as coverage here.
 - **Charge saved method** — gated by `SupportsChargeSavedMethod` in the rail registry: NMI and Stripe only. last-verified: weekly / env: sandbox + Stripe test mode / how: `TestChargeOutstanding_NMISandbox_CollectsRealCharge`, `TestLiveNMIInvoiceCollectionAgainstSandbox`, `TestLiveStripeInvoiceCollectionAgainstTestAccount`. CCBill and Solana have no collection adapter, so arrears settlement and auto top-up do not exist on those rails.
-- **Credits** — three different things, often conflated. (1) Credits declared on a product's `credits_spec` are granted rail-agnostically when a purchase or renewal registers, so they follow whatever checkout works on the rail. (2) Auto top-up charges a saved method and is therefore NMI/Stripe only. (3) A standalone **catalog credit-purchase price** can be declared and quoted, but `DepositCatalogCreditPurchase` has **no production caller** — the surface is defined and tested, never wired. That is a gap on every rail, not a per-rail limitation.
+- **Credits** — three different things, often conflated. (1) Credits declared on a product's `credits_spec` are granted rail-agnostically when a purchase or renewal registers, so they follow whatever checkout works on the rail. (2) Auto top-up charges a saved method and is therefore NMI/Stripe only. (3) A standalone **catalog credit-purchase price** can be declared and quoted, but nothing can BUY one: a top-up product's offers are rate-priced rows in `catalog_credit_purchase_prices`, never `prices` rows, so no checkout session can name one. or#896 deleted the unreachable `DepositCatalogCreditPurchase` wrapper (a second money-writer duplicating `MoneyService.Deposit`, which `POST /v1/service/credits/deposit` already drives live); the quote remains and a host delivers the quoted lot through that live deposit path. That is a gap on every rail, not a per-rail limitation.
 
 ## Catalog and reconciliation
 
@@ -146,7 +150,7 @@ rests on a single dated manual probe.
 | Settlement / payout ingestion | `unsupported` | `unsupported` | `unsupported` | n/a |
 
 - **Price push, NMI** — recurring plans only; a non-recurring price returns `errPendingManualLink`. The lifecycle E2E creates its plan **out of band** via raw `recurring=add_plan`, so the adapter's own push path has never run against the sandbox.
-- **Price push, Stripe** — find-or-create by content-addressed `lookup_key`. Two tests do reach Stripe test mode (`TestLiveStripeCatalogAutoCreateReusesContentKeys`, `TestLiveStripeExtrasListing`) but **no workflow runs either**, so they are not standing evidence. Both also carry **no build tag** — they compile into a default `go test ./...` and are held back only by an env check.
+- **Price push, Stripe** — find-or-create by content-addressed `lookup_key`. Two tests do reach Stripe test mode (`TestLiveStripeCatalogAutoCreateReusesContentKeys`, `TestLiveStripeExtrasListing`) but **no workflow runs either**, so they are still not standing evidence. Since or#896 they carry the `stripelive` build tag (`go test -tags=stripelive ./pkg/service/ -run TestLiveStripe`), so they are absent from the default build rather than silently skipped in it.
 - **Price push, CCBill** — `AutoCreate` always returns `errPendingManualLink`; the operator creates the FlexForm in CCBill's admin and links `flex_id` + `form_name`. This surfaces as `pending_manual_actions` on the price rather than an error, which is the intended behavior.
 - **Catalog update, NMI** — `Update` is a deliberate no-op: amount and frequency are immutable post-create and `is_active` is not representable.
 - **Drift detection, CCBill** — impossible, not missing: FlexForms are write-only redirect URLs and DataLink exports members, not catalog objects. There is no catalog-list endpoint to diff against, so CCBill is excluded from the reconciliation job by design.

--- a/internal/app/build_runtime.go
+++ b/internal/app/build_runtime.go
@@ -403,6 +403,15 @@ func buildRuntimeWithOverrides(cfg *config.Config, overrides *runtimeOverrides) 
 	if runtime.SubscriptionLifecycleService != nil {
 		runtime.SubscriptionLifecycleService.SetDeferredDeleteScheduler(systemDeferredDeletes)
 	}
+	// or#896: a merchant-initiated cancel goes through the same durable
+	// intents as the user path — admin-origin (a human asked for it, so it
+	// executes under mode=limited like the user cancel) and rate-ceiling gated.
+	if runtime.AdminSubscriptionService != nil {
+		runtime.AdminSubscriptionService.SetDeferredDeleteScheduler(newIntentDeferredDeleteScheduler(database, rateCeiling, intents.OriginAdmin,
+			"merchant-initiated cancellation; remote NMI subscription must stop rebilling"))
+		runtime.AdminSubscriptionService.SetCCBillCancelScheduler(intents.NewCCBillCancelScheduler(database, rateCeiling, intents.OriginAdmin,
+			"merchant-initiated cancellation; remote CCBill subscription must stop rebilling"))
+	}
 
 	// #684: fetch-and-converge wake-ups. Late-bound to the runtime so it works
 	// whether the producer came from config or an embedded host's external
@@ -776,7 +785,6 @@ func createServices(database *db.DB, cfg *config.Config, railConfigs railresolve
 		entitlementService,
 		notificationService,
 		purchaseService,
-		collectionResolver,
 		clock,
 	)
 	adminSubscriptionService.StripeService = &subscriptions.StripeService{Config: cfg, Rails: railConfigs}

--- a/internal/http/handlers/admin_cancel_intents_integration_test.go
+++ b/internal/http/handlers/admin_cancel_intents_integration_test.go
@@ -1,0 +1,194 @@
+//go:build integration
+
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/intents"
+	"github.com/open-rails/openrails/internal/modules/catalog"
+	"github.com/open-rails/openrails/internal/modules/entitlements"
+	"github.com/open-rails/openrails/internal/modules/payments"
+	"github.com/open-rails/openrails/internal/modules/subscriptions"
+)
+
+// or#896 tasks 3 + 4: the MERCHANT-initiated cancel (admin API) drives the same
+// durable provider intents as the user-initiated one. It used to call NMI
+// synchronously with no intent and no verify leg — an unresolvable PSP logged a
+// warning and returned nil, so the local row went terminal while NMI kept
+// rebilling — and it REFUSED CCBill outright while the findings queue happily
+// cancelled it.
+
+// adminSubscriptionService builds the production AdminSubscriptionService with
+// admin-origin intent schedulers, exactly as build_runtime wires it.
+func (fx *findingsFixture) adminSubscriptionService() *subscriptions.AdminSubscriptionService {
+	fx.t.Helper()
+	clock := clockwork.NewRealClock()
+	priceSvc := catalog.NewPriceService(fx.dbi)
+	productSvc := catalog.NewProductService(fx.dbi)
+	svc := subscriptions.NewAdminSubscriptionService(
+		subscriptions.NewSubscriptionService(fx.dbi, priceSvc, productSvc, nil, clock),
+		productSvc,
+		priceSvc,
+		entitlements.NewEntitlementService(fx.dbi, clock),
+		subscriptions.NewNotificationService(fx.dbi, nil),
+		payments.NewPaymentService(fx.dbi, clock),
+		clock,
+	)
+	svc.SetDeferredDeleteScheduler(intents.NewNMIDeleteScheduler(fx.dbi, nil, intents.OriginAdmin, "merchant cancel"))
+	svc.SetCCBillCancelScheduler(intents.NewCCBillCancelScheduler(fx.dbi, nil, intents.OriginAdmin, "merchant cancel"))
+	return svc
+}
+
+func (fx *findingsFixture) subscriptionRow(id uuid.UUID) *models.Subscription {
+	fx.t.Helper()
+	sub, err := subscriptions.NewSubscriptionRepo(fx.dbi).GetByID(fx.ctx, id)
+	require.NoError(fx.t, err)
+	return sub
+}
+
+type railIntentRow struct {
+	ID     uuid.UUID
+	Status string
+	Origin string
+}
+
+func (fx *findingsFixture) railIntent(t *testing.T, intentType string, subID uuid.UUID) railIntentRow {
+	t.Helper()
+	var row railIntentRow
+	require.NoError(t, fx.dbi.Pool().QueryRow(fx.ctx,
+		`SELECT id, status, origin FROM openrails.rail_intents
+		 WHERE merchant_id = $1 AND intent_type = $2 AND subscription_id = $3`,
+		fx.merchant, intentType, subID).Scan(&row.ID, &row.Status, &row.Origin))
+	return row
+}
+
+// TestMerchantCancelNMIRidesDurableIntent: merchant cancel -> local cancel +
+// admin-origin delete intent committed together, the deferred-delete marker
+// pinning "rail side not yet confirmed" -> the executor confirms against the
+// (fake) gateway -> intent succeeded and the marker clears, i.e. the local row
+// only becomes terminal once NMI actually dropped the schedule.
+func TestMerchantCancelNMIRidesDurableIntent(t *testing.T) {
+	fx := newFindingsFixture(t)
+	subID := fx.seedActiveSubscription("psid-merchant-cancel")
+
+	require.NoError(t, fx.adminSubscriptionService().CancelSubscription(fx.ctx, subID, "chargeback risk", true))
+
+	sub := fx.subscriptionRow(subID)
+	assert.Equal(t, models.StatusCancelled, sub.Status)
+	require.NotNil(t, sub.CancelType)
+	assert.Equal(t, models.CancelTypeMerchant, *sub.CancelType)
+	require.NotNil(t, sub.DeletionScheduledAt,
+		"the rail-side delete is still unconfirmed: the marker must hold until the intent says otherwise")
+
+	intent := fx.railIntent(t, intents.TypeNMIDeleteSubscription, subID)
+	assert.Equal(t, intents.StatusPending, intent.Status, "the remote cancel is durable, not fire-and-forget")
+	assert.Equal(t, string(intents.OriginAdmin), intent.Origin)
+
+	// Drain: verify-then-execute against the gateway, then finalize.
+	_, err := fx.deleteRunner().RunExecuteOnce(fx.ctx)
+	require.NoError(t, err)
+
+	assert.EqualValues(t, 1, fx.fake.deleteCalls.Load(), "the schedule was actually deleted at NMI")
+	after := fx.railIntent(t, intents.TypeNMIDeleteSubscription, subID)
+	assert.Equal(t, intents.StatusSucceeded, after.Status)
+	assert.Nil(t, fx.subscriptionRow(subID).DeletionScheduledAt,
+		"confirmation clears the marker — only now is the cancellation terminal")
+}
+
+// TestMerchantCancelNMIAmbiguousOutcomeParksForVerification: the gateway
+// answers the delete with a transport failure. The intent must park as
+// unknown_needs_verify (never blind-complete), and the local row must keep its
+// unconfirmed marker rather than claim the schedule is gone.
+func TestMerchantCancelNMIAmbiguousOutcomeParksForVerification(t *testing.T) {
+	fx := newFindingsFixture(t)
+	subID := fx.seedActiveSubscription("psid-merchant-ambiguous")
+	fx.fake.deleteFails.Store(true)
+
+	require.NoError(t, fx.adminSubscriptionService().CancelSubscription(fx.ctx, subID, "fraud", true))
+
+	_, err := fx.deleteRunner().RunExecuteOnce(fx.ctx)
+	require.NoError(t, err)
+
+	intent := fx.railIntent(t, intents.TypeNMIDeleteSubscription, subID)
+	assert.Equal(t, intents.StatusUnknownNeedsVerify, intent.Status,
+		"a possibly-sent delete verifies; it is never reported done on a guess")
+	require.NotNil(t, fx.subscriptionRow(subID).DeletionScheduledAt,
+		"the marker survives an unknown outcome — the row must not lie about the rail")
+
+	// The delete did land; the verifier's read resolves it and finalizes.
+	fx.fake.deleteFails.Store(false)
+	fx.fake.subDeleted.Store(true)
+	_, err = fx.dbi.Pool().Exec(fx.ctx,
+		`UPDATE openrails.rail_intents SET next_attempt_at = now() WHERE id = $1`, intent.ID)
+	require.NoError(t, err)
+	_, err = fx.deleteRunner().RunVerifyOnce(fx.ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, intents.StatusSucceeded, fx.railIntent(t, intents.TypeNMIDeleteSubscription, subID).Status)
+	assert.Nil(t, fx.subscriptionRow(subID).DeletionScheduledAt)
+}
+
+// TestMerchantCancelCCBillDrivesTheLiveVerifiedCancel: the admin API used to
+// REFUSE CCBill ("cancel operation not supported for rail 'ccbill'") while the
+// findings queue cancelled it happily — one operation, two answers. Both
+// surfaces now queue the same admin-origin ccbill_cancel_subscription intent,
+// and it drains through the live-verified DataLink SMS cancel (#696 Phase 0).
+func TestMerchantCancelCCBillDrivesTheLiveVerifiedCancel(t *testing.T) {
+	fx := newFindingsFixture(t)
+	subID := fx.seedActiveCCBillSubscription("ccsub-admin-" + uuid.NewString()[:8])
+
+	require.NoError(t, fx.adminSubscriptionService().CancelSubscription(fx.ctx, subID, "merchant request", true))
+
+	sub := fx.subscriptionRow(subID)
+	assert.Equal(t, models.StatusCancelled, sub.Status)
+	require.NotNil(t, sub.CancelType)
+	assert.Equal(t, models.CancelTypeMerchant, *sub.CancelType)
+
+	intent := fx.railIntent(t, intents.TypeCCBillCancelSubscription, subID)
+	assert.Equal(t, intents.StatusPending, intent.Status, "the remote cancel is durable, not refused")
+	assert.Equal(t, string(intents.OriginAdmin), intent.Origin,
+		"same intent, same origin as the findings-queue action (TestFindingsQueueApproveCCBillCancelAndRefund)")
+
+	// It drains through the same DataLink choke point the findings queue uses.
+	fake, client := newFakeCCBillSMS(t)
+	runner := &intents.Runner{
+		Store:    intents.NewStore(fx.dbi),
+		Registry: intents.NewRegistry(newAdminFindingsCCBillCancelHandler(fx.dbi, client)),
+		Config:   fx.rt.Config,
+		Breaker:  intents.NewVolumeBreaker(fx.dbi),
+	}
+	_, err := runner.RunExecuteOnce(fx.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, intents.StatusSucceeded, fx.railIntent(t, intents.TypeCCBillCancelSubscription, subID).Status)
+	assert.EqualValues(t, 1, fake.cancelCalls.Load(), "the merchant cancel actually reached CCBill")
+}
+
+// TestMerchantCancelSolanaNamesTheWalletEndpoints: a Solana cancel needs the
+// subscriber's signature; the merchant surface says so instead of half-doing it.
+func TestMerchantCancelSolanaNamesTheWalletEndpoints(t *testing.T) {
+	fx := newFindingsFixture(t)
+	productID, priceID := fx.seedSecondProduct()
+	subID := uuid.New()
+	now := time.Now().UTC()
+	fx.exec(`INSERT INTO openrails.subscriptions
+	          (id, price_id, product_id, status, rail, rail_subscription_id,
+	           current_period_starts_at, current_period_ends_at, started_at, customer_id, merchant_id)
+	        VALUES ($1, $2, $3, 'active', 'solana', 'pda-merchant-cancel', $4, $5, $4, $6, $7)`,
+		subID, priceID, productID, now.Add(-24*time.Hour), now.Add(6*24*time.Hour), fx.customer, fx.merchant)
+
+	err := fx.adminSubscriptionService().CancelSubscription(fx.ctx, subID, "merchant request", true)
+	require.ErrorIs(t, err, subscriptions.ErrSolanaCancelNeedsWalletSignature)
+	assert.Contains(t, err.Error(), "solana-cancel-tx")
+	assert.Contains(t, err.Error(), "solana-cancel")
+
+	assert.Equal(t, models.StatusActive, fx.subscriptionRow(subID).Status,
+		"a refused cancel changes nothing locally")
+}

--- a/internal/http/handlers/admin_catalog.go
+++ b/internal/http/handlers/admin_catalog.go
@@ -37,6 +37,10 @@ func writeCatalogError(r *httprequest.Request, err error) {
 	// Map known business errors to stable status codes + machine-readable codes.
 	msg := strings.ToLower(err.Error())
 	switch {
+	// or#896: a trial declared on a rail that cannot execute one is a bad
+	// DECLARATION — 400 with the limitation named, never a generic 500.
+	case errors.Is(err, billingservice.ErrTrialUnsupportedOnRail):
+		r.ErrorJSON(http.StatusBadRequest, err.Error())
 	// or#782: product_not_found/price_not_found (the stable codes the lookup
 	// helpers rewrite "sql: no rows" into) match on the UNDERSCORE form — without
 	// it every missing-or-foreign id fell through to a 500, so a cross-merchant

--- a/internal/http/handlers/admin_findings_integration_test.go
+++ b/internal/http/handlers/admin_findings_integration_test.go
@@ -54,6 +54,10 @@ type fakeNMIGateway struct {
 	refundCalls  atomic.Int64
 	deleteCalls  atomic.Int64
 	subDeleted   atomic.Bool
+	// deleteFails makes DELETE answer a transport-level failure — the
+	// ambiguous outcome the delete intent must verify rather than assume
+	// (or#896).
+	deleteFails atomic.Bool
 }
 
 func newFakeNMIGateway(t *testing.T) (*fakeNMIGateway, *nmi.NMIClient) {
@@ -71,6 +75,11 @@ func newFakeNMIGateway(t *testing.T) (*fakeNMIGateway, *nmi.NMIClient) {
 			fmt.Fprint(w, `{"object":"subscription","id":"psid","delayed_condition":"active"}`)
 		case r.Method == http.MethodDelete && strings.Contains(r.URL.Path, "/subscriptions/"):
 			f.deleteCalls.Add(1)
+			if f.deleteFails.Load() {
+				w.WriteHeader(http.StatusBadGateway)
+				fmt.Fprint(w, `{"type":"internalError","error_code":"E_INTERNAL","message":"delete failed"}`)
+				return
+			}
 			f.subDeleted.Store(true)
 			fmt.Fprint(w, `{}`)
 		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/refund"):

--- a/internal/http/handlers/admin_users.go
+++ b/internal/http/handlers/admin_users.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -252,6 +253,10 @@ func AdminCancelSubscription(r *httprequest.Request) {
 			r.ErrorJSON(http.StatusNotFound, "subscription not found")
 		case strings.Contains(msg, "not active"):
 			r.ErrorJSON(http.StatusConflict, "subscription is not active")
+		// or#896: a Solana cancel is the subscriber's signature to give, not a
+		// server-side operation — name the endpoints instead of a 500.
+		case errors.Is(err, subscriptions.ErrSolanaCancelNeedsWalletSignature):
+			r.ErrorJSON(http.StatusBadRequest, msg)
 		case strings.Contains(msg, "not supported for rail"):
 			r.ErrorJSON(http.StatusBadRequest, msg)
 		default:

--- a/internal/http/handlers/payment_methods.go
+++ b/internal/http/handlers/payment_methods.go
@@ -239,6 +239,11 @@ func CreatePaymentMethod(r *httprequest.Request) {
 			"request_id": r.RequestID(),
 			"user_id":    user.ID,
 		}).Error("Failed to create payment method")
+		// or#896: an unsupported rail is not a misconfiguration — say so.
+		if errors.Is(err, paymentmethods.ErrPaymentMethodsUnsupportedOnRail) {
+			r.ErrorJSON(http.StatusBadRequest, err.Error())
+			return
+		}
 		if errors.Is(err, merchants.ErrSecretBackendUnavailable) {
 			r.ErrorJSON(http.StatusServiceUnavailable, "payment rail credentials are temporarily unavailable")
 			return
@@ -372,8 +377,9 @@ func UpdatePaymentMethod(r *httprequest.Request) {
 		}
 	}
 
-	if !rails.IsNMI(pm.Rail) {
-		r.ErrorJSON(http.StatusBadRequest, "Only NMI-backed payment methods can be updated")
+	if !rails.SupportsPaymentMethodCRUD(pm.Rail) {
+		// or#896: name the rail and where the instrument actually lives.
+		r.ErrorJSON(http.StatusBadRequest, paymentmethods.RailPaymentMethodsUnsupported(string(pm.Rail)).Error())
 		return
 	}
 
@@ -403,6 +409,10 @@ func UpdatePaymentMethod(r *httprequest.Request) {
 	updated, err := r.State.RailPaymentMethodService.UpdatePaymentMethod(ctx, pm, updateReq)
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{"payment_method_id": methodID, "user_id": user.ID}).Error("Failed to update payment method")
+		if errors.Is(err, paymentmethods.ErrPaymentMethodsUnsupportedOnRail) {
+			r.ErrorJSON(http.StatusBadRequest, err.Error())
+			return
+		}
 		if errors.Is(err, merchants.ErrSecretBackendUnavailable) {
 			r.ErrorJSON(http.StatusServiceUnavailable, "payment rail credentials are temporarily unavailable")
 			return

--- a/internal/http/handlers/subscription_lifecycle.go
+++ b/internal/http/handlers/subscription_lifecycle.go
@@ -91,6 +91,14 @@ func CancelSubscription(r *httprequest.Request) {
 		return
 	}
 
+	// or#896: Solana is refused HERE, synchronously, with the dedicated
+	// endpoints named. Queuing it would park a job that can only fail
+	// permanently — the cancel is a transaction the subscriber's wallet signs.
+	if sub.Rail == models.RailSolana {
+		r.ErrorJSON(http.StatusBadRequest, subscriptions.ErrSolanaCancelNeedsWalletSignature.Error())
+		return
+	}
+
 	// #696: CCBill cancels queue like every other rail — the worker's user
 	// cancel path records the local runway cancel + durable remote-cancel intent.
 	_, err = r.State.RiverProducer.Insert(r.Request.Context(), riverjobs.CancelSubscriptionArgs{

--- a/internal/integrationharness/merchant_catalog_http_test.go
+++ b/internal/integrationharness/merchant_catalog_http_test.go
@@ -518,6 +518,88 @@ SELECT aggregation FROM openrails.catalog_meters WHERE merchant_id = $1 AND key 
 	require.Equal(t, "sum", agg)
 }
 
+// or#896: a `trial:` first phase declared on a rail that cannot execute one
+// (NMI, Solana) is REFUSED at publish, naming the limitation — it used to be
+// accepted, dropped, and the subscriber charged the full amount immediately.
+// The rails that can execute one (Stripe, CCBill) still publish.
+func TestCatalogPublishRefusesTrialOnRailsWithoutFirstPhase(t *testing.T) {
+	ctx := context.Background()
+	h := New(t, ctx)
+	surface := h.StartStandalone("usd")
+	token := surface.MintAPIKey(
+		dbtest.TestMerchantSlug,
+		"catalog-trials-"+uuid.NewString(),
+		[]string{controlplane.PermMerchantCatalogRead, controlplane.PermMerchantCatalogUpdate},
+	)
+	mid := dbtest.TestMerchantID.UUID()
+
+	publish := func(t *testing.T, psp string) (int, []byte, string) {
+		t.Helper()
+		productKey := "trial-guard-" + strings.ReplaceAll(uuid.NewString(), "-", "")
+		t.Cleanup(func() {
+			_, _ = h.Pool().Exec(ctx, "DELETE FROM openrails.prices WHERE merchant_id = $1 AND product_id IN (SELECT id FROM openrails.products WHERE merchant_id = $1 AND key = $2)", mid, productKey)
+			_, _ = h.Pool().Exec(ctx, "DELETE FROM openrails.products WHERE merchant_id = $1 AND key = $2", mid, productKey)
+		})
+		manifest := catalog.Manifest{
+			Version: catalog.SupportedVersion,
+			Products: []catalog.Product{{
+				Key:         productKey,
+				DisplayName: "Trial Guard",
+				TierGroup:   "trial-guard-" + psp,
+				Prices: []catalog.Price{{
+					Currency:   "USD",
+					UnitAmount: 23_000_000,
+					Duration:   "30d",
+					AutoRenew:  true,
+					PSPs:       []string{psp},
+					Trial:      &catalog.PriceTrial{UnitAmount: 0, Duration: "7d"},
+				}},
+			}},
+		}
+		status, body := requestJSON(t, http.MethodPost, surface.BaseURL+"/v1/merchant/catalog/publish", token, map[string]any{
+			"catalog": manifest,
+			"insert":  true,
+		})
+		return status, body, productKey
+	}
+
+	for _, psp := range []string{"nmi", "solana"} {
+		t.Run(psp+" is refused", func(t *testing.T) {
+			status, body, productKey := publish(t, psp)
+			require.Equal(t, http.StatusBadRequest, status, string(body))
+			require.Contains(t, string(body), "trial")
+			require.Contains(t, string(body), psp)
+			require.Contains(t, string(body), "silently dropped")
+
+			// The refusal is total: no price row was written for the product.
+			var priceCount int
+			require.NoError(t, h.Pool().QueryRow(ctx, `
+SELECT count(*) FROM openrails.prices pr
+JOIN openrails.products p ON p.id = pr.product_id
+WHERE p.merchant_id = $1 AND p.key = $2`, mid, productKey).Scan(&priceCount))
+			require.Zero(t, priceCount, "a refused trial must leave no price behind")
+		})
+	}
+
+	for _, psp := range []string{"stripe", "ccbill"} {
+		t.Run(psp+" still publishes", func(t *testing.T) {
+			status, body, productKey := publish(t, psp)
+			require.Equal(t, http.StatusOK, status, string(body))
+
+			var trialAmount *int64
+			var trialHours *int
+			require.NoError(t, h.Pool().QueryRow(ctx, `
+SELECT pr.trial_unit_amount, pr.trial_duration_hours FROM openrails.prices pr
+JOIN openrails.products p ON p.id = pr.product_id
+WHERE p.merchant_id = $1 AND p.key = $2`, mid, productKey).Scan(&trialAmount, &trialHours))
+			require.NotNil(t, trialAmount)
+			require.Equal(t, int64(0), *trialAmount)
+			require.NotNil(t, trialHours)
+			require.Equal(t, 7*24, *trialHours)
+		})
+	}
+}
+
 func ptrI64(v int64) *int64 { return &v }
 
 func TestNativeCatalogLifecycleHTTP(t *testing.T) {

--- a/internal/modules/money/catalog_ratecard_integration_test.go
+++ b/internal/modules/money/catalog_ratecard_integration_test.go
@@ -173,10 +173,19 @@ VALUES ($1, $2, 1, 'image-credit', 'USD', 1000000, '{
 	require.Equal(t, unit, quote.Unit)
 	require.NotNil(t, quote.ExpiresAt)
 
-	quote, trx, err := svc.DepositCatalogCreditPurchase(ctx, payer, payer.UUID().String(), money.CatalogCreditPurchaseQuoteInput{
-		ProductKey:  productKey,
-		SpendMicros: 50_000_000,
-	}, "checkout_"+uuid.NewString())
+	// or#896: delivery is the LIVE deposit path (the one POST
+	// /v1/service/credits/deposit drives) fed by the quote — there is no second
+	// catalog-specific money writer.
+	sourceID := "checkout_" + uuid.NewString()
+	trx, err := svc.Deposit(ctx, money.DepositParams{
+		CustomerID: &payer,
+		Invoker:    payer.UUID().String(),
+		Currency:   quote.Unit,
+		Amount:     quote.TotalCredits,
+		Source:     "credit_purchase",
+		SourceID:   &sourceID,
+		ExpiresAt:  quote.ExpiresAt,
+	})
 	require.NoError(t, err)
 	require.Equal(t, quote.TotalCredits, trx.Amount)
 	require.Equal(t, unit, trx.Currency)
@@ -185,10 +194,17 @@ VALUES ($1, $2, 1, 'image-credit', 'USD', 1000000, '{
 	require.NoError(t, err)
 	require.Equal(t, quote.TotalCredits, bal.Balance)
 
-	_, _, err = svc.DepositCatalogCreditPurchase(ctx, payer, payer.UUID().String(), money.CatalogCreditPurchaseQuoteInput{
-		ProductKey:  productKey,
-		SpendMicros: 50_000_000,
-	}, derefString(trx.SourceID))
+	// Same payment source id = same deposit: a replayed settlement never
+	// double-credits the quoted lot.
+	_, err = svc.Deposit(ctx, money.DepositParams{
+		CustomerID: &payer,
+		Invoker:    payer.UUID().String(),
+		Currency:   quote.Unit,
+		Amount:     quote.TotalCredits,
+		Source:     "credit_purchase",
+		SourceID:   trx.SourceID,
+		ExpiresAt:  quote.ExpiresAt,
+	})
 	require.NoError(t, err)
 	bal, err = svc.GetBalanceForCustomer(ctx, payer, unit)
 	require.NoError(t, err)
@@ -289,9 +305,3 @@ VALUES ($1, $2, 1, 'image-credit', 'USD', 1000000, '{
 	require.Equal(t, int64(50_000_000), quote.PaidAmount)
 }
 
-func derefString(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
-}

--- a/internal/modules/money/credit_purchase.go
+++ b/internal/modules/money/credit_purchase.go
@@ -1,3 +1,15 @@
+// Catalog credit-purchase pricing: quotes a variable top-up offer
+// (catalog_credit_purchase_prices) both ways — spend -> credits and
+// credits -> spend — against the declared charge model.
+//
+// or#896: this file deliberately stops at the QUOTE. The former
+// DepositCatalogCreditPurchase wrapper (quote-then-Deposit) had no production
+// caller on any rail and duplicated the live deposit path
+// (MoneyService.Deposit, reached by POST /v1/service/credits/deposit); a
+// checkout leg that could reach it does not exist — a top-up product's offers
+// are rate-priced rows in the sidecar table, never `prices` rows, so no
+// checkout session can name one. Delivery is the caller's Deposit call with
+// the quote's unit/amount/expiry, keyed on its own payment source id.
 package money
 
 import (
@@ -8,9 +20,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/shared/moneyutil"
-	"github.com/open-rails/openrails/pkg/identity"
 	"github.com/open-rails/openrails/pkg/merchant"
 	"github.com/open-rails/openrails/pkg/pricing"
 )
@@ -119,32 +129,6 @@ func (s *MoneyService) QuoteCatalogCreditPurchase(ctx context.Context, input Cat
 		EffectiveUnitAmount: effective,
 		ExpiresAt:           expiresAt,
 	}, nil
-}
-
-func (s *MoneyService) DepositCatalogCreditPurchase(ctx context.Context, payer identity.CustomerID, invoker string, input CatalogCreditPurchaseQuoteInput, sourceID string) (*CatalogCreditPurchaseQuote, *models.MoneyTransaction, error) {
-	sourceID = strings.TrimSpace(sourceID)
-	if sourceID == "" {
-		return nil, nil, fmt.Errorf("source_id required")
-	}
-	quote, err := s.QuoteCatalogCreditPurchase(ctx, input)
-	if err != nil {
-		return nil, nil, err
-	}
-	desc := fmt.Sprintf("credit_purchase product=%s paid=%d base=%d bonus=%d total=%d", quote.ProductKey, quote.PaidAmount, quote.BaseCredits, quote.BonusCredits, quote.TotalCredits)
-	trx, err := s.Deposit(ctx, DepositParams{
-		CustomerID:  &payer,
-		Invoker:     invoker,
-		Currency:    quote.Unit,
-		Amount:      quote.TotalCredits,
-		Source:      "credit_purchase",
-		SourceID:    &sourceID,
-		ExpiresAt:   quote.ExpiresAt,
-		Description: &desc,
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	return quote, trx, nil
 }
 
 func (s *MoneyService) loadCatalogCreditPurchase(ctx context.Context, productKey, currency, provider string) (catalogCreditPurchaseRow, error) {

--- a/internal/modules/paymentmethods/payment_method.go
+++ b/internal/modules/paymentmethods/payment_method.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/open-rails/openrails/internal/db"
 	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/modules/payments/rails"
 )
 
 type PaymentMethodService struct {
@@ -22,7 +23,37 @@ func NewPaymentMethodService(db *db.DB) *PaymentMethodService {
 var (
 	ErrPaymentMethodNotFound     = errors.New("payment method not found")
 	ErrPaymentMethodAccessDenied = errors.New("payment method access denied")
+
+	// ErrPaymentMethodsUnsupportedOnRail marks a rail that has no first-party
+	// payment-instrument CRUD (or#896). It is an UNSUPPORTED SURFACE, not a
+	// misconfiguration: the request must never read as "PSP is not configured",
+	// which sends the operator hunting for credentials that were never needed.
+	ErrPaymentMethodsUnsupportedOnRail = errors.New("payment methods are not managed by OpenRails on this rail")
 )
+
+// knownRail reports whether the name is a declared rail (as opposed to a
+// merchant PSP key, which resolves through the PSP catalog).
+func knownRail(rail models.Rail) bool {
+	_, ok := rails.Lookup(rail)
+	return ok
+}
+
+// RailPaymentMethodsUnsupported builds the honest per-rail refusal, naming
+// where the instrument actually lives.
+func RailPaymentMethodsUnsupported(rail string) error {
+	var where string
+	switch strings.ToLower(strings.TrimSpace(rail)) {
+	case string(models.RailStripe):
+		where = "Stripe owns the instrument: cards are added and removed through Stripe Checkout and the Stripe Billing Portal"
+	case string(models.RailCCBill):
+		where = "CCBill owns the vault: instruments are managed on CCBill's own consumer surfaces"
+	case string(models.RailSolana):
+		where = "a Solana wallet is not a stored instrument; there is nothing for OpenRails to vault"
+	default:
+		where = "OpenRails holds no instrument vault for this rail"
+	}
+	return fmt.Errorf("%w: rail %q — %s", ErrPaymentMethodsUnsupportedOnRail, rail, where)
+}
 
 func (s *PaymentMethodService) Create(ctx context.Context, method *models.PaymentMethod) error {
 	return s.repo.Create(ctx, method)

--- a/internal/modules/paymentmethods/rail_payment_method_service.go
+++ b/internal/modules/paymentmethods/rail_payment_method_service.go
@@ -167,8 +167,19 @@ func (s *RailPaymentMethodService) CreatePaymentMethod(ctx context.Context, user
 		return nil, errors.New("provider is required")
 	}
 
+	// or#896: refuse an unsupported RAIL honestly before credential resolution.
+	// A reserved gateway name (stripe/ccbill/solana) resolves to itself, so the
+	// old code reported "PSP 'stripe' is not configured" — a misconfiguration
+	// message for a surface that does not exist on that rail.
+	if rail := models.Rail(psp); knownRail(rail) && !rails.SupportsPaymentMethodCRUD(rail) {
+		return nil, RailPaymentMethodsUnsupported(psp)
+	}
+
 	client, scope, err := s.resolveNMIClientByName(ctx, psp)
 	if err != nil {
+		if errors.Is(err, ErrPaymentMethodsUnsupportedOnRail) {
+			return nil, err
+		}
 		return nil, fmt.Errorf("PSP '%s' is not configured: %w", psp, err)
 	}
 	rail := psp
@@ -333,8 +344,10 @@ func (s *RailPaymentMethodService) resolveNMIClientByName(ctx context.Context, n
 				return nil, nil, fmt.Errorf("resolve PSP %q: %w", name, err)
 			}
 			if found {
-				if !rails.IsNMI(models.Rail(scope.Rail)) {
-					return nil, nil, fmt.Errorf("PSP %q is on rail %s, not an NMI rail", name, scope.Rail)
+				if !rails.SupportsPaymentMethodCRUD(models.Rail(scope.Rail)) {
+					// or#896: honest unsupported-surface refusal, not a
+					// credential complaint about a PSP that resolved fine.
+					return nil, nil, RailPaymentMethodsUnsupported(scope.Rail)
 				}
 				client, err := s.resolveNMIClientForScope(ctx, scope)
 				if err != nil {
@@ -474,6 +487,10 @@ func (s *RailPaymentMethodService) UpdatePaymentMethod(ctx context.Context, pm *
 	rail := strings.ToLower(string(pm.Rail))
 	if rail == "" {
 		return nil, errors.New("payment method rail is required")
+	}
+
+	if !rails.SupportsPaymentMethodCRUD(models.Rail(rail)) {
+		return nil, RailPaymentMethodsUnsupported(rail)
 	}
 
 	client, _, err := s.resolveNMIClient(ctx, rail, pm.PspID)
@@ -651,6 +668,10 @@ func (s *RailPaymentMethodService) deletePaymentMethodGuards(ctx context.Context
 	rail := strings.ToLower(string(pm.Rail))
 	if rail == "" {
 		return false, nil, errors.New("payment method rail is required")
+	}
+
+	if !rails.SupportsPaymentMethodCRUD(models.Rail(rail)) {
+		return false, nil, RailPaymentMethodsUnsupported(rail)
 	}
 
 	// #682 shared-vault handling: deleting the remote vault customer destroys

--- a/internal/modules/payments/rails/registry.go
+++ b/internal/modules/payments/rails/registry.go
@@ -63,6 +63,20 @@ type Descriptor struct {
 	// on this rail (prepaid auto-top-up #239, arrears settlement #241).
 	SupportsChargeSavedMethod bool
 
+	// SupportsCatalogTrial: the rail can honour a catalog first phase
+	// (`trial:` — free or paid intro) declared on a price (or#896). Stripe
+	// maps it onto subscription_data[trial_end]; CCBill's FlexForm carries the
+	// terms and OpenRails validates the billed amount against them. NMI's
+	// add_subscription and Solana's on-chain plan have no first-phase concept —
+	// declaring a trial there is REFUSED at catalog push, never silently dropped.
+	SupportsCatalogTrial bool
+
+	// SupportsPaymentMethodCRUD: OpenRails owns first-party payment-instrument
+	// CRUD on this rail (or#896). NMI only — its customer vault is the one
+	// instrument store OpenRails writes. Stripe delegates to Checkout / the
+	// Billing Portal, CCBill owns its own vault, Solana has no instrument.
+	SupportsPaymentMethodCRUD bool
+
 	// OpenRailsDrivenDunning: OpenRails owns the retry timing (models grace
 	// access as explicit entitlement windows during dunning). NMI + Solana
 	// recurring (#256/#257) — both charged by an OpenRails worker. Stripe
@@ -142,6 +156,8 @@ var descriptors = []Descriptor{
 		true,          // HasRailMerchantAccounts
 		false,         // HasRemoteCustomer (#682: vault ids are per-card instrument containers, not persons)
 		true,          // SupportsChargeSavedMethod
+		false,         // SupportsCatalogTrial (add_subscription has no first phase — or#896 refuses the declaration)
+		true,          // SupportsPaymentMethodCRUD (the customer vault)
 		true,          // OpenRailsDrivenDunning
 		true,          // RemoteDeleteOnTerminalCancel (or NMI keeps retrying the schedule forever)
 		nmiAutoBilled,
@@ -158,6 +174,8 @@ var descriptors = []Descriptor{
 		true,          // HasRailMerchantAccounts
 		false,         // HasRemoteCustomer (keys on subscription_id)
 		false,         // SupportsChargeSavedMethod
+		true,          // SupportsCatalogTrial (FlexForm terms; OpenRails validates the billed amount)
+		false,         // SupportsPaymentMethodCRUD (CCBill owns the vault)
 		false,         // OpenRailsDrivenDunning (CCBill retries itself)
 		false,         // RemoteDeleteOnTerminalCancel (CCBill drives its own lifecycle)
 		autoBilledAlways,
@@ -171,6 +189,8 @@ var descriptors = []Descriptor{
 		true,     // HasRailMerchantAccounts
 		true,     // HasRemoteCustomer (cus_*)
 		true,     // SupportsChargeSavedMethod
+		true,     // SupportsCatalogTrial (subscription_data[trial_end]; a PAID intro is refused separately)
+		false,    // SupportsPaymentMethodCRUD (Checkout / Billing Portal own instrument mutation)
 		false,    // OpenRailsDrivenDunning (Stripe dunning + webhooks)
 		false,    // RemoteDeleteOnTerminalCancel (Stripe cancels its own schedule)
 		autoBilledNever,
@@ -187,6 +207,8 @@ var descriptors = []Descriptor{
 		true,     // HasRailMerchantAccounts
 		false,    // HasRemoteCustomer (keys on wallet address)
 		false,    // SupportsChargeSavedMethod
+		false,    // SupportsCatalogTrial (the on-chain plan has one period price — or#896 refuses the declaration)
+		false,    // SupportsPaymentMethodCRUD (a wallet is not an instrument we hold)
 		true,     // OpenRailsDrivenDunning (recurring pulled by our worker)
 		false,    // RemoteDeleteOnTerminalCancel (local cancel cascade stops the cranker)
 		autoBilledNever,
@@ -200,6 +222,8 @@ var descriptors = []Descriptor{
 		false,    // HasRailMerchantAccounts (no integration; display-only vestige)
 		false,    // HasRemoteCustomer
 		false,    // SupportsChargeSavedMethod
+		false,    // SupportsCatalogTrial
+		false,    // SupportsPaymentMethodCRUD
 		false,    // OpenRailsDrivenDunning
 		false,    // RemoteDeleteOnTerminalCancel
 		autoBilledNever,
@@ -246,6 +270,21 @@ func HasRemoteCustomer(rail models.Rail) bool {
 func SupportsRailMerchantAccounts(rail models.Rail) bool {
 	d, ok := Lookup(rail)
 	return ok && d.HasRailMerchantAccounts
+}
+
+// SupportsCatalogTrial reports whether a catalog `trial:` first phase can be
+// executed on this rail (or#896). Unknown rails: false — a trial declared
+// against something we cannot classify is refused, never dropped.
+func SupportsCatalogTrial(rail models.Rail) bool {
+	d, ok := Lookup(rail)
+	return ok && d.SupportsCatalogTrial
+}
+
+// SupportsPaymentMethodCRUD reports whether OpenRails owns first-party
+// payment-instrument CRUD on this rail (or#896). Unknown rails: false.
+func SupportsPaymentMethodCRUD(rail models.Rail) bool {
+	d, ok := Lookup(rail)
+	return ok && d.SupportsPaymentMethodCRUD
 }
 
 // AutoBilled reports whether the provider rebills the subscription itself

--- a/internal/modules/payments/rails/registry_test.go
+++ b/internal/modules/payments/rails/registry_test.go
@@ -60,15 +60,17 @@ func TestRegistryPinnedFacts(t *testing.T) {
 		autoBilledNilPM      bool
 		autoBilledWithMethod bool
 		remoteDeleteTerminal bool
+		catalogTrial         bool
+		paymentMethodCRUD    bool
 		activeCancelMode     CancelMode
 	}{
 		// 3 keys: security_key, webhook_signing_secret, custodian_api_key (or#879 custody).
-		{models.RailNMI, false, true, true, true, 3, true, false, true, CancelModeDestructive},      // remoteCustomer=false per #682
-		{models.RailCCBill, false, false, false, true, 3, true, true, false, CancelModeDestructive}, // #696: DataLink SMS cancel, no resume
+		{models.RailNMI, false, true, true, true, 3, true, false, true, false, true, CancelModeDestructive},      // remoteCustomer=false per #682; or#896: no first phase, owns the vault
+		{models.RailCCBill, false, false, false, true, 3, true, true, false, true, false, CancelModeDestructive}, // #696: DataLink SMS cancel, no resume
 		// 4 keys: secret_key, webhook_signing_secret, _thin, _previous (#856 rollover overlap).
-		{models.RailStripe, true, true, false, true, 4, false, false, false, CancelModeReversible},
-		{models.RailSolana, false, false, true, true, 0, false, false, false, CancelModeDestructive},
-		{models.RailPayPal, false, false, false, false, 0, false, false, false, CancelModeDestructive},
+		{models.RailStripe, true, true, false, true, 4, false, false, false, true, false, CancelModeReversible},
+		{models.RailSolana, false, false, true, true, 0, false, false, false, false, false, CancelModeDestructive},
+		{models.RailPayPal, false, false, false, false, 0, false, false, false, false, false, CancelModeDestructive},
 	}
 	// #682: the rebill-driver mode is EXPLICIT now — a method ref alone no longer
 	// flips NMI to our-rebill; RebillDriver does.
@@ -101,6 +103,12 @@ func TestRegistryPinnedFacts(t *testing.T) {
 		}
 		if d.RemoteDeleteOnTerminalCancel != c.remoteDeleteTerminal {
 			t.Errorf("%s: RemoteDeleteOnTerminalCancel = %v", c.rail, d.RemoteDeleteOnTerminalCancel)
+		}
+		if got := SupportsCatalogTrial(c.rail); got != c.catalogTrial {
+			t.Errorf("%s: SupportsCatalogTrial = %v", c.rail, got)
+		}
+		if got := SupportsPaymentMethodCRUD(c.rail); got != c.paymentMethodCRUD {
+			t.Errorf("%s: SupportsPaymentMethodCRUD = %v", c.rail, got)
 		}
 		if got := CancelModeFor(&models.Subscription{Rail: c.rail, Status: models.StatusActive}, time.Now()); got != c.activeCancelMode {
 			t.Errorf("%s: CancelModeFor(active) = %v, want %v", c.rail, got, c.activeCancelMode)

--- a/internal/modules/subscriptions/admin_service.go
+++ b/internal/modules/subscriptions/admin_service.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jonboulle/clockwork"
+	"github.com/open-rails/openrails/internal/db"
 	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/modules/catalog"
 	"github.com/open-rails/openrails/internal/modules/entitlements"
@@ -36,11 +38,25 @@ type AdminSubscriptionService struct {
 	EntitlementService  *entitlements.EntitlementService
 	NotificationService *NotificationService
 	PaymentService      *payments.PaymentService
-	// NMIResolver arms store-scoped NMI clients per merchant (#788).
-	NMIResolver   NMIClientSource
 	StripeService *StripeService
 	clock         clockwork.Clock
+
+	// deferDelete / ccbillCancel enqueue the durable remote-cancel intents for
+	// a merchant-initiated cancel (or#896), admin-origin. Injected
+	// post-construction in build_runtime, exactly like the user service's.
+	deferDelete  DeferredDeleteScheduler
+	ccbillCancel CCBillRemoteCancelScheduler
 	// No user directory enrichment; IdP subject is stored on subscription
+}
+
+// SetDeferredDeleteScheduler injects the admin-origin NMI delete scheduler.
+func (s *AdminSubscriptionService) SetDeferredDeleteScheduler(d DeferredDeleteScheduler) {
+	s.deferDelete = d
+}
+
+// SetCCBillCancelScheduler injects the admin-origin CCBill cancel scheduler.
+func (s *AdminSubscriptionService) SetCCBillCancelScheduler(c CCBillRemoteCancelScheduler) {
+	s.ccbillCancel = c
 }
 
 // SetClock sets the clock for this service. Used for testing.
@@ -173,36 +189,18 @@ func (s *AdminSubscriptionService) UpdateSubscription(ctx context.Context, subsc
 	return nil
 }
 
-// cancelWithNMI cancels a subscription with NMI if applicable
-func (s *AdminSubscriptionService) cancelWithNMI(ctx context.Context, subscription *models.Subscription) error {
-	if !rails.IsNMI(subscription.Rail) {
-		return nil // Not an NMI-backed subscription, nothing to do
-	}
-
-	if s.NMIResolver == nil || subscription.RailSubscriptionID == "" {
-		return nil // No NMI resolver configured or no subscription ID
-	}
-
-	client, provider, ok, err := NMIClientForExistingSubscription(ctx, s.NMIResolver, subscription)
-	if err != nil {
-		return fmt.Errorf("resolve subscription provider account: %w", err)
-	}
-	if !ok {
-		log.WithFields(log.Fields{
-			"subscription_id": subscription.ID,
-			"rail":            provider,
-		}).Warn("NMI provider not configured for admin cancel")
-		return nil // Log warning but don't fail the cancellation
-	}
-
-	if err := client.DeleteRecurringSubscription(ctx, subscription.RailSubscriptionID); err != nil {
-		return fmt.Errorf("failed to cancel subscription with NMI provider '%s': %w", provider, err)
-	}
-
-	return nil
-}
-
-// CancelSubscription cancels a subscription (admin)
+// CancelSubscription cancels a subscription (admin/merchant-initiated).
+//
+// or#896: the rail side rides the SAME durable intent pipeline the
+// user-initiated cancel uses (#674 write-through provider intents). It used to
+// call the gateway synchronously with no intent and no verify leg, and an
+// unresolvable PSP only logged a warning — so the local row flipped to
+// cancelled while NMI happily kept rebilling. Now the local cancellation and
+// the remote-cancel intent commit in ONE transaction: the row is never
+// terminal while the rail-side schedule survives unconfirmed (the
+// DeletionScheduledAt marker stays set until the intent's own verify-then-
+// execute leg confirms the NMI subscription is gone), and an ambiguous
+// provider outcome parks for verification instead of lying.
 func (s *AdminSubscriptionService) CancelSubscription(ctx context.Context, subscriptionID uuid.UUID, reason string, revokeAccess bool) error {
 	subscription, err := s.SubscriptionService.GetByID(ctx, subscriptionID)
 	if err != nil {
@@ -213,15 +211,39 @@ func (s *AdminSubscriptionService) CancelSubscription(ctx context.Context, subsc
 		return fmt.Errorf("subscription is not active")
 	}
 
-	if !rails.IsNMI(subscription.Rail) && subscription.Rail != models.RailStripe {
-		return fmt.Errorf("cancel operation not supported for rail '%s'", subscription.Rail)
-	}
+	now := s.now()
 
-	// Cancel with payment rail first.
+	// enqueueRemoteIntent commits the rail's durable remote-mutation intent in
+	// the SAME transaction as the local cancellation (nil = no remote intent:
+	// the rail either has nothing to stop or was cancelled inline above).
+	var enqueueRemoteIntent func(ctx context.Context, tx pgx.Tx) error
+
 	switch {
 	case rails.IsNMI(subscription.Rail):
-		if err := s.cancelWithNMI(ctx, subscription); err != nil {
-			return err
+		if subscription.RailSubscriptionID != "" {
+			if s.deferDelete == nil {
+				return fmt.Errorf("nmi remote-delete scheduler unavailable")
+			}
+			// Marker + intent commit together: the cancellation is not
+			// destructive (and not terminal rail-side) until the intent
+			// confirms NMI dropped the schedule.
+			subscription.DeletionScheduledAt = &now
+			enqueueRemoteIntent = func(ctx context.Context, tx pgx.Tx) error {
+				return s.deferDelete.WithTx(tx).ScheduleNMIDelete(ctx, subscription.CustomerID.String(), subscription.ID, now)
+			}
+		}
+	case subscription.Rail == models.RailCCBill:
+		// or#896: the admin path used to REFUSE CCBill while the findings
+		// queue supported it — same operation, two answers. The DataLink
+		// cancelSubscription wire is live-verified (#696 Phase 0), so the
+		// refusal was stale: drive the same durable intent here.
+		if subscription.RailSubscriptionID != "" {
+			if s.ccbillCancel == nil {
+				return fmt.Errorf("ccbill remote-cancel scheduler unavailable")
+			}
+			enqueueRemoteIntent = func(ctx context.Context, tx pgx.Tx) error {
+				return s.ccbillCancel.WithTx(tx).ScheduleCCBillCancel(ctx, subscription.CustomerID.String(), subscription.ID)
+			}
 		}
 	case subscription.Rail == models.RailStripe:
 		if s.StripeService == nil {
@@ -230,9 +252,12 @@ func (s *AdminSubscriptionService) CancelSubscription(ctx context.Context, subsc
 		if err := s.StripeService.CancelSubscription(ctx, subscription.RailSubscriptionID); err != nil {
 			return fmt.Errorf("failed to cancel subscription with Stripe: %w", err)
 		}
+	case subscription.Rail == models.RailSolana:
+		return ErrSolanaCancelNeedsWalletSignature
+	default:
+		return fmt.Errorf("cancel operation not supported for rail '%s'", subscription.Rail)
 	}
 
-	now := s.now()
 	cancelType := models.CancelTypeMerchant
 	subscription.Status = models.StatusCancelled
 	subscription.CancelledAt = &now
@@ -242,8 +267,21 @@ func (s *AdminSubscriptionService) CancelSubscription(ctx context.Context, subsc
 		subscription.CancelFeedback = &reason
 	}
 
-	if err := s.SubscriptionService.Update(ctx, subscription); err != nil {
-		return fmt.Errorf("failed to update subscription: %w", err)
+	if err := s.SubscriptionService.Database().MerchantTx(ctx, func(ctx context.Context, tx pgx.Tx) error {
+		txdb := db.NewWithPgxTx(tx)
+		txSubSvc := NewSubscriptionService(txdb, catalog.NewPriceService(txdb), catalog.NewProductService(txdb), nil, s.clock)
+		if err := txSubSvc.Update(ctx, subscription); err != nil {
+			return fmt.Errorf("failed to update subscription: %w", err)
+		}
+		if enqueueRemoteIntent != nil {
+			return enqueueRemoteIntent(ctx, tx)
+		}
+		return nil
+	}); err != nil {
+		if enqueueRemoteIntent != nil {
+			return fmt.Errorf("failed to persist cancellation with remote intent: %w", err)
+		}
+		return err
 	}
 
 	if revokeAccess && s.EntitlementService != nil {
@@ -358,7 +396,6 @@ func NewAdminSubscriptionService(
 	entitlementService *entitlements.EntitlementService,
 	notificationService *NotificationService,
 	paymentService *payments.PaymentService,
-	nmiResolver NMIClientSource,
 	clocks ...clockwork.Clock,
 ) *AdminSubscriptionService {
 	return &AdminSubscriptionService{
@@ -368,7 +405,6 @@ func NewAdminSubscriptionService(
 		EntitlementService:  entitlementService,
 		NotificationService: notificationService,
 		PaymentService:      paymentService,
-		NMIResolver:         nmiResolver,
 		clock:               timeutil.FirstClock(clocks...),
 	}
 }

--- a/internal/modules/subscriptions/user_service.go
+++ b/internal/modules/subscriptions/user_service.go
@@ -32,6 +32,19 @@ var (
 	ErrSubscriptionNotActive    = errors.New("subscription is not active")
 	ErrNotificationNotFound     = errors.New("notification not found")
 	ErrNotificationAccessDenied = errors.New("notification does not belong to user")
+
+	// ErrSolanaCancelNeedsWalletSignature refuses the rail-agnostic cancel on
+	// Solana (or#896). A Solana cancel is an on-chain transaction the
+	// SUBSCRIBER'S wallet must sign — OpenRails holds no authority to revoke
+	// the delegation and never DB-only "soft cancels" a chain-truth
+	// subscription. This used to fall through the worker's default branch into
+	// a facade with no Solana case and fail permanently, which read as a bug
+	// rather than a rail fact.
+	ErrSolanaCancelNeedsWalletSignature = errors.New(
+		"cancelling a Solana subscription requires the subscriber's wallet signature: " +
+			"POST /v1/me/subscriptions/{id}/solana-cancel-tx to build the unsigned cancel_subscription " +
+			"transaction, sign and send it from the wallet, then POST /v1/me/subscriptions/{id}/solana-cancel " +
+			"with the signature to confirm and mirror it")
 )
 
 // UserSubscriptionService handles user-facing subscription operations
@@ -534,6 +547,8 @@ func (s *UserSubscriptionService) CancelUserSubscription(ctx context.Context, us
 		enqueueRemoteIntent = func(ctx context.Context, tx pgx.Tx) error {
 			return s.ccbillCancel.WithTx(tx).ScheduleCCBillCancel(ctx, userID, subscription.ID)
 		}
+	case subscription.Rail == models.RailSolana:
+		return ErrSolanaCancelNeedsWalletSignature
 	default:
 		return fmt.Errorf("unable to cancel subscription for rail %s", subscription.Rail)
 	}

--- a/internal/river/jobs_subscription_manage.go
+++ b/internal/river/jobs_subscription_manage.go
@@ -113,6 +113,14 @@ func (w CancelSubscriptionWorker) cancel(ctx context.Context, args CancelSubscri
 		"rail":            sub.Rail,
 	}).Info("processing subscription cancellation")
 
+	// or#896: a Solana cancel needs the subscriber's wallet signature, so this
+	// job can never complete — cancel it instead of retrying a rail fact
+	// forever (the API refuses the request up front; this covers jobs already
+	// queued and any other producer).
+	if sub.Rail == models.RailSolana {
+		return river.JobCancel(subscriptions.ErrSolanaCancelNeedsWalletSignature)
+	}
+
 	switch sub.Rail {
 	case models.RailStripe:
 		if w.SubscriptionLifecycleService == nil {

--- a/pkg/service/catalog_extras_live_test.go
+++ b/pkg/service/catalog_extras_live_test.go
@@ -1,0 +1,48 @@
+//go:build stripelive
+
+// Live (read-only) Stripe extras-listing smoke (or#896): tagged so it is
+// evidence when a lane runs it and absent otherwise.
+//
+//	go test -tags=stripelive ./pkg/service/ -run TestLiveStripeExtrasListing -v
+
+package service
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/modules/catalog"
+	"github.com/open-rails/openrails/internal/railresolve"
+)
+
+// TestLiveStripeExtrasListing runs the extras-detection LISTING (GETs only;
+// nothing is ever archived) against a real Stripe account. Opt-in via
+// OPENRAILS_LIVE_STRIPE_KEY; use a TEST-mode key.
+func TestLiveStripeExtrasListing(t *testing.T) {
+	key := strings.TrimSpace(os.Getenv("OPENRAILS_LIVE_STRIPE_KEY"))
+	if key == "" {
+		t.Skip("set OPENRAILS_LIVE_STRIPE_KEY (a Stripe TEST key) to run the live read-only extras listing")
+	}
+	rails := railresolve.FixedSet{
+		"stripe": {Rail: models.RailStripe, Stripe: &config.StripeRailConfig{SecretKey: key}},
+	}
+	lister := &catalog.StripeCatalogService{Config: &config.Config{}, Rails: rails}
+	products, prices, err := fetchStripeCatalog(context.Background(), lister)
+	if err != nil {
+		t.Fatalf("live stripe listing: %v", err)
+	}
+	// Empty local snapshot: every remote object shows up classified ours/foreign.
+	extras := computeStripeExtras(products, prices, buildSnapshotFromRows(nil, nil))
+	t.Logf("live stripe account: %d products, %d prices, %d extras vs an empty catalog", len(products), len(prices), len(extras))
+	for _, e := range extras {
+		marker := "foreign"
+		if e.Owned {
+			marker = "openrails-marked"
+		}
+		t.Logf("  %s %s (%s) active=%v [%s]", e.ObjectType, e.ExternalID, e.Label, e.Active, marker)
+	}
+}

--- a/pkg/service/catalog_extras_test.go
+++ b/pkg/service/catalog_extras_test.go
@@ -2,10 +2,8 @@ package service
 
 import (
 	"context"
-	"github.com/open-rails/openrails/internal/railresolve"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -482,35 +480,5 @@ func TestComputeSolanaSunsetExtras(t *testing.T) {
 	}
 	if e.Label != "premium.usd.23000000.30" {
 		t.Errorf("label should be the price content key, got %q", e.Label)
-	}
-}
-
-// -- live smoke (read-only; opt-in) ------------------------------------------------
-
-// TestLiveStripeExtrasListing runs the extras-detection LISTING (GETs only;
-// nothing is ever archived) against a real Stripe account. Opt-in via
-// OPENRAILS_LIVE_STRIPE_KEY; use a TEST-mode key.
-func TestLiveStripeExtrasListing(t *testing.T) {
-	key := strings.TrimSpace(os.Getenv("OPENRAILS_LIVE_STRIPE_KEY"))
-	if key == "" {
-		t.Skip("set OPENRAILS_LIVE_STRIPE_KEY (a Stripe TEST key) to run the live read-only extras listing")
-	}
-	rails := railresolve.FixedSet{
-		"stripe": {Rail: models.RailStripe, Stripe: &config.StripeRailConfig{SecretKey: key}},
-	}
-	lister := &catalog.StripeCatalogService{Config: &config.Config{}, Rails: rails}
-	products, prices, err := fetchStripeCatalog(context.Background(), lister)
-	if err != nil {
-		t.Fatalf("live stripe listing: %v", err)
-	}
-	// Empty local snapshot: every remote object shows up classified ours/foreign.
-	extras := computeStripeExtras(products, prices, buildSnapshotFromRows(nil, nil))
-	t.Logf("live stripe account: %d products, %d prices, %d extras vs an empty catalog", len(products), len(prices), len(extras))
-	for _, e := range extras {
-		marker := "foreign"
-		if e.Owned {
-			marker = "openrails-marked"
-		}
-		t.Logf("  %s %s (%s) active=%v [%s]", e.ObjectType, e.ExternalID, e.Label, e.Active, marker)
 	}
 }

--- a/pkg/service/catalog_provider_stripe_live_test.go
+++ b/pkg/service/catalog_provider_stripe_live_test.go
@@ -1,3 +1,11 @@
+//go:build stripelive
+
+// Live Stripe catalog tests (or#896): they hit the REAL Stripe test account.
+// Tagged so they are evidence when a lane runs them and absent otherwise —
+// never silently compiled into `go test ./...` and skipped on an env check.
+//
+//	go test -tags=stripelive ./pkg/service/ -run TestLiveStripe -v
+
 package service
 
 import (

--- a/pkg/service/catalog_providers.go
+++ b/pkg/service/catalog_providers.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/modules/catalog"
+	railreg "github.com/open-rails/openrails/internal/modules/payments/rails"
 )
 
 // Issue #208 declarative-provider primitives.
@@ -54,6 +55,11 @@ var errPendingManualLink = errors.New("provider requires a manual link")
 // provider slot converges on a later push-catalog once writes are allowed.
 // Verification reads always run.
 var errRemoteWritesDisabled = errors.New("catalog provider writes are disabled (mode=limited/readonly)")
+
+// ErrTrialUnsupportedOnRail refuses a `trial:` first phase declared against a
+// rail that cannot execute one (or#896). Exported so the HTTP layer answers
+// 400 (a declaration the operator must fix), never 500.
+var ErrTrialUnsupportedOnRail = errors.New("trial first phase is not supported on this rail")
 
 // remoteWritesDisabledMessage is the pending_manual_link message used when the
 // operating mode (not a missing capability) deferred the provider write.
@@ -291,6 +297,26 @@ func (s *Service) resolveProviders(ctx context.Context, product *models.Product,
 				name, strings.Join(sortedAdapterNames(adapters), ", "))
 		}
 		targets = append(targets, t)
+	}
+
+	// or#896: a `trial:` first phase is only executable where the rail has a
+	// first-phase concept (rails.SupportsCatalogTrial). NMI's add_subscription
+	// and Solana's on-chain plan carry one price for every period, so a trial
+	// declared against them used to be accepted and DROPPED — the subscriber
+	// was charged full price immediately. Refuse the declaration instead; the
+	// price never reaches the DB and the operator sees the limitation named.
+	if req.TrialUnitAmount != nil || req.TrialDurationHours != nil {
+		for _, t := range targets {
+			if railreg.SupportsCatalogTrial(models.Rail(t.rail)) {
+				continue
+			}
+			return nil, nil, nil, fmt.Errorf(
+				"%w: price declares a trial first phase, but PSP %q is on rail %s, which cannot execute one: "+
+					"%s subscriptions bill one amount every period, so the trial would be silently dropped and "+
+					"the subscriber charged the full amount immediately. Remove `trial:` from this price, or "+
+					"declare it only on a PSP whose rail supports trials (stripe, ccbill)",
+				ErrTrialUnsupportedOnRail, t.declared, t.rail, t.rail)
+		}
 	}
 
 	// The price substance (product key + immutable money terms) is the same for the

--- a/pkg/service/catalog_providers_test.go
+++ b/pkg/service/catalog_providers_test.go
@@ -377,3 +377,57 @@ func TestMobiusAdapter_AttachMissingPlanDeferredWhenWritesDisabled(t *testing.T)
 		t.Fatal("adapter performed a direct-post write while writes were disabled")
 	}
 }
+
+// or#896: a `trial:` first phase declared against a rail with no first-phase
+// concept is REFUSED at push. It used to be accepted and dropped — the
+// subscriber was charged the full amount immediately on enrolment.
+func TestResolveProviders_TrialRefusedOnRailsWithoutFirstPhase(t *testing.T) {
+	trialAmount := int64(0)
+	trialHours := 7 * 24
+	newReq := func(psp string) CreatePriceRequest {
+		hours := 30 * 24
+		return CreatePriceRequest{
+			ProductID:           uuid.New(),
+			UnitAmount:          23_000_000,
+			Currency:            "usd",
+			AccessDurationHours: &hours,
+			AutoRenew:           true,
+			TrialUnitAmount:     &trialAmount,
+			TrialDurationHours:  &trialHours,
+			PSPs:                []string{psp},
+		}
+	}
+
+	for _, psp := range []string{"nmi", "solana"} {
+		s := newUnconfiguredService()
+		req := newReq(psp)
+		_, _, _, err := s.resolveProviders(context.Background(), &models.Product{ID: req.ProductID, Key: "premium"}, req, uuid.New())
+		if err == nil {
+			t.Fatalf("%s: a trial on this rail must be refused, not silently dropped", psp)
+		}
+		for _, want := range []string{"trial", psp, "silently dropped"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("%s: error %q does not name %q", psp, err, want)
+			}
+		}
+	}
+
+	// The rails that can execute a first phase keep working.
+	for _, psp := range []string{"stripe", "ccbill"} {
+		s := newUnconfiguredService()
+		req := newReq(psp)
+		if _, _, _, err := s.resolveProviders(context.Background(), &models.Product{ID: req.ProductID, Key: "premium"}, req, uuid.New()); err != nil {
+			t.Errorf("%s: trials are supported here, got %v", psp, err)
+		}
+	}
+
+	// A trial-free price on NMI/Solana is untouched.
+	for _, psp := range []string{"nmi", "solana"} {
+		s := newUnconfiguredService()
+		req := newReq(psp)
+		req.TrialUnitAmount, req.TrialDurationHours = nil, nil
+		if _, _, _, err := s.resolveProviders(context.Background(), &models.Product{ID: req.ProductID, Key: "premium"}, req, uuid.New()); err != nil {
+			t.Errorf("%s: a price with no trial must still resolve, got %v", psp, err)
+		}
+	}
+}

--- a/pkg/service/catalog_sidecars_integration_test.go
+++ b/pkg/service/catalog_sidecars_integration_test.go
@@ -162,10 +162,17 @@ VALUES ($1, $2, 'Gem Top-up', $3)`, productID, productKey, merchantID)
 	require.Equal(t, qualifiedUnit, quote.Unit)
 	require.Equal(t, int64(1_000), quote.TotalCredits)
 
-	_, trx, err := moneySvc.DepositCatalogCreditPurchase(ctx, payer, payerID.String(), money.CatalogCreditPurchaseQuoteInput{
-		ProductKey:  productKey,
-		SpendMicros: 10_000_000,
-	}, "checkout_"+uuid.NewString())
+	// or#896: the quote prices it; the live deposit path delivers it.
+	sourceID := "checkout_" + uuid.NewString()
+	trx, err := moneySvc.Deposit(ctx, money.DepositParams{
+		CustomerID: &payer,
+		Invoker:    payerID.String(),
+		Currency:   quote.Unit,
+		Amount:     quote.TotalCredits,
+		Source:     "credit_purchase",
+		SourceID:   &sourceID,
+		ExpiresAt:  quote.ExpiresAt,
+	})
 	require.NoError(t, err)
 	require.Equal(t, qualifiedUnit, trx.Currency)
 	bal, err := moneySvc.GetBalanceForCustomer(ctx, payer, qualifiedUnit)

--- a/tests/cancel_subscription_test.go
+++ b/tests/cancel_subscription_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/modules/subscriptions"
 )
 
 func TestCancelSubscriptionRequiresAuth(t *testing.T) {
@@ -156,4 +157,47 @@ func TestCancelSubscriptionAuthBoundaries(t *testing.T) {
 
 	routerA.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// or#896: the rail-agnostic cancel used to accept a Solana subscription, queue
+// a job, fall through the worker's default branch into a facade with no Solana
+// case, and fail permanently. A Solana cancel is an on-chain transaction the
+// SUBSCRIBER'S wallet must sign, so the request is refused synchronously with
+// the dedicated endpoints named — and nothing local changes.
+func TestCancelSubscriptionSolanaNamesDedicatedEndpoints(t *testing.T) {
+	suite := getSharedTestSuite(t)
+	userID := uuid.New().String()
+	router := newHostSeamSelfRouter(t, suite, userID, nil)
+
+	products := suite.SeedProducts()
+	priceID := products[0].Prices[0].ID
+
+	sub := suite.CreateTestSubscriptionWithOptions(SubscriptionOptions{
+		UserID:    userID,
+		PriceID:   priceID,
+		Status:    models.StatusActive,
+		Rail:      models.RailSolana,
+		RailSubID: "test-solana-sub-" + uuid.NewString(),
+	})
+
+	jsonBody, _ := json.Marshal(map[string]string{"feedback": "I want to cancel"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/v1/me/subscriptions/"+sub.ID.String()+"/cancel", bytes.NewReader(jsonBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+merchantDelegatedTestToken)
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	body := w.Body.String()
+	assert.Contains(t, body, "solana-cancel-tx", "the refusal must name the prepare endpoint")
+	assert.Contains(t, body, "solana-cancel", "the refusal must name the confirm endpoint")
+	assert.Contains(t, body, "wallet")
+
+	assert.Equal(t, models.StatusActive, suite.GetSubscription(sub.ID).Status,
+		"a refused cancel leaves the subscription untouched")
+
+	// The service refuses it too, so no other producer can drive a DB-only
+	// "soft cancel" of a chain-truth subscription.
+	err := suite.App.Runtime.UserSubscriptionService.CancelUserSubscription(suite.MerchantCtx(), userID, "direct")
+	require.ErrorIs(t, err, subscriptions.ErrSolanaCancelNeedsWalletSignature)
 }

--- a/tests/payment_methods_test.go
+++ b/tests/payment_methods_test.go
@@ -410,3 +410,41 @@ func TestUpdatePaymentMethod(t *testing.T) {
 		assert.Equal(t, http.StatusForbidden, w.Code, "Should return 403 Forbidden")
 	})
 }
+
+// or#896: a payment-method create on a rail OpenRails does not vault for used
+// to answer "PSP 'stripe' is not configured" — a credential complaint about a
+// surface that does not exist. It now names the rail and where the instrument
+// actually lives.
+func TestCreatePaymentMethodUnsupportedRailIsHonest(t *testing.T) {
+	suite, _ := SetupSuiteWithMockNMI(t)
+	userID := uuid.New().String()
+	token := suite.MintUserToken(userID, "pm-unsupported-"+uuid.NewString()+"@test.example.com")
+
+	cases := map[string]string{
+		"stripe": "Billing Portal",
+		"ccbill": "CCBill owns the vault",
+		"solana": "wallet",
+	}
+	for psp, expect := range cases {
+		t.Run(psp, func(t *testing.T) {
+			jsonBody, _ := json.Marshal(map[string]string{
+				"payment_token": "test-token-" + psp,
+				"first_name":    "Test",
+				"last_name":     "User",
+				"provider":      psp,
+			})
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("POST", "/v1/me/payment-methods", bytes.NewReader(jsonBody))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+token)
+			suite.Server.Handler().ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+			body := w.Body.String()
+			assert.Contains(t, body, "not managed by OpenRails on this rail")
+			assert.Contains(t, body, expect)
+			assert.NotContains(t, body, "is not configured",
+				"an unsupported surface must never read as a misconfiguration")
+		})
+	}
+}


### PR DESCRIPTION
Closes the rail-support gaps `docs/rails/certification-matrix.md` (or#290) exposed. Seven items, each with its own commit and its matrix cells restated.

## 1. Trials silently dropped on NMI and Solana → refused loudly

`Price.GetTrial` has two readers (Stripe checkout, CCBill webhook validation); NMI enrolment and the Solana on-chain plan never read it, and nothing rejected the combination — the subscriber was charged full price immediately.

The rail registry now declares `SupportsCatalogTrial` (unkeyed literals, so every rail must answer), and `resolveProviders` refuses a price whose declared PSPs resolve to a rail without a first phase. The price never reaches the DB; `writeCatalogError` maps the typed `ErrTrialUnsupportedOnRail` to 400 instead of a generic 500. Stripe/CCBill unchanged.

Proof: `TestCatalogPublishRefusesTrialOnRailsWithoutFirstPhase` publishes a real manifest over HTTP — nmi/solana refused with no price row left behind, stripe/ccbill still publish with the trial persisted — plus `TestResolveProviders_TrialRefusedOnRailsWithoutFirstPhase`.

Matrix: free trial + paid intro on NMI/Solana move `unsupported (silent)` → `unsupported (guarded)`.

## 2. Solana rail-agnostic cancel → explicit refusal naming the dedicated endpoints

Routing it to the on-chain path is not possible, let alone clean: `cancel_subscription` is a transaction the **subscriber's wallet** must sign (prepare → sign+send → confirm → mirror), and OpenRails never DB-only soft-cancels a chain-truth subscription. So it refuses, per the fallback in the ruling.

`POST /subscriptions/:id/cancel` now answers 400 naming `solana-cancel-tx` / `solana-cancel` before queuing anything; `CancelUserSubscription` refuses for any other producer; and the worker `river.JobCancel`s a Solana job rather than retrying a rail fact forever (covers jobs queued before this change).

Proof: `TestCancelSubscriptionSolanaNamesDedicatedEndpoints` (HTTP 400 + endpoints named + subscription untouched + service-level `ErrorIs`).

## 3. NMI merchant cancel → durable intent

`admin_service.go` called `DeleteRecurringSubscription` synchronously with no intent and no verify leg, and an unresolvable PSP logged a warning and returned nil — the local row flipped to `cancelled` while NMI kept rebilling.

It now mirrors the user path: local cancellation + `nmi_delete_subscription` intent (admin origin) commit in **one** transaction, the `deletion_scheduled_at` marker holds while the rail side is unconfirmed, and the handler's verify-then-execute leg clears it only on confirmation. A missing scheduler is a loud failure, not a silent local-only cancel. `AdminSubscriptionService.NMIResolver` is gone with its last caller.

Proof: `TestMerchantCancelNMIRidesDurableIntent` (intent pending + admin origin + marker held → executor confirms against the fake gateway → succeeded, marker cleared) and `TestMerchantCancelNMIAmbiguousOutcomeParksForVerification` (delete answers 502 → `unknown_needs_verify`, marker survives → verifier resolves it).

## 4. CCBill merchant-cancel split-brain → unified on supported

The admin API refused CCBill while the findings queue cancelled it. The admin path now queues the same admin-origin `ccbill_cancel_subscription` intent and the refusal is deleted.

Proof: `TestMerchantCancelCCBillDrivesTheLiveVerifiedCancel` — admin cancel → local cancelled + pending admin-origin intent → drained through the same fake DataLink server the findings-queue test uses, `cancelSubscription` actually sent. Sits beside `TestFindingsQueueApproveCCBillCancelAndRefund`, so both entry points are pinned agreeing.

## 5. Stripe payment-method CRUD → honest `unsupported`

`SupportsPaymentMethodCRUD` (NMI only) gates create/update/delete. A Stripe/CCBill/Solana request now says *"payment methods are not managed by OpenRails on this rail"* and names where the instrument lives (Stripe Checkout / Billing Portal, CCBill's vault, a wallet is not an instrument) instead of `PSP 'stripe' is not configured`.

Proof: `TestCreatePaymentMethodUnsupportedRailIsHonest` — 400, the honest message, and an explicit assertion that the body never says "is not configured".

## 6. `DepositCatalogCreditPurchase` → DELETED (evidence)

- **No caller, and none reachable.** Its only references were two tests. `QuoteCatalogCreditPurchase` had none either.
- **No checkout path can ever feed it.** A credit top-up product's offers are rate-priced rows in `catalog_credit_purchase_prices`; `planPrices` skips every price carrying `model:`, so they are never `prices` rows, and checkout resolves a session strictly from a `price_id`. There is no variable-amount checkout leg to wire it to — building one is a feature, not a wiring.
- **It duplicated the wired path.** The live way to deposit credits is `MoneyService.Deposit` via `POST /v1/service/credits/deposit`; the wrapper was a second money-writer doing quote-then-`Deposit`.

So the ledger-writing half is deleted forward-only, and the **quote** (pure pricing over the declared offer table, which round-trips through push/dump) stays. Both tests now deliver the quoted lot through the live deposit path — same unit, same amount, same expiry, keyed on the payment source id — including the replay-is-idempotent assertion, so the pricing math and the delivery contract are both still proven. Matrix cell restated: `unsupported — priced, never checkout-able`.

## 7. Stripe live-shaped tests → `stripelive` build tag

`TestLiveStripeCatalogAutoCreate*` and `TestLiveStripeExtrasListing` compiled into a default `go test ./...` and were held back only by an env check. Both now carry the `stripelive` tag — the convention `internal/modules/catalog`'s live Stripe tests already use — so they are evidence when a lane asks for them and absent otherwise. `TestLiveStripeExtrasListing` moved to its own tagged file.

## Gates

`go build ./...`, `go vet ./...` (untagged, `integration`, `stripelive`), `go test ./...` (unit), `sql-lint` (clean), `migration-lint` (clean, no migrations added), `golangci-lint run ./...` (0 issues). Integration green with `-p 1` on `./tests`, `./pkg/service`, `./internal/http/handlers`, `./internal/modules/{subscriptions,paymentmethods,money}`, `./internal/river`, `./internal/intents`, `./internal/integrationharness`. sqlc untouched — no `internal/db/queries` or `migrations/` change in this branch.

One flake seen and re-run green in isolation: `TestOr891_ServiceRefusesMoneyWritesWithoutAKey` failed once on a testcontainers reaper race (shared box, unrelated to this branch).
