### PR TITLE
or#893: a provider pull is bound to the PSP that armed it; watermarks stop being global

### DIFF
--- a/internal/db/gen/models.go
+++ b/internal/db/gen/models.go
@@ -1110,9 +1110,8 @@ type OpenrailsRailRefreshWatermark struct {
 	ID         uuid.UUID
 	MerchantID uuid.UUID
 	Rail       string
-	// Current PSP row when resolvable; NULL is the compatibility/global lane for providers without a bound account identity.
-	PspID  *uuid.UUID
-	PspKey *uuid.UUID
+	// The PSP whose event stream this cursor bounds. Required (or#893): a pull arms from exactly one PSP, and a watermark shared across PSPs skips the events of every PSP but the one that advanced it.
+	PspID uuid.UUID
 	// Refresh domain. events currently covers provider transaction/subscription event windows.
 	EventDomain string
 	// Exclusive lower bound for the next successful bounded provider event refresh window.

--- a/internal/db/gen/reconciliation.sql.go
+++ b/internal/db/gen/reconciliation.sql.go
@@ -1059,7 +1059,7 @@ SELECT s.id, s.status, s.rail,
             SELECT 1 FROM openrails.rail_refresh_watermarks w
             WHERE w.merchant_id = s.merchant_id
               AND w.rail = s.rail
-              AND (w.psp_id IS NULL OR w.psp_id = s.psp_id)
+              AND w.psp_id = s.psp_id
               AND w.watermark_at > s.current_period_ends_at
        ))::bool AS watermark_newer_than_period_end
 FROM openrails.subscriptions s
@@ -1811,12 +1811,12 @@ SELECT id, customer_id, rail, rail_customer_ref AS vault_id, last_four, card_typ
        expiry_date
 FROM openrails.payment_methods
 WHERE rail = ANY ($1::text[])
-  AND ($2::uuid IS NULL OR psp_id = $2::uuid)
+  AND psp_id = $2::uuid
 `
 
 type ReconcileListPaymentMethodsByRailsParams struct {
 	Rails []string
-	PspID *uuid.UUID
+	PspID uuid.UUID
 }
 
 type ReconcileListPaymentMethodsByRailsRow struct {
@@ -1866,13 +1866,13 @@ FROM openrails.payments
 WHERE rail::text = ANY ($1::text[])
   AND deleted_at IS NULL
   AND transaction_id = ANY ($2::text[])
-  AND ($3::uuid IS NULL OR psp_id = $3::uuid)
+  AND psp_id = $3::uuid
 `
 
 type ReconcileListPaymentsByTransactionIDsParams struct {
 	Rails          []string
 	TransactionIds []string
-	PspID          *uuid.UUID
+	PspID          uuid.UUID
 }
 
 type ReconcileListPaymentsByTransactionIDsRow struct {
@@ -2009,12 +2009,12 @@ SELECT id, customer_id, price_id, product_id, status, rail,
 FROM openrails.subscriptions
 WHERE rail = ANY ($1::text[])
   AND deleted_at IS NULL
-  AND ($2::uuid IS NULL OR psp_id = $2::uuid)
+  AND psp_id = $2::uuid
 `
 
 type ReconcileListSubscriptionsByRailsParams struct {
 	Rails []string
-	PspID *uuid.UUID
+	PspID uuid.UUID
 }
 
 type ReconcileListSubscriptionsByRailsRow struct {
@@ -2121,6 +2121,9 @@ WHERE pr.id = $11
       WHERE s.rail_subscription_id = $4
         AND s.deleted_at IS NULL
         AND s.rail = ANY ($12::text[])
+        -- narg here NARROWS nothing: a nil PSP (the declared legacy-book
+        -- import) dedupes against EVERY PSP, which is the conservative side.
+        -- The read queries above are where nil-wide matching was dangerous.
         AND ($10::uuid IS NULL OR s.psp_id = $10::uuid)
   )
 RETURNING id, entitlements_spec_snapshot

--- a/internal/db/queries/EXEMPTIONS.md
+++ b/internal/db/queries/EXEMPTIONS.md
@@ -181,7 +181,7 @@ production writes. Deliberately not started.
 
 ### The inline exemptions
 
-Ten statements, fourteen rule instances, all in already-applied migrations and
+Fourteen statements, twenty rule instances, all in already-applied migrations and
 all classified **PERMANENT — history**:
 rewriting them changes no live database and the honest record is what actually
 ran. The rules stay armed for new migrations.
@@ -197,6 +197,7 @@ ran. The rules stay armed for new migrations.
 | `0031` vault_fingerprint→fingerprint | `renaming-column` | Same hard-cut rationale as `0025` (or#871): `vault` is reserved for HashiCorp Vault, and a caller still naming `vault_fingerprint` must fail loudly rather than read a stale alias. |
 | `0031` payments token_type CHECK | `constraint-missing-not-valid` | The two `UPDATE`s immediately above rewrite every row the re-added CHECK then validates, in the same transaction — the constraint is dropped and restored only to move `provider_vault`/`pan_via_vault` to their new names. |
 | `0044` host_lifecycle_events.currency | `adding-not-nullable-field` | The rule's own suggested fix — stay nullable, add a `CHECK` — provably cannot satisfy the invariant it exists for: CUR-1 reads `information_schema.columns.is_nullable`, so only the column attribute counts. The scan is inherent to `SET NOT NULL`, not the constraint two-step the sibling rule covers, so no file split reduces it. The table is a delivery feed created in `0037` and pruned after delivery, so the scan is over a small, short-lived table. |
+| `0060` rail_refresh_watermarks PSP cut | `ban-drop-column`, `adding-not-nullable-field`, `disallowed-unique-constraint`, `adding-foreign-key-constraint`, `constraint-missing-not-valid` | or#893 deletes the table's NULL/global lane. `psp_key` is a generated column that existed only to key that lane; the `DELETE … WHERE psp_id IS NULL` two statements earlier removes every row the `SET NOT NULL` and the re-keyed UNIQUE then validate. The table is a resumable cursor — one row per (merchant, rail, PSP, domain) — so every scan here is over a handful of rows, and `NOT VALID` buys nothing inside a single-transaction migrator (see `0014`). |
 
 A new migration that genuinely needs one of these must add the constraint
 `NOT VALID` and `VALIDATE CONSTRAINT` it in a *later* file — one transaction

--- a/internal/db/queries/reconciliation.sql
+++ b/internal/db/queries/reconciliation.sql
@@ -339,7 +339,7 @@ SELECT id, customer_id, price_id, product_id, status, rail,
 FROM openrails.subscriptions
 WHERE rail = ANY (sqlc.arg(rails)::text[])
   AND deleted_at IS NULL
-  AND (sqlc.narg(psp_id)::uuid IS NULL OR psp_id = sqlc.narg(psp_id)::uuid);
+  AND psp_id = sqlc.arg(psp_id)::uuid;
 
 -- name: ReconcileListPaymentsByTransactionIDs :many
 SELECT id, customer_id, rail, transaction_id, amount, status,
@@ -348,7 +348,7 @@ FROM openrails.payments
 WHERE rail::text = ANY (sqlc.arg(rails)::text[])
   AND deleted_at IS NULL
   AND transaction_id = ANY (sqlc.arg(transaction_ids)::text[])
-  AND (sqlc.narg(psp_id)::uuid IS NULL OR psp_id = sqlc.narg(psp_id)::uuid);
+  AND psp_id = sqlc.arg(psp_id)::uuid;
 
 -- name: ReconcileListPaymentMethodsByRails :many
 -- Reconcile is NMI-vault-specific: rail_customer_ref IS the NMI customer_vault_id
@@ -357,7 +357,7 @@ SELECT id, customer_id, rail, rail_customer_ref AS vault_id, last_four, card_typ
        expiry_date
 FROM openrails.payment_methods
 WHERE rail = ANY (sqlc.arg(rails)::text[])
-  AND (sqlc.narg(psp_id)::uuid IS NULL OR psp_id = sqlc.narg(psp_id)::uuid);
+  AND psp_id = sqlc.arg(psp_id)::uuid;
 
 -- name: ReconcileListSolanaSubscriptionRefs :many
 SELECT subscription_pda, plan_pda, subscriber_wallet
@@ -480,6 +480,9 @@ WHERE pr.id = sqlc.arg(price_id)
       WHERE s.rail_subscription_id = sqlc.arg(rail_subscription_id)
         AND s.deleted_at IS NULL
         AND s.rail = ANY (sqlc.arg(rails)::text[])
+        -- narg here NARROWS nothing: a nil PSP (the declared legacy-book
+        -- import) dedupes against EVERY PSP, which is the conservative side.
+        -- The read queries above are where nil-wide matching was dangerous.
         AND (sqlc.narg(psp_id)::uuid IS NULL OR s.psp_id = sqlc.narg(psp_id)::uuid)
   )
 RETURNING id, entitlements_spec_snapshot;
@@ -561,7 +564,7 @@ SELECT s.id, s.status, s.rail,
             SELECT 1 FROM openrails.rail_refresh_watermarks w
             WHERE w.merchant_id = s.merchant_id
               AND w.rail = s.rail
-              AND (w.psp_id IS NULL OR w.psp_id = s.psp_id)
+              AND w.psp_id = s.psp_id
               AND w.watermark_at > s.current_period_ends_at
        ))::bool AS watermark_newer_than_period_end
 FROM openrails.subscriptions s

--- a/internal/reconcile/account_updater_integration_test.go
+++ b/internal/reconcile/account_updater_integration_test.go
@@ -37,14 +37,15 @@ func TestReconcileAdoptsAccountUpdaterRefreshedCard(t *testing.T) {
 		vaultID  = "vault-au-" + uuid.NewString()[:8]
 		methodID = uuid.New()
 	)
+	psp := seedTestPSPBindingFor(t, appDB, baseCtx, mid.UUID(), "nmi")
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
-		seeded = seedReconcileFixtures(t, ctx, appDB, mid.UUID())
+		seeded = seedReconcileFixtures(t, ctx, appDB, mid.UUID(), psp.ID)
 		_, err := appDB.Qx(ctx).Exec(ctx, `
 			INSERT INTO openrails.payment_methods
 			  (id, merchant_id, customer_id, rail, rail_customer_ref, rail_method_ref,
-			   initial_transaction_id, last_four, card_type, expiry_date)
-			VALUES ($1, $2, $3, 'nmi', $4, '', '', '1111', 'visa', '1226')`,
-			methodID, mid.UUID(), seeded.subjectID, vaultID)
+			   initial_transaction_id, last_four, card_type, expiry_date, psp_id)
+			VALUES ($1, $2, $3, 'nmi', $4, '', '', '1111', 'visa', '1226', $5)`,
+			methodID, mid.UUID(), seeded.subjectID, vaultID, psp.ID)
 		return err
 	}))
 	t.Cleanup(func() {
@@ -95,7 +96,7 @@ func TestReconcileAdoptsAccountUpdaterRefreshedCard(t *testing.T) {
 
 	var enforce *RunResult
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
-		res, err := newEngine(snapshot()).Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+		res, err := newEngine(snapshot()).Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: map[Provider]RailMerchantAccountBinding{ProviderNMI: psp}})
 		enforce = res
 		return err
 	}))
@@ -150,7 +151,7 @@ func TestReconcileAdoptsAccountUpdaterRefreshedCard(t *testing.T) {
 	// to fix the provider's card back to our old copy.
 	var second *RunResult
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
-		res, err := newEngine(snapshot()).Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+		res, err := newEngine(snapshot()).Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: map[Provider]RailMerchantAccountBinding{ProviderNMI: psp}})
 		second = res
 		return err
 	}))

--- a/internal/reconcile/cancel_budget_test.go
+++ b/internal/reconcile/cancel_budget_test.go
@@ -56,7 +56,7 @@ func TestCancellationCapHaltsATruncatedRoster(t *testing.T) {
 	}
 	eng, store, writer := newTestEngine(ProviderNMI, snap, local)
 
-	res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+	res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 	require.Error(t, err, "170 planned cancellations must halt the pass")
 	assert.Contains(t, err.Error(), "cancellation cap")
 	assert.True(t, res.Summary.Providers["nmi"].Aborted)
@@ -99,7 +99,7 @@ func TestCancellationCapAllowsNormalConvergence(t *testing.T) {
 	}
 	eng, _, writer := newTestEngine(ProviderNMI, snap, local)
 
-	res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+	res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 	require.NoError(t, err)
 	assert.False(t, res.Summary.Providers["nmi"].Aborted)
 	assert.Equal(t, 3, writer.calls["cancel"])

