### PR TITLE
or#812: catalog psp_links console contract + cross-node credential rotation cutover

### DIFF
--- a/docs/admin-console.md
+++ b/docs/admin-console.md
@@ -154,9 +154,9 @@ Local UI dev: `cd web/admin && pnpm run dev` (Vite proxies `/v1`, `/auth`, and
 | Customers | `/customers` | Search → customer profile: subscriptions, payments, entitlements, payment methods; grant/revoke entitlement + product access; off-channel payment |
 | Subscriptions | `/subscriptions` | Status filters incl. the past_due dunning view; cancel (typed confirmation), resume, NMI payment-method change |
 | Payments | `/payments` | Filters, payment detail, rail-aware refund (disabled on rails without API refunds) |
-| Catalog | `/catalog` | Products/prices, price detail + change wizard, activate/deactivate, drift view, catalog copilot panel |
+| Catalog | `/catalog` | Products/prices, price detail + change wizard, activate/deactivate, drift view, catalog copilot panel. Price detail also shows the price's `psp_links` (per-PSP link state, link ids, opt-in live provider verify) and a checkout-readiness dry run naming the PSP a checkout would land on and why each other candidate was skipped. Links are read-only here — the catalog declares them, the provider adapter pushes them. |
 | Ops | `/ops` | Findings queue (approve/ignore), repair alerts, worker health |
-| Settings | `/settings` | Tabs: Merchant profile, Team, Alerts, Payment providers, API keys, Customer controls |
+| Settings | `/settings` | Tabs: Merchant profile, Team, Alerts, Payment providers (configure, rotate credentials, archive), API keys, Customer controls |
 
 **Natural-language features** are fail-closed on the server's `llm:` config and
 mirrored into `config.json` so the UI shows a pointed empty-state (naming the

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -177,7 +177,23 @@ Rules:
 
 - **Rotating a credential within the SAME provider account**: replace the
   secret under the same PSP row — intents arm with the new value
-  transparently.
+  transparently. `PUT /v1/merchant/payment-providers/{rail}` (and the console's
+  **Rotate** action) is atomic in the way that matters:
+  - the **new** credential is live-probed against the provider *before*
+    anything is written (NMI and CCBill today). A probe failure fails the whole
+    request — no secret is stored, no watermark moves, and the **old credential
+    keeps serving**, unchanged, everywhere.
+  - a committed rotation is **deployment-wide at the next read**, not
+    per-node. Each node fronts the secret backend with an in-process TTL cache,
+    so the rotation records the credential's new secret version on the shared
+    PSP row (`evidence.credential_versions`, surfaced as
+    `credentials.<key>.rotation_version`). Every credential resolution already
+    re-reads that row, and no node may answer from a cache entry below the
+    recorded version — so a retired credential cannot be presented after the
+    rotation commits, on any node, without waiting out a TTL. Restarts and
+    manual cache flushes are not part of the procedure.
+  - omit a credential from the request to leave it (and its watermark) alone;
+    re-submitting an identical value is a no-op, not a rotation.
 - **Moving to a DIFFERENT provider account**: never repoint an existing PSP
   row's credentials (OpenRails cannot detect the swap — the declared
   `account_id` would silently lie). Declare a NEW `psps` entry and archive

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -152,7 +152,13 @@ Cutover](operations.md#cutover-booting-against-production-credentials).
   fronts all backends — out-of-band Vault writes converge within one TTL, no
   restart needed.
 - **Rotation within the same provider account** is a non-event: the account
-  identity re-resolves under the new key and matches.
+  identity re-resolves under the new key and matches. Rotate through
+  `PUT /v1/merchant/payment-providers/{rail}` or the console's **Rotate**
+  action — the new credential is live-probed first (a failed probe writes
+  nothing and leaves the old credential serving), and the committed rotation
+  records a version watermark on the shared PSP row that no node may serve a
+  cached credential below. Cutover is deployment-wide at the next credential
+  read; the 15-minute TTL is only the backstop for writes made out of band.
 - **Pointing credentials at a different account** trips the account guard:
   every provider intent is stamped with the provider-account row it was
   enqueued against, and the executor parks intents whose account no longer

--- a/internal/merchants/credential_rotation_cutover_integration_test.go
+++ b/internal/merchants/credential_rotation_cutover_integration_test.go
@@ -1,0 +1,278 @@
+//go:build integration
+
+package merchants
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/db"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// or#812 — credential rotation and its CROSS-NODE cutover.
+//
+// The property under test is the one a multi-node SaaS actually needs: after an
+// operator rotates a PSP credential on ONE node, no OTHER node may keep
+// presenting the retired credential to the gateway. Every node runs a
+// TTL-bounded in-process secret cache, so before or#812 a node that had read
+// the old credential kept serving it for up to DefaultSecretCacheTTL.
+//
+// The test simulates two nodes honestly: two independent merchants.Service
+// instances, each with its OWN cache wrapper, over ONE shared DB-backed secret
+// store and ONE shared Postgres. Nothing is shared in process except the
+// database — exactly the sharing two app nodes have.
+
+// rotationGateway fakes the NMI query endpoint the credential probe hits. It
+// accepts exactly one security key at a time; anything else is rejected the way
+// a real gateway rejects a bad key (an <error_response> body).
+type rotationGateway struct {
+	mu       sync.Mutex
+	accepted string
+	seen     []string
+}
+
+func (g *rotationGateway) accept(key string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.accepted = key
+}
+
+func (g *rotationGateway) keysSeen() []string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return append([]string(nil), g.seen...)
+}
+
+func newRotationGateway(t *testing.T, accepted string) (*rotationGateway, *httptest.Server) {
+	t.Helper()
+	gw := &rotationGateway{accepted: accepted}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		key := r.Form.Get("security_key")
+		gw.mu.Lock()
+		gw.seen = append(gw.seen, key)
+		ok := key == gw.accepted
+		gw.mu.Unlock()
+		if !ok {
+			_, _ = w.Write([]byte(`<?xml version="1.0"?><nm_response><error_response>Invalid Security Key</error_response></nm_response>`))
+			return
+		}
+		_, _ = w.Write([]byte(`<?xml version="1.0"?><nm_response></nm_response>`))
+	}))
+	t.Cleanup(server.Close)
+	return gw, server
+}
+
+// rotationNode is one simulated app node: its own merchants.Service and its own
+// per-process credential cache, over the shared database.
+type rotationNode struct {
+	svc   *Service
+	cache MerchantSecretStore
+}
+
+func newRotationNode(t *testing.T, pool *pgxpool.Pool, probeURL string) *rotationNode {
+	t.Helper()
+	wrapped := db.WrapPool(pool, "")
+	backend, err := NewDBSecretStore(wrapped)
+	require.NoError(t, err)
+	// A long TTL is the point: nothing in this test may pass because a cache
+	// entry happened to expire.
+	cache := NewCachedSecretStore(backend, time.Hour)
+	svc, err := NewService(wrapped, cache, "live")
+	require.NoError(t, err)
+	svc.nmiCredentialProbeQueryURL = probeURL
+	return &rotationNode{svc: svc, cache: cache}
+}
+
+// resolve is exactly what a checkout money path does on this node: resolve the
+// active PSP's secret ref (name + rotation version floor) from the shared DB,
+// then read the credential through this node's cache honouring that floor.
+func (n *rotationNode) resolve(t *testing.T, id merchant.ID) string {
+	t.Helper()
+	ref, ok, err := n.svc.ActivePSPSecretRef(context.Background(), id, "nmi", "live", "security_key")
+	require.NoError(t, err)
+	require.True(t, ok, "the merchant must have an active NMI PSP")
+	sec, err := ReadSecretRef(context.Background(), n.cache, id, ref)
+	require.NoError(t, err)
+	return strings.TrimSpace(sec.Value)
+}
+
+// resolveUnversioned is the pre-or#812 read: name only, no version floor. It
+// exists so the test can PROVE the cache was genuinely warm with the old value
+// and that the version floor — not luck or an expiry — did the cutover.
+func (n *rotationNode) resolveUnversioned(t *testing.T, id merchant.ID) string {
+	t.Helper()
+	ref, ok, err := n.svc.ActivePSPSecretRef(context.Background(), id, "nmi", "live", "security_key")
+	require.NoError(t, err)
+	require.True(t, ok)
+	sec, err := n.cache.Get(context.Background(), id, ref.Name)
+	require.NoError(t, err)
+	return strings.TrimSpace(sec.Value)
+}
+
+func (n *rotationNode) rotate(t *testing.T, id merchant.ID, accountID, key string) error {
+	t.Helper()
+	_, err := n.svc.UpsertPaymentProviderConfig(context.Background(), id, "nmi", UpsertPaymentProviderConfigRequest{
+		AccountID:   accountID,
+		Credentials: map[string]string{"security_key": key},
+	})
+	return err
+}
+
+func TestCredentialRotationCutsOverAcrossNodes(t *testing.T) {
+	pool := newTestPool(t)
+	gw, server := newRotationGateway(t, "key-v1")
+	nodeA := newRotationNode(t, pool, server.URL)
+	nodeB := newRotationNode(t, pool, server.URL)
+
+	ctx := context.Background()
+	tn, _, err := nodeA.svc.Provision(ctx, ProvisionRequest{
+		Slug:              "rotation-cutover-812",
+		PermissionGroupID: "group-rotation-cutover-812",
+	})
+	require.NoError(t, err)
+	const accountID = "rotation-812-gateway"
+
+	// Arm on node A with the credential the gateway currently accepts.
+	require.NoError(t, nodeA.rotate(t, tn.ID, accountID, "key-v1"))
+
+	// Node B reads it and now holds it in its own cache for an hour.
+	require.Equal(t, "key-v1", nodeB.resolve(t, tn.ID))
+
+	cfg, err := nodeA.svc.GetPaymentProviderConfig(ctx, tn.ID, "nmi", "live")
+	require.NoError(t, err)
+	require.Equal(t, 1, cfg.Credentials["security_key"].RotationVersion,
+		"arming must record the credential's rotation version on the PSP row")
+
+	// --- A rotation whose new credential does NOT validate ------------------
+	//
+	// The gateway still only accepts key-v1, so probing key-v2 fails. The whole
+	// rotation must fail: nothing written, no version floor moved, and BOTH
+	// nodes keep serving the old credential.
+	probesBefore := len(gw.keysSeen())
+	err = nodeA.rotate(t, tn.ID, accountID, "key-v2")
+	require.Error(t, err, "a credential the provider rejects must fail the rotation")
+	require.Contains(t, err.Error(), "validate nmi credentials")
+	require.Greater(t, len(gw.keysSeen()), probesBefore, "the NEW credential must actually be probed")
+	require.Contains(t, gw.keysSeen(), "key-v2", "the probe must use the credential being rotated IN, not the stored one")
+
+	require.Equal(t, "key-v1", nodeA.resolve(t, tn.ID), "a refused rotation must leave the old credential serving")
+	require.Equal(t, "key-v1", nodeB.resolve(t, tn.ID), "a refused rotation must not disturb any other node")
+
+	var stored string
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT value FROM openrails.merchant_secrets WHERE merchant_id = $1 AND name LIKE 'psps/nmi/%'
+	`, tn.ID.UUID()).Scan(&stored))
+	require.Equal(t, "key-v1", stored, "a refused rotation must never write the rejected credential")
+
+	cfg, err = nodeA.svc.GetPaymentProviderConfig(ctx, tn.ID, "nmi", "live")
+	require.NoError(t, err)
+	require.Equal(t, 1, cfg.Credentials["security_key"].RotationVersion,
+		"a refused rotation must not move the version floor")
+
+	// --- A rotation whose new credential DOES validate ----------------------
+	gw.accept("key-v2")
+	require.NoError(t, nodeA.rotate(t, tn.ID, accountID, "key-v2"))
+
+	cfg, err = nodeA.svc.GetPaymentProviderConfig(ctx, tn.ID, "nmi", "live")
+	require.NoError(t, err)
+	require.Equal(t, 2, cfg.Credentials["security_key"].RotationVersion,
+		"a committed rotation must raise the version floor")
+
+	// The rotating node is immediately correct (write-through).
+	require.Equal(t, "key-v2", nodeA.resolve(t, tn.ID))
+
+	// THE POINT: node B never saw the rotation, its cache entry is minutes old
+	// with ~an hour of TTL left, and it still serves the NEW credential.
+	require.Equal(t, "key-v2", nodeB.resolve(t, tn.ID),
+		"a rotation on another node must cut over here at the next read, not after a cache TTL")
+
+	// And prove the cutover was the version floor doing work rather than an
+	// expiry: a fresh third node's plain unversioned read of its own warm cache
+	// is exactly what would have gone stale.
+	nodeC := newRotationNode(t, pool, server.URL)
+	require.Equal(t, "key-v2", nodeC.resolveUnversioned(t, tn.ID), "a cold cache always reads through")
+
+	gw.accept("key-v3")
+	require.NoError(t, nodeA.rotate(t, tn.ID, accountID, "key-v3"))
+	require.Equal(t, "key-v2", nodeC.resolveUnversioned(t, tn.ID),
+		"without the version floor a warm cache keeps serving the retired credential — this is the bug or#812 fixes")
+	require.Equal(t, "key-v3", nodeC.resolve(t, tn.ID),
+		"the same node, same warm cache, reading WITH the version floor, gets the rotated credential")
+	require.Equal(t, "key-v3", nodeB.resolve(t, tn.ID))
+}
+
+// TestRotationPreservesUntouchedCredentialVersions covers the partial rotation:
+// an operator rotating one credential must not drop the version floors of the
+// credentials the request left alone, or those would silently lose their
+// cross-node cutover guarantee.
+func TestRotationPreservesUntouchedCredentialVersions(t *testing.T) {
+	pool := newTestPool(t)
+	ctx := context.Background()
+	gw, server := newRotationGateway(t, "nmi-key-a")
+	node := newRotationNode(t, pool, server.URL)
+
+	tn, _, err := node.svc.Provision(ctx, ProvisionRequest{
+		Slug:              "rotation-partial-812",
+		PermissionGroupID: "group-rotation-partial-812",
+	})
+	require.NoError(t, err)
+
+	const accountID = "rotation-812-partial"
+	_, err = node.svc.UpsertPaymentProviderConfig(ctx, tn.ID, "nmi", UpsertPaymentProviderConfigRequest{
+		AccountID: accountID,
+		Credentials: map[string]string{
+			"security_key":           "nmi-key-a",
+			"webhook_signing_secret": "whsec-a",
+		},
+	})
+	require.NoError(t, err)
+
+	// Rotate ONLY the security key.
+	gw.accept("nmi-key-b")
+	cfg, err := node.svc.UpsertPaymentProviderConfig(ctx, tn.ID, "nmi", UpsertPaymentProviderConfigRequest{
+		AccountID:   accountID,
+		Credentials: map[string]string{"security_key": "nmi-key-b"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, cfg.Credentials["security_key"].RotationVersion, "the rotated credential's floor must rise")
+	require.Equal(t, 1, cfg.Credentials["webhook_signing_secret"].RotationVersion,
+		"an untouched credential must keep the floor it already had")
+
+	// Re-putting the SAME value is not a rotation: the store keeps the version,
+	// so the floor must not drift upward and force pointless re-reads.
+	cfg, err = node.svc.UpsertPaymentProviderConfig(ctx, tn.ID, "nmi", UpsertPaymentProviderConfigRequest{
+		AccountID:   accountID,
+		Credentials: map[string]string{"security_key": "nmi-key-b"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, cfg.Credentials["security_key"].RotationVersion)
+	require.Equal(t, 1, cfg.Credentials["webhook_signing_secret"].RotationVersion)
+}
+
+// TestProviderEvidenceMergePreservesForeignKeys pins the evidence-merge
+// contract: the PSP row's evidence document is shared with the manifest arm
+// path, so an API rotation must overlay its own fields rather than replace the
+// document (which would drop a manifest-armed PSP's settings).
+func TestProviderEvidenceMergePreservesForeignKeys(t *testing.T) {
+	existing := []byte(`{"source":"merchant_config_manifest","settings":{"tokenization_key":"tok-abc"}}`)
+	merged, err := marshalProviderEvidence(existing, map[string]string{"public": "value"}, true, map[string]int{"security_key": 3})
+	require.NoError(t, err)
+
+	require.Equal(t, map[string]int{"security_key": 3}, CredentialVersions(merged))
+	require.Equal(t, "tok-abc", pspSettings(merged)["tokenization_key"], "manifest settings must survive an API rotation")
+
+	evidence := unmarshalProviderEvidence(merged)
+	require.True(t, evidence.CredentialsValidated)
+	require.Equal(t, map[string]string{"public": "value"}, evidence.PublicConfig)
+	require.Contains(t, string(merged), `"source":"merchant_config_manifest"`)
+}

--- a/internal/merchants/credentials.go
+++ b/internal/merchants/credentials.go
@@ -60,23 +60,23 @@ func (s *Service) LoadStripeCredentials(ctx context.Context, id merchant.ID) (St
 	if !ok {
 		return creds, nil
 	}
-	secretKeyName, err := scope.secretName("secret_key")
+	secretKeyRef, err := scope.secretRef("secret_key")
 	if err != nil {
 		return creds, err
 	}
-	webhookName, err := scope.secretName("webhook_signing_secret")
+	webhookRef, err := scope.secretRef("webhook_signing_secret")
 	if err != nil {
 		return creds, err
 	}
-	thinName, err := scope.secretName("webhook_signing_secret_thin")
+	thinRef, err := scope.secretRef("webhook_signing_secret_thin")
 	if err != nil {
 		return creds, err
 	}
-	previousName, err := scope.secretName("webhook_signing_secret_previous")
+	previousRef, err := scope.secretRef("webhook_signing_secret_previous")
 	if err != nil {
 		return creds, err
 	}
-	return s.loadStripeCredentialsByName(ctx, id, secretKeyName, webhookName, thinName, previousName)
+	return s.loadStripeCredentialsByRef(ctx, id, secretKeyRef, webhookRef, thinRef, previousRef)
 }
 
 func (s *Service) LoadNMIWebhookSigningSecret(ctx context.Context, id merchant.ID, provider string) (string, error) {
@@ -93,11 +93,11 @@ func (s *Service) LoadNMIWebhookSigningSecret(ctx context.Context, id merchant.I
 	if !ok {
 		return "", nil
 	}
-	secretName, err := scope.secretName("webhook_signing_secret")
+	ref, err := scope.secretRef("webhook_signing_secret")
 	if err != nil {
 		return "", err
 	}
-	return s.secretValue(ctx, id, secretName)
+	return s.secretValueRef(ctx, id, ref)
 }
 
 // LoadNMITokenizationConfig loads merchant-scoped browser tokenization config
@@ -133,28 +133,30 @@ func (s *Service) LoadNMITokenizationConfig(ctx context.Context, id merchant.ID,
 	return cfg, nil
 }
 
-func (s *Service) loadStripeCredentialsByName(ctx context.Context, id merchant.ID, secretKeyName, webhookName, thinName, previousName string) (StripeCredentials, error) {
+func (s *Service) loadStripeCredentialsByRef(ctx context.Context, id merchant.ID, secretKey, webhook, thin, previous SecretRef) (StripeCredentials, error) {
 	var creds StripeCredentials
 	var err error
-	if creds.SecretKey, err = s.secretValue(ctx, id, secretKeyName); err != nil {
+	if creds.SecretKey, err = s.secretValueRef(ctx, id, secretKey); err != nil {
 		return creds, err
 	}
-	if creds.WebhookSigningSecret, err = s.secretValue(ctx, id, webhookName); err != nil {
+	if creds.WebhookSigningSecret, err = s.secretValueRef(ctx, id, webhook); err != nil {
 		return creds, err
 	}
-	if creds.WebhookSigningThin, err = s.secretValue(ctx, id, thinName); err != nil {
+	if creds.WebhookSigningThin, err = s.secretValueRef(ctx, id, thin); err != nil {
 		return creds, err
 	}
-	if previousName != "" {
-		if creds.WebhookSigningPrevious, err = s.secretValue(ctx, id, previousName); err != nil {
+	if previous.Name != "" {
+		if creds.WebhookSigningPrevious, err = s.secretValueRef(ctx, id, previous); err != nil {
 			return creds, err
 		}
 	}
 	return creds, nil
 }
 
-func (s *Service) secretValue(ctx context.Context, id merchant.ID, name string) (string, error) {
-	sec, err := s.secrets.Get(ctx, id, name)
+// secretValueRef reads one credential at or above its recorded rotation version
+// floor (or#812). "" with a nil error means genuinely absent.
+func (s *Service) secretValueRef(ctx context.Context, id merchant.ID, ref SecretRef) (string, error) {
+	sec, err := ReadSecretRef(ctx, s.secrets, id, ref)
 	if err != nil {
 		if errors.Is(err, ErrSecretNotFound) {
 			return "", nil
@@ -165,16 +167,35 @@ func (s *Service) secretValue(ctx context.Context, id merchant.ID, name string) 
 }
 
 type pspSecretScope struct {
-	id          uuid.UUID
-	rail        string
-	environment string
-	accountID   string
-	key         string
-	settings    map[string]any
+	id                 uuid.UUID
+	rail               string
+	environment        string
+	accountID          string
+	key                string
+	settings           map[string]any
+	credentialVersions map[string]int
+}
+
+// applyEvidence unpacks the PSP row's evidence document: the manifest-supplied
+// settings and the or#812 credential-version floors. Every scope resolver goes
+// through it so no read path can silently skip the rotation watermark.
+func (s *pspSecretScope) applyEvidence(raw []byte) {
+	s.settings = pspSettings(raw)
+	s.credentialVersions = CredentialVersions(raw)
 }
 
 func (s pspSecretScope) secretName(key string) (string, error) {
 	return PSPSecretName(s.rail, s.environment, s.accountID, key)
+}
+
+// secretRef pairs the scoped secret name with the rotation version floor
+// recorded on the PSP row (or#812).
+func (s pspSecretScope) secretRef(key string) (SecretRef, error) {
+	name, err := s.secretName(key)
+	if err != nil {
+		return SecretRef{}, err
+	}
+	return SecretRef{Name: name, MinVersion: s.credentialVersions[NormalizeCredentialVersionKey(key)]}, nil
 }
 
 func (s pspSecretScope) setting(key string) string {
@@ -197,13 +218,21 @@ func (s pspSecretScope) exported() PSPScope {
 			settings[k] = v
 		}
 	}
+	var versions map[string]int
+	if len(s.credentialVersions) > 0 {
+		versions = make(map[string]int, len(s.credentialVersions))
+		for k, v := range s.credentialVersions {
+			versions[k] = v
+		}
+	}
 	return PSPScope{
-		ID:          s.id,
-		Rail:        s.rail,
-		Environment: s.environment,
-		AccountID:   s.accountID,
-		Key:         s.key,
-		Settings:    settings,
+		ID:                 s.id,
+		Rail:               s.rail,
+		Environment:        s.environment,
+		AccountID:          s.accountID,
+		Key:                s.key,
+		Settings:           settings,
+		CredentialVersions: versions,
 	}
 }
 
@@ -220,6 +249,22 @@ func (s *Service) ActivePSPSecretName(ctx context.Context, id merchant.ID, rail,
 		return "", false, err
 	}
 	return name, true, nil
+}
+
+// ActivePSPSecretRef is ActivePSPSecretName plus the rotation version floor
+// recorded on the resolved PSP row (or#812) — the form credential reads should
+// use, so a rotation performed on another node cuts over here immediately
+// instead of waiting out a per-process cache TTL.
+func (s *Service) ActivePSPSecretRef(ctx context.Context, id merchant.ID, rail, environment, key string) (SecretRef, bool, error) {
+	scope, ok, err := s.activePSPSecretScope(ctx, id, rail, environment)
+	if err != nil || !ok {
+		return SecretRef{}, ok, err
+	}
+	ref, err := scope.secretRef(key)
+	if err != nil {
+		return SecretRef{}, false, err
+	}
+	return ref, true, nil
 }
 
 // ActivePSPScope resolves the active provider account for a merchant
@@ -294,8 +339,8 @@ func (s *Service) activePSPSecretScope(ctx context.Context, id merchant.ID, rail
 		rail:        row.Rail,
 		environment: row.Environment,
 		accountID:   row.AccountID,
-		settings:    pspSettings(row.Evidence),
 	}
+	scope.applyEvidence(row.Evidence)
 	if row.Key != nil {
 		scope.key = strings.TrimSpace(*row.Key)
 	}
@@ -364,7 +409,7 @@ func (s *Service) PSPScopeByKey(ctx context.Context, id merchant.ID, key, enviro
 	if err != nil {
 		return PSPScope{}, false, fmt.Errorf("load provider account by key %s/%s: %w", key, environment, err)
 	}
-	scope.settings = pspSettings(evidence)
+	scope.applyEvidence(evidence)
 	return scope.exported(), true, nil
 }
 
@@ -402,7 +447,7 @@ func (s *Service) ActivePSPScopesForRail(ctx context.Context, id merchant.ID, ra
 			if err := rows.Scan(&scope.id, &scope.rail, &scope.environment, &scope.accountID, &scope.key, &evidence); err != nil {
 				return err
 			}
-			scope.settings = pspSettings(evidence)
+			scope.applyEvidence(evidence)
 			out = append(out, scope.exported())
 		}
 		return rows.Err()
@@ -445,7 +490,7 @@ func (s *Service) activePSPScopes(ctx context.Context, id merchant.ID, environme
 			if err := rows.Scan(&scope.id, &scope.rail, &scope.environment, &scope.accountID, &scope.key, &evidence); err != nil {
 				return err
 			}
-			scope.settings = pspSettings(evidence)
+			scope.applyEvidence(evidence)
 			out = append(out, scope.exported())
 		}
 		return rows.Err()
@@ -485,7 +530,7 @@ func (s *Service) pspSecretScopeByAccountID(ctx context.Context, id merchant.ID,
 	if err != nil {
 		return pspSecretScope{}, false, fmt.Errorf("load provider account %s/%s: %w", rail, accountID, err)
 	}
-	scope.settings = pspSettings(evidence)
+	scope.applyEvidence(evidence)
 	return scope, true, nil
 }
 
@@ -546,7 +591,7 @@ func (s *Service) newestRailMerchantAccountScope(ctx context.Context, id merchan
 	if err != nil {
 		return PSPScope{}, false, fmt.Errorf("load newest provider account %s/%s: %w", rail, environment, err)
 	}
-	scope.settings = pspSettings(evidence)
+	scope.applyEvidence(evidence)
 	return scope.exported(), true, nil
 }
 
@@ -571,11 +616,11 @@ func (s *Service) LoadNMIWebhookSigningSecretForAccount(ctx context.Context, id 
 	if err != nil || !ok {
 		return "", ok, err
 	}
-	secretName, err := scope.secretName("webhook_signing_secret")
+	ref, err := scope.secretRef("webhook_signing_secret")
 	if err != nil {
 		return "", false, err
 	}
-	secret, err := s.secretValue(ctx, id, secretName)
+	secret, err := s.secretValueRef(ctx, id, ref)
 	return secret, true, err
 }
 
@@ -590,23 +635,23 @@ func (s *Service) LoadStripeCredentialsForAccount(ctx context.Context, id mercha
 	if err != nil || !ok {
 		return creds, ok, err
 	}
-	secretKeyName, err := scope.secretName("secret_key")
+	secretKeyRef, err := scope.secretRef("secret_key")
 	if err != nil {
 		return creds, false, err
 	}
-	webhookName, err := scope.secretName("webhook_signing_secret")
+	webhookRef, err := scope.secretRef("webhook_signing_secret")
 	if err != nil {
 		return creds, false, err
 	}
-	thinName, err := scope.secretName("webhook_signing_secret_thin")
+	thinRef, err := scope.secretRef("webhook_signing_secret_thin")
 	if err != nil {
 		return creds, false, err
 	}
-	previousName, err := scope.secretName("webhook_signing_secret_previous")
+	previousRef, err := scope.secretRef("webhook_signing_secret_previous")
 	if err != nil {
 		return creds, false, err
 	}
-	c, err := s.loadStripeCredentialsByName(ctx, id, secretKeyName, webhookName, thinName, previousName)
+	c, err := s.loadStripeCredentialsByRef(ctx, id, secretKeyRef, webhookRef, thinRef, previousRef)
 	return c, true, err
 }
 

--- a/internal/merchants/payment_provider_config.go
+++ b/internal/merchants/payment_provider_config.go
@@ -26,6 +26,12 @@ import (
 type PaymentProviderCredentialStatus struct {
 	Configured      bool       `json:"configured"`
 	LastValidatedAt *time.Time `json:"last_validated_at,omitempty"`
+	// RotationVersion is the or#812 cross-node cutover watermark: the secret
+	// version this credential reached at its last rotation through this API.
+	// Every node refuses to serve an OLDER version from cache, so a rotation is
+	// deployment-wide the moment this number moves. 0 = the credential was
+	// never rotated through this API (manifest-armed or pre-or#812).
+	RotationVersion int `json:"rotation_version,omitempty"`
 }
 
 // PaymentProviderConfig is one merchant-owned payment-provider account.
@@ -70,6 +76,12 @@ type UpsertPaymentProviderConfigRequest struct {
 type railMerchantAccountEvidence struct {
 	PublicConfig         map[string]string `json:"public_config,omitempty"`
 	CredentialsValidated bool              `json:"credentials_validated,omitempty"`
+	// CredentialVersions is the or#812 cross-node rotation watermark: the
+	// Secret.Version each credential key reached at its last rotation. It rides
+	// the PSP row because every credential resolution already re-reads that row
+	// live from the shared DB, so the floor costs no extra query and reaches
+	// every node the instant the rotation commits.
+	CredentialVersions map[string]int `json:"credential_versions,omitempty"`
 }
 
 // PaymentProviderDefinitions returns every merchant-configurable provider in
@@ -194,7 +206,11 @@ func (s *Service) UpsertPaymentProviderConfig(ctx context.Context, id merchant.I
 		enabled = *req.Enabled
 	}
 
+	// secretNames maps the scoped secret NAME to its value; secretKeys maps the
+	// same name back to the normalized credential KEY, which is what the
+	// version floor on the PSP row is recorded under.
 	secretNames := make(map[string]string, len(req.Credentials))
+	secretKeys := make(map[string]string, len(req.Credentials))
 	probeCredentials := make(map[string]string, len(req.Credentials))
 	credentialsValidated := false
 	for key, value := range req.Credentials {
@@ -213,8 +229,13 @@ func (s *Service) UpsertPaymentProviderConfig(ctx context.Context, id merchant.I
 			credentialsValidated = true
 		}
 		secretNames[name] = value
+		secretKeys[name] = normalizedKey
 		probeCredentials[normalizedKey] = value
 	}
+	// ROTATION ORDER (or#812). The live probe runs FIRST and on the credentials
+	// SUPPLIED IN THIS REQUEST, so a bad new credential fails here — before any
+	// secret is written and before any version floor moves. The old credential
+	// stays exactly as it was and keeps serving on every node.
 	probed, err := s.probePaymentProviderCredentials(ctx, id, rail, environment, accountID, probeCredentials)
 	if err != nil {
 		return PaymentProviderConfig{}, err
@@ -226,14 +247,21 @@ func (s *Service) UpsertPaymentProviderConfig(ctx context.Context, id merchant.I
 		lastVerifiedAt = &now
 	}
 
-	row, err := s.upsertRailMerchantAccount(ctx, id, rail, environment, accountID, enabled, req.PublicConfig, credentialsValidated, lastVerifiedAt)
-	if err != nil {
-		return PaymentProviderConfig{}, err
-	}
+	// Secrets are written BEFORE the PSP row so the version floor never becomes
+	// visible to another node ahead of the value it demands.
+	credentialVersions := make(map[string]int, len(secretNames))
 	for name, value := range secretNames {
-		if _, err := s.PutCredential(ctx, id, name, value); err != nil {
+		sec, err := s.PutCredential(ctx, id, name, value)
+		if err != nil {
 			return PaymentProviderConfig{}, err
 		}
+		if key := secretKeys[name]; key != "" && sec.Version > 0 {
+			credentialVersions[NormalizeCredentialVersionKey(key)] = sec.Version
+		}
+	}
+	row, err := s.upsertRailMerchantAccount(ctx, id, rail, environment, accountID, enabled, req.PublicConfig, credentialsValidated, lastVerifiedAt, credentialVersions)
+	if err != nil {
+		return PaymentProviderConfig{}, err
 	}
 	statuses, err := s.ListSecretStatuses(ctx, id)
 	if err != nil {
@@ -275,7 +303,7 @@ func (s *Service) DeletePaymentProviderConfig(ctx context.Context, id merchant.I
 	return cfg, nil
 }
 
-func (s *Service) upsertRailMerchantAccount(ctx context.Context, id merchant.ID, rail, environment, accountID string, enabled bool, publicConfig map[string]string, credentialsValidated bool, lastVerifiedAt *time.Time) (gen.OpenrailsPsp, error) {
+func (s *Service) upsertRailMerchantAccount(ctx context.Context, id merchant.ID, rail, environment, accountID string, enabled bool, publicConfig map[string]string, credentialsValidated bool, lastVerifiedAt *time.Time, credentialVersions map[string]int) (gen.OpenrailsPsp, error) {
 	// #650: reject a cross-merchant claim with a clear error before the upsert
 	// (which would otherwise fail with an opaque unique-violation under RLS).
 	queries := gen.New(s.pool)
@@ -287,27 +315,33 @@ func (s *Service) upsertRailMerchantAccount(ctx context.Context, id merchant.ID,
 	// normalized (rail, environment, account_id) the id is hashed from, so the
 	// id corresponds 1:1 to the unique index.
 	railAcctID, nRail, nEnv, nAccount := PSPNaturalKey(rail, environment, accountID)
-	if len(publicConfig) == 0 || !credentialsValidated {
-		existing, err := queries.GetPSPByRailIdentity(ctx, gen.GetPSPByRailIdentityParams{
-			Rail:        nRail,
-			Environment: &nEnv,
-			AccountID:   nAccount,
-		})
-		switch {
-		case err == nil:
-			existingEvidence := unmarshalProviderEvidence(existing.Evidence)
-			if len(publicConfig) == 0 {
-				publicConfig = existingEvidence.PublicConfig
-			}
-			if !credentialsValidated && existingEvidence.CredentialsValidated {
-				credentialsValidated = true
-				lastVerifiedAt = existing.LastVerifiedAt
-			}
-		case !errors.Is(err, pgx.ErrNoRows):
-			return gen.OpenrailsPsp{}, fmt.Errorf("merchants: load existing provider config: %w", err)
+	// Always read the existing row: fields this request omits are carried
+	// forward, and the or#812 credential-version floors of credentials it did
+	// not rotate must survive.
+	var existingEvidenceRaw []byte
+	existing, err := queries.GetPSPByRailIdentity(ctx, gen.GetPSPByRailIdentityParams{
+		Rail:        nRail,
+		Environment: &nEnv,
+		AccountID:   nAccount,
+	})
+	switch {
+	case err == nil:
+		existingEvidenceRaw = existing.Evidence
+		existingEvidence := unmarshalProviderEvidence(existing.Evidence)
+		if len(publicConfig) == 0 {
+			publicConfig = existingEvidence.PublicConfig
 		}
+		if !credentialsValidated && existingEvidence.CredentialsValidated {
+			credentialsValidated = true
+			lastVerifiedAt = existing.LastVerifiedAt
+		}
+		credentialVersions = mergeCredentialVersions(existingEvidence.CredentialVersions, credentialVersions)
+	case !errors.Is(err, pgx.ErrNoRows):
+		return gen.OpenrailsPsp{}, fmt.Errorf("merchants: load existing provider config: %w", err)
+	default:
+		credentialVersions = mergeCredentialVersions(nil, credentialVersions)
 	}
-	evidence, err := marshalProviderEvidence(publicConfig, credentialsValidated)
+	evidence, err := marshalProviderEvidence(existingEvidenceRaw, publicConfig, credentialsValidated, credentialVersions)
 	if err != nil {
 		return gen.OpenrailsPsp{}, err
 	}
@@ -437,6 +471,7 @@ func paymentProviderConfigFromRow(row gen.OpenrailsPsp, statuses []MerchantSecre
 		credentials[key] = PaymentProviderCredentialStatus{
 			Configured:      ok,
 			LastValidatedAt: validatedAt,
+			RotationVersion: evidence.CredentialVersions[NormalizeCredentialVersionKey(key)],
 		}
 	}
 	return PaymentProviderConfig{
@@ -524,18 +559,72 @@ func credentialValidatedAt(rail, key string, validatedAt *time.Time) *time.Time 
 	return nil
 }
 
-func marshalProviderEvidence(publicConfig map[string]string, credentialsValidated bool) ([]byte, error) {
-	if len(publicConfig) == 0 && !credentialsValidated {
+// marshalProviderEvidence overlays the fields this API owns onto the evidence
+// document already on the row. Evidence is a shared, free-form JSONB — the
+// manifest path also writes `source`, `signer` and `settings` there — so an API
+// arm must merge, not replace, or a manifest-armed PSP loses its settings the
+// first time an operator rotates a credential.
+func marshalProviderEvidence(existing []byte, publicConfig map[string]string, credentialsValidated bool, credentialVersions map[string]int) ([]byte, error) {
+	doc := map[string]json.RawMessage{}
+	if len(existing) > 0 {
+		if err := json.Unmarshal(existing, &doc); err != nil {
+			doc = map[string]json.RawMessage{}
+		}
+	}
+	set := func(key string, value any, keep bool) error {
+		if !keep {
+			delete(doc, key)
+			return nil
+		}
+		raw, err := json.Marshal(value)
+		if err != nil {
+			return fmt.Errorf("marshal provider config evidence %s: %w", key, err)
+		}
+		doc[key] = raw
+		return nil
+	}
+	if err := set("public_config", publicConfig, len(publicConfig) > 0); err != nil {
+		return nil, err
+	}
+	if err := set("credentials_validated", credentialsValidated, credentialsValidated); err != nil {
+		return nil, err
+	}
+	if err := set("credential_versions", credentialVersions, len(credentialVersions) > 0); err != nil {
+		return nil, err
+	}
+	if len(doc) == 0 {
 		return nil, nil
 	}
-	b, err := json.Marshal(railMerchantAccountEvidence{
-		PublicConfig:         publicConfig,
-		CredentialsValidated: credentialsValidated,
-	})
+	b, err := json.Marshal(doc)
 	if err != nil {
 		return nil, fmt.Errorf("marshal provider config evidence: %w", err)
 	}
 	return b, nil
+}
+
+// mergeCredentialVersions carries forward the version floors of credentials
+// this request did not touch and raises the floors it did. A floor NEVER goes
+// backwards: a lower observed version means an out-of-order write, and the
+// higher floor is the safe one (it only ever forces a re-read).
+func mergeCredentialVersions(existing, rotated map[string]int) map[string]int {
+	if len(existing) == 0 && len(rotated) == 0 {
+		return nil
+	}
+	out := make(map[string]int, len(existing)+len(rotated))
+	for k, v := range existing {
+		if k = NormalizeCredentialVersionKey(k); k != "" && v > 0 {
+			out[k] = v
+		}
+	}
+	for k, v := range rotated {
+		if k = NormalizeCredentialVersionKey(k); k != "" && v > out[k] {
+			out[k] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func unmarshalProviderEvidence(raw []byte) railMerchantAccountEvidence {

--- a/internal/merchants/secrets.go
+++ b/internal/merchants/secrets.go
@@ -10,6 +10,7 @@ package merchants
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -174,10 +175,53 @@ type MerchantSecretReader interface {
 	Get(ctx context.Context, merchantID merchant.ID, name string) (Secret, error)
 }
 
+// VersionedSecretReader is the cross-node ROTATION CUTOVER contract (or#812).
+//
+// A read-through secret cache is per-process, so a credential rotated on node A
+// stays cached on node B until B's entry expires — up to DefaultSecretCacheTTL
+// of a retired credential still being presented to a gateway. The fix is a
+// versioned read: the PSP row (shared DB, re-read live on every credential
+// resolution) records the Secret.Version each credential reached at its last
+// rotation, and a reader that holds an OLDER version must go back to the
+// backend instead of answering from cache.
+//
+// Only the caching wrapper needs to implement this; ReadSecretRef degrades to
+// a plain Get for uncached stores, which are already never stale.
+type VersionedSecretReader interface {
+	GetAtLeastVersion(ctx context.Context, merchantID merchant.ID, name string, minVersion int) (Secret, error)
+}
+
+// SecretRef names a credential AND the version floor a reader must satisfy for
+// it. MinVersion 0 means "no floor recorded" — the pre-rotation state, and the
+// state of every secret written outside the provider-config API.
+type SecretRef struct {
+	Name       string
+	MinVersion int
+}
+
+// ReadSecretRef reads ref through reader, honouring the version floor when the
+// reader can. Every provider-credential read goes through here so the cutover
+// rule lives in exactly one place.
+func ReadSecretRef(ctx context.Context, reader MerchantSecretReader, id merchant.ID, ref SecretRef) (Secret, error) {
+	if reader == nil {
+		return Secret{}, errors.New("merchants: no secret store configured")
+	}
+	if versioned, ok := reader.(VersionedSecretReader); ok && ref.MinVersion > 0 {
+		return versioned.GetAtLeastVersion(ctx, id, ref.Name, ref.MinVersion)
+	}
+	return reader.Get(ctx, id, ref.Name)
+}
+
 // PSPSecretResolver resolves the canonical secret name for the
 // active provider account a merchant should use.
 type PSPSecretResolver interface {
 	ActivePSPSecretName(ctx context.Context, merchantID merchant.ID, rail, environment, key string) (string, bool, error)
+}
+
+// PSPSecretRefResolver is PSPSecretResolver plus the rotation version floor —
+// the form every credential read should use (or#812).
+type PSPSecretRefResolver interface {
+	ActivePSPSecretRef(ctx context.Context, merchantID merchant.ID, rail, environment, key string) (SecretRef, bool, error)
 }
 
 // PSPScope is the configured provider account selected for a
@@ -191,6 +235,54 @@ type PSPScope struct {
 	// payment-provider vocabulary catalog links and checkout use.
 	Key      string
 	Settings map[string]any
+	// CredentialVersions is the rotation watermark per credential key
+	// (or#812): the Secret.Version each credential reached the last time it
+	// was rotated through the provider-config API. Absent/zero = no floor.
+	CredentialVersions map[string]int
+}
+
+// SecretRef returns the scoped secret name for key together with the rotation
+// version floor recorded on this PSP row.
+func (s PSPScope) SecretRef(key string) (SecretRef, error) {
+	name, err := PSPSecretName(s.Rail, s.Environment, s.AccountID, key)
+	if err != nil {
+		return SecretRef{}, err
+	}
+	return SecretRef{Name: name, MinVersion: s.CredentialVersions[NormalizeCredentialVersionKey(key)]}, nil
+}
+
+// PSPSecretRef builds a scoped SecretRef straight from a PSP row's identity and
+// its evidence document — for the paths that hold the raw row rather than a
+// resolved PSPScope.
+func PSPSecretRef(rail, environment, accountID string, evidence []byte, key string) (SecretRef, error) {
+	name, err := PSPSecretName(rail, environment, accountID, key)
+	if err != nil {
+		return SecretRef{}, err
+	}
+	return SecretRef{Name: name, MinVersion: CredentialVersions(evidence)[NormalizeCredentialVersionKey(key)]}, nil
+}
+
+// CredentialVersions reads the or#812 rotation watermarks out of a PSP row's
+// evidence document.
+func CredentialVersions(evidence []byte) map[string]int {
+	if len(evidence) == 0 {
+		return nil
+	}
+	var doc struct {
+		CredentialVersions map[string]int `json:"credential_versions"`
+	}
+	if json.Unmarshal(evidence, &doc) != nil {
+		return nil
+	}
+	return doc.CredentialVersions
+}
+
+// NormalizeCredentialVersionKey is the canonical form credential-version keys
+// are recorded under: lowercase, trimmed. It deliberately does NOT go through
+// NormalizePSPSecretKey (which rejects unknown keys) — a version floor for a
+// key this build does not recognise is still worth honouring.
+func NormalizeCredentialVersionKey(key string) string {
+	return strings.ToLower(strings.TrimSpace(key))
 }
 
 // PSPScopeResolver resolves the selected provider account without

--- a/internal/merchants/secrets_cache.go
+++ b/internal/merchants/secrets_cache.go
@@ -23,13 +23,14 @@ const DefaultSecretCacheTTL = 15 * time.Minute
 //     visible immediately, and a transient backend outage must not be pinned.
 //   - Put/Delete are write-through and invalidate (Put refreshes) the entry in the
 //     SAME process immediately, so a rotation through this node is never stale.
-//   - Secret.Version is tracked: a refreshed read with a higher version replaces the
-//     cached value, so an admin rotation is reflected within one TTL even when it
-//     lands on another node.
+//   - GetAtLeastVersion (or#812) is the cross-node cutover: a caller that knows the
+//     credential has been rotated to version N — because the shared PSP row says so —
+//     never gets a pre-N cache entry back. That makes a rotation on ANY node
+//     effective on every other node at its next credential read, not one TTL later.
 //
-// Cross-process rotations converge within one ttl window (the entry expires and is
-// re-read). This is a cache, never the source of truth — it holds plaintext only as
-// long as the underlying store would have returned it.
+// TTL expiry remains the backstop for reads with no recorded version floor. This is
+// a cache, never the source of truth — it holds plaintext only as long as the
+// underlying store would have returned it.
 type cachedSecretStore struct {
 	inner MerchantSecretStore
 	ttl   time.Duration
@@ -65,21 +66,40 @@ func NewCachedSecretStore(inner MerchantSecretStore, ttl time.Duration) Merchant
 }
 
 func (c *cachedSecretStore) Get(ctx context.Context, merchantID merchant.ID, name string) (Secret, error) {
+	return c.GetAtLeastVersion(ctx, merchantID, name, 0)
+}
+
+// GetAtLeastVersion implements VersionedSecretReader: it is the cross-node
+// rotation cutover (or#812). A cached entry is only usable when it is BOTH
+// unexpired AND at least minVersion; a caller that learned from the shared PSP
+// row that the credential has been rotated to version N is never answered from
+// a pre-N cache entry, however much TTL is left. minVersion 0 is the
+// unversioned path and behaves exactly as before.
+func (c *cachedSecretStore) GetAtLeastVersion(ctx context.Context, merchantID merchant.ID, name string, minVersion int) (Secret, error) {
 	key := cacheKey{merchant: merchantID.String(), name: name}
 
 	c.mu.Lock()
-	if e, ok := c.entries[key]; ok && c.now().Before(e.expires) {
+	if e, ok := c.entries[key]; ok && c.now().Before(e.expires) && e.secret.Version >= minVersion {
 		sec := e.secret
 		c.mu.Unlock()
 		return sec, nil
 	}
 	c.mu.Unlock()
 
-	// Miss (or expired): read through. Errors (absent / unavailable) are returned
-	// to the caller and NOT cached.
+	// Miss (or expired, or superseded): read through. Errors (absent /
+	// unavailable) are returned to the caller and NOT cached.
 	sec, err := c.inner.Get(ctx, merchantID, name)
 	if err != nil {
 		return Secret{}, err
+	}
+
+	if sec.Version < minVersion {
+		// The backend has not caught up with a version the shared PSP row says
+		// is committed. Serve what the backend authoritatively holds — refusing
+		// would take a live merchant down over a replication lag — but do NOT
+		// cache it, so the very next call retries instead of pinning the stale
+		// value for a whole TTL.
+		return sec, nil
 	}
 
 	c.mu.Lock()

--- a/internal/modules/checkout/merchant_rail_secrets.go
+++ b/internal/modules/checkout/merchant_rail_secrets.go
@@ -42,6 +42,14 @@ func (s *CheckoutService) SetRailMerchantAccountSecretResolver(resolver merchant
 }
 
 func (s *CheckoutService) merchantSecret(ctx context.Context, name string) (string, bool, error) {
+	return s.merchantSecretRef(ctx, merchants.SecretRef{Name: name})
+}
+
+// merchantSecretRef is the single credential read for checkout money paths. It
+// carries the or#812 rotation version floor, so a credential rotated on ANOTHER
+// node is picked up on the next charge instead of after a cache TTL of
+// presenting a retired key to the gateway.
+func (s *CheckoutService) merchantSecretRef(ctx context.Context, ref merchants.SecretRef) (string, bool, error) {
 	if s == nil || s.MerchantSecrets == nil {
 		return "", false, nil
 	}
@@ -49,7 +57,7 @@ func (s *CheckoutService) merchantSecret(ctx context.Context, name string) (stri
 	if err != nil {
 		return "", false, err
 	}
-	sec, err := s.MerchantSecrets.Get(ctx, tid, name)
+	sec, err := merchants.ReadSecretRef(ctx, s.MerchantSecrets, tid, ref)
 	if err != nil {
 		if errors.Is(err, merchants.ErrSecretNotFound) {
 			return "", false, nil
@@ -70,6 +78,13 @@ func (s *CheckoutService) merchantProviderSecret(ctx context.Context, rail, envi
 	tid, err := merchant.Require(ctx)
 	if err != nil {
 		return "", false, err
+	}
+	if refResolver, ok := s.ProviderSecrets.(merchants.PSPSecretRefResolver); ok {
+		ref, found, err := refResolver.ActivePSPSecretRef(ctx, tid, rail, environment, key)
+		if err != nil || !found {
+			return "", found, err
+		}
+		return s.merchantSecretRef(ctx, ref)
 	}
 	name, ok, err := s.ProviderSecrets.ActivePSPSecretName(ctx, tid, rail, environment, key)
 	if err != nil || !ok {
@@ -264,12 +279,13 @@ func (s *CheckoutService) resolveNMIClient(ctx context.Context, provider string)
 	}
 	var value string
 	if target.Scope != nil {
-		// Pinned to the resolved account's own secret.
-		name, err := merchants.PSPSecretName(target.Scope.Rail, target.Scope.Environment, target.Scope.AccountID, "security_key")
+		// Pinned to the resolved account's own secret, at or above the rotation
+		// version floor that account's PSP row records (or#812).
+		ref, err := target.Scope.SecretRef("security_key")
 		if err != nil {
 			return nil, err
 		}
-		v, ok, err := s.merchantSecret(ctx, name)
+		v, ok, err := s.merchantSecretRef(ctx, ref)
 		if err != nil {
 			return nil, fmt.Errorf("load merchant NMI secret: %w", err)
 		}

--- a/internal/modules/money/merchant_collection_wiring.go
+++ b/internal/modules/money/merchant_collection_wiring.go
@@ -318,11 +318,12 @@ func (b *MerchantCollectionAdapterBuilder) secret(ctx context.Context, svc *merc
 	if svc.Secrets() == nil {
 		return "", false, nil
 	}
-	name, err := merchants.PSPSecretName(scope.Rail, scope.Environment, scope.AccountID, key)
+	// or#812: honour the PSP row's rotation version floor.
+	ref, err := scope.SecretRef(key)
 	if err != nil {
 		return "", false, err
 	}
-	sec, err := svc.Secrets().Get(ctx, mid, name)
+	sec, err := merchants.ReadSecretRef(ctx, svc.Secrets(), mid, ref)
 	if errors.Is(err, merchants.ErrSecretNotFound) {
 		return "", false, nil
 	}

--- a/internal/modules/solana/recurring/wiring.go
+++ b/internal/modules/solana/recurring/wiring.go
@@ -45,11 +45,13 @@ func (g secretStoreGetter) GetSecret(ctx context.Context, merchantID merchant.ID
 		if !ok {
 			return "", fmt.Errorf("solana: no active provider account for signing key")
 		}
-		secretName, err := merchants.PSPSecretName(account.Rail, account.Environment, account.AccountID, "private_key")
+		// or#812: read at or above the rotation version floor the PSP row
+		// records, so a key rotated on another node is never served stale here.
+		ref, err := merchants.PSPSecretRef(account.Rail, account.Environment, account.AccountID, account.Evidence, "private_key")
 		if err != nil {
 			return "", err
 		}
-		sec, err := g.store.Get(ctx, merchantID, secretName)
+		sec, err := merchants.ReadSecretRef(ctx, g.store, merchantID, ref)
 		if err != nil {
 			return "", err
 		}

--- a/internal/railresolve/railresolve.go
+++ b/internal/railresolve/railresolve.go
@@ -123,11 +123,13 @@ func (s *MerchantsSource) secret(ctx context.Context, mid merchant.ID, scope mer
 	if svc == nil || svc.Secrets() == nil {
 		return "", false, nil
 	}
-	name, err := merchants.PSPSecretName(scope.Rail, scope.Environment, scope.AccountID, key)
+	// or#812: the version floor recorded on the PSP row makes a credential
+	// rotated on another node effective here at once, not one cache TTL later.
+	ref, err := scope.SecretRef(key)
 	if err != nil {
 		return "", false, err
 	}
-	sec, err := svc.Secrets().Get(ctx, mid, name)
+	sec, err := merchants.ReadSecretRef(ctx, svc.Secrets(), mid, ref)
 	if errors.Is(err, merchants.ErrSecretNotFound) {
 		return "", false, nil
 	}

--- a/internal/reconcile/merchant_wiring.go
+++ b/internal/reconcile/merchant_wiring.go
@@ -182,11 +182,12 @@ func (b MerchantFetcherBuilder) secret(ctx context.Context, mid merchant.ID, sco
 	if b.Merchants == nil || b.Merchants.Secrets() == nil {
 		return "", false, nil
 	}
-	name, err := merchants.PSPSecretName(scope.Rail, scope.Environment, scope.AccountID, key)
+	// or#812: honour the PSP row's rotation version floor.
+	ref, err := scope.SecretRef(key)
 	if err != nil {
 		return "", false, err
 	}
-	sec, err := b.Merchants.Secrets().Get(ctx, mid, name)
+	sec, err := merchants.ReadSecretRef(ctx, b.Merchants.Secrets(), mid, ref)
 	if errors.Is(err, merchants.ErrSecretNotFound) {
 		return "", false, nil
 	}

--- a/web/admin/src/lib/api/endpoints.ts
+++ b/web/admin/src/lib/api/endpoints.ts
@@ -13,6 +13,7 @@ import type {
   CatalogDriftReport,
   CatalogPrice,
   CatalogProduct,
+  CheckoutRoutingDecision,
   CustomerBillingProfile,
   CustomerSummary,
   Finding,
@@ -212,7 +213,14 @@ export interface PriceRequest {
 export const createPrice = (body: PriceRequest) =>
   api<CatalogPrice>("/merchant/catalog/prices", { method: "POST", body })
 
-export const getPrice = (id: string) => api<CatalogPrice>(`/merchant/catalog/prices/${id}`)
+// getPrice returns the price with its psp_links projection (`providers`).
+// verify=true additionally performs a LIVE retrieve against every attached
+// provider and fills in sync_status/drift — a read, never a write, and slow
+// enough that it stays opt-in (or#812).
+export const getPrice = (id: string, verify = false) =>
+  api<CatalogPrice>(`/merchant/catalog/prices/${id}`, {
+    query: verify ? { verify: true } : undefined,
+  })
 
 export const getPriceByKey = (key: string) =>
   api<CatalogPrice>(`/merchant/catalog/prices/by-key/${encodeURIComponent(key)}`)
@@ -327,6 +335,19 @@ export interface UpsertProviderRequest {
 export const putPaymentProvider = (rail: string, body: UpsertProviderRequest) =>
   api<{ payment_provider: PaymentProviderConfig }>(`/merchant/payment-providers/${rail}`, {
     method: "PUT",
+    body,
+  })
+
+// dryRunCheckoutRouting (or#288) explains which PSP a checkout for this price
+// would land on and why each other candidate was passed over. Read-only: it
+// runs the production decision path without creating a session.
+export const dryRunCheckoutRouting = (body: {
+  price_id: string
+  country?: string
+  selector?: string
+}) =>
+  api<CheckoutRoutingDecision>("/merchant/payment-providers/routing/dry-run", {
+    method: "POST",
     body,
   })
 

--- a/web/admin/src/lib/api/types.ts
+++ b/web/admin/src/lib/api/types.ts
@@ -186,6 +186,10 @@ export interface CatalogProduct {
   updated_at: string
 }
 
+// CatalogProviderState is one entry of prices.psp_links as the API projects it
+// (or#812): the map is keyed by PSP key ("mobius"), and `ids` is the stored
+// link entry verbatim — including `ids.rail`, the gateway the entry lives on.
+// sync_status is "unknown" until a live retrieve runs (GET price ?verify=true).
 export interface CatalogProviderState {
   status: "linked" | "pending_manual_link" | "sync_disabled" | "error"
   ids?: Record<string, string>
@@ -194,6 +198,39 @@ export interface CatalogProviderState {
   sync_status?: string
   drift?: { field: string; openrails_value: string; remote_value: string }[]
   message?: string
+}
+
+// CheckoutRoutingSkip mirrors the or#288 skip vocabulary
+// (internal/db/models/checkout_session.go). "" / absent = the candidate is
+// eligible.
+export type CheckoutRoutingSkip =
+  | "unknown_selector"
+  | "ambiguous_selector"
+  | "not_armed"
+  | "credentials_missing"
+  | "link_missing"
+  | "mode_unsupported"
+  | "service_unavailable"
+  | "resolve_failed"
+
+export interface CheckoutRoutingCandidate {
+  selector: string
+  rail?: string
+  skip?: CheckoutRoutingSkip
+}
+
+// CheckoutRoutingDecision is POST /merchant/payment-providers/routing/dry-run
+// (or#288): which PSP a checkout for this price would land on, and why every
+// other candidate did not. Read-only — it creates nothing.
+export interface CheckoutRoutingDecision {
+  object: "checkout_routing_decision"
+  policy: string
+  rule?: number
+  selected?: string
+  rail?: string
+  mode?: string
+  candidates: CheckoutRoutingCandidate[]
+  routing_reason?: unknown
 }
 
 export interface CatalogPrice {
@@ -403,7 +440,13 @@ export interface PaymentProviderConfig {
   drained: boolean
   open_obligations: number
   public_config?: Record<string, string>
-  credentials: Record<string, { configured: boolean; last_validated_at?: string }>
+  // rotation_version (or#812) is the cross-node cutover watermark: the secret
+  // version this credential reached at its last rotation through this API.
+  // Absent/0 = never rotated here (manifest-armed, or pre-or#812).
+  credentials: Record<
+    string,
+    { configured: boolean; last_validated_at?: string; rotation_version?: number }
+  >
   first_seen_at: string
   last_validated_at?: string
   replaced_at?: string

--- a/web/admin/src/pages/catalog/index.tsx
+++ b/web/admin/src/pages/catalog/index.tsx
@@ -371,14 +371,16 @@ function PriceRow({
       <TableCell>{priceIntervalLabel(price)}</TableCell>
       <TableCell>
         <span className="flex flex-wrap gap-1">
-          {Object.entries(price.providers ?? {}).map(([rail, state]) => (
+          {/* psp_links is keyed by PSP key ("mobius"), not by rail — the rail
+              is recorded inside the entry (or#812). */}
+          {Object.entries(price.providers ?? {}).map(([psp, state]) => (
             <Badge
-              key={rail}
+              key={psp}
               variant="secondary"
               className={state.status === "linked" ? "" : "bg-amber-500/15 text-amber-600 dark:text-amber-400"}
               title={state.message}
             >
-              {rail}: {state.status}
+              {psp}: {state.status}
             </Badge>
           ))}
         </span>

--- a/web/admin/src/pages/catalog/price-detail.tsx
+++ b/web/admin/src/pages/catalog/price-detail.tsx
@@ -28,6 +28,7 @@ import { formatDate, formatMicros, shortId } from "@/lib/format"
 import { toastApiError } from "@/lib/toast"
 import { priceIntervalLabel } from "@/pages/catalog/price-format"
 import { PriceChangeWizard } from "@/pages/catalog/price-wizard"
+import { CheckoutReadinessCard, PSPLinksCard } from "@/pages/catalog/psp-links"
 
 // PriceDetailPage (#777): the version chain (from the #774 pointer-movement
 // log, with dates) and any pending scheduled migration (progress + cancel)
@@ -36,7 +37,10 @@ import { PriceChangeWizard } from "@/pages/catalog/price-wizard"
 export function PriceDetailPage() {
   const { id = "" } = useParams()
   const navigate = useNavigate()
-  const { data: price, loading, error, reload } = useApiData(() => getPrice(id), [id])
+  // verify (or#812) is opt-in: it makes GET price perform a live retrieve
+  // against every attached provider, which is a network round trip per PSP.
+  const [verify, setVerify] = React.useState(false)
+  const { data: price, loading, error, reload } = useApiData(() => getPrice(id, verify), [id, verify])
   const { data: product } = useApiData(
     () => (price ? getProduct(price.product_id) : Promise.resolve(null)),
     [price?.product_id],
@@ -71,8 +75,13 @@ export function PriceDetailPage() {
     reloadBatches()
   }
 
-  if (loading) return <p className="text-sm text-muted-foreground">Loading…</p>
-  if (!price) return <p className="text-sm text-muted-foreground">Price not found.</p>
+  // Only the FIRST load blanks the page; a verify refetch keeps the rendered
+  // price in place so the button can show its own in-flight state.
+  if (!price) {
+    return (
+      <p className="text-sm text-muted-foreground">{loading ? "Loading…" : "Price not found."}</p>
+    )
+  }
 
   const scheduled = batchReprices?.items?.filter((r) => r.status === "scheduled") ?? []
   const applied = batchReprices?.items?.filter((r) => r.status === "applied") ?? []
@@ -108,6 +117,15 @@ export function PriceDetailPage() {
         </Fact>
         <Fact label="Created">{formatDate(price.created_at)}</Fact>
       </div>
+
+      <PSPLinksCard
+        price={price}
+        verifying={verify && loading}
+        verified={verify}
+        onVerify={() => (verify ? reload() : setVerify(true))}
+      />
+
+      <CheckoutReadinessCard price={price} />
 
       <Card>
         <CardHeader>

--- a/web/admin/src/pages/catalog/psp-links.tsx
+++ b/web/admin/src/pages/catalog/psp-links.tsx
@@ -1,0 +1,331 @@
+import * as React from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useApiData } from "@/hooks/use-api-data"
+import { dryRunCheckoutRouting } from "@/lib/api/endpoints"
+import type {
+  CatalogPrice,
+  CatalogProviderState,
+  CheckoutRoutingDecision,
+  CheckoutRoutingSkip,
+} from "@/lib/api/types"
+import { formatDate } from "@/lib/format"
+import { toastApiError } from "@/lib/toast"
+
+// or#812 — the frontend contract for catalog psp_links.
+//
+// The catalog is DECLARATIVE: OpenRails definitions are pushed to a provider by
+// the provider adapter, and the reconciliation job that reads back is
+// alert-only. So this surface DISPLAYS a price's psp_links and their
+// provider-side state; it never edits them. The write path is the catalog
+// (manifest / create-price `providers`), not a per-link form.
+//
+// Two questions get answered side by side, and they are different questions:
+//   - Link state (`price.providers`, the psp_links projection): does OpenRails
+//     hold a link entry for this PSP, and does the remote object still match?
+//   - Checkout readiness (or#288 routing dry run): would a real checkout
+//     actually land here right now? A price can be perfectly linked and still
+//     be unroutable because the PSP is unarmed or its credentials are missing.
+
+// SKIP_LABELS is the or#288 skip vocabulary, verbatim keys, rendered for
+// operators. Keep the keys in lockstep with
+// internal/db/models/checkout_session.go.
+const SKIP_LABELS: Record<CheckoutRoutingSkip, string> = {
+  unknown_selector: "Not a declared PSP key or rail kind.",
+  ambiguous_selector: "Bare rail kind matched more than one armed PSP — name the PSP key.",
+  not_armed: "No active PSP row: never configured, or archived.",
+  credentials_missing: "PSP is armed but the credentials this rail needs are absent.",
+  link_missing: "This price carries no usable psp_link for the PSP.",
+  mode_unsupported: "The rail cannot serve this checkout mode (one-off vs subscription).",
+  service_unavailable: "The runtime service backing this rail is not wired.",
+  resolve_failed: "The selector could not be resolved at decision time.",
+}
+
+function skipLabel(skip?: string) {
+  if (!skip) return ""
+  return SKIP_LABELS[skip as CheckoutRoutingSkip] ?? skip
+}
+
+const OK_BADGE = "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400"
+const WARN_BADGE = "bg-amber-500/15 text-amber-600 dark:text-amber-400"
+const BAD_BADGE = "bg-red-500/15 text-red-600 dark:text-red-400"
+
+function linkStatusClass(status: CatalogProviderState["status"]) {
+  if (status === "linked") return OK_BADGE
+  if (status === "error") return BAD_BADGE
+  return WARN_BADGE
+}
+
+// syncStatusClass: "unknown" is deliberately NEUTRAL, not a warning — it means
+// nobody has looked yet, which is the honest default until Verify runs.
+function syncStatusClass(sync?: string) {
+  switch (sync) {
+    case "in_sync":
+      return OK_BADGE
+    case "drifted":
+    case "missing":
+      return BAD_BADGE
+    case "never_synced":
+    case "sync_disabled":
+      return WARN_BADGE
+    default:
+      return ""
+  }
+}
+
+// LINK_ID_ORDER puts the identifying fields first; anything else the adapter
+// stored follows in sorted order. `rail` is pulled out into its own column.
+const LINK_ID_ORDER = [
+  "price_id",
+  "product_id",
+  "plan_id",
+  "form_name",
+  "flex_id",
+  "recurring_billing_option_id",
+  "lookup_key",
+  "provider",
+]
+
+function linkEntries(ids?: Record<string, string>) {
+  const rest = Object.entries(ids ?? {}).filter(([k, v]) => k !== "rail" && v !== "")
+  rest.sort(([a], [b]) => {
+    const ia = LINK_ID_ORDER.indexOf(a)
+    const ib = LINK_ID_ORDER.indexOf(b)
+    if (ia !== ib) return (ia < 0 ? LINK_ID_ORDER.length : ia) - (ib < 0 ? LINK_ID_ORDER.length : ib)
+    return a.localeCompare(b)
+  })
+  return rest
+}
+
+export function PSPLinksCard({
+  price,
+  verifying,
+  verified,
+  onVerify,
+}: {
+  price: CatalogPrice
+  verifying: boolean
+  verified: boolean
+  onVerify: () => void
+}) {
+  const links = Object.entries(price.providers ?? {}).sort(([a], [b]) => a.localeCompare(b))
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-2">
+        <div className="grid gap-1">
+          <CardTitle className="text-sm">PSP links</CardTitle>
+          <CardDescription>
+            The price's <code className="font-mono">psp_links</code>, keyed by PSP. Links are
+            declared by the catalog and pushed by the provider adapter — they are not edited
+            here. "Verify" performs a live read-only retrieve against each attached provider.
+          </CardDescription>
+        </div>
+        <Button variant="outline" size="sm" disabled={verifying || !links.length} onClick={onVerify}>
+          {verifying ? "Verifying…" : "Verify"}
+        </Button>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {!links.length ? (
+          <p className="text-sm text-muted-foreground">
+            No PSP links. This price exists in OpenRails only — no checkout can be routed to a
+            provider for it.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>PSP</TableHead>
+                  <TableHead>Rail</TableHead>
+                  <TableHead>Link</TableHead>
+                  <TableHead>Provider sync</TableHead>
+                  <TableHead>Link ids</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {links.map(([psp, state]) => (
+                  <TableRow key={psp}>
+                    <TableCell className="font-mono text-xs">{psp}</TableCell>
+                    <TableCell className="text-xs">{state.ids?.rail ?? "—"}</TableCell>
+                    <TableCell>
+                      <Badge variant="secondary" className={linkStatusClass(state.status)}>
+                        {state.status}
+                      </Badge>
+                      {state.message && (
+                        <p className="mt-1 max-w-xs text-xs text-muted-foreground">{state.message}</p>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="secondary" className={syncStatusClass(state.sync_status)}>
+                        {state.sync_status ?? "unknown"}
+                      </Badge>
+                      {state.last_synced_at && (
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {formatDate(state.last_synced_at)}
+                        </p>
+                      )}
+                      {state.drift?.map((d) => (
+                        <p key={d.field} className="mt-1 text-xs text-muted-foreground">
+                          {d.field}: ours {d.openrails_value} · theirs {d.remote_value}
+                        </p>
+                      ))}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">
+                      {linkEntries(state.ids).length ? (
+                        <div className="grid gap-0.5">
+                          {linkEntries(state.ids).map(([k, v]) => (
+                            <span key={k}>
+                              {k}={v}
+                            </span>
+                          ))}
+                        </div>
+                      ) : (
+                        "—"
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+        {!!price.pending_manual_actions?.length && (
+          <div className="rounded-md border border-amber-500/40 p-3 text-xs">
+            {price.pending_manual_actions.map((a) => (
+              <p key={`${a.provider}-${a.action}`}>
+                <span className="font-mono">{a.provider}</span>: {a.hint || a.action}
+              </p>
+            ))}
+          </div>
+        )}
+        {!verified && !!links.length && (
+          <p className="text-xs text-muted-foreground">
+            Provider sync reads "unknown" until Verify runs — OpenRails does not claim a remote
+            object matches without having looked.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+// CheckoutReadinessCard answers the operator's real question — "can someone buy
+// this right now, and if not, why?" — with the or#288 dry run, so the console
+// and the routed checkout can never disagree.
+export function CheckoutReadinessCard({ price }: { price: CatalogPrice }) {
+  const {
+    data: decision,
+    loading: busy,
+    error,
+    reload,
+  } = useApiData<CheckoutRoutingDecision>(
+    () => dryRunCheckoutRouting({ price_id: price.id }),
+    [price.id],
+  )
+
+  React.useEffect(() => {
+    if (error) toastApiError(error, "Check checkout readiness")
+  }, [error])
+
+  const eligible = decision?.candidates.filter((c) => !c.skip) ?? []
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-start justify-between gap-2">
+        <div className="grid gap-1">
+          <CardTitle className="text-sm">Checkout readiness</CardTitle>
+          <CardDescription>
+            Where a checkout for this price would land right now, and why every other candidate
+            was passed over. This runs the production routing decision — no session is created.
+          </CardDescription>
+        </div>
+        <Button variant="outline" size="sm" disabled={busy} onClick={reload}>
+          {busy ? "Checking…" : "Re-check"}
+        </Button>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {!decision ? (
+          <p className="text-sm text-muted-foreground">
+            {busy ? "Checking…" : "Routing could not be evaluated."}
+          </p>
+        ) : (
+          <>
+            <p className="text-sm">
+              {decision.selected ? (
+                <>
+                  Selected <span className="font-mono">{decision.selected}</span>
+                  {decision.rail && <> on {decision.rail}</>}
+                  {decision.mode && <> · {decision.mode}</>} · policy {decision.policy}
+                  {decision.rule !== undefined && <> (rule {decision.rule})</>}
+                </>
+              ) : (
+                <span className="text-amber-600 dark:text-amber-400">
+                  No PSP is eligible — this price cannot be checked out.
+                </span>
+              )}
+            </p>
+            {!decision.candidates.length ? (
+              <p className="text-sm text-muted-foreground">No PSP candidates were evaluated.</p>
+            ) : (
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>PSP</TableHead>
+                      <TableHead>Rail</TableHead>
+                      <TableHead>Verdict</TableHead>
+                      <TableHead>Why</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {decision.candidates.map((c) => (
+                      <TableRow key={c.selector}>
+                        <TableCell className="font-mono text-xs">
+                          {c.selector}
+                          {c.selector === decision.selected && (
+                            <Badge variant="secondary" className={`ml-2 ${OK_BADGE}`}>
+                              selected
+                            </Badge>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-xs">{c.rail || "—"}</TableCell>
+                        <TableCell>
+                          <Badge
+                            variant="secondary"
+                            className={c.skip ? WARN_BADGE : OK_BADGE}
+                          >
+                            {c.skip ?? "eligible"}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-xs text-muted-foreground">
+                          {skipLabel(c.skip)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+            {!!decision.candidates.length && eligible.length === 0 && (
+              <p className="text-xs text-muted-foreground">
+                A <span className="font-mono">link_missing</span> verdict is a catalog problem
+                (push the price to the provider); the other classes are PSP configuration —
+                fix them under Settings → Payment providers.
+              </p>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/web/admin/src/pages/settings/index.tsx
+++ b/web/admin/src/pages/settings/index.tsx
@@ -245,7 +245,12 @@ function ProvidersTab() {
             </TableHeader>
             <TableBody>
               {data.data.map((p) => (
-                <ProviderRow key={p.id} provider={p} onDone={reload} />
+                <ProviderRow
+                  key={p.id}
+                  provider={p}
+                  providerDefinitions={data.provider_definitions ?? []}
+                  onDone={reload}
+                />
               ))}
             </TableBody>
           </Table>
@@ -255,7 +260,22 @@ function ProvidersTab() {
   )
 }
 
-function ProviderRow({ provider, onDone }: { provider: PaymentProviderConfig; onDone: () => void }) {
+function credentialTitle(c: { last_validated_at?: string; rotation_version?: number }) {
+  const parts: string[] = []
+  if (c.last_validated_at) parts.push(`validated ${formatDate(c.last_validated_at)}`)
+  if (c.rotation_version) parts.push(`rotation v${c.rotation_version}`)
+  return parts.length ? parts.join(" · ") : undefined
+}
+
+function ProviderRow({
+  provider,
+  providerDefinitions,
+  onDone,
+}: {
+  provider: PaymentProviderConfig
+  providerDefinitions: PaymentProviderDefinition[]
+  onDone: () => void
+}) {
   const [busy, setBusy] = React.useState(false)
   return (
     <TableRow className={provider.archived ? "opacity-60" : undefined}>
@@ -269,9 +289,12 @@ function ProviderRow({ provider, onDone }: { provider: PaymentProviderConfig; on
               key={name}
               variant="secondary"
               className={c.configured ? "" : "bg-amber-500/15 text-amber-600 dark:text-amber-400"}
-              title={c.last_validated_at ? `validated ${formatDate(c.last_validated_at)}` : undefined}
+              title={credentialTitle(c)}
             >
               {name}
+              {!!c.rotation_version && (
+                <span className="ml-1 opacity-60">v{c.rotation_version}</span>
+              )}
             </Badge>
           ))}
         </span>
@@ -291,28 +314,153 @@ function ProviderRow({ provider, onDone }: { provider: PaymentProviderConfig; on
       </TableCell>
       <TableCell className="text-right">
         {!provider.archived && (
+          <div className="flex justify-end gap-2">
+            <RotateCredentialsDialog
+              provider={provider}
+              credentialKeys={
+                providerDefinitions.find((d) => d.rail === provider.rail)?.credential_keys ??
+                Object.keys(provider.credentials)
+              }
+              onDone={onDone}
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={busy}
+              onClick={async () => {
+                setBusy(true)
+                try {
+                  await deletePaymentProvider(provider.rail, provider.environment)
+                  toast.success("Provider archived")
+                  onDone()
+                } catch (err) {
+                  toastApiError(err, "Archive provider")
+                } finally {
+                  setBusy(false)
+                }
+              }}
+            >
+              Archive
+            </Button>
+          </div>
+        )}
+      </TableCell>
+    </TableRow>
+  )
+}
+
+// RotateCredentialsDialog is the or#812 rotation flow. Three properties the
+// operator needs stated, because all three are real server behaviour:
+//
+//  1. The NEW credential is live-probed BEFORE anything is written. A failed
+//     probe fails the whole rotation — no secret is stored, no version floor
+//     moves, and the OLD credential keeps serving unchanged.
+//  2. A committed rotation is deployment-wide, not just this node: it raises the
+//     credential's version floor on the shared PSP row, and every node refuses
+//     to answer a credential read from a cache entry below that floor.
+//  3. Plaintext is dropped from browser state the moment it is submitted.
+function RotateCredentialsDialog({
+  provider,
+  credentialKeys,
+  onDone,
+}: {
+  provider: PaymentProviderConfig
+  credentialKeys: string[]
+  onDone: () => void
+}) {
+  const [open, setOpen] = React.useState(false)
+  const [credentials, setCredentials] = React.useState<Record<string, string>>({})
+  const [busy, setBusy] = React.useState(false)
+  const supplied = Object.entries(credentials).filter(([, v]) => v.trim() !== "")
+
+  const close = (next: boolean) => {
+    // Never leave plaintext in state behind a closed dialog.
+    if (!next) setCredentials({})
+    setOpen(next)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={close}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          Rotate
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            Rotate {provider.rail} credentials · {provider.account_id}
+          </DialogTitle>
+          <DialogDescription>
+            The new credential is validated against the live provider before it is stored. If
+            that check fails, nothing is written and the current credential keeps serving. Leave
+            a field blank to keep the credential it holds now.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-3">
+          {credentialKeys.map((name) => {
+            const current = provider.credentials[name]
+            return (
+              <Field key={name} label={name} id={`rot-${provider.id}-${name}`}>
+                <Input
+                  id={`rot-${provider.id}-${name}`}
+                  type="password"
+                  autoComplete="new-password"
+                  placeholder={current?.configured ? "unchanged" : "not configured"}
+                  value={credentials[name] ?? ""}
+                  onChange={(e) =>
+                    setCredentials((c) => ({ ...c, [name]: e.target.value }))
+                  }
+                />
+                <p className="text-xs text-muted-foreground">
+                  {current?.rotation_version
+                    ? `current rotation v${current.rotation_version}`
+                    : "no rotation recorded"}
+                  {current?.last_validated_at &&
+                    ` · last validated ${formatDate(current.last_validated_at)}`}
+                </p>
+              </Field>
+            )
+          })}
+          <p className="text-xs text-muted-foreground">
+            On success every OpenRails node cuts over to the new credential at its next charge
+            or pull — the rotation raises a version floor that no node's credential cache may
+            serve below. No restart, no waiting out a cache TTL.
+          </p>
+        </div>
+        <DialogFooter>
           <Button
-            variant="outline"
-            size="sm"
-            disabled={busy}
+            disabled={busy || supplied.length === 0}
             onClick={async () => {
               setBusy(true)
               try {
-                await deletePaymentProvider(provider.rail, provider.environment)
-                toast.success("Provider archived")
+                await putPaymentProvider(provider.rail, {
+                  account_id: provider.account_id,
+                  credentials: Object.fromEntries(supplied),
+                })
+                // Clear plaintext before anything else can await.
+                setCredentials({})
+                toast.success(
+                  `Credentials validated and rotated. Every node serves the new ${provider.rail} credential from its next read.`,
+                )
+                setOpen(false)
                 onDone()
               } catch (err) {
-                toastApiError(err, "Archive provider")
+                setCredentials({})
+                toastApiError(
+                  err,
+                  "Rotation refused — the current credential is unchanged and still serving",
+                )
               } finally {
                 setBusy(false)
               }
             }}
           >
-            Archive
+            {busy ? "Validating…" : "Validate & rotate"}
           </Button>
-        )}
-      </TableCell>
-    </TableRow>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }
 


### PR DESCRIPTION
Closes the two tasks the or#812 board audit named as still open on `dev`. Everything else in the issue (live NMI/CCBill probes, truthful `credentialValidatedAt`, registry-driven provider UI, plaintext cleared on submit) landed in PR #205.

## 1 — the frontend contract for catalog `psp_links`

**Conclusion up front: this is a DISPLAY surface, not an edit surface, and deliberately so.**

The catalog is declarative. OpenRails definitions are pushed to a provider by the provider adapter (`AutoCreate` / `Attach`), and the pull reconciliation job is alert-only — it never mutates providers. A per-link edit form in the console would be a second, competing writer for state the catalog already owns, and the first divergence between it and the manifest would be silent. So the console shows links and their provider-side state and points at the catalog for changes. The one write already in the console (the #777 price-change wizard) stays as it is: it carries `Object.keys(price.providers)` forward so a version bump does not silently lose its links.

**No API change was needed.** `CatalogPrice.Providers` is already the `psp_links` projection — a typed `ProviderState` per PSP key with `ids` (the stored link entry verbatim, `rail` inside), `lookup_key`, `status`, `sync_status`, `drift`. `GET .../prices/{id}?verify=true` already performs a live retrieve against every attached provider. Both were simply unrendered.

Price detail now has:

- **PSP links** — one row per link: PSP key, the rail from `ids.rail`, link status, provider sync + drift + last-synced, and the stored link ids. `sync_status` renders as neutral `unknown` until Verify runs, rather than as a warning: nobody has looked yet, and saying otherwise would be exactly the "configured reported as validated" dishonesty this issue was filed about. **Verify** is an explicit button — it is a network round trip per attached PSP.
- **Checkout readiness** — the or#288 routing dry run (`POST /merchant/payment-providers/routing/dry-run`), which answers a genuinely different question: a price can be perfectly linked and still unroutable because its PSP is unarmed or its credentials are missing. Every candidate's verdict is rendered with the skip class verbatim (`not_armed`, `credentials_missing`, `link_missing`, `mode_unsupported`, …) plus an operator-facing gloss. The vocabulary keys mirror `internal/db/models/checkout_session.go` — one source, so the console and the routed checkout cannot disagree.

The catalog list's provider badges were labelled `rail: status`; `psp_links` is keyed by **PSP key**, not rail. Renamed.

## 2 — credential rotation UX + cross-node cache cutover

### What already worked

Tracing the PUT path first: `UpsertPaymentProviderConfig` live-probes the credentials **supplied in the request** (`probePaymentProviderCredentials`, NMI + CCBill) *before* it writes anything, and returns the probe error. So "probe the new credential before committing it, fail the rotation on probe failure, keep the old credential serving" was already true server-side. It was just never stated anywhere an operator could see, and never tested as a property.

### What did not work

The gap is the cutover. Each node wraps the secret backend in `cachedSecretStore` — a per-process TTL cache, `DefaultSecretCacheTTL` = 15 minutes. `Put` refreshes the entry on the node doing the write, so the rotating node is instantly correct. **Every other node keeps serving the old credential until its entry expires.** For a design target of multi-node SaaS that is up to fifteen minutes of presenting a retired credential to a gateway, with no way to shorten it but a restart.

Everything else on the path was already live-per-call: `activePSPSecretScope` re-reads the `psps` row from the shared DB on every credential resolution, and NMI/CCBill clients are constructed per call. There is no client map to invalidate. The cache is the only stale layer.

### The mechanism: a versioned credential read

Considered pub/sub (Redis) and rejected it: Redis is optional in this codebase (`redis not configured; cache operating in-memory only`), a dropped message silently reopens the whole window, and it adds a second propagation channel next to the DB. The PSP row is a better carrier because **it is already read live on the very same call that produces the secret name** — the floor costs no extra query and cannot arrive late.

- The rotation records each credential's resulting `Secret.Version` on the PSP row under `evidence.credential_versions`. All three backends (DB, Vault KV, memory) already maintain a real monotonic version; the DB store bumps only on an actual value change, so re-submitting an identical value is correctly not a rotation.
- `SecretRef{Name, MinVersion}` + `VersionedSecretReader.GetAtLeastVersion`. A cached entry is a hit only if it is unexpired **and** at least `MinVersion`.
- Ordering: secrets are written **before** the PSP row, so a floor is never visible ahead of the value it demands.
- A backend read that comes back *below* the floor (replication lag) is served but **not cached** — refusing would take a live merchant down over lag, and caching it would pin the stale value for a full TTL. The next call retries.
- Floors merge rather than replace: a partial rotation keeps the floors of credentials it did not touch, and a floor never moves backwards.

Every provider-credential read moved onto `SecretRef`: checkout (`merchantProviderSecret` and the pinned-PSP NMI path), the pull/reconcile lane, collection wiring, `railresolve`, the Solana signer, and the Stripe/NMI webhook-secret loads. Uncached stores fall through to a plain `Get` — they were never stale.

TTL expiry stays as the backstop for out-of-band writes (someone editing Vault directly), which have no recorded floor by construction.

### Incidental fix

The API arm marshalled the `evidence` document from scratch, but evidence is shared with the manifest arm path, which writes `source`, `signer` and `settings` there. Rotating a credential on a manifest-armed PSP therefore dropped its settings. It now merges the fields this API owns onto the existing document.

### Console

Rotation is its own flow rather than a re-run of "Configure provider": per-PSP **Rotate**, registry-driven credential fields, blank = keep the current value, plaintext cleared from React state on submit *and* on dialog close. It states the two guarantees where the operator is standing — a failed probe writes nothing and leaves the old credential serving, and a committed rotation is deployment-wide at the next read, no restart and no waiting out a TTL. `rotation_version` is surfaced per credential (`v2`) so the watermark is visible rather than folklore.

### Test

`internal/merchants/credential_rotation_cutover_integration_test.go` — three independent `merchants.Service` instances, each with its **own** cache wrapper, over one shared Postgres and one shared DB-backed secret store. Nothing shared in-process but the database: exactly the sharing two app nodes have. TTL is set to an hour so nothing can pass by expiring. `resolve()` performs the same two calls checkout's `merchantProviderSecret` makes.

Against a fake NMI gateway that accepts one key at a time:

1. Arm node A, node B reads and caches it.
2. Rotate to a credential the gateway rejects → the rotation errors, the probe is confirmed to have used the *new* key, the stored secret is unchanged, the floor has not moved, and **both** nodes still serve the old credential.
3. Rotate to a credential the gateway accepts → node A immediate, and **node B serves the new one despite an hour of TTL remaining**.
4. Proof it was the floor and not an expiry: the same node, the same warm cache, read *without* the floor, still hands back the retired credential — and read *with* it, hands back the rotated one.

Plus partial-rotation floor preservation and the evidence-merge contract.

## Verification

- `go build ./...`, `go vet -tags integration ./...` clean.
- Unit suites green for `internal/merchants`, `internal/modules/checkout`, `internal/railresolve`, `internal/reconcile`, `pkg/service`, `internal/http`.
- Integration green (`-p 1`, testcontainers, stale DSN unset): `internal/merchants` (full package), `internal/modules/checkout`, `internal/reconcile`, `internal/railresolve`, `internal/merchantsecrets`, `internal/integrationharness`, `internal/bootstrap`.
- Console: `tsc --noEmit` clean, `eslint src` clean (one pre-existing `data-table.tsx` warning), `vite build` succeeds. Lockfile untouched.
- No migration: `evidence` is existing JSONB.