--- a/internal/reconcile/converge/converge_needs_verification_integration_test.go
+++ b/internal/reconcile/converge/converge_needs_verification_integration_test.go
@@ -117,7 +117,7 @@ func TestConverge_PeriodOverdue_WatermarkEvidence(t *testing.T) {
 	e := NewConvergeEngine(appDB)
 	sfx := uuid.NewString()[:8]
 	prod, price, sub, pm, wm := uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()
-	var cust uuid.UUID
+	var cust, psp uuid.UUID
 	periodEnd := time.Now().UTC().Add(-30 * 24 * time.Hour) // stale period
 	start := periodEnd.Add(-30 * 24 * time.Hour)
 
@@ -130,11 +130,16 @@ func TestConverge_PeriodOverdue_WatermarkEvidence(t *testing.T) {
 		exec(`INSERT INTO openrails.products (id,key,display_name,entitlements_spec,merchant_id) VALUES ($1,$2,$2,'{}'::jsonb,$3)`, prod, "wmev-"+sfx, merchantID)
 		exec(`INSERT INTO openrails.prices (id,product_id,amount,currency,merchant_id) VALUES ($1,$2,5000000,'USD',$3)`, price, prod, merchantID)
 		exec(`INSERT INTO openrails.payment_methods (id,merchant_id,customer_id,rail,rail_customer_ref,rail_method_ref,initial_transaction_id) VALUES ($1,$2,$3,'nmi','wm-cust','wm-vault','wm-tx')`, pm, merchantID, cust)
-		exec(`INSERT INTO openrails.subscriptions (id,merchant_id,customer_id,product_id,price_id,status,rail,payment_method_id,started_at,current_period_starts_at,current_period_ends_at)
-		      VALUES ($1,$2,$3,$4,$5,'active','nmi',$6,$7,$7,$8)`, sub, merchantID, cust, prod, price, pm, start, periodEnd)
-		// Provider truth synced past the period end (global NMI lane).
-		exec(`INSERT INTO openrails.rail_refresh_watermarks (id,merchant_id,rail,event_domain,watermark_at) VALUES ($1,$2,'nmi','events',$3)`,
-			wm, merchantID, time.Now().UTC().Add(-time.Hour))
+		// or#893: the watermark is the cursor of ONE PSP's event stream, so it is
+		// only evidence about the subscriptions of THAT PSP. Both rows name it.
+		require.NoError(t, appDB.Qx(ctx).QueryRow(ctx,
+			`INSERT INTO openrails.psps (merchant_id, rail, account_id) VALUES ($1,'nmi',$2) RETURNING id`,
+			merchantID, "nmi-wmev-"+sfx).Scan(&psp))
+		exec(`INSERT INTO openrails.subscriptions (id,merchant_id,customer_id,product_id,price_id,status,rail,payment_method_id,started_at,current_period_starts_at,current_period_ends_at,psp_id)
+		      VALUES ($1,$2,$3,$4,$5,'active','nmi',$6,$7,$7,$8,$9)`, sub, merchantID, cust, prod, price, pm, start, periodEnd, psp)
+		// Provider truth synced past the period end, for THIS PSP.
+		exec(`INSERT INTO openrails.rail_refresh_watermarks (id,merchant_id,rail,psp_id,event_domain,watermark_at) VALUES ($1,$2,'nmi',$3,'events',$4)`,
+			wm, merchantID, psp, time.Now().UTC().Add(-time.Hour))
 		return nil
 	}))
 	t.Cleanup(func() {
@@ -145,6 +150,7 @@ func TestConverge_PeriodOverdue_WatermarkEvidence(t *testing.T) {
 			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.payment_methods WHERE id=$1`, pm)
 			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.prices WHERE id=$1`, price)
 			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.products WHERE id=$1`, prod)
+			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.psps WHERE id=$1`, psp)
 			return nil
 		})
 	})
@@ -155,6 +161,67 @@ func TestConverge_PeriodOverdue_WatermarkEvidence(t *testing.T) {
 		var s string
 		require.NoError(t, appDB.Qx(ctx).QueryRow(ctx, `SELECT status FROM openrails.subscriptions WHERE id=$1`, sub).Scan(&s))
 		require.Equal(t, "past_due", s, "watermark newer than period end = ownership evidence -> dunning")
+		return nil
+	}))
+}
+
+// or#893: the same watermark is NOT evidence about a SIBLING PSP's book. It used
+// to be — the evidence leg matched `w.psp_id IS NULL OR w.psp_id = s.psp_id`, so
+// one freshly-pulled account vouched for an account nobody had read, and the
+// sibling's lapsed subscription was demoted to dunning on a pull it never had.
+func TestConverge_PeriodOverdue_WatermarkOfAnotherPSPIsNotEvidence(t *testing.T) {
+	appDB := startReconcilePostgres(t)
+	merchantID := dbtest.TestMerchantID.UUID()
+	baseCtx := merchant.WithID(context.Background(), dbtest.TestMerchantID)
+	e := NewConvergeEngine(appDB)
+	sfx := uuid.NewString()[:8]
+	prod, price, sub, pm, wm := uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	var cust, pulledPSP, silentPSP uuid.UUID
+	periodEnd := time.Now().UTC().Add(-30 * 24 * time.Hour)
+	start := periodEnd.Add(-30 * 24 * time.Hour)
+
+	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
+		cust = dbtest.EnsureCustomerIDPgx(ctx, t, appDB.Qx(ctx), uuid.NewString())
+		exec := func(sql string, args ...any) {
+			_, err := appDB.Qx(ctx).Exec(ctx, sql, args...)
+			require.NoError(t, err)
+		}
+		exec(`INSERT INTO openrails.products (id,key,display_name,entitlements_spec,merchant_id) VALUES ($1,$2,$2,'{}'::jsonb,$3)`, prod, "wmsib-"+sfx, merchantID)
+		exec(`INSERT INTO openrails.prices (id,product_id,amount,currency,merchant_id) VALUES ($1,$2,5000000,'USD',$3)`, price, prod, merchantID)
+		exec(`INSERT INTO openrails.payment_methods (id,merchant_id,customer_id,rail,rail_customer_ref,rail_method_ref,initial_transaction_id) VALUES ($1,$2,$3,'nmi','sib-cust','sib-vault','sib-tx')`, pm, merchantID, cust)
+		require.NoError(t, appDB.Qx(ctx).QueryRow(ctx,
+			`INSERT INTO openrails.psps (merchant_id, rail, account_id) VALUES ($1,'nmi',$2) RETURNING id`,
+			merchantID, "nmi-pulled-"+sfx).Scan(&pulledPSP))
+		require.NoError(t, appDB.Qx(ctx).QueryRow(ctx,
+			`INSERT INTO openrails.psps (merchant_id, rail, account_id) VALUES ($1,'nmi',$2) RETURNING id`,
+			merchantID, "nmi-silent-"+sfx).Scan(&silentPSP))
+		// The lapsed subscription belongs to the PSP nobody pulled.
+		exec(`INSERT INTO openrails.subscriptions (id,merchant_id,customer_id,product_id,price_id,status,rail,payment_method_id,started_at,current_period_starts_at,current_period_ends_at,psp_id)
+		      VALUES ($1,$2,$3,$4,$5,'active','nmi',$6,$7,$7,$8,$9)`, sub, merchantID, cust, prod, price, pm, start, periodEnd, silentPSP)
+		// Fresh provider truth — but for the OTHER account.
+		exec(`INSERT INTO openrails.rail_refresh_watermarks (id,merchant_id,rail,psp_id,event_domain,watermark_at) VALUES ($1,$2,'nmi',$3,'events',$4)`,
+			wm, merchantID, pulledPSP, time.Now().UTC().Add(-time.Hour))
+		return nil
+	}))
+	t.Cleanup(func() {
+		_ = appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
+			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.rail_refresh_watermarks WHERE id=$1`, wm)
+			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.reconciliation_findings WHERE merchant_id=$1 AND subject_key=$2`, merchantID, "subscription:"+sub.String())
+			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.subscriptions WHERE id=$1`, sub)
+			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.payment_methods WHERE id=$1`, pm)
+			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.prices WHERE id=$1`, price)
+			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.products WHERE id=$1`, prod)
+			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.psps WHERE id=ANY($1)`, []uuid.UUID{pulledPSP, silentPSP})
+			return nil
+		})
+	})
+
+	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
+		_, err := e.Converge(ctx, Scope{Merchant: dbtest.TestMerchantID, Customer: &cust})
+		require.NoError(t, err)
+		var s string
+		require.NoError(t, appDB.Qx(ctx).QueryRow(ctx, `SELECT status FROM openrails.subscriptions WHERE id=$1`, sub).Scan(&s))
+		require.Equal(t, "unknown", s, "a sibling PSP's watermark is not ownership evidence: no evidence parks the row, it does not dun it")
 		return nil
 	}))
 }

--- a/internal/reconcile/destructive_guards_integration_test.go
+++ b/internal/reconcile/destructive_guards_integration_test.go
@@ -26,14 +26,24 @@ type guardCohort struct {
 	subs     []uuid.UUID
 	railSubs []string
 	suffix   string
+	// psp is the PSP the cohort's mirror rows carry — a pull must be bound to
+	// it to see them at all (or#893).
+	psp RailMerchantAccountBinding
 }
 
 // seedGuardCohort creates n NMI subscriptions in `status`, each with a live
 // `premium` entitlement window, and registers their cleanup.
 func seedGuardCohort(t *testing.T, appDB *db.DB, baseCtx context.Context, n int, status string, periodEnd time.Time) guardCohort {
 	t.Helper()
+	return seedGuardCohortForPSP(t, appDB, baseCtx, n, status, periodEnd, seedTestPSPBinding(t, appDB, baseCtx, "nmi"))
+}
+
+// seedGuardCohortForPSP seeds the cohort under a NAMED PSP (or#893: mirror rows
+// carry the PSP that produced them, and a pull only ever sees its own).
+func seedGuardCohortForPSP(t *testing.T, appDB *db.DB, baseCtx context.Context, n int, status string, periodEnd time.Time, psp RailMerchantAccountBinding) guardCohort {
+	t.Helper()
 	merchantID := dbtest.TestMerchantID.UUID()
-	c := guardCohort{suffix: uuid.NewString()[:8]}
+	c := guardCohort{suffix: uuid.NewString()[:8], psp: psp}
 	start := periodEnd.Add(-30 * 24 * time.Hour)
 
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
@@ -52,9 +62,9 @@ func seedGuardCohort(t *testing.T, appDB *db.DB, baseCtx context.Context, n int,
 			      VALUES ($1,$2,5000000,'USD',720,true,$3)`, price, prod, merchantID)
 			exec(`INSERT INTO openrails.subscriptions
 			        (id,merchant_id,customer_id,product_id,price_id,status,rail,rail_subscription_id,
-			         started_at,current_period_starts_at,current_period_ends_at,entitlements_spec_snapshot)
-			      VALUES ($1,$2,$3,$4,$5,$6,'nmi',$7,$8,$8,$9,jsonb_build_object('premium',null))`,
-				sub, merchantID, cust, prod, price, status, rs, start, periodEnd)
+			         started_at,current_period_starts_at,current_period_ends_at,entitlements_spec_snapshot,psp_id)
+			      VALUES ($1,$2,$3,$4,$5,$6,'nmi',$7,$8,$8,$9,jsonb_build_object('premium',null),$10)`,
+				sub, merchantID, cust, prod, price, status, rs, start, periodEnd, psp.ID)
 			exec(`INSERT INTO openrails.entitlements (merchant_id,customer_id,entitlement,start_at,end_at,source_id,source_type)
 			      VALUES ($1,$2,'premium',$3,$4,$5,'subscription')`,
 				merchantID, cust, start, periodEnd.Add(720*time.Hour), sub)
@@ -277,8 +287,10 @@ func TestPull_SecondPSPBookSurvivesASinglePSPPull(t *testing.T) {
 	baseCtx := merchant.WithID(context.Background(), dbtest.TestMerchantID)
 	now := time.Now().UTC().Truncate(time.Second)
 
-	pulled := seedGuardCohort(t, appDB, baseCtx, 6, "active", now.Add(30*24*time.Hour))
-	unpulled := seedGuardCohort(t, appDB, baseCtx, 6, "active", now.Add(30*24*time.Hour))
+	armed := seedTestPSPBinding(t, appDB, baseCtx, "nmi")
+	sibling := seedTestPSPBinding(t, appDB, baseCtx, "nmi")
+	pulled := seedGuardCohortForPSP(t, appDB, baseCtx, 6, "active", now.Add(30*24*time.Hour), armed)
+	unpulled := seedGuardCohortForPSP(t, appDB, baseCtx, 6, "active", now.Add(30*24*time.Hour), sibling)
 
 	// The armed PSP's roster: complete and exhaustive FOR ITS OWN ACCOUNT.
 	next := now.Add(30 * 24 * time.Hour)
@@ -311,8 +323,11 @@ func TestPull_SecondPSPBookSurvivesASinglePSPPull(t *testing.T) {
 			Mode:      ModeEnforce,
 			Mutations: &LocalMutationPolicy{Insert: false, Overwrite: true},
 			Providers: []Provider{ProviderNMI},
-			// Two PSPs declared active on nmi; this pass read one.
-			PSPCoverage: map[Provider]PSPCoverage{ProviderNMI: {Declared: 2, Pulled: 1}},
+			// or#893: the pass is BOUND to the PSP it armed from, so the sibling's
+			// book is not even in the local set it diffs. #841's coverage strip is
+			// the second belt: two PSPs declared active, this pass read one.
+			PSPs:        map[Provider]RailMerchantAccountBinding{ProviderNMI: armed},
+			PSPCoverage: map[Provider]PSPCoverage{ProviderNMI: {Declared: 2, Pulled: 1, Binding: armed}},
 		})
 		return err
 	}))

--- a/internal/reconcile/engine.go
+++ b/internal/reconcile/engine.go
@@ -102,9 +102,10 @@ type RunParams struct {
 	// SubscriptionsExhaustive: a roster that saw one of two accounts cannot
 	// prove a subscription of the OTHER account is gone.
 	PSPCoverage map[Provider]PSPCoverage
-	// PSPs optionally binds each provider section to one
-	// merchant-scoped provider account. When set, the engine scopes local mirror
-	// reads and local materialization writes to that account id.
+	// PSPs binds each provider section to the ONE merchant-scoped PSP whose
+	// credentials armed its fetcher. REQUIRED (or#893): the engine scopes local
+	// mirror reads and stamps local materialization writes with it, and a
+	// provider with no binding is refused rather than run account-agnostically.
 	PSPs map[Provider]RailMerchantAccountBinding
 	// Since/Until bound the transaction window passed to the fetchers.
 	Since time.Time
@@ -372,10 +373,15 @@ func (e *Engine) runProvider(ctx context.Context, runID uuid.UUID, provider Prov
 	}
 
 	fetcher := e.Fetchers[provider]
-	binding := params.PSPs[provider]
-	if binding.ID != uuid.Nil {
-		rep.PspID = binding.ID.String()
+	// or#893: a pull is always bound to the ONE PSP whose credentials armed its
+	// fetcher. An unbound section used to read and write the rail's local mirror
+	// account-agnostically: the roster of PSP A was diffed against the rows of
+	// PSP B, and every row it materialised carried NULL provenance. Refuse.
+	binding, ok := params.PSPs[provider]
+	if !ok || binding.ID == uuid.Nil {
+		return rep, nil, nil, nil, fmt.Errorf("no PSP binding for provider %s: a pull must name the PSP its credentials armed from", provider)
 	}
+	rep.PspID = binding.ID.String()
 	snap, err := fetcher.Fetch(ctx, FetchParams{
 		Since:     params.Since,
 		Until:     params.Until,
@@ -386,9 +392,7 @@ func (e *Engine) runProvider(ctx context.Context, runID uuid.UUID, provider Prov
 	if err != nil {
 		return rep, nil, nil, nil, fmt.Errorf("fetch: %w", err)
 	}
-	if binding.ID != uuid.Nil {
-		snap.PspID = binding.ID.String()
-	}
+	snap.PspID = binding.ID.String()
 	// #841: strip the absence proof when the pass did not read every active PSP
 	// on the rail. A merchant running mobius + paykings on NMI would otherwise
 	// have the non-armed PSP's entire book cancelled as "absent from an
@@ -404,7 +408,7 @@ func (e *Engine) runProvider(ctx context.Context, runID uuid.UUID, provider Prov
 	rep.RemoteTransactions = len(snap.Transactions)
 	rep.RemotePaymentMethods = len(snap.PaymentMethods)
 
-	local, err := e.Local.Load(ctx, provider, nullableRailMerchantAccountID(binding))
+	local, err := e.Local.Load(ctx, provider, binding.ID)
 	if err != nil {
 		return rep, nil, nil, nil, fmt.Errorf("load local state: %w", err)
 	}
@@ -437,7 +441,7 @@ func (e *Engine) runProvider(ctx context.Context, runID uuid.UUID, provider Prov
 	// Local payments are looked up by the snapshot's transaction identity
 	// set (plus refund->charge links) rather than a date window.
 	txnIDs := collectTxnLookupIDs(snap)
-	localPayments, err := e.Local.PaymentsByTransactionIDs(ctx, provider, nullableRailMerchantAccountID(binding), txnIDs)
+	localPayments, err := e.Local.PaymentsByTransactionIDs(ctx, provider, binding.ID, txnIDs)
 	if err != nil {
 		return rep, nil, nil, nil, fmt.Errorf("load local payments: %w", err)
 	}
@@ -447,7 +451,7 @@ func (e *Engine) runProvider(ctx context.Context, runID uuid.UUID, provider Prov
 		Materialize:   params.Mode == ModeEnforce && params.Mutations.allowsInsert(),
 		EvidenceFloor: e.evidenceFloor(ctx),
 	})
-	bindApplyActions(findings, nullableRailMerchantAccountID(binding))
+	bindApplyActions(findings, binding.ID)
 
 	if snap.Capabilities.Transactions {
 		history, historyNote := e.fetchHistory(ctx, provider, params)
@@ -719,17 +723,11 @@ func (e *Engine) coveredWindow(provider Provider, params RunParams, now time.Tim
 	return since, until
 }
 
-func nullableRailMerchantAccountID(binding RailMerchantAccountBinding) *uuid.UUID {
-	if binding.ID == uuid.Nil {
-		return nil
-	}
-	return &binding.ID
-}
-
-func bindApplyActions(findings []Finding, pspID *uuid.UUID) {
-	if pspID == nil {
-		return
-	}
+// bindApplyActions stamps the pull's PSP onto every local write the pass will
+// perform. or#893: the pass always HAS a PSP now (runProvider refuses a section
+// without one), so no mirror row the pull path creates is unattributed.
+func bindApplyActions(findings []Finding, psp uuid.UUID) {
+	pspID := &psp
 	for i := range findings {
 		a := findings[i].Apply
 		if a == nil {

--- a/internal/reconcile/engine_test.go
+++ b/internal/reconcile/engine_test.go
@@ -57,7 +57,7 @@ type fakeLocal struct {
 	payments []LocalPayment
 }
 
-func (l *fakeLocal) Load(ctx context.Context, provider Provider, _ *uuid.UUID) (*LocalState, error) {
+func (l *fakeLocal) Load(ctx context.Context, provider Provider, _ uuid.UUID) (*LocalState, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	cp := LocalState{
@@ -74,7 +74,7 @@ func (l *fakeLocal) entsSnapshot() []localEntitlement {
 	return append([]localEntitlement(nil), l.ents...)
 }
 
-func (l *fakeLocal) PaymentsByTransactionIDs(ctx context.Context, provider Provider, _ *uuid.UUID, ids []string) ([]LocalPayment, error) {
+func (l *fakeLocal) PaymentsByTransactionIDs(ctx context.Context, provider Provider, _ uuid.UUID, ids []string) ([]LocalPayment, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	want := map[string]bool{}
@@ -650,7 +650,7 @@ func TestDiffTaxonomy(t *testing.T) {
 			},
 		}
 		eng, store, writer := newTestEngine(ProviderNMI, snap, local)
-		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 		require.NoError(t, err)
 
 		ps1 := findByType(res.Findings, FindingRemoteSubMissingLocal)
@@ -678,7 +678,7 @@ func TestDiffTaxonomy(t *testing.T) {
 			},
 		}
 		eng, _, _ := newTestEngine(ProviderNMI, snap, local)
-		res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 		require.NoError(t, err)
 		ps1 := findByType(res.Findings, FindingRemoteSubMissingLocal)
 		require.Len(t, ps1, 1)
@@ -710,7 +710,7 @@ func TestDiffTaxonomy(t *testing.T) {
 		eng, store, writer := newTestEngine(ProviderNMI, snap, local)
 		// 1 of 2 remote-live clears the ratio breaker, 1 cancellation clears the
 		// per-pass cap.
-		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 		require.NoError(t, err)
 
 		ps2 := findByType(res.Findings, FindingLocalActiveRemoteDead)
@@ -726,7 +726,7 @@ func TestDiffTaxonomy(t *testing.T) {
 		assert.Equal(t, 1, writer.calls["revoke"])
 
 		// Local state converged: the subscription is cancelled, entitlements gone.
-		st, _ := local.Load(ctx, ProviderNMI, nil)
+		st, _ := local.Load(ctx, ProviderNMI, uuid.Nil)
 		for _, s := range st.Subscriptions {
 			if s.ID == dead.ID {
 				assert.Equal(t, "cancelled", s.Status)
@@ -750,7 +750,7 @@ func TestDiffTaxonomy(t *testing.T) {
 			},
 		}
 		eng, _, _ := newTestEngine(ProviderStripe, snap, local)
-		res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderStripe}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderStripe}, PSPs: testPSPs(ProviderStripe)})
 		require.NoError(t, err)
 		ps2 := findByType(res.Findings, FindingLocalActiveRemoteDead)
 		require.Len(t, ps2, 1)
@@ -767,7 +767,7 @@ func TestDiffTaxonomy(t *testing.T) {
 			// Empty ACTIVEMEMBERS + no termination events: proves nothing.
 		}
 		eng, _, _ := newTestEngine(ProviderCCBill, snap, local)
-		res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderCCBill}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderCCBill}, PSPs: testPSPs(ProviderCCBill)})
 		require.NoError(t, err)
 		assert.Empty(t, findByType(res.Findings, FindingLocalActiveRemoteDead))
 	})
@@ -787,7 +787,7 @@ func TestDiffTaxonomy(t *testing.T) {
 			},
 		}
 		eng, store, writer := newTestEngine(ProviderStripe, snap, local)
-		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderStripe}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderStripe}, PSPs: testPSPs(ProviderStripe)})
 		require.NoError(t, err)
 		ps3 := findByType(res.Findings, FindingStatusMismatch)
 		require.Len(t, ps3, 1)
@@ -806,7 +806,7 @@ func TestDiffTaxonomy(t *testing.T) {
 		rec := store.record(ProviderStripe, FindingStatusMismatch, sub.ID.String())
 		assert.Equal(t, FindingStatusAutoFixed, rec.Status)
 
-		st, _ := local.Load(ctx, ProviderStripe, nil)
+		st, _ := local.Load(ctx, ProviderStripe, uuid.Nil)
 		assert.Equal(t, "active", st.Subscriptions[0].Status)
 		require.NotNil(t, st.Subscriptions[0].CurrentPeriodEndsAt)
 		assert.True(t, st.Subscriptions[0].CurrentPeriodEndsAt.Equal(remoteEnd))
@@ -827,7 +827,7 @@ func TestDiffTaxonomy(t *testing.T) {
 			},
 		}
 		eng, _, writer := newTestEngine(ProviderStripe, snap, local)
-		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderStripe}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderStripe}, PSPs: testPSPs(ProviderStripe)})
 		require.NoError(t, err)
 		ps3 := findByType(res.Findings, FindingStatusMismatch)
 		require.Len(t, ps3, 1)
@@ -853,7 +853,7 @@ func TestDiffTaxonomy(t *testing.T) {
 			},
 		}
 		eng, store, writer := newTestEngine(ProviderNMI, snap, local)
-		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 		require.NoError(t, err)
 
 		ps4 := findByType(res.Findings, FindingChargeMissingLocal)
@@ -865,7 +865,7 @@ func TestDiffTaxonomy(t *testing.T) {
 		assert.Equal(t, FindingStatusAutoFixed, rec.Status)
 
 		// Payment exists + entitlement granted for the current period.
-		payments, _ := local.PaymentsByTransactionIDs(ctx, ProviderNMI, nil, []string{"txn-1001"})
+		payments, _ := local.PaymentsByTransactionIDs(ctx, ProviderNMI, uuid.Nil, []string{"txn-1001"})
 		require.Len(t, payments, 1)
 		assert.Equal(t, sub.CustomerID, payments[0].CustomerID)
 		ents := local.entsSnapshot()
@@ -895,7 +895,7 @@ func TestDiffTaxonomy(t *testing.T) {
 			Transactions: []RemoteTransaction{txn},
 		}
 		eng, _, writer := newTestEngine(ProviderNMI, snap, local)
-		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 		require.NoError(t, err)
 		ps4 := findByType(res.Findings, FindingChargeMissingLocal)
 		require.Len(t, ps4, 1)
@@ -930,7 +930,7 @@ func TestDiffTaxonomy(t *testing.T) {
 			Transactions: []RemoteTransaction{refund},
 		}
 		eng, store, writer := newTestEngine(ProviderNMI, snap, local)
-		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 		require.NoError(t, err)
 
 		ps5 := findByType(res.Findings, FindingRefundUnrecorded)
@@ -938,7 +938,7 @@ func TestDiffTaxonomy(t *testing.T) {
 		assert.Equal(t, 1, writer.calls["record_refund"])
 		rec := store.record(ProviderNMI, FindingRefundUnrecorded, "txn-5001")
 		assert.Equal(t, FindingStatusAutoFixed, rec.Status)
-		payments, _ := local.PaymentsByTransactionIDs(ctx, ProviderNMI, nil, []string{"txn-5001"})
+		payments, _ := local.PaymentsByTransactionIDs(ctx, ProviderNMI, uuid.Nil, []string{"txn-5001"})
 		require.Len(t, payments, 1)
 		assert.Equal(t, "refunded", payments[0].Status)
 	})
@@ -964,7 +964,7 @@ func TestDiffTaxonomy(t *testing.T) {
 			},
 		}
 		eng, _, _ := newTestEngine(ProviderStripe, snap, local)
-		res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderStripe}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderStripe}, PSPs: testPSPs(ProviderStripe)})
 		require.NoError(t, err)
 		assert.Empty(t, findByType(res.Findings, FindingRefundUnrecorded))
 	})
@@ -989,7 +989,7 @@ func TestDiffTaxonomy(t *testing.T) {
 			},
 		}
 		eng, _, writer := newTestEngine(ProviderStripe, snap, local)
-		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderStripe}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderStripe}, PSPs: testPSPs(ProviderStripe)})
 		require.NoError(t, err)
 		ps6 := findByType(res.Findings, FindingChargebackActiveSub)
 		require.Len(t, ps6, 1)
@@ -1019,7 +1019,7 @@ func TestDiffTaxonomy(t *testing.T) {
 			},
 		}
 		eng, store, writer := newTestEngine(ProviderNMI, snap, local)
-		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 		require.NoError(t, err)
 		ps7 := findByType(res.Findings, FindingPaymentMethodMismatch)
 		require.Len(t, ps7, 1)
@@ -1027,7 +1027,7 @@ func TestDiffTaxonomy(t *testing.T) {
 		assert.Equal(t, 1, writer.calls["adopt_vault"])
 		rec := store.record(ProviderNMI, FindingPaymentMethodMismatch, "vault-7")
 		assert.Equal(t, FindingStatusAutoFixed, rec.Status)
-		st, _ := local.Load(ctx, ProviderNMI, nil)
+		st, _ := local.Load(ctx, ProviderNMI, uuid.Nil)
 		assert.Equal(t, "2222", st.PaymentMethods[0].LastFour)
 	})
 
@@ -1049,7 +1049,7 @@ func TestDiffTaxonomy(t *testing.T) {
 			},
 		}
 		eng, _, writer := newTestEngine(ProviderNMI, snap, local)
-		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 		require.NoError(t, err)
 		ps8 := findByType(res.Findings, FindingDuplicateSubscriptions)
 		require.Len(t, ps8, 1)
@@ -1083,7 +1083,7 @@ func TestPullProofsOnlyFromCompletedProviders(t *testing.T) {
 	eng, _, _ := newTestEngine(ProviderNMI, okSnap, local)
 	eng.Fetchers[ProviderStripe] = &fakeFetcher{provider: ProviderStripe, err: fmt.Errorf("stripe down")}
 
-	res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory})
+	res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, PSPs: testPSPs(ProviderNMI, ProviderStripe, ProviderCCBill, ProviderSolana)})
 	require.Error(t, err, "the failed provider fails the run")
 	require.NotNil(t, res)
 
@@ -1109,7 +1109,7 @@ func TestCircuitBreakerAbortsAbsenceBasedPS2(t *testing.T) {
 		},
 	}
 	eng, store, writer := newTestEngine(ProviderNMI, snap, local)
-	res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+	res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "circuit breaker")
 	assert.Equal(t, "failed", res.Status)
@@ -1137,7 +1137,7 @@ func TestSmallMerchantsAreProtectedFromEmptyRosters(t *testing.T) {
 			Coverage:     SnapshotCoverage{SubscriptionsExhaustive: true},
 		}
 		eng, _, writer := newTestEngine(ProviderNMI, snap, local)
-		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 		require.Error(t, err, "book of %d: an empty roster must not sail through", book)
 		assert.Contains(t, err.Error(), "circuit breaker")
 		assert.True(t, res.Summary.Providers["nmi"].Aborted)
@@ -1161,12 +1161,12 @@ func TestIdentityStableAcrossRuns(t *testing.T) {
 	}
 	eng, store, _ := newTestEngine(ProviderStripe, snap, local)
 
-	res1, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderStripe}})
+	res1, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderStripe}, PSPs: testPSPs(ProviderStripe)})
 	require.NoError(t, err)
 	require.Len(t, res1.Findings, 1)
 	assert.Equal(t, 1, res1.Summary.Providers["stripe"].NewFindings)
 
-	res2, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderStripe}})
+	res2, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderStripe}, PSPs: testPSPs(ProviderStripe)})
 	require.NoError(t, err)
 	require.Len(t, res2.Findings, 1)
 	assert.Equal(t, 0, res2.Summary.Providers["stripe"].NewFindings)
@@ -1191,7 +1191,7 @@ func TestAutoResolveOnDisappearance(t *testing.T) {
 		},
 	}
 	eng, store, _ := newTestEngine(ProviderStripe, deadSnap, local)
-	_, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderStripe}})
+	_, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderStripe}, PSPs: testPSPs(ProviderStripe)})
 	require.NoError(t, err)
 	require.Equal(t, FindingStatusReconcileRequired, store.record(ProviderStripe, FindingLocalActiveRemoteDead, sub.ID.String()).Status)
 
@@ -1203,7 +1203,7 @@ func TestAutoResolveOnDisappearance(t *testing.T) {
 			{RailSubscriptionID: "sub_vanish", Status: SubscriptionStatusActive, NextBillingAt: tp(*sub.CurrentPeriodEndsAt)},
 		},
 	}}
-	res2, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderStripe}})
+	res2, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderStripe}, PSPs: testPSPs(ProviderStripe)})
 	require.NoError(t, err)
 
 	rec := store.record(ProviderStripe, FindingLocalActiveRemoteDead, sub.ID.String())
@@ -1231,7 +1231,7 @@ func TestIntentAnnotationForRecordedDelete(t *testing.T) {
 		},
 	}
 	eng, _, writer := newTestEngine(ProviderNMI, snap, local)
-	res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+	res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 	require.NoError(t, err)
 
 	ps3 := findByType(res.Findings, FindingStatusMismatch)
@@ -1270,7 +1270,7 @@ func TestCapabilityGating(t *testing.T) {
 		PaymentMethods: []RemotePaymentMethod{{RailCustomerRef: "vault-gate", CardLast4: "9999", CardExpiry: "1299"}},
 	}
 	eng, _, _ := newTestEngine(ProviderNMI, snap, local)
-	res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}})
+	res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 	require.NoError(t, err)
 
 	assert.Empty(t, findByType(res.Findings, FindingChargebackActiveSub), "PS-6 must be capability-gated")
@@ -1293,7 +1293,7 @@ func TestEnforceIsIdempotent(t *testing.T) {
 	}
 	eng, store, writer := newTestEngine(ProviderNMI, snap, local)
 
-	res1, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+	res1, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 	require.NoError(t, err)
 	assert.Equal(t, 1, res1.Summary.Providers["nmi"].AutoFixed)
 	firstCalls := writer.totalCalls()
@@ -1301,7 +1301,7 @@ func TestEnforceIsIdempotent(t *testing.T) {
 
 	// Second enforce run: local state already converged, so the diff is empty
 	// and no write happens.
-	res2, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+	res2, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 	require.NoError(t, err)
 	assert.Empty(t, res2.Findings, "second enforce run must see a converged state")
 	assert.Equal(t, 0, res2.Summary.Providers["nmi"].AutoFixed)
@@ -1326,7 +1326,7 @@ func TestAdvisoryNeverWrites(t *testing.T) {
 		},
 	}
 	eng, store, writer := newTestEngine(ProviderNMI, snap, local)
-	res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}})
+	res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 	require.NoError(t, err)
 	require.NotEmpty(t, res.Findings)
 	assert.Zero(t, writer.totalCalls(), "advisory mode performs zero local writes")
@@ -1348,7 +1348,7 @@ func TestDismissedFindingsStayDismissed(t *testing.T) {
 		},
 	}
 	eng, store, writer := newTestEngine(ProviderStripe, snap, local)
-	_, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderStripe}})
+	_, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderStripe}, PSPs: testPSPs(ProviderStripe)})
 	require.NoError(t, err)
 
 	rec := store.record(ProviderStripe, FindingLocalActiveRemoteDead, sub.ID.String())
@@ -1356,7 +1356,7 @@ func TestDismissedFindingsStayDismissed(t *testing.T) {
 	rec.Status = FindingStatusIgnored
 	store.mu.Unlock()
 
-	_, err = eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderStripe}})
+	_, err = eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderStripe}, PSPs: testPSPs(ProviderStripe)})
 	require.NoError(t, err)
 	rec = store.record(ProviderStripe, FindingLocalActiveRemoteDead, sub.ID.String())
 	assert.Equal(t, FindingStatusIgnored, rec.Status)
@@ -1456,7 +1456,7 @@ func TestMaterializePS1(t *testing.T) {
 	t.Run("advisory PS-1 stays requires_review (advisory never writes)", func(t *testing.T) {
 		local, snap, _ := materializeFixture()
 		eng, store, writer := newTestEngine(ProviderNMI, snap, local)
-		res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 		require.NoError(t, err)
 		ps1 := findByType(res.Findings, FindingRemoteSubMissingLocal)
 		require.Len(t, ps1, 1)
@@ -1469,7 +1469,7 @@ func TestMaterializePS1(t *testing.T) {
 	t.Run("resolvable PS-1 materializes with payment + entitlements and resolves enforced", func(t *testing.T) {
 		local, snap, price := materializeFixture()
 		eng, store, writer := newTestEngine(ProviderNMI, snap, local)
-		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 		require.NoError(t, err)
 
 		ps1 := findByType(res.Findings, FindingRemoteSubMissingLocal)
@@ -1486,7 +1486,7 @@ func TestMaterializePS1(t *testing.T) {
 		assert.Equal(t, true, rec.ResolutionEvid["payment_backfilled"])
 
 		// The local subscription exists with remote status/periods…
-		st, _ := local.Load(ctx, ProviderNMI, nil)
+		st, _ := local.Load(ctx, ProviderNMI, uuid.Nil)
 		var created *LocalSubscription
 		for i := range st.Subscriptions {
 			if st.Subscriptions[i].RailSubscriptionID == "remote-77" {
@@ -1500,14 +1500,14 @@ func TestMaterializePS1(t *testing.T) {
 		assert.True(t, created.CurrentPeriodEndsAt.Equal(*snap.Subscriptions[0].NextBillingAt))
 
 		// …the snapshot charge is backfilled and entitlements granted.
-		payments, _ := local.PaymentsByTransactionIDs(ctx, ProviderNMI, nil, []string{"txn-mat-1"})
+		payments, _ := local.PaymentsByTransactionIDs(ctx, ProviderNMI, uuid.Nil, []string{"txn-mat-1"})
 		require.Len(t, payments, 1)
 		ents := local.entsSnapshot()
 		require.Len(t, ents, 1)
 		assert.Equal(t, created.ID, ents[0].SourceID)
 
 		// Re-run: converged, no duplicate, no second materialize write.
-		res2, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+		res2, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 		require.NoError(t, err)
 		assert.Empty(t, findByType(res2.Findings, FindingRemoteSubMissingLocal))
 		assert.Equal(t, 1, writer.calls["materialize"])
@@ -1523,7 +1523,7 @@ func TestMaterializePS1(t *testing.T) {
 			RailSubscriptionID: "other-1", Status: SubscriptionStatusActive,
 		})
 		eng, _, writer := newTestEngine(ProviderNMI, snap, local)
-		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 		require.NoError(t, err)
 		ps1 := findByType(res.Findings, FindingRemoteSubMissingLocal)
 		require.Len(t, ps1, 1)
@@ -1536,7 +1536,7 @@ func TestMaterializePS1(t *testing.T) {
 		local, snap, _ := materializeFixture()
 		local.state.Prices = nil // no provider link anywhere
 		eng, _, writer := newTestEngine(ProviderNMI, snap, local)
-		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 		require.NoError(t, err)
 		ps1 := findByType(res.Findings, FindingRemoteSubMissingLocal)
 		require.Len(t, ps1, 1)
@@ -1550,7 +1550,7 @@ func TestMaterializePS1(t *testing.T) {
 		snap.Subscriptions[0].Status = SubscriptionStatusPastDue
 		snap.Subscriptions[0].NextBillingAt = nil
 		eng, _, writer := newTestEngine(ProviderNMI, snap, local)
-		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 		require.NoError(t, err)
 		ps1 := findByType(res.Findings, FindingRemoteSubMissingLocal)
 		require.Len(t, ps1, 1)
@@ -1602,7 +1602,7 @@ func TestDunningForensicsHistorySource(t *testing.T) {
 			{Table: "subscription_events", EventType: "subscription_cancelled", Rail: "nmi", RailSubscriptionID: "nmi-hist", OccurredAt: histAt.Add(24 * time.Hour)},
 			{Table: "payment_events", EventType: "charge_failed", Rail: "nmi", OccurredAt: histAt}, // uncorrelated: no ids
 		}}
-		res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 		require.NoError(t, err)
 
 		d := res.Summary.Providers["nmi"].Dunning
@@ -1639,7 +1639,7 @@ func TestDunningForensicsHistorySource(t *testing.T) {
 		local, snap, _ := newFixture()
 		eng, _, _ := newTestEngine(ProviderNMI, snap, local)
 		eng.History = &fakeHistorySource{configured: true, err: fmt.Errorf("dial tcp: connection refused")}
-		res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 		require.NoError(t, err, "history source failure must not fail the run")
 		d := res.Summary.Providers["nmi"].Dunning
 		require.NotNil(t, d)
@@ -1651,7 +1651,7 @@ func TestDunningForensicsHistorySource(t *testing.T) {
 		local, snap, _ := newFixture()
 		eng, _, _ := newTestEngine(ProviderNMI, snap, local)
 		eng.History = &fakeHistorySource{configured: false}
-		res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}})
+		res, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}, PSPs: testPSPs(ProviderNMI)})
 		require.NoError(t, err)
 		d := res.Summary.Providers["nmi"].Dunning
 		require.NotNil(t, d)
@@ -1675,4 +1675,77 @@ func TestParseRebillOrderID(t *testing.T) {
 	assert.False(t, ok)
 	_, ok = parseRebillOrderID("upgrade-12345678-87654321")
 	assert.False(t, ok)
+}
+
+// testPSPs is the or#893 binding every pull now requires: a pass is bound to
+// the ONE PSP whose credentials armed its fetcher. Unit fakes ignore the id;
+// what matters is that the engine refuses to run without it.
+func testPSPs(providers ...Provider) map[Provider]RailMerchantAccountBinding {
+	out := make(map[Provider]RailMerchantAccountBinding, len(providers))
+	for _, p := range providers {
+		out[p] = RailMerchantAccountBinding{ID: uuid.New(), Rail: string(p), AccountID: string(p) + "-test-account"}
+	}
+	return out
+}
+
+// or#893: a pull section with no PSP binding used to run account-agnostically —
+// it read the rail's ENTIRE local mirror (so PSP A's roster judged PSP B's
+// subscriptions) and stamped every row it wrote with NULL provenance. The
+// binding is now a precondition, and the refusal is the whole point: the pull
+// plane always knows which PSP armed it, so an unbound section is a wiring bug,
+// never a lane to fall back to.
+func TestRunRefusesAProviderSectionWithNoPSPBinding(t *testing.T) {
+	ctx := context.Background()
+	local := &fakeLocal{}
+	dead := liveLocalSub(ProviderNMI, "vanished-1")
+	local.state.Subscriptions = []LocalSubscription{dead}
+	withLiveEntitlement(local, &dead)
+	snap := &RemoteSnapshot{
+		Provider:      ProviderNMI,
+		Capabilities:  Capabilities{Subscriptions: true},
+		Coverage:      SnapshotCoverage{SubscriptionsExhaustive: true},
+		Subscriptions: []RemoteSubscription{},
+	}
+	eng, _, writer := newTestEngine(ProviderNMI, snap, local)
+
+	_, err := eng.Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no PSP binding for provider nmi")
+	// And it refused BEFORE touching local state: no cancel, no mirror write.
+	assert.Zero(t, writer.totalCalls())
+
+	// A zero-uuid binding is the same absence wearing a struct.
+	_, err = eng.Run(ctx, RunParams{
+		Mode:      ModeEnforce,
+		Providers: []Provider{ProviderNMI},
+		PSPs:      map[Provider]RailMerchantAccountBinding{ProviderNMI: {Rail: "nmi", AccountID: "mobius"}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no PSP binding for provider nmi")
+	assert.Zero(t, writer.totalCalls())
+}
+
+// or#893: every local write the pass plans carries the pull's PSP. Before, a
+// nil binding short-circuited bindApplyActions and the mirror row landed with
+// NULL provenance — invisible to a PSP-scoped prune, and indistinguishable from
+// the row a sibling PSP would have produced.
+func TestApplyActionsCarryThePullsPSP(t *testing.T) {
+	psp := uuid.New()
+	findings := []Finding{
+		{Apply: &ApplyAction{BackfillPayment: &BackfillPaymentAction{TransactionID: "txn-1"}}},
+		{Apply: &ApplyAction{RecordRefund: &RecordRefundAction{TransactionID: "re-1"}}},
+		{Apply: &ApplyAction{Materialize: &MaterializeSubscriptionAction{
+			RailSubscriptionID: "sub-1",
+			Backfill:           &BackfillPaymentAction{TransactionID: "txn-2"},
+		}}},
+	}
+	bindApplyActions(findings, psp)
+	require.NotNil(t, findings[0].Apply.BackfillPayment.PspID)
+	assert.Equal(t, psp, *findings[0].Apply.BackfillPayment.PspID)
+	require.NotNil(t, findings[1].Apply.RecordRefund.PspID)
+	assert.Equal(t, psp, *findings[1].Apply.RecordRefund.PspID)
+	require.NotNil(t, findings[2].Apply.Materialize.PspID)
+	assert.Equal(t, psp, *findings[2].Apply.Materialize.PspID)
+	require.NotNil(t, findings[2].Apply.Materialize.Backfill.PspID)
+	assert.Equal(t, psp, *findings[2].Apply.Materialize.Backfill.PspID)
 }

--- a/internal/reconcile/evidence_floor_integration_test.go
+++ b/internal/reconcile/evidence_floor_integration_test.go
@@ -82,13 +82,14 @@ func enforcingPullEngine(appDB *db.DB, snap *RemoteSnapshot, now time.Time) *Eng
 	}
 }
 
-func runEnforcingPull(t *testing.T, appDB *db.DB, baseCtx context.Context, eng *Engine) {
+func runEnforcingPull(t *testing.T, appDB *db.DB, baseCtx context.Context, eng *Engine, psp RailMerchantAccountBinding) {
 	t.Helper()
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
 		_, err := eng.Run(ctx, RunParams{
 			Mode:      ModeEnforce,
 			Mutations: &LocalMutationPolicy{Insert: false, Overwrite: true},
 			Providers: []Provider{ProviderNMI},
+			PSPs:      map[Provider]RailMerchantAccountBinding{ProviderNMI: psp},
 		})
 		return err
 	}))
@@ -131,7 +132,7 @@ func TestPull_ArmedMerchantWillNotCancelOnEvidencePredatingTheFirstPull(t *testi
 	// The decline landed 50 days ago — 43 days before this deployment first
 	// looked at the merchant. It came with the imported book.
 	snap := legacyDeclineSnapshot(now, periodEnd, cohort, now.Add(-50*24*time.Hour))
-	runEnforcingPull(t, appDB, baseCtx, enforcingPullEngine(appDB, snap, now))
+	runEnforcingPull(t, appDB, baseCtx, enforcingPullEngine(appDB, snap, now), cohort.psp)
 
 	cancelled, live := guardCounts(t, appDB, baseCtx, cohort)
 	require.Zero(t, cancelled, "%d subscriptions were cancelled on evidence this deployment never observed", cancelled)
@@ -169,7 +170,7 @@ func TestPull_ArmedMerchantStillConvergesOnEvidenceAfterTheFirstPull(t *testing.
 
 	// Declined three days ago — four days after the first pull.
 	snap := legacyDeclineSnapshot(now, periodEnd, cohort, now.Add(-3*24*time.Hour))
-	runEnforcingPull(t, appDB, baseCtx, enforcingPullEngine(appDB, snap, now))
+	runEnforcingPull(t, appDB, baseCtx, enforcingPullEngine(appDB, snap, now), cohort.psp)
 
 	cancelled, live := guardCounts(t, appDB, baseCtx, cohort)
 	require.Equal(t, len(cohort.subs), cancelled, "the floor must not freeze convergence on evidence we observed")

--- a/internal/reconcile/integration_test.go
+++ b/internal/reconcile/integration_test.go
@@ -69,7 +69,7 @@ type seededState struct {
 // seedReconcileFixtures inserts a product, price, tenant subject, and two NMI
 // subscriptions (one that the fake snapshot will keep alive, one that it
 // drops), plus a live subscription-sourced entitlement on each.
-func seedReconcileFixtures(t *testing.T, ctx context.Context, appDB *db.DB, merchantID uuid.UUID) seededState {
+func seedReconcileFixtures(t *testing.T, ctx context.Context, appDB *db.DB, merchantID, pspID uuid.UUID) seededState {
 	t.Helper()
 	s := seededState{
 		productID: uuid.New(),
@@ -112,10 +112,10 @@ func seedReconcileFixtures(t *testing.T, ctx context.Context, appDB *db.DB, merc
 		exec(`INSERT INTO openrails.subscriptions
 		        (id, price_id, product_id, status, rail, rail_subscription_id,
 		         current_period_starts_at, current_period_ends_at, started_at,
-		         entitlements_spec_snapshot, customer_id, merchant_id)
-		      VALUES ($1, $2, $3, 'active', 'nmi', $4, $5, $6, $5, jsonb_build_object($8::text, null), $7, $9)`,
+		         entitlements_spec_snapshot, customer_id, merchant_id, psp_id)
+		      VALUES ($1, $2, $3, 'active', 'nmi', $4, $5, $6, $5, jsonb_build_object($8::text, null), $7, $9, $10)`,
 			subID, priceID, productID, fmt.Sprintf("it-%d-%s", i, suffix),
-			periodStart, periodEnd, s.subjectID, entName, merchantID)
+			periodStart, periodEnd, s.subjectID, entName, merchantID, pspID)
 		entID := uuid.New()
 		if subID == s.subDead {
 			entID = s.entDeadID
@@ -173,9 +173,10 @@ func TestReconcileEngineIntegration(t *testing.T) {
 	mid := newReconcileMerchant(t, appDB)
 	baseCtx := merchant.WithID(context.Background(), mid)
 
+	psp := seedTestPSPBindingFor(t, appDB, baseCtx, mid.UUID(), "nmi")
 	var seeded seededState
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
-		seeded = seedReconcileFixtures(t, ctx, appDB, mid.UUID())
+		seeded = seedReconcileFixtures(t, ctx, appDB, mid.UUID(), psp.ID)
 		return nil
 	}))
 
@@ -201,7 +202,7 @@ func TestReconcileEngineIntegration(t *testing.T) {
 	// ---- advisory: findings persisted, zero local writes -------------------
 	var advisory *RunResult
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
-		res, err := newEngine(snap).Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}})
+		res, err := newEngine(snap).Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}, PSPs: map[Provider]RailMerchantAccountBinding{ProviderNMI: psp}})
 		advisory = res
 		return err
 	}))
@@ -244,7 +245,7 @@ func TestReconcileEngineIntegration(t *testing.T) {
 	// ---- enforce: local state converges, findings auto_fixed ---------------
 	var enforce *RunResult
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
-		res, err := newEngine(snap).Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+		res, err := newEngine(snap).Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: map[Provider]RailMerchantAccountBinding{ProviderNMI: psp}})
 		enforce = res
 		return err
 	}))
@@ -300,7 +301,7 @@ func TestReconcileEngineIntegration(t *testing.T) {
 	// ---- rerun enforce: stable -----------------------------------------------
 	var rerun *RunResult
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
-		res, err := newEngine(snap).Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+		res, err := newEngine(snap).Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: map[Provider]RailMerchantAccountBinding{ProviderNMI: psp}})
 		rerun = res
 		return err
 	}))
@@ -349,7 +350,7 @@ func TestReconcileEngineIntegration(t *testing.T) {
 	fixedSnap := *snap
 	fixedSnap.Subscriptions = snap.Subscriptions[:1] // ghosts + dups disappear
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
-		res, err := newEngine(&fixedSnap).Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}})
+		res, err := newEngine(&fixedSnap).Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}, PSPs: map[Provider]RailMerchantAccountBinding{ProviderNMI: psp}})
 		require.NoError(t, err)
 		assert.GreaterOrEqual(t, res.Summary.Providers["nmi"].AutoResolved, int64(1), "PS-8 vanished")
 
@@ -383,6 +384,7 @@ func TestReconcileMaterializeIntegration(t *testing.T) {
 	planID := "mat-plan-" + suffix
 	entName := "premium-mat-" + suffix
 
+	psp := seedTestPSPBinding(t, appDB, baseCtx, "nmi")
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
 		subjectIDHolder = dbtest.EnsureCustomerIDPgx(ctx, t, appDB.Qx(ctx), uuid.NewString())
 		exec := func(sql string, args ...any) {
@@ -399,8 +401,8 @@ func TestReconcileMaterializeIntegration(t *testing.T) {
 		      VALUES ($1, $2, 14990000, 'USD', 720, true, jsonb_build_object('nmi', jsonb_build_object('rail', 'nmi', 'plan_id', $3::text)), $4)`,
 			priceID, productID, planID, dbtest.TestMerchantID.UUID())
 		// Identity anchor: a stored payment method holding the remote vault id.
-		exec(`INSERT INTO openrails.payment_methods (id, customer_id, rail, rail_customer_ref, initial_transaction_id, last_four, expiry_date, merchant_id)
-		      VALUES ($1, $2, 'nmi', $3, 'init-txn-'||$4::text, '1111', '1029', $5)`, pmID, subjectIDHolder, railCustomerRef, suffix, dbtest.TestMerchantID.UUID())
+		exec(`INSERT INTO openrails.payment_methods (id, customer_id, rail, rail_customer_ref, initial_transaction_id, last_four, expiry_date, merchant_id, psp_id)
+		      VALUES ($1, $2, 'nmi', $3, 'init-txn-'||$4::text, '1111', '1029', $5, $6)`, pmID, subjectIDHolder, railCustomerRef, suffix, dbtest.TestMerchantID.UUID(), psp.ID)
 		return nil
 	}))
 	subjectID := subjectIDHolder
@@ -458,7 +460,7 @@ func TestReconcileMaterializeIntegration(t *testing.T) {
 
 	// ---- advisory: both PS-1 stay requires_review, nothing is created ----------
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
-		res, err := newEngine().Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}})
+		res, err := newEngine().Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}, PSPs: map[Provider]RailMerchantAccountBinding{ProviderNMI: psp}})
 		require.NoError(t, err)
 		for _, f := range res.Findings {
 			if f.Type == FindingRemoteSubMissingLocal {
@@ -475,7 +477,7 @@ func TestReconcileMaterializeIntegration(t *testing.T) {
 	// ---- enforce: resolvable PS-1 materializes automatically ------------------
 	var matRun *RunResult
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
-		res, err := newEngine().Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+		res, err := newEngine().Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: map[Provider]RailMerchantAccountBinding{ProviderNMI: psp}})
 		matRun = res
 		return err
 	}))
@@ -545,7 +547,7 @@ func TestReconcileMaterializeIntegration(t *testing.T) {
 
 	// ---- re-run: idempotent, no duplicate subscription ------------------------
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
-		res, err := newEngine().Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}})
+		res, err := newEngine().Run(ctx, RunParams{Mode: ModeEnforce, Providers: []Provider{ProviderNMI}, PSPs: map[Provider]RailMerchantAccountBinding{ProviderNMI: psp}})
 		require.NoError(t, err)
 		for _, f := range res.Findings {
 			assert.NotEqual(t, resolvablePSID, f.SubjectKey, "materialized PS-1 must not re-diff")
@@ -563,6 +565,7 @@ func TestReconcileMaterializeIntegration(t *testing.T) {
 func TestReconcileRunRecordsFailure(t *testing.T) {
 	appDB := startReconcilePostgres(t)
 	baseCtx := merchant.WithID(context.Background(), dbtest.TestMerchantID)
+	psp := seedTestPSPBinding(t, appDB, baseCtx, "nmi")
 	store := &PGStore{DB: appDB}
 	eng := &Engine{
 		Fetchers: map[Provider]RailFetcher{ProviderNMI: &fakeFetcher{provider: ProviderNMI, err: fmt.Errorf("query.php unreachable")}},
@@ -572,7 +575,7 @@ func TestReconcileRunRecordsFailure(t *testing.T) {
 	}
 	var res *RunResult
 	err := appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
-		r, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}})
+		r, err := eng.Run(ctx, RunParams{Mode: ModeAdvisory, Providers: []Provider{ProviderNMI}, PSPs: map[Provider]RailMerchantAccountBinding{ProviderNMI: psp}})
 		res = r
 		return err
 	})
@@ -602,6 +605,7 @@ func TestReconcileAdoptPreservesScheduledProviderActions(t *testing.T) {
 	suffix := uuid.NewString()[:8]
 	productID, priceID, schedPriceID, subID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
 	deleteAt := time.Now().UTC().Add(11 * 24 * time.Hour).Truncate(time.Second)
+	psp := seedTestPSPBinding(t, appDB, baseCtx, "nmi")
 
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
 		customer := dbtest.EnsureCustomerIDPgx(ctx, t, appDB.Qx(ctx), uuid.NewString())
@@ -621,10 +625,10 @@ func TestReconcileAdoptPreservesScheduledProviderActions(t *testing.T) {
 		exec(`INSERT INTO openrails.subscriptions
 		        (id, price_id, product_id, status, rail, rail_subscription_id,
 		         current_period_starts_at, current_period_ends_at, started_at,
-		         deletion_scheduled_at, scheduled_price_id, entitlements_spec_snapshot, customer_id, merchant_id)
-		      VALUES ($1,$2,$3,'active','nmi',$4,$5,$6,$5,$7,$8,'{}'::jsonb,$9,$10)`,
+		         deletion_scheduled_at, scheduled_price_id, entitlements_spec_snapshot, customer_id, merchant_id, psp_id)
+		      VALUES ($1,$2,$3,'active','nmi',$4,$5,$6,$5,$7,$8,'{}'::jsonb,$9,$10,$11)`,
 			subID, priceID, productID, "sa-sub-"+suffix,
-			time.Now().Add(-20*24*time.Hour), time.Now().Add(10*24*time.Hour), deleteAt, schedPriceID, customer, merchantID)
+			time.Now().Add(-20*24*time.Hour), time.Now().Add(10*24*time.Hour), deleteAt, schedPriceID, customer, merchantID, psp.ID)
 		return nil
 	}))
 

--- a/internal/reconcile/local.go
+++ b/internal/reconcile/local.go
@@ -125,9 +125,13 @@ type LocalState struct {
 // provider snapshot. PaymentsByTransactionIDs is queried separately (bounded
 // by the snapshot's transaction set rather than a date window, so clock skew
 // between us and the rail can not fake a missing payment).
+//
+// or#893: pspID is REQUIRED. The mirror rows of one PSP are not the mirror
+// rows of its sibling on the same rail, and a nil-means-every-PSP read let one
+// account's roster judge another account's book.
 type LocalStateLoader interface {
-	Load(ctx context.Context, provider Provider, providerAccountID *uuid.UUID) (*LocalState, error)
-	PaymentsByTransactionIDs(ctx context.Context, provider Provider, providerAccountID *uuid.UUID, transactionIDs []string) ([]LocalPayment, error)
+	Load(ctx context.Context, provider Provider, pspID uuid.UUID) (*LocalState, error)
+	PaymentsByTransactionIDs(ctx context.Context, provider Provider, pspID uuid.UUID, transactionIDs []string) ([]LocalPayment, error)
 }
 
 // PGLocalStateLoader loads local state through the sqlc layer on a
@@ -138,7 +142,7 @@ type PGLocalStateLoader struct {
 
 var _ LocalStateLoader = (*PGLocalStateLoader)(nil)
 
-func (l *PGLocalStateLoader) Load(ctx context.Context, provider Provider, providerAccountID *uuid.UUID) (*LocalState, error) {
+func (l *PGLocalStateLoader) Load(ctx context.Context, provider Provider, pspID uuid.UUID) (*LocalState, error) {
 	names := localRailNames(provider)
 	q := l.DB.Gen(ctx)
 
@@ -146,7 +150,7 @@ func (l *PGLocalStateLoader) Load(ctx context.Context, provider Provider, provid
 
 	subs, err := q.ReconcileListSubscriptionsByRails(ctx, gen.ReconcileListSubscriptionsByRailsParams{
 		Rails: names,
-		PspID: providerAccountID,
+		PspID: pspID,
 	})
 	if err != nil {
 		return nil, err
@@ -222,7 +226,7 @@ func (l *PGLocalStateLoader) Load(ctx context.Context, provider Provider, provid
 
 	pms, err := q.ReconcileListPaymentMethodsByRails(ctx, gen.ReconcileListPaymentMethodsByRailsParams{
 		Rails: names,
-		PspID: providerAccountID,
+		PspID: pspID,
 	})
 	if err != nil {
 		return nil, err
@@ -249,13 +253,13 @@ func (l *PGLocalStateLoader) Load(ctx context.Context, provider Provider, provid
 	return state, nil
 }
 
-func (l *PGLocalStateLoader) PaymentsByTransactionIDs(ctx context.Context, provider Provider, providerAccountID *uuid.UUID, transactionIDs []string) ([]LocalPayment, error) {
+func (l *PGLocalStateLoader) PaymentsByTransactionIDs(ctx context.Context, provider Provider, pspID uuid.UUID, transactionIDs []string) ([]LocalPayment, error) {
 	if len(transactionIDs) == 0 {
 		return nil, nil
 	}
 	rows, err := l.DB.Gen(ctx).ReconcileListPaymentsByTransactionIDs(ctx, gen.ReconcileListPaymentsByTransactionIDsParams{
 		Rails:          localRailNames(provider),
-		PspID:          providerAccountID,
+		PspID:          pspID,
 		TransactionIds: transactionIDs,
 	})
 	if err != nil {

--- a/internal/reconcile/provider_accounts_integration_test.go
+++ b/internal/reconcile/provider_accounts_integration_test.go
@@ -102,26 +102,26 @@ func TestRailMerchantAccountScopedLocalStateDoesNotBlendCollidingProviderIDs(t *
 
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
 		loader := &PGLocalStateLoader{DB: appDB}
-		stateA, err := loader.Load(ctx, ProviderNMI, &accountA.ID)
+		stateA, err := loader.Load(ctx, ProviderNMI, accountA.ID)
 		require.NoError(t, err)
 		require.Len(t, stateA.Subscriptions, 1)
 		require.Equal(t, customerA, stateA.Subscriptions[0].CustomerID)
 		require.Len(t, stateA.PaymentMethods, 1)
 		require.Equal(t, "1111", stateA.PaymentMethods[0].LastFour)
 
-		paymentsA, err := loader.PaymentsByTransactionIDs(ctx, ProviderNMI, &accountA.ID, []string{"txn-1111", "txn-2222"})
+		paymentsA, err := loader.PaymentsByTransactionIDs(ctx, ProviderNMI, accountA.ID, []string{"txn-1111", "txn-2222"})
 		require.NoError(t, err)
 		require.Len(t, paymentsA, 1)
 		require.Equal(t, customerA, paymentsA[0].CustomerID)
 
-		stateB, err := loader.Load(ctx, ProviderNMI, &accountB.ID)
+		stateB, err := loader.Load(ctx, ProviderNMI, accountB.ID)
 		require.NoError(t, err)
 		require.Len(t, stateB.Subscriptions, 1)
 		require.Equal(t, customerB, stateB.Subscriptions[0].CustomerID)
 		require.Len(t, stateB.PaymentMethods, 1)
 		require.Equal(t, "2222", stateB.PaymentMethods[0].LastFour)
 
-		paymentsB, err := loader.PaymentsByTransactionIDs(ctx, ProviderNMI, &accountB.ID, []string{"txn-1111", "txn-2222"})
+		paymentsB, err := loader.PaymentsByTransactionIDs(ctx, ProviderNMI, accountB.ID, []string{"txn-1111", "txn-2222"})
 		require.NoError(t, err)
 		require.Len(t, paymentsB, 1)
 		require.Equal(t, customerB, paymentsB[0].CustomerID)

--- a/internal/reconcile/psp_binding_testhelper_integration_test.go
+++ b/internal/reconcile/psp_binding_testhelper_integration_test.go
@@ -1,0 +1,50 @@
+//go:build integration
+
+package reconcile
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/db"
+	"github.com/open-rails/openrails/internal/db/gen"
+	"github.com/open-rails/openrails/internal/dbtest"
+)
+
+// seedTestPSPBinding declares one PSP for the test merchant and returns the
+// binding a pull must now carry (or#893): the engine refuses a provider section
+// with no PSP, because an unbound pass read the whole rail's mirror — every
+// PSP's book at once — and wrote unattributed rows.
+func seedTestPSPBinding(t *testing.T, appDB *db.DB, baseCtx context.Context, rail string) RailMerchantAccountBinding {
+	t.Helper()
+	return seedTestPSPBindingFor(t, appDB, baseCtx, dbtest.TestMerchantID.UUID(), rail)
+}
+
+// seedTestPSPBindingFor is seedTestPSPBinding for a test-owned merchant.
+func seedTestPSPBindingFor(t *testing.T, appDB *db.DB, baseCtx context.Context, merchantID uuid.UUID, rail string) RailMerchantAccountBinding {
+	t.Helper()
+	accountID := rail + "-acct-" + uuid.NewString()[:8]
+	var row gen.OpenrailsPsp
+	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
+		now := time.Now().UTC()
+		var err error
+		row, err = appDB.Gen(ctx).UpsertPSP(ctx, gen.UpsertPSPParams{
+			MerchantID:     merchantID,
+			Rail:           rail,
+			AccountID:      accountID,
+			LastVerifiedAt: &now,
+		})
+		return err
+	}))
+	t.Cleanup(func() {
+		_ = appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
+			_, _ = appDB.Qx(ctx).Exec(ctx, `DELETE FROM openrails.psps WHERE id=$1`, row.ID)
+			return nil
+		})
+	})
+	return RailMerchantAccountBinding{ID: row.ID, Rail: rail, AccountID: accountID}
+}

--- a/internal/river/jobs_provider_refresh.go
+++ b/internal/river/jobs_provider_refresh.go
@@ -464,10 +464,19 @@ func (w *ProviderRefreshWorker) runEventRefresh(ctx context.Context, mid uuid.UU
 	result := providerRefreshMerchantResult{}
 	providers := refreshProviders(fetchers)
 	for _, provider := range providers {
-		// Runtime provider-account identity resolution was removed (#592):
-		// watermarks key globally per merchant+provider and reconcile runs
-		// account-agnostic (psps is an operator-declared catalog).
-		providerRes := w.runProviderEventWindows(ctx, mid, provider, mode, coverage, nil, nil, fetchers)
+		// or#893: the pass already KNOWS which PSP armed the rail's fetcher —
+		// resolveScopeCoverage recorded it. It used to be thrown away, so the
+		// watermark keyed globally per (merchant, rail) and reconcile ran
+		// account-agnostic: pulling mobius advanced paykings' watermark past
+		// events nobody had read, and every mirror row landed unattributed.
+		binding := coverage[provider].Binding
+		if binding.ID == uuid.Nil {
+			result.ProviderErrors++
+			log.WithContext(ctx).WithFields(log.Fields{"merchant_id": mid, "provider": provider}).
+				Error("Provider Refresh: rail armed without a resolved PSP; refusing an unattributed pull")
+			continue
+		}
+		providerRes := w.runProviderEventWindows(ctx, mid, provider, mode, coverage, binding, fetchers)
 		result.add(providerRes)
 	}
 	return result
@@ -495,15 +504,17 @@ func refreshProviders(fetchers map[reconcile.Provider]reconcile.RailFetcher) []r
 	return providers
 }
 
-func (w *ProviderRefreshWorker) runProviderEventWindows(ctx context.Context, mid uuid.UUID, provider reconcile.Provider, mode reconcile.Mode, coverage map[reconcile.Provider]reconcile.PSPCoverage, accountID *uuid.UUID, bindings map[reconcile.Provider]reconcile.RailMerchantAccountBinding, fetchers map[reconcile.Provider]reconcile.RailFetcher) providerRefreshProviderResult {
+func (w *ProviderRefreshWorker) runProviderEventWindows(ctx context.Context, mid uuid.UUID, provider reconcile.Provider, mode reconcile.Mode, coverage map[reconcile.Provider]reconcile.PSPCoverage, binding reconcile.RailMerchantAccountBinding, fetchers map[reconcile.Provider]reconcile.RailFetcher) providerRefreshProviderResult {
 	out := providerRefreshProviderResult{Providers: 1}
+	pspID := binding.ID
+	bindings := map[reconcile.Provider]reconcile.RailMerchantAccountBinding{provider: binding}
 	now := w.now()
 	horizon := now.Add(-w.safetyLag())
 	if !horizon.After(time.Time{}) {
 		return out
 	}
 
-	since, err := w.loadWatermark(ctx, mid, provider, accountID, horizon.Add(-w.initialLookback()))
+	since, err := w.loadWatermark(ctx, mid, provider, pspID, horizon.Add(-w.initialLookback()))
 	if err != nil {
 		out.WatermarkErrors++
 		log.WithContext(ctx).WithError(err).WithField("provider", provider).Warn("Provider Refresh: load watermark failed")
@@ -544,7 +555,7 @@ func (w *ProviderRefreshWorker) runProviderEventWindows(ctx context.Context, mid
 		res, err := engine.Run(ctx, params)
 		if err != nil {
 			out.ProviderErrors++
-			if werr := w.recordWatermarkFailure(ctx, mid, provider, accountID, since, now, err); werr != nil {
+			if werr := w.recordWatermarkFailure(ctx, mid, provider, pspID, since, now, err); werr != nil {
 				out.WatermarkErrors++
 				log.WithContext(ctx).WithError(werr).WithField("provider", provider).Warn("Provider Refresh: record failed provider attempt failed")
 			}
@@ -572,7 +583,7 @@ func (w *ProviderRefreshWorker) runProviderEventWindows(ctx context.Context, mid
 				log.WithContext(ctx).WithError(derr).WithField("provider", provider).Warn("Provider Refresh: record webhook drift failed")
 			}
 		}
-		if err := w.recordWatermarkSuccess(ctx, mid, provider, accountID, until, now); err != nil {
+		if err := w.recordWatermarkSuccess(ctx, mid, provider, pspID, until, now); err != nil {
 			out.WatermarkErrors++
 			log.WithContext(ctx).WithError(err).WithField("provider", provider).Warn("Provider Refresh: advance watermark failed")
 			break
@@ -589,7 +600,7 @@ func (w *ProviderRefreshWorker) runProviderEventWindows(ctx context.Context, mid
 	return out
 }
 
-func (w *ProviderRefreshWorker) loadWatermark(ctx context.Context, mid uuid.UUID, provider reconcile.Provider, accountID *uuid.UUID, fallback time.Time) (time.Time, error) {
+func (w *ProviderRefreshWorker) loadWatermark(ctx context.Context, mid uuid.UUID, provider reconcile.Provider, pspID uuid.UUID, fallback time.Time) (time.Time, error) {
 	var watermark time.Time
 	err := w.DB.Qx(ctx).QueryRow(ctx, `
 SELECT watermark_at
@@ -597,8 +608,8 @@ SELECT watermark_at
  WHERE merchant_id = $1::uuid
    AND rail = $2::text
    AND event_domain = $3::text
-   AND psp_key = COALESCE($4::uuid, '00000000-0000-0000-0000-000000000000'::uuid)
-`, mid, string(provider), providerRefreshDomainEvents, accountID).Scan(&watermark)
+   AND psp_id = $4::uuid
+`, mid, string(provider), providerRefreshDomainEvents, pspID).Scan(&watermark)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return fallback.UTC(), nil
 	}
@@ -608,7 +619,7 @@ SELECT watermark_at
 	return watermark.UTC(), nil
 }
 
-func (w *ProviderRefreshWorker) recordWatermarkSuccess(ctx context.Context, mid uuid.UUID, provider reconcile.Provider, accountID *uuid.UUID, watermark, attemptedAt time.Time) error {
+func (w *ProviderRefreshWorker) recordWatermarkSuccess(ctx context.Context, mid uuid.UUID, provider reconcile.Provider, pspID uuid.UUID, watermark, attemptedAt time.Time) error {
 	_, err := w.DB.Qx(ctx).Exec(ctx, `
 INSERT INTO openrails.rail_refresh_watermarks (
     merchant_id, rail, psp_id, event_domain, watermark_at,
@@ -621,11 +632,11 @@ DO UPDATE SET
     last_succeeded_at = EXCLUDED.last_succeeded_at,
     last_error = NULL,
     updated_at = now()
-`, mid, string(provider), accountID, providerRefreshDomainEvents, watermark.UTC(), attemptedAt.UTC())
+`, mid, string(provider), pspID, providerRefreshDomainEvents, watermark.UTC(), attemptedAt.UTC())
 	return err
 }
 
-func (w *ProviderRefreshWorker) recordWatermarkFailure(ctx context.Context, mid uuid.UUID, provider reconcile.Provider, accountID *uuid.UUID, watermark, attemptedAt time.Time, cause error) error {
+func (w *ProviderRefreshWorker) recordWatermarkFailure(ctx context.Context, mid uuid.UUID, provider reconcile.Provider, pspID uuid.UUID, watermark, attemptedAt time.Time, cause error) error {
 	errText := cause.Error()
 	_, err := w.DB.Qx(ctx).Exec(ctx, `
 INSERT INTO openrails.rail_refresh_watermarks (
@@ -637,7 +648,7 @@ DO UPDATE SET
     last_attempted_at = EXCLUDED.last_attempted_at,
     last_error = EXCLUDED.last_error,
     updated_at = now()
-`, mid, string(provider), accountID, providerRefreshDomainEvents, watermark.UTC(), attemptedAt.UTC(), errText)
+`, mid, string(provider), pspID, providerRefreshDomainEvents, watermark.UTC(), attemptedAt.UTC(), errText)
 	return err
 }
 

--- a/internal/river/jobs_provider_refresh_integration_test.go
+++ b/internal/river/jobs_provider_refresh_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
 	"github.com/open-rails/openrails/internal/db"
+	"github.com/open-rails/openrails/internal/db/gen"
 	"github.com/open-rails/openrails/internal/dbtest"
 	"github.com/open-rails/openrails/internal/reconcile"
 	"github.com/open-rails/openrails/pkg/merchant"
@@ -37,14 +38,16 @@ func TestProviderRefreshWatermarkAdvancesOnlyOnSuccessfulWindow(t *testing.T) {
 		MaxWindows:      2,
 	}
 
+	var pspID uuid.UUID
 	require.NoError(t, dbi.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
-		res := worker.runProviderEventWindows(ctx, merchantID, reconcile.ProviderStripe, reconcile.ModeEnforce, nil, nil, nil, map[reconcile.Provider]reconcile.RailFetcher{
+		pspID = seedRefreshPSPForTest(t, ctx, dbi, merchantID, "stripe")
+		res := worker.runProviderEventWindows(ctx, merchantID, reconcile.ProviderStripe, reconcile.ModeEnforce, nil, reconcile.RailMerchantAccountBinding{ID: pspID, Rail: "stripe"}, map[reconcile.Provider]reconcile.RailFetcher{
 			reconcile.ProviderStripe: successFetcher,
 		})
 		require.Equal(t, 2, res.Windows)
 		require.Zero(t, res.ProviderErrors)
 		require.Len(t, successFetcher.calls, 2)
-		watermark, lastErr := loadProviderRefreshWatermarkForTest(t, ctx, dbi, merchantID)
+		watermark, lastErr := loadProviderRefreshWatermarkForTest(t, ctx, dbi, merchantID, pspID)
 		require.Equal(t, successFetcher.calls[1].Until.UTC(), watermark)
 		require.Nil(t, lastErr)
 		return nil
@@ -52,13 +55,13 @@ func TestProviderRefreshWatermarkAdvancesOnlyOnSuccessfulWindow(t *testing.T) {
 
 	failingFetcher := &providerRefreshRecordingFetcher{provider: reconcile.ProviderStripe, err: errors.New("provider offline")}
 	require.NoError(t, dbi.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
-		before, _ := loadProviderRefreshWatermarkForTest(t, ctx, dbi, merchantID)
-		res := worker.runProviderEventWindows(ctx, merchantID, reconcile.ProviderStripe, reconcile.ModeEnforce, nil, nil, nil, map[reconcile.Provider]reconcile.RailFetcher{
+		before, _ := loadProviderRefreshWatermarkForTest(t, ctx, dbi, merchantID, pspID)
+		res := worker.runProviderEventWindows(ctx, merchantID, reconcile.ProviderStripe, reconcile.ModeEnforce, nil, reconcile.RailMerchantAccountBinding{ID: pspID, Rail: "stripe"}, map[reconcile.Provider]reconcile.RailFetcher{
 			reconcile.ProviderStripe: failingFetcher,
 		})
 		require.Zero(t, res.Windows)
 		require.Equal(t, 1, res.ProviderErrors)
-		after, lastErr := loadProviderRefreshWatermarkForTest(t, ctx, dbi, merchantID)
+		after, lastErr := loadProviderRefreshWatermarkForTest(t, ctx, dbi, merchantID, pspID)
 		require.Equal(t, before, after)
 		require.NotNil(t, lastErr)
 		require.Contains(t, *lastErr, "provider offline")
@@ -78,7 +81,9 @@ func TestProviderRefreshBackfillsEventsAndTerminalState(t *testing.T) {
 	originalPaymentID := uuid.New()
 	customerID := uuid.UUID{}
 	psid := "sub_refresh_" + uuid.NewString()
+	var pspID uuid.UUID
 	require.NoError(t, dbi.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
+		pspID = seedRefreshPSPForTest(t, ctx, dbi, merchantID, "stripe")
 		customerID = dbtest.EnsureCustomerIDPgx(ctx, t, dbi.Qx(ctx), uuid.NewString())
 		exec := func(sql string, args ...any) {
 			_, err := dbi.Qx(ctx).Exec(ctx, sql, args...)
@@ -92,13 +97,13 @@ func TestProviderRefreshBackfillsEventsAndTerminalState(t *testing.T) {
 		exec(`INSERT INTO openrails.subscriptions
 		        (id, price_id, product_id, status, rail, rail_subscription_id,
 		         current_period_starts_at, current_period_ends_at, started_at,
-		         entitlements_spec_snapshot, customer_id, merchant_id)
-		      VALUES ($1, $2, $3, 'active', 'stripe', $4, $5, $6, $5, '{}'::jsonb, $7, $8)`,
-			subID, priceID, productID, psid, now.Add(-35*24*time.Hour), now.Add(-5*24*time.Hour), customerID, merchantID)
+		         entitlements_spec_snapshot, customer_id, merchant_id, psp_id)
+		      VALUES ($1, $2, $3, 'active', 'stripe', $4, $5, $6, $5, '{}'::jsonb, $7, $8, $9)`,
+			subID, priceID, productID, psid, now.Add(-35*24*time.Hour), now.Add(-5*24*time.Hour), customerID, merchantID, pspID)
 		exec(`INSERT INTO openrails.payments
-		        (id, price_id, rail, transaction_id, amount, list_amount, currency, status, subscription_id, purchased_at, merchant_id, customer_id)
-		      VALUES ($1, $2, 'stripe', 'ch_original', 999, 999, 'USD', 'completed', $3, $4, $5, $6)`,
-			originalPaymentID, priceID, subID, now.Add(-20*24*time.Hour), merchantID, customerID)
+		        (id, price_id, rail, transaction_id, amount, list_amount, currency, status, subscription_id, purchased_at, merchant_id, customer_id, psp_id)
+		      VALUES ($1, $2, 'stripe', 'ch_original', 999, 999, 'USD', 'completed', $3, $4, $5, $6, $7)`,
+			originalPaymentID, priceID, subID, now.Add(-20*24*time.Hour), merchantID, customerID, pspID)
 		return nil
 	}))
 
@@ -131,7 +136,7 @@ func TestProviderRefreshBackfillsEventsAndTerminalState(t *testing.T) {
 	}
 
 	require.NoError(t, dbi.RunInMerchantConn(merchant.WithID(context.Background(), merchant.ID(merchantID)), func(ctx context.Context) error {
-		res := worker.runProviderEventWindows(ctx, merchantID, reconcile.ProviderStripe, reconcile.ModeEnforce, nil, nil, nil, map[reconcile.Provider]reconcile.RailFetcher{
+		res := worker.runProviderEventWindows(ctx, merchantID, reconcile.ProviderStripe, reconcile.ModeEnforce, nil, reconcile.RailMerchantAccountBinding{ID: pspID, Rail: "stripe"}, map[reconcile.Provider]reconcile.RailFetcher{
 			reconcile.ProviderStripe: &providerRefreshSnapshotFetcher{provider: reconcile.ProviderStripe, snap: snap},
 		})
 		require.Equal(t, 1, res.Windows)
@@ -209,7 +214,7 @@ func (f *providerRefreshRecordingFetcher) Fetch(_ context.Context, params reconc
 	}, nil
 }
 
-func loadProviderRefreshWatermarkForTest(t *testing.T, ctx context.Context, dbi *db.DB, merchantID uuid.UUID) (time.Time, *string) {
+func loadProviderRefreshWatermarkForTest(t *testing.T, ctx context.Context, dbi *db.DB, merchantID, pspID uuid.UUID) (time.Time, *string) {
 	t.Helper()
 	var watermark time.Time
 	var lastErr *string
@@ -219,8 +224,100 @@ SELECT watermark_at, last_error
  WHERE merchant_id = $1::uuid
    AND rail = 'stripe'
    AND event_domain = 'events'
-   AND psp_id IS NULL
-`, merchantID).Scan(&watermark, &lastErr)
+   AND psp_id = $2::uuid
+`, merchantID, pspID).Scan(&watermark, &lastErr)
 	require.NoError(t, err)
 	return watermark.UTC(), lastErr
+}
+
+// seedRefreshPSPForTest declares one PSP on a rail — or#893 makes a pull refuse
+// to run without the PSP its credentials armed from.
+func seedRefreshPSPForTest(t *testing.T, ctx context.Context, dbi *db.DB, merchantID uuid.UUID, rail string) uuid.UUID {
+	t.Helper()
+	now := time.Now().UTC()
+	row, err := dbi.Gen(ctx).UpsertPSP(ctx, gen.UpsertPSPParams{
+		MerchantID:     merchantID,
+		Rail:           rail,
+		AccountID:      rail + "-acct-" + uuid.NewString()[:8],
+		LastVerifiedAt: &now,
+	})
+	require.NoError(t, err)
+	return row.ID
+}
+
+// or#893: two PSPs on one rail must keep two watermarks. The identity key used
+// to COALESCE a NULL psp_id to the nil uuid and the worker always passed nil,
+// so both accounts shared ONE cursor: pulling mobius advanced it past a window
+// paykings never read, and — watermark_at being an EXCLUSIVE lower bound — that
+// window was skipped for paykings permanently.
+func TestProviderRefreshWatermarksAreScopedPerPSP(t *testing.T) {
+	dsn := dbtest.SharedPostgresDSN(t)
+	dbi := dbtest.OpenAppDB(t, dsn)
+	dbtest.EnsureTestMerchant(context.Background(), t, dbtest.SharedMerchantPool(t, dbtest.TestMerchantID.UUID()))
+	baseCtx := dbtest.WithTestMerchant(context.Background())
+	merchantID := dbtest.TestMerchantID.UUID()
+	now := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
+
+	worker := &ProviderRefreshWorker{
+		DB:              dbi,
+		Clock:           clockwork.NewFakeClockAt(now),
+		Window:          24 * time.Hour,
+		SafetyLag:       time.Hour,
+		InitialLookback: 72 * time.Hour,
+		MaxWindows:      2,
+	}
+
+	require.NoError(t, dbi.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
+		pspA := seedRefreshPSPForTest(t, ctx, dbi, merchantID, "stripe")
+		pspB := seedRefreshPSPForTest(t, ctx, dbi, merchantID, "stripe")
+		require.NotEqual(t, pspA, pspB)
+
+		fetcherA := &providerRefreshRecordingFetcher{provider: reconcile.ProviderStripe}
+		resA := worker.runProviderEventWindows(ctx, merchantID, reconcile.ProviderStripe, reconcile.ModeEnforce, nil,
+			reconcile.RailMerchantAccountBinding{ID: pspA, Rail: "stripe"},
+			map[reconcile.Provider]reconcile.RailFetcher{reconcile.ProviderStripe: fetcherA})
+		require.Equal(t, 2, resA.Windows)
+
+		// B has never been pulled. Its cursor must still be the initial
+		// lookback, NOT the point A advanced to.
+		fetcherB := &providerRefreshRecordingFetcher{provider: reconcile.ProviderStripe}
+		resB := worker.runProviderEventWindows(ctx, merchantID, reconcile.ProviderStripe, reconcile.ModeEnforce, nil,
+			reconcile.RailMerchantAccountBinding{ID: pspB, Rail: "stripe"},
+			map[reconcile.Provider]reconcile.RailFetcher{reconcile.ProviderStripe: fetcherB})
+		require.Equal(t, 2, resB.Windows)
+		require.Equal(t, fetcherA.calls[0].Since.UTC(), fetcherB.calls[0].Since.UTC(),
+			"PSP B's first window must start at the initial lookback, not where PSP A's pull left off")
+
+		wmA, _ := loadProviderRefreshWatermarkForTest(t, ctx, dbi, merchantID, pspA)
+		wmB, _ := loadProviderRefreshWatermarkForTest(t, ctx, dbi, merchantID, pspB)
+		require.Equal(t, fetcherA.calls[1].Until.UTC(), wmA)
+		require.Equal(t, fetcherB.calls[1].Until.UTC(), wmB)
+
+		var rows int
+		require.NoError(t, dbi.Qx(ctx).QueryRow(ctx,
+			`SELECT count(*) FROM openrails.rail_refresh_watermarks
+			  WHERE merchant_id = $1 AND rail = 'stripe' AND psp_id IN ($2, $3)`,
+			merchantID, pspA, pspB).Scan(&rows))
+		require.Equal(t, 2, rows, "each PSP owns its own watermark row")
+		return nil
+	}))
+}
+
+// or#893: the NULL/global lane is gone at the schema level too — the column is
+// NOT NULL, so no writer can re-create an unattributed cursor.
+func TestProviderRefreshWatermarkRejectsAnUnattributedRow(t *testing.T) {
+	dsn := dbtest.SharedPostgresDSN(t)
+	dbi := dbtest.OpenAppDB(t, dsn)
+	dbtest.EnsureTestMerchant(context.Background(), t, dbtest.SharedMerchantPool(t, dbtest.TestMerchantID.UUID()))
+	baseCtx := dbtest.WithTestMerchant(context.Background())
+	merchantID := dbtest.TestMerchantID.UUID()
+
+	require.NoError(t, dbi.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
+		_, err := dbi.Qx(ctx).Exec(ctx, `
+INSERT INTO openrails.rail_refresh_watermarks (merchant_id, rail, psp_id, event_domain, watermark_at)
+VALUES ($1, 'stripe', NULL, 'events', now())`, merchantID)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "psp_id")
+		return nil
+	}))
 }

--- a/migrations/postgres/0060_watermark_psp_required.down.sql
+++ b/migrations/postgres/0060_watermark_psp_required.down.sql
@@ -1,0 +1,35 @@
+SET LOCAL statement_timeout = '60s';
+SET LOCAL lock_timeout = '10s';
+
+DROP INDEX openrails.idx_rail_refresh_watermarks_psp;
+
+ALTER TABLE openrails.rail_refresh_watermarks
+    DROP CONSTRAINT rail_refresh_watermarks_psp_fk;
+
+ALTER TABLE openrails.rail_refresh_watermarks
+    ADD CONSTRAINT rail_refresh_watermarks_psp_fk
+    FOREIGN KEY (psp_id) REFERENCES openrails.psps(id) ON DELETE SET NULL;
+
+ALTER TABLE openrails.rail_refresh_watermarks
+    DROP CONSTRAINT rail_refresh_watermarks_identity_key;
+
+ALTER TABLE openrails.rail_refresh_watermarks
+    ALTER COLUMN psp_id DROP NOT NULL;
+
+ALTER TABLE openrails.rail_refresh_watermarks
+    ADD CONSTRAINT rail_refresh_watermarks_psp_nonzero
+    CHECK ((psp_id IS NULL) OR (psp_id <> '00000000-0000-0000-0000-000000000000'::uuid));
+
+ALTER TABLE openrails.rail_refresh_watermarks
+    ADD COLUMN psp_key uuid
+    GENERATED ALWAYS AS (COALESCE(psp_id, '00000000-0000-0000-0000-000000000000'::uuid)) STORED;
+
+ALTER TABLE openrails.rail_refresh_watermarks
+    ADD CONSTRAINT rail_refresh_watermarks_identity_key
+    UNIQUE (merchant_id, rail, psp_key, event_domain);
+
+CREATE INDEX idx_rail_refresh_watermarks_account
+    ON openrails.rail_refresh_watermarks USING btree (psp_id) WHERE (psp_id IS NOT NULL);
+
+COMMENT ON COLUMN openrails.rail_refresh_watermarks.psp_id IS
+    'Current PSP row when resolvable; NULL is the compatibility/global lane for providers without a bound account identity.';

--- a/migrations/postgres/0060_watermark_psp_required.up.sql
+++ b/migrations/postgres/0060_watermark_psp_required.up.sql
@@ -1,0 +1,72 @@
+-- or#893 phase 1: rail_refresh_watermarks loses its NULL/global lane.
+--
+-- The column comment called NULL "the compatibility/global lane for providers
+-- without a bound account identity". There is no such provider. Every pull arms
+-- from exactly ONE PSP (reconcile.MerchantFetcherBuilder resolves it and records
+-- it as PSPCoverage.Binding) — the refresh worker simply threw that binding away
+-- and passed nil, so 100% of watermarks landed on the global lane.
+--
+-- That is not a compatibility detail, it is data loss: a merchant running mobius
+-- and paykings on nmi shares ONE watermark row. Pulling mobius advances it past
+-- a window paykings never read, and paykings' events in that window are never
+-- fetched again — the watermark is an EXCLUSIVE lower bound, so a skipped window
+-- is skipped permanently. It also lets one PSP's freshness stand as evidence
+-- about another's subscriptions (ListLapsedSubscriptionsWithEvidence's
+-- watermark_newer_than_period_end leg, tightened alongside this migration).
+--
+-- The psp_key generated column existed only to give the NULL lane a unique key.
+-- With psp_id required, the identity is (merchant, rail, psp, domain) directly.
+--
+-- Prelaunch hard cut: existing global-lane rows are DELETED, not backfilled.
+-- A watermark is a resumable cursor, not a record — the next pass re-derives it
+-- from initial_lookback. No production database exists.
+
+SET LOCAL statement_timeout = '60s';
+SET LOCAL lock_timeout = '10s';
+
+DELETE FROM openrails.rail_refresh_watermarks WHERE psp_id IS NULL;
+
+ALTER TABLE openrails.rail_refresh_watermarks
+    DROP CONSTRAINT rail_refresh_watermarks_identity_key;
+
+-- psp_key existed ONLY to give the NULL lane a unique key. Dropping it is the
+-- point of the cut, and it is a generated column no client selects.
+ALTER TABLE openrails.rail_refresh_watermarks
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN psp_key;
+
+ALTER TABLE openrails.rail_refresh_watermarks
+    DROP CONSTRAINT rail_refresh_watermarks_psp_nonzero;
+
+-- The DELETE above already removed every row that could violate it, so the
+-- validating scan is over a table with at most one row per (merchant, rail, PSP).
+ALTER TABLE openrails.rail_refresh_watermarks
+    -- squawk-ignore adding-not-nullable-field
+    ALTER COLUMN psp_id SET NOT NULL;
+
+-- Re-keying the identity: this is the SAME constraint the DROP above removed,
+-- minus the psp_key indirection. Cursor table, one row per (merchant, rail, PSP,
+-- domain) — the index build is over a handful of rows.
+ALTER TABLE openrails.rail_refresh_watermarks
+    -- squawk-ignore disallowed-unique-constraint, constraint-missing-not-valid
+    ADD CONSTRAINT rail_refresh_watermarks_identity_key
+    UNIQUE (merchant_id, rail, psp_id, event_domain);
+
+-- ON DELETE SET NULL was the global lane's other door: deleting a PSP silently
+-- demoted its watermark to "everyone's". A watermark has no meaning without the
+-- PSP whose event stream it bounds.
+ALTER TABLE openrails.rail_refresh_watermarks
+    DROP CONSTRAINT rail_refresh_watermarks_psp_fk;
+
+ALTER TABLE openrails.rail_refresh_watermarks
+    -- squawk-ignore adding-foreign-key-constraint, constraint-missing-not-valid
+    ADD CONSTRAINT rail_refresh_watermarks_psp_fk
+    FOREIGN KEY (psp_id) REFERENCES openrails.psps(id) ON DELETE CASCADE;
+
+DROP INDEX openrails.idx_rail_refresh_watermarks_account;
+
+CREATE INDEX idx_rail_refresh_watermarks_psp
+    ON openrails.rail_refresh_watermarks USING btree (psp_id);
+
+COMMENT ON COLUMN openrails.rail_refresh_watermarks.psp_id IS
+    'The PSP whose event stream this cursor bounds. Required (or#893): a pull arms from exactly one PSP, and a watermark shared across PSPs skips the events of every PSP but the one that advanced it.';

--- a/pkg/embedded/pull_provider.go
+++ b/pkg/embedded/pull_provider.go
@@ -164,7 +164,27 @@ func PullProvider(ctx context.Context, opts PullProviderOptions) error {
 		if len(fetchers) == 0 {
 			return fmt.Errorf("no payment providers configured for reconciliation (no armed rail accounts for this merchant)")
 		}
-		bindings := make(map[reconcile.Provider]reconcile.RailMerchantAccountBinding, len(explicitBindings))
+		// or#893: every armed rail carries the PSP its credentials came from.
+		// An unpinned pull used to run with NO binding at all — reading and
+		// writing the rail's mirror account-agnostically — so default to what
+		// the arming already resolved; --provider-account only overrides it.
+		selected := map[reconcile.Provider]bool{}
+		for _, p := range providers {
+			selected[p] = true
+		}
+		bindings := make(map[reconcile.Provider]reconcile.RailMerchantAccountBinding, len(armed.Coverage))
+		for provider, cov := range armed.Coverage {
+			if _, ok := fetchers[provider]; !ok {
+				continue
+			}
+			if len(selected) > 0 && !selected[provider] {
+				continue
+			}
+			if cov.Binding.ID == uuid.Nil {
+				return fmt.Errorf("rail %s armed without a resolved PSP: refusing an unattributed pull", provider)
+			}
+			bindings[provider] = cov.Binding
+		}
 		for provider, binding := range explicitBindings {
 			bindings[provider] = binding
 		}


### PR DESCRIPTION
First correctness pass of the or#893 forward-only program (Phase 1, task 1's pull-plane half). Not a v1 declaration — prelaunch hygiene.

## The defect

`reconcile.MerchantFetcherBuilder` already resolves which PSP's credentials arm each rail and records it as `PSPCoverage.Binding`. **Both callers threw it away.** `runEventRefresh` passed literal `nil` bindings; the operator pull bound only what `--provider-account` named. So every pull in practice ran unbound, and three things followed:

1. **Watermarks were shared across PSPs.** `rail_refresh_watermarks_identity_key` keyed on a generated `psp_key = COALESCE(psp_id, nil-uuid)` and the worker always wrote NULL. A merchant running mobius + paykings on nmi had **one** cursor: pulling mobius advanced it past a window paykings never read, and `watermark_at` is an *exclusive* lower bound — that window is skipped permanently.
2. **One PSP's roster judged another's book.** `Local.Load` / `PaymentsByTransactionIDs` matched `narg(psp_id) IS NULL OR …`, so an unbound pass diffed PSP A's roster against the entire rail's mirror. #841's "strip SubscriptionsExhaustive when coverage is incomplete" exists to stop that from cancelling the sibling's whole book — it was treating the symptom.
3. **Pull-materialised rows carried NULL provenance.** `bindApplyActions` short-circuited on a nil PSP, so nothing the pull created was attributable — invisible to a PSP-scoped prune, indistinguishable from a sibling's row.

`ListLapsedSubscriptionsWithEvidence` had the same widening in its `watermark_newer_than_period_end` evidence leg (`w.psp_id IS NULL OR w.psp_id = s.psp_id`): a freshly-pulled account was standing as ownership evidence about subscriptions of an account nobody had read, demoting them to dunning.

## The cut

- Bindings derive from the arming in both callers; `Engine.runProvider` **refuses** a section with no PSP rather than falling back to rail-wide.
- `LocalStateLoader` takes a required `uuid.UUID`; the three reconcile mirror reads lose `narg(psp_id) IS NULL OR …`.
- Migration **0060** deletes the watermark table's NULL lane: `psp_key` dropped, `psp_id` NOT NULL, identity re-keyed on `psp_id`, FK `ON DELETE SET NULL` → `CASCADE` (a cursor without its PSP is not a cursor). Existing global-lane rows are deleted, not backfilled — a watermark is a resumable cursor and prelaunch DBs are disposable.
- The lapsed-evidence leg requires `w.psp_id = s.psp_id`.

## Deliberately NOT in this PR

The materialize/backfill/refund **INSERTs** keep a nullable `psp_id`. `billingimport`'s declared legacy-book import is a deliberately provider-neutral writer (`PspID *uuid.UUID`, "nil = unbound legacy lane"), and in the materialize dedupe guard the nil case matches across *every* PSP — the conservative direction, unlike the reads. Making all eight provenance columns NOT NULL is the rest of #893 task 1 and needs the import wire contract decided first (a cross-repo call).

## Tests

Failing-before / refusal proofs:
- `TestRunRefusesAProviderSectionWithNoPSPBinding` — unbound and zero-uuid bindings both refuse, before any local write.
- `TestApplyActionsCarryThePullsPSP` — every planned mirror write is stamped.
- `TestProviderRefreshWatermarksAreScopedPerPSP` — PSP B's first window starts at the initial lookback, not where PSP A left off; two rows, not one.
- `TestProviderRefreshWatermarkRejectsAnUnattributedRow` — the NULL lane is unreachable at the schema level.
- `TestConverge_PeriodOverdue_WatermarkOfAnotherPSPIsNotEvidence` — a sibling's watermark parks the row `unknown` instead of dunning it.
- `TestPull_SecondPSPBookSurvivesASinglePSPPull` (#841) now seeds its two cohorts under two real PSPs, so it proves the structural guarantee rather than the coverage workaround.

Fixtures that seeded mirror rows with no PSP now name one. That is the invariant, not test noise.

## Gates

`go build`, `go vet` (both tags), unit suite, `golangci-lint` (0 issues), `sql-lint` clean, `migration-lint` clean (0060's five squawk exemptions recorded in `internal/db/queries/EXEMPTIONS.md`), sqlc generate+vet+`git diff --exit-code`, 0060 down/up round-trip on a migrations-built DB, and integration green for `internal/reconcile`, `internal/reconcile/converge`, `internal/river`, `pkg/embedded`, `pkg/embedded/controlplane`, `migrations/postgres`, `embed`.

## Coordination

`internal/db/queries/reconciliation.sql` is also touched by the or#837 lane, in a different hunk of `ListLapsedSubscriptionsWithEvidence` (it appends `ORDER BY … LIMIT`; this changes the watermark evidence predicate ~20 lines above). Rebase, don't drop either.

Migration number is 0060 to leave 0045–0059 for the in-flight lanes.