### PR TITLE
or#897 PR 3: the accrual rate cap, and collection/delinquency become per-payer

### DIFF
--- a/client.go
+++ b/client.go
@@ -264,9 +264,14 @@ type AdmitRequest struct {
 	Resource        string `json:"resource,omitempty"`
 	Currency        string `json:"currency,omitempty"`
 	EstimatedAmount int64  `json:"estimated_amount"`
-	RequestID       string `json:"request_id"`
-	Source          string `json:"source,omitempty"`
-	ExpiresAt       *int64 `json:"expires_at,omitempty"`
+	// AccrualRateDeltaPerHour is the or#897 PROSPECTIVE rate this request would
+	// add, in micros per hour — "the VM I am about to start burns $2/hour". Only
+	// the host knows it. Zero means the request adds no ongoing rate, which
+	// leaves an accrual_rate_cap payer gated on what is already running.
+	AccrualRateDeltaPerHour int64  `json:"accrual_rate_delta_per_hour,omitempty"`
+	RequestID               string `json:"request_id"`
+	Source                  string `json:"source,omitempty"`
+	ExpiresAt               *int64 `json:"expires_at,omitempty"`
 	// Roles are the immutable role UUIDs the invoker holds (#473). Each role with a
 	// matching (subject, role) budget-scope policy gates this request's spend in
 	// the same admit verdict. The host reads them from the delegated
@@ -401,15 +406,31 @@ type MerchantTrustLevelSchedule struct {
 type BillingPolicyInput struct {
 	Name string `json:"name"`
 	// Kind is "outstanding_cap" (cap LEDGER-measured unpaid arrears — a credit
-	// line on debt, refused with deny code outstanding_cap_reached) or
-	// "window_spend_cap" (cap NEW spend per rolling window; prior debt drives
-	// delinquency, not admission).
+	// line on debt, refused with outstanding_cap_reached), "window_spend_cap"
+	// (cap NEW spend per rolling window; prior debt drives delinquency, not
+	// admission), or "accrual_rate_cap" (cap the measured accrual RATE in
+	// micros/hour — the cloud quota, refused with accrual_rate_cap_reached).
 	Kind string `json:"kind"`
 	// OutstandingCapAmount (micros) is the credit line for kind=outstanding_cap.
 	// Zero defers to the payer's own arrears credit limit.
 	OutstandingCapAmount int64 `json:"outstanding_cap_amount,omitempty"`
 	// SpendWindows are the rolling NEW-spend ceilings for kind=window_spend_cap.
 	SpendWindows []BudgetWindowInput `json:"spend_windows,omitempty"`
+	// AccrualRateCapPerHour (kind=accrual_rate_cap) caps the measured accrual
+	// rate in micros PER HOUR — the cloud quota. AccrualRateWindowSeconds is the
+	// measurement lookback (default 3600).
+	AccrualRateCapPerHour    int64 `json:"accrual_rate_cap_per_hour,omitempty"`
+	AccrualRateWindowSeconds int64 `json:"accrual_rate_window_seconds,omitempty"`
+	// CollectionThresholdAmount / DelinquencyGraceDays / DelinquencyAmountFloor
+	// override the merchant-wide invoice policy for payers bound here; nil defers
+	// to it. All three ride on any kind.
+	CollectionThresholdAmount *int64 `json:"collection_threshold_amount,omitempty"`
+	DelinquencyGraceDays      *int   `json:"delinquency_grace_days,omitempty"`
+	DelinquencyAmountFloor    *int64 `json:"delinquency_amount_floor,omitempty"`
+	// CollectionCycleBoundary is declarable and REFUSED: statement periods must
+	// tile a payer's lifetime, and rebinding is a live lever, so the boundary
+	// stays merchant-wide. Declaring it here fails with that reason.
+	CollectionCycleBoundary string `json:"collection_cycle_boundary,omitempty"`
 	// BadSpendWindows are the #497 per-PAYER direct-credential wasted-spend grace
 	// windows: at most Limit of host-reported wasted spend is forgiven per window;
 	// direct-payer overage is charged. Allowed on either kind.

--- a/docs/billing-policies.md
+++ b/docs/billing-policies.md
@@ -28,13 +28,37 @@ which cap applies and moves no money.
 |---|---|---|
 | `outstanding_cap` | LEDGER-measured unpaid arrears. Outstanding owed is subtracted from the line, so $155 unpaid against $200 leaves $45. | `outstanding_cap_reached` |
 | `window_spend_cap` | NEW spend per rolling window. Prior debt does **not** gate admission. | `budget_exceeded` |
+| `accrual_rate_cap` | The measured accrual RATE, in micros **per hour** — the cloud quota. Prior debt does not gate it either. | `accrual_rate_cap_reached` |
 
 `outstanding_cap_reached` is deliberately distinct from `insufficient_credit`
 ("this one request does not fit") and from `delinquent_unpaid_invoice` (the time
 axis — the debt may not even be due yet). A host that cannot tell them apart
 cannot say anything useful to the customer.
 
-`accrual_rate_cap` is reserved and currently **refused** with a clear error.
+### The rate cap, and why it takes an input
+
+`outstanding_cap` and `window_spend_cap` are questions about the past: what is
+owed, what has been spent. `accrual_rate_cap` is a question about the future —
+*how fast would money burn from now on* — and only you know what you are about
+to start. So admission takes your **prospective delta**:
+
+```json
+{ "customer_id": "…", "estimated_amount": 1000, "accrual_rate_delta_per_hour": 2000000 }
+```
+
+OpenRails measures what is **already** accruing (rated usage over the policy's
+lookback, scaled to an hour) and refuses when `measured + delta > cap`. A zero
+delta means the request adds no ongoing rate, so it is gated only on what is
+already running.
+
+`accrual_rate_window_seconds` (default 3600, minimum 60) is the measurement
+lookback. It changes the smoothing, never the unit: a short window reacts fast
+and reads bursty, a long one is stable and forgives a spike.
+
+**What it can see.** Only what has been reported. A deployment admitted seconds
+ago has not accrued yet, so your own inventory is always ahead of this reading —
+which is exactly why the delta is an input rather than something we try to
+infer.
 
 ## Declaring
 
@@ -51,6 +75,10 @@ billing_policies:
       - key: monthly
         window: 720h
         limit: 2_000_000_000            # micros — $2000
+  cloud_quota:
+    kind: accrual_rate_cap
+    accrual_rate_cap_per_hour: 10_000_000   # micros/hour — $10/hour deployed
+    accrual_rate_window: 15m                # measurement lookback (default 1h)
 billing_policy_bindings:
   - policy: api_line                    # merchant default (no tier)
   - policy: cloud_monthly
@@ -104,7 +132,18 @@ a TTL.
 
 | Field | Applies to | Meaning |
 |---|---|---|
-| `bad_spend_windows` | either kind | Per-payer wasted-spend grace: at most `limit` of host-reported failed spend forgiven per window; overage is charged at report time. |
-| `policy_currency` | either kind | Currency for checks whose window carries none. Blank means the request's currency. |
+| `bad_spend_windows` | any kind | Per-payer wasted-spend grace: at most `limit` of host-reported failed spend forgiven per window; overage is charged at report time. |
+| `collection_threshold_amount` | any kind | When this payer's accrued arrears is invoiced. Overrides `invoice.collection_threshold` for payers bound here. |
+| `delinquency_grace_days` / `delinquency_amount_floor` | any kind | This payer's [delinquency](arrears-delinquency.md) policy. Overrides the merchant-wide `invoice.delinquency_*` values. |
+| `policy_currency` | any kind | Currency for checks whose window carries none. Blank means the request's currency. |
+
+Collection and delinquency ride on every kind because *what a payer may owe or
+spend* and *when its debt is chased* are separate questions — a cloud tenant's
+debt still ages even though it never gates admission.
+
+**`collection_cycle_boundary` is refused per-policy**, deliberately. A payer's
+statement periods must tile its lifetime with no gap and no overlap, and
+rebinding is a live runtime lever, so a mid-cycle change would bill a stretch
+twice or never. It stays merchant-wide as `invoice.billing_period_boundary`.
 
 All amounts are micros.

--- a/internal/bootstrap/merchant_dump.go
+++ b/internal/bootstrap/merchant_dump.go
@@ -175,13 +175,21 @@ func DumpMerchantConfig(ctx context.Context, cfg *config.Config, cp *controlplan
 		if mt.BillingPolicies == nil {
 			mt.BillingPolicies = map[string]BillingPolicyConfig{}
 		}
-		mt.BillingPolicies[name] = BillingPolicyConfig{
-			Kind:            string(body.Kind),
-			OutstandingCap:  body.OutstandingCapAmount,
-			SpendWindows:    dumpBudgetWindows(body.SpendWindows),
-			BadSpendWindows: dumpBudgetWindows(body.BadSpendWindows),
-			PolicyCurrency:  body.PolicyCurrency,
+		entry := BillingPolicyConfig{
+			Kind:                   string(body.Kind),
+			OutstandingCap:         body.OutstandingCapAmount,
+			SpendWindows:           dumpBudgetWindows(body.SpendWindows),
+			AccrualRateCapPerHour:  body.AccrualRateCapPerHour,
+			BadSpendWindows:        dumpBudgetWindows(body.BadSpendWindows),
+			CollectionThreshold:    body.CollectionThresholdAmount,
+			DelinquencyGraceDays:   body.DelinquencyGraceDays,
+			DelinquencyAmountFloor: body.DelinquencyAmountFloor,
+			PolicyCurrency:         body.PolicyCurrency,
 		}
+		if body.AccrualRateWindowSeconds > 0 {
+			entry.AccrualRateWindow = formatWindowSeconds(body.AccrualRateWindowSeconds)
+		}
+		mt.BillingPolicies[name] = entry
 	}
 	storedBindings, err := policyStore.ListDeclarativeBindings(mctx)
 	if err != nil {

--- a/internal/bootstrap/merchant_manifest.go
+++ b/internal/bootstrap/merchant_manifest.go
@@ -466,17 +466,31 @@ type MerchantConfig struct {
 // BillingPolicyConfig is one manifest billing policy (or#897). Amounts are in
 // the currency's micros; window durations are Go durations ("720h").
 type BillingPolicyConfig struct {
-	// Kind: outstanding_cap | window_spend_cap. accrual_rate_cap is declarable
-	// and refused with a real answer until or#897 PR 3.
+	// Kind: outstanding_cap | window_spend_cap | accrual_rate_cap.
 	Kind string `yaml:"kind" koanf:"kind"`
 	// OutstandingCap (micros, kind=outstanding_cap) is the credit line on unpaid
 	// arrears. Omitted defers to the payer's own arrears credit limit.
 	OutstandingCap int64 `yaml:"outstanding_cap,omitempty" koanf:"outstanding_cap"`
 	// SpendWindows (kind=window_spend_cap) are the rolling NEW-spend ceilings.
 	SpendWindows []BudgetWindowConfig `yaml:"spend_windows,omitempty" koanf:"spend_windows"`
+	// AccrualRateCapPerHour (micros per HOUR, kind=accrual_rate_cap) is the cloud
+	// quota. AccrualRateWindow is the measurement lookback as a Go duration
+	// ("1h"); omitted means one hour. It changes the smoothing, never the unit.
+	AccrualRateCapPerHour int64  `yaml:"accrual_rate_cap_per_hour,omitempty" koanf:"accrual_rate_cap_per_hour"`
+	AccrualRateWindow     string `yaml:"accrual_rate_window,omitempty" koanf:"accrual_rate_window"`
 	// BadSpendWindows are the #497 per-PAYER wasted-spend grace windows.
 	BadSpendWindows []BudgetWindowConfig `yaml:"bad_spend_windows,omitempty" koanf:"bad_spend_windows"`
-	PolicyCurrency  string               `yaml:"policy_currency,omitempty" koanf:"policy_currency"`
+	// CollectionThreshold (micros) is when payers bound here are invoiced;
+	// DelinquencyGraceDays / DelinquencyAmountFloor are their delinquency policy.
+	// Each overrides the merchant-wide `invoice:` block for those payers only.
+	CollectionThreshold *int64 `yaml:"collection_threshold,omitempty" koanf:"collection_threshold"`
+	// CollectionCycleBoundary is declarable and REFUSED: statement periods must
+	// tile a payer's lifetime, and rebinding is a live lever, so the boundary
+	// stays merchant-wide. Declaring it here fails with that reason.
+	CollectionCycleBoundary string `yaml:"collection_cycle_boundary,omitempty" koanf:"collection_cycle_boundary"`
+	DelinquencyGraceDays    *int   `yaml:"delinquency_grace_days,omitempty" koanf:"delinquency_grace_days"`
+	DelinquencyAmountFloor  *int64 `yaml:"delinquency_amount_floor,omitempty" koanf:"delinquency_amount_floor"`
+	PolicyCurrency          string `yaml:"policy_currency,omitempty" koanf:"policy_currency"`
 }
 
 // BillingPolicyBindingConfig binds one DECLARATIVE rung to a policy name: a
@@ -1314,7 +1328,6 @@ func reconcileManifestMerchantConfiguration(ctx context.Context, cfg *config.Con
 		return err
 	}
 
-
 	for _, entry := range pspEntries(mt.PSPs) {
 		if secretStore == nil {
 			return fmt.Errorf("merchant bootstrap: provider account secrets require a secret store")
@@ -1374,12 +1387,26 @@ func reconcileManifestBillingPolicies(ctx context.Context, database *db.DB, mt M
 		if err != nil {
 			return err
 		}
+		var rateWindowSeconds int64
+		if raw := strings.TrimSpace(src.AccrualRateWindow); raw != "" {
+			d, perr := time.ParseDuration(raw)
+			if perr != nil {
+				return fmt.Errorf("billing policy %s: accrual_rate_window: %w", name, perr)
+			}
+			rateWindowSeconds = int64(d / time.Second)
+		}
 		body, err := merchantconfig.NormalizeBillingPolicy(name, models.BillingPolicy{
-			Kind:                 models.BillingPolicyKind(src.Kind),
-			OutstandingCapAmount: src.OutstandingCap,
-			SpendWindows:         spend,
-			BadSpendWindows:      badSpend,
-			PolicyCurrency:       src.PolicyCurrency,
+			Kind:                      models.BillingPolicyKind(src.Kind),
+			OutstandingCapAmount:      src.OutstandingCap,
+			SpendWindows:              spend,
+			AccrualRateCapPerHour:     src.AccrualRateCapPerHour,
+			AccrualRateWindowSeconds:  rateWindowSeconds,
+			BadSpendWindows:           badSpend,
+			CollectionThresholdAmount: src.CollectionThreshold,
+			CollectionCycleBoundary:   src.CollectionCycleBoundary,
+			DelinquencyGraceDays:      src.DelinquencyGraceDays,
+			DelinquencyAmountFloor:    src.DelinquencyAmountFloor,
+			PolicyCurrency:            src.PolicyCurrency,
 		})
 		if err != nil {
 			return err

--- a/internal/bootstrap/or897_billing_policy_manifest_integration_test.go
+++ b/internal/bootstrap/or897_billing_policy_manifest_integration_test.go
@@ -18,8 +18,15 @@ func TestReconcileMerchantManifestAppliesBillingPolicies(t *testing.T) {
 	cp := newMerchantManifestControlPlane(t, pool)
 	manifest := cozyArtMerchantManifest()
 	mt := manifest.Merchants["cozy-art"]
+	threshold, grace := int64(50_000_000), 7
 	mt.BillingPolicies = map[string]BillingPolicyConfig{
-		"api_line": {Kind: "outstanding_cap", OutstandingCap: 200_000_000},
+		"api_line": {
+			Kind: "outstanding_cap", OutstandingCap: 200_000_000,
+			CollectionThreshold: &threshold, DelinquencyGraceDays: &grace,
+		},
+		"cloud_quota": {
+			Kind: "accrual_rate_cap", AccrualRateCapPerHour: 10_000_000, AccrualRateWindow: "15m",
+		},
 		"cloud_monthly": {
 			Kind:         "window_spend_cap",
 			SpendWindows: []BudgetWindowConfig{{Key: "monthly", Window: "720h", Limit: 2_000_000_000}},
@@ -49,6 +56,27 @@ func TestReconcileMerchantManifestAppliesBillingPolicies(t *testing.T) {
 	require.EqualValues(t, 200_000_000, cap)
 
 	var windowSeconds, limit int64
+	// The rate cap and the collection/delinquency fields land in the body too.
+	var ratePerHour, rateWindow int64
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT (policy ->> 'accrual_rate_cap_per_hour')::bigint,
+		       (policy ->> 'accrual_rate_window_seconds')::bigint
+		FROM openrails.billing_policies
+		WHERE merchant_id = $1::uuid AND name = 'cloud_quota'
+	`, merchantID).Scan(&ratePerHour, &rateWindow))
+	require.EqualValues(t, 10_000_000, ratePerHour)
+	require.EqualValues(t, 900, rateWindow, "15m must reach the store as seconds")
+
+	var storedThreshold, storedGrace int64
+	require.NoError(t, pool.QueryRow(ctx, `
+		SELECT (policy ->> 'collection_threshold_amount')::bigint,
+		       (policy ->> 'delinquency_grace_days')::bigint
+		FROM openrails.billing_policies
+		WHERE merchant_id = $1::uuid AND name = 'api_line'
+	`, merchantID).Scan(&storedThreshold, &storedGrace))
+	require.EqualValues(t, 50_000_000, storedThreshold)
+	require.EqualValues(t, 7, storedGrace)
+
 	require.NoError(t, pool.QueryRow(ctx, `
 		SELECT (policy #>> '{spend_windows,0,window_seconds}')::bigint,
 		       (policy #>> '{spend_windows,0,limit}')::bigint
@@ -76,7 +104,7 @@ func TestReconcileMerchantManifestAppliesBillingPolicies(t *testing.T) {
 	var policies, bindings int
 	require.NoError(t, pool.QueryRow(ctx, `SELECT count(*) FROM openrails.billing_policies WHERE merchant_id = $1::uuid`, merchantID).Scan(&policies))
 	require.NoError(t, pool.QueryRow(ctx, `SELECT count(*) FROM openrails.billing_policy_bindings WHERE merchant_id = $1::uuid`, merchantID).Scan(&bindings))
-	require.Equal(t, 2, policies)
+	require.Equal(t, 3, policies)
 	require.Equal(t, 2, bindings)
 }
 
@@ -92,7 +120,13 @@ func TestReconcileMerchantManifestRefusesInvalidBillingPolicy(t *testing.T) {
 		policy BillingPolicyConfig
 		want   string
 	}{
-		{"pr3 kind", BillingPolicyConfig{Kind: "accrual_rate_cap"}, "not implemented yet"},
+		{"rate cap with no rate", BillingPolicyConfig{Kind: "accrual_rate_cap"}, "requires a positive accrual_rate_cap_per_hour"},
+		{"per-policy cycle boundary", BillingPolicyConfig{
+			Kind: "outstanding_cap", CollectionCycleBoundary: "calendar_month",
+		}, "cannot be per-policy"},
+		{"unparseable rate window", BillingPolicyConfig{
+			Kind: "accrual_rate_cap", AccrualRateCapPerHour: 1, AccrualRateWindow: "one hour",
+		}, "accrual_rate_window"},
 		{"unknown kind", BillingPolicyConfig{Kind: "spend_cap"}, `unknown kind "spend_cap"`},
 		{"missing kind", BillingPolicyConfig{}, "kind is required"},
 		{"cross-kind limit", BillingPolicyConfig{

--- a/internal/db/gen/delinquency.sql.go
+++ b/internal/db/gen/delinquency.sql.go
@@ -275,19 +275,39 @@ func (q *Queries) ListNonCurrentDelinquency(ctx context.Context, arg ListNonCurr
 }
 
 const listOverdueInvoiceAggregates = `-- name: ListOverdueInvoiceAggregates :many
-SELECT customer_id,
-       currency,
-       MIN(due_at)::timestamptz AS overdue_since,
-       COALESCE(SUM(amount_due), 0)::bigint AS overdue_amount,
-       COUNT(*)::bigint AS overdue_invoices
-FROM openrails.invoices
-WHERE merchant_id = $1
-  AND status IN ('open', 'past_due')
-  AND amount_due > 0
-  AND due_at IS NOT NULL
-  AND due_at < $2::timestamptz
-GROUP BY customer_id, currency
-ORDER BY MIN(due_at), customer_id, currency
+SELECT i.customer_id,
+       i.currency,
+       MIN(i.due_at)::timestamptz AS overdue_since,
+       COALESCE(SUM(i.amount_due), 0)::bigint AS overdue_amount,
+       COUNT(*)::bigint AS overdue_invoices,
+       -- -1 = NO OVERRIDE (fall back to the merchant-wide policy). An explicit
+       -- sentinel, not a guess: both values are validated non-negative, so -1
+       -- cannot collide with a declared one, and a nullable LATERAL column
+       -- would be inferred non-null by sqlc and mis-scan.
+       COALESCE(pol.grace_days, -1)::int AS grace_days,
+       COALESCE(pol.amount_floor, -1)::bigint AS amount_floor
+FROM openrails.invoices i
+LEFT JOIN LATERAL (
+    SELECT (p.policy ->> 'delinquency_grace_days')::int AS grace_days,
+           (p.policy ->> 'delinquency_amount_floor')::bigint AS amount_floor
+    FROM openrails.billing_policy_bindings b
+    JOIN openrails.billing_policies p
+      ON p.merchant_id = b.merchant_id AND p.name = b.policy_name
+    LEFT JOIN openrails.money_settings ms
+      ON ms.merchant_id = i.merchant_id AND ms.customer_id = i.customer_id AND ms.currency = i.currency
+    WHERE b.merchant_id = i.merchant_id
+      AND (b.customer_id = i.customer_id OR b.customer_id IS NULL)
+      AND (b.tier = ms.tier OR b.tier IS NULL)
+    ORDER BY (b.customer_id IS NOT NULL) DESC, (b.tier IS NOT NULL) DESC
+    LIMIT 1
+) pol ON true
+WHERE i.merchant_id = $1
+  AND i.status IN ('open', 'past_due')
+  AND i.amount_due > 0
+  AND i.due_at IS NOT NULL
+  AND i.due_at < $2::timestamptz
+GROUP BY i.customer_id, i.currency, pol.grace_days, pol.amount_floor
+ORDER BY MIN(i.due_at), i.customer_id, i.currency
 LIMIT $3
 `
 
@@ -303,6 +323,8 @@ type ListOverdueInvoiceAggregatesRow struct {
 	OverdueSince    time.Time
 	OverdueAmount   int64
 	OverdueInvoices int64
+	GraceDays       int32
+	AmountFloor     int64
 }
 
 // The ENTER leg of the evaluation: per (payer, currency), how much is overdue
@@ -313,6 +335,11 @@ type ListOverdueInvoiceAggregatesRow struct {
 // OLDEST DEBT FIRST, and capped: one pass is bounded work. If a merchant ever
 // has more overdue payers than the cap, the ones who have owed longest are the
 // ones evaluated — truncation with a defensible order beats an unbounded pass.
+//
+// or#897: each row also carries the BOUND policy's delinquency overrides, so a
+// pass over N payers stays one query. money_settings.tier supplies the tier
+// rung, so the same most-specific-wins resolution the admission path runs is
+// available here without an N+1 per candidate.
 func (q *Queries) ListOverdueInvoiceAggregates(ctx context.Context, arg ListOverdueInvoiceAggregatesParams) ([]ListOverdueInvoiceAggregatesRow, error) {
 	rows, err := q.db.Query(ctx, listOverdueInvoiceAggregates, arg.MerchantID, arg.Now, arg.RowLimit)
 	if err != nil {
@@ -328,6 +355,8 @@ func (q *Queries) ListOverdueInvoiceAggregates(ctx context.Context, arg ListOver
 			&i.OverdueSince,
 			&i.OverdueAmount,
 			&i.OverdueInvoices,
+			&i.GraceDays,
+			&i.AmountFloor,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/gen/invoices.sql.go
+++ b/internal/db/gen/invoices.sql.go
@@ -925,10 +925,21 @@ JOIN openrails.invoice_items ii
  AND ii.invoice_id IS NULL
  AND ii.status = 'pending'
  AND ii.invoice_at < $2::timestamptz
+LEFT JOIN LATERAL (
+    SELECT (p.policy ->> 'collection_threshold_amount')::bigint AS threshold
+    FROM openrails.billing_policy_bindings b
+    JOIN openrails.billing_policies p
+      ON p.merchant_id = b.merchant_id AND p.name = b.policy_name
+    WHERE b.merchant_id = s.merchant_id
+      AND (b.customer_id = s.customer_id OR b.customer_id IS NULL)
+      AND (b.tier = s.tier OR b.tier IS NULL)
+    ORDER BY (b.customer_id IS NOT NULL) DESC, (b.tier IS NOT NULL) DESC
+    LIMIT 1
+) pol ON true
 WHERE s.merchant_id = $1
   AND s.billing_mode = 'arrears'
   AND s.credit_limit_amount > 0
-GROUP BY s.merchant_id, s.customer_id, s.currency, s.credit_limit_amount
+GROUP BY s.merchant_id, s.customer_id, s.currency, s.credit_limit_amount, pol.threshold
 HAVING COALESCE(SUM(ii.amount), 0)::bigint + (
     SELECT COALESCE(SUM(i.amount_due), 0)::bigint
     FROM openrails.invoices i
@@ -937,7 +948,9 @@ HAVING COALESCE(SUM(ii.amount), 0)::bigint + (
       AND i.currency = s.currency
       AND i.status IN ('open', 'past_due')
       AND i.amount_due > 0
-) >= CASE WHEN $3::bigint > 0 THEN $3::bigint ELSE s.credit_limit_amount END
+) >= COALESCE(
+    pol.threshold,
+    CASE WHEN $3::bigint > 0 THEN $3::bigint ELSE s.credit_limit_amount END)
 ORDER BY period_from ASC
 `
 
@@ -954,6 +967,11 @@ type ListInvoiceThresholdCandidatesRow struct {
 	PeriodAnchor time.Time
 }
 
+// or#897: the trigger amount is the BOUND billing policy's
+// collection_threshold_amount when the payer has one, else the merchant-wide
+// threshold, else the payer's own credit line. Resolved in SQL through the same
+// most-specific-wins rungs the admission path uses (money_settings.tier supplies
+// the tier rung), so a per-payer trigger costs no extra round trip.
 func (q *Queries) ListInvoiceThresholdCandidates(ctx context.Context, arg ListInvoiceThresholdCandidatesParams) ([]ListInvoiceThresholdCandidatesRow, error) {
 	rows, err := q.db.Query(ctx, listInvoiceThresholdCandidates, arg.MerchantID, arg.Cutoff, arg.MinThreshold)
 	if err != nil {

--- a/internal/db/gen/usage_events.sql.go
+++ b/internal/db/gen/usage_events.sql.go
@@ -388,3 +388,33 @@ func (q *Queries) ServiceUsageRollup(ctx context.Context, arg ServiceUsageRollup
 	}
 	return items, nil
 }
+
+const sumUsageAmountSince = `-- name: SumUsageAmountSince :one
+SELECT COALESCE(SUM(amount), 0)::bigint AS total_amount
+FROM openrails.usage_events
+WHERE merchant_id = $1 AND customer_id = $2 AND currency = $3
+  AND occurred_at >= $4::timestamptz
+`
+
+type SumUsageAmountSinceParams struct {
+	MerchantID uuid.UUID
+	CustomerID uuid.UUID
+	Currency   string
+	Since      time.Time
+}
+
+// or#897 accrual_rate_cap: the payer's rated usage over a LOOKBACK WINDOW, for
+// the measured accrual rate. Window-bounded by construction — it reads what the
+// payer did in the last N seconds, never its history — and served by
+// ix_usage_events_payer_time (merchant_id, customer_id, occurred_at).
+func (q *Queries) SumUsageAmountSince(ctx context.Context, arg SumUsageAmountSinceParams) (int64, error) {
+	row := q.db.QueryRow(ctx, sumUsageAmountSince,
+		arg.MerchantID,
+		arg.CustomerID,
+		arg.Currency,
+		arg.Since,
+	)
+	var total_amount int64
+	err := row.Scan(&total_amount)
+	return total_amount, err
+}

--- a/internal/db/models/billing_policy.go
+++ b/internal/db/models/billing_policy.go
@@ -22,10 +22,11 @@ const (
 	// gate on prior debt — an unpaid invoice drives delinquency, not admission.
 	BillingPolicyWindowSpendCap BillingPolicyKind = "window_spend_cap"
 
-	// BillingPolicyAccrualRateCap caps the measured accrual RATE (the cloud
-	// quota: "no more than $X deployed at any instant"). Representable so the
-	// vocabulary is complete and a manifest that declares it fails with a real
-	// answer; REFUSED by the validator until or#897 PR 3 builds the measurement.
+	// BillingPolicyAccrualRateCap caps the measured accrual RATE — the cloud
+	// quota, "no more than $X/hour deployed at any instant". The host pre-admits a
+	// prospective deployment by passing its rate DELTA; OpenRails measures what is
+	// already accruing and answers from the bound cap. Like window_spend_cap and
+	// unlike outstanding_cap, prior debt never gates it.
 	BillingPolicyAccrualRateCap BillingPolicyKind = "accrual_rate_cap"
 )
 
@@ -52,9 +53,56 @@ type BillingPolicy struct {
 	// overage is charged at report time. Orthogonal to Kind, so allowed on any.
 	BadSpendWindows []BudgetWindowPolicy `json:"bad_spend_windows,omitempty"`
 
+	// AccrualRateCapPerHour is the ceiling on the payer's measured accrual RATE,
+	// in micros PER HOUR (kind=accrual_rate_cap only). Micros/hour is canonical on
+	// every surface — the host's prospective delta speaks it too — so no caller has
+	// to know the merchant's measurement window.
+	AccrualRateCapPerHour int64 `json:"accrual_rate_cap_per_hour,omitempty"`
+
+	// AccrualRateWindowSeconds is the LOOKBACK the rate is measured over
+	// (kind=accrual_rate_cap only; 0 means DefaultAccrualRateWindowSeconds). It
+	// smooths the measurement, it does not change the unit: a short window reacts
+	// fast and reads bursty, a long one is stable and forgives a spike.
+	AccrualRateWindowSeconds int64 `json:"accrual_rate_window_seconds,omitempty"`
+
+	// CollectionThresholdAmount (micros) is when this payer's accrued arrears is
+	// invoiced. Overrides the merchant-wide invoice.collection_threshold for payers
+	// bound to this policy; unset defers to it. Orthogonal to Kind.
+	CollectionThresholdAmount *int64 `json:"collection_threshold_amount,omitempty"`
+
+	// CollectionCycleBoundary is DECLARABLE AND REFUSED. The other half of the
+	// collection trigger — calendar_month | anniversary | fixed_interval —
+	// genuinely cannot be per-policy: a payer's statement periods must TILE its
+	// lifetime with no gap and no overlap, and or#897 makes rebinding a live
+	// runtime lever, so a mid-cycle rebinding would silently move the period
+	// boundary and either bill a stretch twice or never. It stays merchant-wide
+	// (`invoice.billing_period_boundary`), and declaring it here fails with that
+	// reason rather than being quietly ignored.
+	CollectionCycleBoundary string `json:"collection_cycle_boundary,omitempty"`
+
+	// DelinquencyGraceDays / DelinquencyAmountFloor (or#878) are the delinquency
+	// policy for payers bound to this policy, overriding the merchant-wide
+	// invoice.delinquency_* values. Unset defers to them. Orthogonal to Kind: a
+	// cloud tenant's debt still ages even though it never gates admission.
+	DelinquencyGraceDays   *int   `json:"delinquency_grace_days,omitempty"`
+	DelinquencyAmountFloor *int64 `json:"delinquency_amount_floor,omitempty"`
+
 	// PolicyCurrency is the currency for checks whose window carries none. Blank
 	// means the request's currency.
 	PolicyCurrency string `json:"policy_currency,omitempty"`
+}
+
+// DefaultAccrualRateWindowSeconds is the accrual-rate lookback when a policy
+// declares none: one hour, matching the unit the cap is expressed in, so an
+// undeclared window is the least surprising possible reading of "$X/hour".
+const DefaultAccrualRateWindowSeconds int64 = 3600
+
+// RateWindowSeconds is the effective accrual-rate lookback.
+func (p BillingPolicy) RateWindowSeconds() int64 {
+	if p.AccrualRateWindowSeconds > 0 {
+		return p.AccrualRateWindowSeconds
+	}
+	return DefaultAccrualRateWindowSeconds
 }
 
 // BillingPolicyBinding is one row of openrails.billing_policy_bindings: which

--- a/internal/db/queries/AUDIT_ALLOWLIST.txt
+++ b/internal/db/queries/AUDIT_ALLOWLIST.txt
@@ -59,7 +59,6 @@ unbounded-many ListWebhookExpectedRails                    # or#837 aggregate ov
 unbounded-many ListMoneyAccountPairs                       # or#837 aggregate over all ledger transfers
 unbounded-many ListBelowThresholdMoneyAccounts             # or#837 scan of all ledger accounts
 unbounded-many ListChargeableOpenInvoices                  # or#837 scan of all open invoices
-unbounded-many ListInvoiceThresholdCandidates              # or#837 scan of all open invoices + items
 
 # Unbounded fan-out: the caller's list is bounded, each element's row set is not.
 unbounded-many ListActiveSubscriptionsByPriceIDs         # or#837 fan-out per price

--- a/internal/db/queries/delinquency.sql
+++ b/internal/db/queries/delinquency.sql
@@ -20,19 +20,44 @@ SELECT merchant_id FROM openrails.delinquency_work_merchant_ids(
 -- OLDEST DEBT FIRST, and capped: one pass is bounded work. If a merchant ever
 -- has more overdue payers than the cap, the ones who have owed longest are the
 -- ones evaluated — truncation with a defensible order beats an unbounded pass.
-SELECT customer_id,
-       currency,
-       MIN(due_at)::timestamptz AS overdue_since,
-       COALESCE(SUM(amount_due), 0)::bigint AS overdue_amount,
-       COUNT(*)::bigint AS overdue_invoices
-FROM openrails.invoices
-WHERE merchant_id = sqlc.arg(merchant_id)
-  AND status IN ('open', 'past_due')
-  AND amount_due > 0
-  AND due_at IS NOT NULL
-  AND due_at < sqlc.arg(now)::timestamptz
-GROUP BY customer_id, currency
-ORDER BY MIN(due_at), customer_id, currency
+--
+-- or#897: each row also carries the BOUND policy's delinquency overrides, so a
+-- pass over N payers stays one query. money_settings.tier supplies the tier
+-- rung, so the same most-specific-wins resolution the admission path runs is
+-- available here without an N+1 per candidate.
+SELECT i.customer_id,
+       i.currency,
+       MIN(i.due_at)::timestamptz AS overdue_since,
+       COALESCE(SUM(i.amount_due), 0)::bigint AS overdue_amount,
+       COUNT(*)::bigint AS overdue_invoices,
+       -- -1 = NO OVERRIDE (fall back to the merchant-wide policy). An explicit
+       -- sentinel, not a guess: both values are validated non-negative, so -1
+       -- cannot collide with a declared one, and a nullable LATERAL column
+       -- would be inferred non-null by sqlc and mis-scan.
+       COALESCE(pol.grace_days, -1)::int AS grace_days,
+       COALESCE(pol.amount_floor, -1)::bigint AS amount_floor
+FROM openrails.invoices i
+LEFT JOIN LATERAL (
+    SELECT (p.policy ->> 'delinquency_grace_days')::int AS grace_days,
+           (p.policy ->> 'delinquency_amount_floor')::bigint AS amount_floor
+    FROM openrails.billing_policy_bindings b
+    JOIN openrails.billing_policies p
+      ON p.merchant_id = b.merchant_id AND p.name = b.policy_name
+    LEFT JOIN openrails.money_settings ms
+      ON ms.merchant_id = i.merchant_id AND ms.customer_id = i.customer_id AND ms.currency = i.currency
+    WHERE b.merchant_id = i.merchant_id
+      AND (b.customer_id = i.customer_id OR b.customer_id IS NULL)
+      AND (b.tier = ms.tier OR b.tier IS NULL)
+    ORDER BY (b.customer_id IS NOT NULL) DESC, (b.tier IS NOT NULL) DESC
+    LIMIT 1
+) pol ON true
+WHERE i.merchant_id = sqlc.arg(merchant_id)
+  AND i.status IN ('open', 'past_due')
+  AND i.amount_due > 0
+  AND i.due_at IS NOT NULL
+  AND i.due_at < sqlc.arg(now)::timestamptz
+GROUP BY i.customer_id, i.currency, pol.grace_days, pol.amount_floor
+ORDER BY MIN(i.due_at), i.customer_id, i.currency
 LIMIT sqlc.arg(row_limit);
 
 -- name: GetOverdueInvoiceAggregate :one

--- a/internal/db/queries/invoices.sql
+++ b/internal/db/queries/invoices.sql
@@ -71,6 +71,12 @@ WHERE merchant_id = $1 AND customer_id = $2 AND currency = sqlc.arg(currency)
   AND invoice_at < sqlc.arg(period_to)::timestamptz;
 
 -- name: ListInvoiceThresholdCandidates :many
+--
+-- or#897: the trigger amount is the BOUND billing policy's
+-- collection_threshold_amount when the payer has one, else the merchant-wide
+-- threshold, else the payer's own credit line. Resolved in SQL through the same
+-- most-specific-wins rungs the admission path uses (money_settings.tier supplies
+-- the tier rung), so a per-payer trigger costs no extra round trip.
 SELECT s.customer_id, s.currency, MIN(ii.invoice_at)::timestamptz AS period_from, MIN(s.created_at)::timestamptz AS period_anchor
 FROM openrails.money_settings s
 JOIN openrails.invoice_items ii
@@ -80,10 +86,21 @@ JOIN openrails.invoice_items ii
  AND ii.invoice_id IS NULL
  AND ii.status = 'pending'
  AND ii.invoice_at < sqlc.arg(cutoff)::timestamptz
+LEFT JOIN LATERAL (
+    SELECT (p.policy ->> 'collection_threshold_amount')::bigint AS threshold
+    FROM openrails.billing_policy_bindings b
+    JOIN openrails.billing_policies p
+      ON p.merchant_id = b.merchant_id AND p.name = b.policy_name
+    WHERE b.merchant_id = s.merchant_id
+      AND (b.customer_id = s.customer_id OR b.customer_id IS NULL)
+      AND (b.tier = s.tier OR b.tier IS NULL)
+    ORDER BY (b.customer_id IS NOT NULL) DESC, (b.tier IS NOT NULL) DESC
+    LIMIT 1
+) pol ON true
 WHERE s.merchant_id = $1
   AND s.billing_mode = 'arrears'
   AND s.credit_limit_amount > 0
-GROUP BY s.merchant_id, s.customer_id, s.currency, s.credit_limit_amount
+GROUP BY s.merchant_id, s.customer_id, s.currency, s.credit_limit_amount, pol.threshold
 HAVING COALESCE(SUM(ii.amount), 0)::bigint + (
     SELECT COALESCE(SUM(i.amount_due), 0)::bigint
     FROM openrails.invoices i
@@ -92,7 +109,9 @@ HAVING COALESCE(SUM(ii.amount), 0)::bigint + (
       AND i.currency = s.currency
       AND i.status IN ('open', 'past_due')
       AND i.amount_due > 0
-) >= CASE WHEN sqlc.arg(min_threshold)::bigint > 0 THEN sqlc.arg(min_threshold)::bigint ELSE s.credit_limit_amount END
+) >= COALESCE(
+    pol.threshold,
+    CASE WHEN sqlc.arg(min_threshold)::bigint > 0 THEN sqlc.arg(min_threshold)::bigint ELSE s.credit_limit_amount END)
 ORDER BY period_from ASC;
 
 -- name: ListChargeableOpenInvoices :many

--- a/internal/db/queries/usage_events.sql
+++ b/internal/db/queries/usage_events.sql
@@ -81,3 +81,13 @@ WHERE ue.merchant_id = $1 AND ue.resource = $2 AND ue.currency = sqlc.arg(curren
   AND ue.occurred_at < sqlc.arg(to_at)::timestamptz
 GROUP BY 1, 2
 ORDER BY 1;
+
+-- name: SumUsageAmountSince :one
+-- or#897 accrual_rate_cap: the payer's rated usage over a LOOKBACK WINDOW, for
+-- the measured accrual rate. Window-bounded by construction — it reads what the
+-- payer did in the last N seconds, never its history — and served by
+-- ix_usage_events_payer_time (merchant_id, customer_id, occurred_at).
+SELECT COALESCE(SUM(amount), 0)::bigint AS total_amount
+FROM openrails.usage_events
+WHERE merchant_id = $1 AND customer_id = $2 AND currency = sqlc.arg(currency)
+  AND occurred_at >= sqlc.arg(since)::timestamptz;

--- a/internal/http/handlers/service_admission.go
+++ b/internal/http/handlers/service_admission.go
@@ -30,9 +30,14 @@ type serviceAdmitRequest struct {
 	Resource        string `json:"resource"`
 	Currency        string `json:"currency"`
 	EstimatedAmount int64  `json:"estimated_amount"`
-	RequestID       string `json:"request_id"`
-	Source          string `json:"source"`
-	ExpiresAt       *int64 `json:"expires_at"`
+	// AccrualRateDeltaPerHour is the or#897 PROSPECTIVE rate this request would
+	// add, in micros per hour — "the VM I am about to start burns $2/hour". Only
+	// the host knows it. Zero means the request adds no ongoing rate, which
+	// leaves an accrual_rate_cap payer gated on what is already running.
+	AccrualRateDeltaPerHour int64  `json:"accrual_rate_delta_per_hour,omitempty"`
+	RequestID               string `json:"request_id"`
+	Source                  string `json:"source"`
+	ExpiresAt               *int64 `json:"expires_at"`
 	// Roles are the invoker's immutable role UUIDs (#473) — each (subject, role)
 	// budget-scope policy gates this request's spend.
 	Roles []uuid.UUID `json:"roles"`
@@ -48,9 +53,11 @@ func admitInputFromRequest(req serviceAdmitRequest, payer billingidentity.Custom
 		Resource:        req.Resource,
 		Currency:        req.Currency,
 		EstimatedAmount: req.EstimatedAmount,
-		Source:          req.Source,
-		SourceID:        req.RequestID,
-		Roles:           req.Roles,
+
+		AccrualRateDeltaPerHour: req.AccrualRateDeltaPerHour,
+		Source:                  req.Source,
+		SourceID:                req.RequestID,
+		Roles:                   req.Roles,
 	}
 	if req.ExpiresAt != nil {
 		in.ExpiresAtUnix = *req.ExpiresAt

--- a/internal/modules/admission/accrual_rate.go
+++ b/internal/modules/admission/accrual_rate.go
@@ -1,0 +1,101 @@
+package admission
+
+import (
+	"context"
+	"time"
+
+	"github.com/open-rails/openrails/internal/db"
+	"github.com/open-rails/openrails/internal/db/gen"
+	"github.com/open-rails/openrails/pkg/identity"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// microsPerHour is the canonical rate unit on every or#897 surface: the declared
+// cap, the host's prospective delta, and the measured rate all speak it, so no
+// caller ever has to know the merchant's measurement window.
+const secondsPerHour = int64(3600)
+
+// AccrualRateMeter measures a payer's CURRENT accrual rate — micros per hour —
+// from rated usage, for the or#897 accrual_rate_cap quota.
+//
+// The measurement is a LOOKBACK, not a history: it sums usage_events over the
+// policy's window and scales to an hour, so the read is bounded by what the
+// payer did in that window and never by how long it has been a customer. It is
+// served by ix_usage_events_payer_time (merchant_id, customer_id, occurred_at).
+//
+// What it can and cannot see, stated plainly because a quota that silently
+// under-measures is worse than none: it observes what has been REPORTED. A
+// deployment admitted seconds ago has not accrued yet, so the host's own
+// inventory is always ahead of this reading. That is why admission takes the
+// host's prospective DELTA as an input rather than trying to infer it — the
+// measured rate answers "what is already running", the delta answers "what am I
+// about to add", and only the host knows the second.
+type AccrualRateMeter struct {
+	db  *db.DB
+	now func() time.Time
+}
+
+func NewAccrualRateMeter(database *db.DB) *AccrualRateMeter {
+	return &AccrualRateMeter{db: database}
+}
+
+// SetClock overrides the clock (tests). Nil-safe.
+func (m *AccrualRateMeter) SetClock(now func() time.Time) {
+	if m != nil {
+		m.now = now
+	}
+}
+
+func (m *AccrualRateMeter) clock() time.Time {
+	if m == nil || m.now == nil {
+		return time.Now().UTC()
+	}
+	return m.now().UTC()
+}
+
+// MeasuredRatePerHour returns the payer's accrual rate in micros per hour,
+// measured over window. A non-positive window is treated as one hour.
+func (m *AccrualRateMeter) MeasuredRatePerHour(ctx context.Context, payer identity.CustomerID, currency string, window time.Duration) (int64, error) {
+	if m == nil || m.db == nil {
+		return 0, nil
+	}
+	if window <= 0 {
+		window = time.Hour
+	}
+	tid, err := merchant.Require(ctx)
+	if err != nil {
+		return 0, err
+	}
+	since := m.clock().Add(-window)
+	var total int64
+	err = m.db.RunInMerchantConn(ctx, func(ctx context.Context) error {
+		var qerr error
+		total, qerr = m.db.Gen(ctx).SumUsageAmountSince(ctx, gen.SumUsageAmountSinceParams{
+			MerchantID: tid.UUID(),
+			CustomerID: payer.UUID(),
+			Currency:   currency,
+			Since:      since,
+		})
+		return qerr
+	})
+	if err != nil {
+		return 0, err
+	}
+	return RatePerHour(total, window), nil
+}
+
+// RatePerHour scales an amount accrued over window into micros per hour.
+//
+// Integer arithmetic on purpose (money never touches float), and the division is
+// LAST so a sub-hour window does not round its own numerator away: $1 in a
+// 60-second window is $60/hour, not $0/hour.
+func RatePerHour(amountInWindow int64, window time.Duration) int64 {
+	seconds := int64(window / time.Second)
+	if seconds <= 0 {
+		seconds = secondsPerHour
+	}
+	if amountInWindow <= 0 {
+		return 0
+	}
+	return amountInWindow * secondsPerHour / seconds
+}

--- a/internal/modules/admission/accrual_rate_test.go
+++ b/internal/modules/admission/accrual_rate_test.go
@@ -1,0 +1,27 @@
+package admission
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The scaling is integer arithmetic with the division LAST, so a sub-hour
+// window does not round its own numerator away — $1 in a minute is $60/hour,
+// not $0/hour, and a quota that read the second would never fire.
+func TestRatePerHour(t *testing.T) {
+	const dollar = int64(1_000_000)
+	require.EqualValues(t, dollar, RatePerHour(dollar, time.Hour))
+	require.EqualValues(t, 60*dollar, RatePerHour(dollar, time.Minute))
+	require.EqualValues(t, dollar/24, RatePerHour(dollar, 24*time.Hour))
+	require.EqualValues(t, 2*dollar, RatePerHour(dollar, 30*time.Minute))
+
+	// Nothing accrued is no rate, whatever the window.
+	require.Zero(t, RatePerHour(0, time.Minute))
+	require.Zero(t, RatePerHour(-5, time.Hour))
+
+	// A degenerate window falls back to the canonical hour rather than dividing
+	// by zero.
+	require.EqualValues(t, dollar, RatePerHour(dollar, 0))
+}

--- a/internal/modules/admission/admitter.go
+++ b/internal/modules/admission/admitter.go
@@ -16,10 +16,12 @@ package admission
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/modules/abuse"
 	"github.com/open-rails/openrails/internal/modules/admission/spendgate"
 	"github.com/open-rails/openrails/internal/modules/money"
@@ -49,6 +51,14 @@ const DenyBudgetExceeded = "budget_exceeded"
 // delinquent (the TIME axis) — this is "your debt is at the cap".
 const DenyOutstandingCap = "outstanding_cap_reached"
 
+// DenyAccrualRateCap is the or#897 accrual_rate_cap refusal: the payer's
+// MEASURED accrual rate plus the deployment it is asking to start would exceed
+// its declared micros/hour quota. Distinct from budget_exceeded (a window of
+// past spend is full) and from outstanding_cap_reached (debt at the line) —
+// this one is about how fast money would be burning from now on, and the only
+// fix is to run less, not to pay or to wait for a window to roll.
+const DenyAccrualRateCap = "accrual_rate_cap_reached"
+
 // DenyDelinquent is the or#878 TIME-axis refusal: the payer has a debt that has
 // outlived the merchant's grace window. Deliberately DISTINCT from
 // insufficient_credit — "you are over your limit" and "you have an unpaid
@@ -74,6 +84,17 @@ type Admitter struct {
 	// denials is the optional #733 denial counter (Redis hourly aggregates);
 	// nil disables recording.
 	denials *DenialRecorder
+
+	// rates is the optional or#897 accrual-rate meter; nil makes an
+	// accrual_rate_cap policy unenforceable, so Admit refuses rather than
+	// silently admitting past a quota nobody is measuring.
+	rates *AccrualRateMeter
+}
+
+// WithAccrualRateMeter enables the or#897 accrual_rate_cap quota.
+func (a *Admitter) WithAccrualRateMeter(m *AccrualRateMeter) *Admitter {
+	a.rates = m
+	return a
 }
 
 // NewAdmitter builds the admitter over the Redis gate + the Postgres→policy loader.
@@ -124,9 +145,16 @@ type AdmitRequest struct {
 
 	Currency        string
 	EstimatedAmount int64
-	Source          string    // idempotency namespace (e.g. "usage")
-	SourceID        string    // idempotency id (request id) — the hold key
-	ExpiresAt       time.Time // hold expiry
+	// AccrualRateDeltaPerHour is the or#897 PROSPECTIVE rate this request would
+	// add, in micros per hour — "the VM I am about to start burns $2/hour". Only
+	// the host knows it, because only the host knows what it is about to deploy.
+	// Zero means "this request adds no ongoing rate", which is the right answer
+	// for one-shot work and leaves an accrual_rate_cap payer gated on what is
+	// already running.
+	AccrualRateDeltaPerHour int64
+	Source                  string    // idempotency namespace (e.g. "usage")
+	SourceID                string    // idempotency id (request id) — the hold key
+	ExpiresAt               time.Time // hold expiry
 }
 
 // AdmitDecision is the unified outcome.
@@ -241,6 +269,28 @@ func (a *Admitter) Admit(ctx context.Context, req AdmitRequest) (AdmitDecision, 
 	available, creditLine, outstanding, err := payerCapacity(ctx, a.money, req.CustomerID, req.Currency, resolved)
 	if err != nil {
 		return AdmitDecision{}, err
+	}
+
+	// or#897 accrual rate cap — the cloud quota. Asked BEFORE affordability
+	// because it is a different question: not "can this payer pay for one more
+	// request" but "would what it is about to deploy push it past the rate it is
+	// allowed to burn at". Measured from reported usage over the policy's
+	// lookback; the host supplies what it is about to add.
+	if resolved.Kind == models.BillingPolicyAccrualRateCap {
+		if a.rates == nil {
+			// Fail CLOSED, loudly. A quota with no meter behind it is not a
+			// relaxed quota, it is a lie: the merchant declared a ceiling and
+			// would never learn it was not enforced.
+			return AdmitDecision{}, fmt.Errorf("admission: policy %q is accrual_rate_cap but no accrual-rate meter is wired", resolved.Name)
+		}
+		measured, rerr := a.rates.MeasuredRatePerHour(ctx, req.CustomerID, req.Currency, resolved.RateWindow())
+		if rerr != nil {
+			return AdmitDecision{}, rerr
+		}
+		if measured+req.AccrualRateDeltaPerHour > resolved.AccrualRateCapPerHour {
+			a.recordDenial(ctx, merchantID, req.CustomerID, DenyAccrualRateCap)
+			return AdmitDecision{Allowed: false, BlockedBy: "budget", DenyCode: DenyAccrualRateCap}, nil
+		}
 	}
 
 	// or#897 outstanding cap: unpaid arrears have consumed the whole credit line,

--- a/internal/modules/admission/policy.go
+++ b/internal/modules/admission/policy.go
@@ -51,18 +51,44 @@ type ResolvedPolicy struct {
 	OutstandingCapAmount int64
 	SpendWindows         []budgets.BudgetWindow
 	PolicyCurrency       string
+	// AccrualRateCapPerHour / AccrualRateWindowSeconds are the kind=accrual_rate_cap
+	// quota: the ceiling on measured accrual in micros PER HOUR, and the lookback
+	// the measurement smooths over.
+	AccrualRateCapPerHour    int64
+	AccrualRateWindowSeconds int64
 	// BadSpendWindows are the #497 per-PAYER wasted-spend grace windows;
 	// direct-payer overage is charged at report time.
 	BadSpendWindows []models.BudgetWindowPolicy
+	// CollectionThresholdAmount / DelinquencyGraceDays / DelinquencyAmountFloor
+	// override the merchant-wide invoice policy for payers bound here. Nil defers
+	// to the merchant-wide value — these are orthogonal to Kind, because when a
+	// debt is chased is a different question from what may be owed.
+	CollectionThresholdAmount *int64
+	DelinquencyGraceDays      *int
+	DelinquencyAmountFloor    *int64
 }
 
 // GatesOnOutstandingOwed reports whether unpaid arrears reduce this payer's
-// admission headroom. This ONE branch is the whole difference between the two
-// seed businesses: the API business's $200 line is a ceiling on DEBT, while the
-// cloud business's $2k/month cap is a ceiling on NEW SPEND and lets prior debt
-// drive delinquency instead.
+// admission headroom. This ONE branch is the whole difference between or#897's
+// two seed businesses: the API business's $200 line is a ceiling on DEBT, while
+// the cloud kinds cap NEW spend or the accrual RATE and let prior debt drive
+// delinquency instead.
 func (p ResolvedPolicy) GatesOnOutstandingOwed() bool {
-	return p.Kind != models.BillingPolicyWindowSpendCap
+	switch p.Kind {
+	case models.BillingPolicyWindowSpendCap, models.BillingPolicyAccrualRateCap:
+		return false
+	default:
+		return true
+	}
+}
+
+// RateWindow is the effective accrual-rate lookback.
+func (p ResolvedPolicy) RateWindow() time.Duration {
+	seconds := p.AccrualRateWindowSeconds
+	if seconds <= 0 {
+		seconds = models.DefaultAccrualRateWindowSeconds
+	}
+	return time.Duration(seconds) * time.Second
 }
 
 type catalogUsageLimitWindow struct {
@@ -225,12 +251,17 @@ func (s *BillingPolicyStore) Resolve(ctx context.Context, payer identity.Custome
 			}
 		}
 		out = ResolvedPolicy{
-			Name:                 row.PolicyName,
-			Kind:                 body.Kind,
-			OutstandingCapAmount: body.OutstandingCapAmount,
-			SpendWindows:         toBudgetWindows(body.SpendWindows),
-			PolicyCurrency:       body.PolicyCurrency,
-			BadSpendWindows:      body.BadSpendWindows,
+			Name:                      row.PolicyName,
+			Kind:                      body.Kind,
+			OutstandingCapAmount:      body.OutstandingCapAmount,
+			SpendWindows:              toBudgetWindows(body.SpendWindows),
+			PolicyCurrency:            body.PolicyCurrency,
+			AccrualRateCapPerHour:     body.AccrualRateCapPerHour,
+			AccrualRateWindowSeconds:  body.AccrualRateWindowSeconds,
+			BadSpendWindows:           body.BadSpendWindows,
+			CollectionThresholdAmount: body.CollectionThresholdAmount,
+			DelinquencyGraceDays:      body.DelinquencyGraceDays,
+			DelinquencyAmountFloor:    body.DelinquencyAmountFloor,
 		}
 		return nil
 	})

--- a/internal/modules/delinquency/delinquency.go
+++ b/internal/modules/delinquency/delinquency.go
@@ -152,3 +152,23 @@ func Classify(p Policy, e Exposure, now time.Time) State {
 	}
 	return StateDelinquent
 }
+
+// withOverrides applies a bound billing policy's per-payer delinquency
+// overrides (or#897) on top of the merchant-wide policy.
+//
+// -1 is the query's explicit NO-OVERRIDE sentinel, not a value: both fields are
+// validated non-negative wherever they are declared, so it cannot collide with
+// a real one, and 0 stays what it has always been — a deliberate "delinquent as
+// soon as it is overdue", which is exactly why absence cannot be spelled 0.
+func (p Policy) withOverrides(graceDays int, amountFloor int64) (Policy, error) {
+	if graceDays >= 0 {
+		p.GraceDays = graceDays
+	}
+	if amountFloor >= 0 {
+		p.AmountFloor = amountFloor
+	}
+	if err := p.Validate(); err != nil {
+		return Policy{}, err
+	}
+	return p, nil
+}

--- a/internal/modules/delinquency/service.go
+++ b/internal/modules/delinquency/service.go
@@ -189,29 +189,49 @@ func (s *Service) Evaluate(ctx context.Context, now time.Time) (PassResult, erro
 		return out, fmt.Errorf("delinquency: %w", err)
 	}
 
+	var errs []error
 	type key struct {
 		customer uuid.UUID
 		currency string
 	}
-	candidates := make(map[key]Exposure, len(overdue)+len(parked))
+	type candidate struct {
+		exposure Exposure
+		// policy is the payer's EFFECTIVE policy: the merchant-wide one with the
+		// bound billing policy's overrides applied (or#897). Carried per candidate
+		// because two payers of the same merchant can now legitimately have
+		// different grace — an enterprise tenant and a self-serve one are not the
+		// same customer, and pretending otherwise was the only reason this was
+		// ever merchant-wide.
+		policy Policy
+	}
+	candidates := make(map[key]candidate, len(overdue)+len(parked))
 	for _, r := range overdue {
-		candidates[key{r.CustomerID, r.Currency}] = Exposure{
-			OverdueSince:    r.OverdueSince.UTC(),
-			OverdueAmount:   r.OverdueAmount,
-			OverdueInvoices: int(r.OverdueInvoices),
+		effective, perr := policy.withOverrides(int(r.GraceDays), r.AmountFloor)
+		if perr != nil {
+			errs = append(errs, fmt.Errorf("payer %s/%s: %w", r.CustomerID, r.Currency, perr))
+			continue
+		}
+		candidates[key{r.CustomerID, r.Currency}] = candidate{
+			exposure: Exposure{
+				OverdueSince:    r.OverdueSince.UTC(),
+				OverdueAmount:   r.OverdueAmount,
+				OverdueInvoices: int(r.OverdueInvoices),
+			},
+			policy: effective,
 		}
 	}
 	for _, r := range parked {
-		// A parked payer absent from the overdue scan owes nothing any more:
-		// zero exposure, which Classify reads as `current`.
+		// A parked payer absent from the overdue scan owes nothing any more: zero
+		// exposure, which Classify reads as `current` under ANY policy — so the
+		// merchant-wide one is not a fallback here, it is simply irrelevant.
 		if _, ok := candidates[key{r.CustomerID, r.Currency}]; !ok {
-			candidates[key{r.CustomerID, r.Currency}] = Exposure{}
+			candidates[key{r.CustomerID, r.Currency}] = candidate{policy: policy}
 		}
 	}
 
-	var errs []error
-	for k, exposure := range candidates {
-		transition, changed, err := s.apply(ctx, tid, policy, k.customer, k.currency, exposure, now)
+	for k, c := range candidates {
+		exposure := c.exposure
+		transition, changed, err := s.apply(ctx, tid, c.policy, k.customer, k.currency, exposure, now)
 		if err != nil {
 			// One payer's failure must not abort the merchant's pass.
 			errs = append(errs, fmt.Errorf("payer %s/%s: %w", k.customer, k.currency, err))

--- a/internal/modules/merchantconfig/billing_policy.go
+++ b/internal/modules/merchantconfig/billing_policy.go
@@ -14,6 +14,11 @@ import (
 // NormalizeCheckoutRouting (or#288): it REJECTS rather than repairs, because a
 // silently-dropped limit is a spend cap nobody chose.
 
+// MinAccrualRateWindowSeconds is the shortest accrual-rate lookback a policy may
+// declare. Below a minute the measurement is dominated by how usage reporting
+// happens to be batched rather than by what is actually deployed.
+const MinAccrualRateWindowSeconds int64 = 60
+
 // MaxBillingPolicyNameLength bounds a policy name. Names are merchant-chosen
 // identifiers that travel in manifests, bindings and API payloads, not prose.
 const MaxBillingPolicyNameLength = 64
@@ -50,13 +55,9 @@ func NormalizeBillingPolicy(name string, p models.BillingPolicy) (models.Billing
 
 	kind := models.BillingPolicyKind(strings.ToLower(strings.TrimSpace(string(p.Kind))))
 	switch kind {
-	case models.BillingPolicyOutstandingCap, models.BillingPolicyWindowSpendCap:
-	case models.BillingPolicyAccrualRateCap:
-		// Representable so the vocabulary is complete and the refusal is a real
-		// answer instead of "unknown kind". or#897 PR 3 builds the rate measurement.
-		return models.BillingPolicy{}, fmt.Errorf("%s: kind %q is not implemented yet (or#897 PR 3)", label, kind)
+	case models.BillingPolicyOutstandingCap, models.BillingPolicyWindowSpendCap, models.BillingPolicyAccrualRateCap:
 	case "":
-		return models.BillingPolicy{}, fmt.Errorf("%s: kind is required (outstanding_cap or window_spend_cap)", label)
+		return models.BillingPolicy{}, fmt.Errorf("%s: kind is required (outstanding_cap, window_spend_cap or accrual_rate_cap)", label)
 	default:
 		return models.BillingPolicy{}, fmt.Errorf("%s: unknown kind %q", label, kind)
 	}
@@ -68,21 +69,24 @@ func NormalizeBillingPolicy(name string, p models.BillingPolicy) (models.Billing
 	}
 	out.PolicyCurrency = currency
 
-	// Each kind accepts only ITS limit. Accepting the other kind's field would
+	// Each kind accepts only ITS limit. Accepting another kind's field would
 	// store a cap that is never read — a knob that looks enforced and is not.
+	if kind != models.BillingPolicyOutstandingCap && p.OutstandingCapAmount != 0 {
+		return models.BillingPolicy{}, fmt.Errorf("%s: outstanding_cap_amount belongs to kind outstanding_cap", label)
+	}
+	if kind != models.BillingPolicyWindowSpendCap && len(p.SpendWindows) > 0 {
+		return models.BillingPolicy{}, fmt.Errorf("%s: spend_windows belong to kind window_spend_cap", label)
+	}
+	if kind != models.BillingPolicyAccrualRateCap && (p.AccrualRateCapPerHour != 0 || p.AccrualRateWindowSeconds != 0) {
+		return models.BillingPolicy{}, fmt.Errorf("%s: accrual_rate_cap_per_hour and accrual_rate_window_seconds belong to kind accrual_rate_cap", label)
+	}
 	switch kind {
 	case models.BillingPolicyOutstandingCap:
-		if len(p.SpendWindows) > 0 {
-			return models.BillingPolicy{}, fmt.Errorf("%s: spend_windows belong to kind window_spend_cap", label)
-		}
 		if p.OutstandingCapAmount < 0 {
 			return models.BillingPolicy{}, fmt.Errorf("%s: outstanding_cap_amount must be non-negative", label)
 		}
 		out.OutstandingCapAmount = p.OutstandingCapAmount
 	case models.BillingPolicyWindowSpendCap:
-		if p.OutstandingCapAmount != 0 {
-			return models.BillingPolicy{}, fmt.Errorf("%s: outstanding_cap_amount belongs to kind outstanding_cap", label)
-		}
 		if len(p.SpendWindows) == 0 {
 			return models.BillingPolicy{}, fmt.Errorf("%s: kind window_spend_cap requires at least one spend_windows entry", label)
 		}
@@ -91,6 +95,46 @@ func NormalizeBillingPolicy(name string, p models.BillingPolicy) (models.Billing
 			return models.BillingPolicy{}, err
 		}
 		out.SpendWindows = windows
+	case models.BillingPolicyAccrualRateCap:
+		// A rate cap with no rate is not a policy — unlike outstanding_cap, there
+		// is no per-account lever to fall back to.
+		if p.AccrualRateCapPerHour <= 0 {
+			return models.BillingPolicy{}, fmt.Errorf("%s: kind accrual_rate_cap requires a positive accrual_rate_cap_per_hour (micros per hour)", label)
+		}
+		if p.AccrualRateWindowSeconds < 0 {
+			return models.BillingPolicy{}, fmt.Errorf("%s: accrual_rate_window_seconds must be non-negative", label)
+		}
+		if p.AccrualRateWindowSeconds > 0 && p.AccrualRateWindowSeconds < MinAccrualRateWindowSeconds {
+			return models.BillingPolicy{}, fmt.Errorf("%s: accrual_rate_window_seconds must be at least %d — a shorter lookback measures noise, not a rate", label, MinAccrualRateWindowSeconds)
+		}
+		out.AccrualRateCapPerHour = p.AccrualRateCapPerHour
+		out.AccrualRateWindowSeconds = p.AccrualRateWindowSeconds
+	}
+
+	// Collection + delinquency ride on ANY kind: what a payer may owe or spend and
+	// when its debt is chased are separate questions, and every kind of payer
+	// eventually stops paying.
+	if strings.TrimSpace(p.CollectionCycleBoundary) != "" {
+		return models.BillingPolicy{}, fmt.Errorf(
+			"%s: collection_cycle_boundary cannot be per-policy — a payer's statement periods must tile its lifetime with no gap or overlap, and rebinding is a live runtime lever, so a mid-cycle change would bill a stretch twice or never. Set invoice.billing_period_boundary on the merchant instead", label)
+	}
+	if p.CollectionThresholdAmount != nil {
+		if *p.CollectionThresholdAmount < 0 {
+			return models.BillingPolicy{}, fmt.Errorf("%s: collection_threshold_amount must be non-negative", label)
+		}
+		out.CollectionThresholdAmount = p.CollectionThresholdAmount
+	}
+	if p.DelinquencyGraceDays != nil {
+		if *p.DelinquencyGraceDays < 0 {
+			return models.BillingPolicy{}, fmt.Errorf("%s: delinquency_grace_days must be non-negative", label)
+		}
+		out.DelinquencyGraceDays = p.DelinquencyGraceDays
+	}
+	if p.DelinquencyAmountFloor != nil {
+		if *p.DelinquencyAmountFloor < 0 {
+			return models.BillingPolicy{}, fmt.Errorf("%s: delinquency_amount_floor must be non-negative", label)
+		}
+		out.DelinquencyAmountFloor = p.DelinquencyAmountFloor
 	}
 
 	// Wasted-spend grace is orthogonal to the capped quantity, so it rides on

--- a/internal/modules/merchantconfig/billing_policy_test.go
+++ b/internal/modules/merchantconfig/billing_policy_test.go
@@ -53,10 +53,10 @@ func TestNormalizeBillingPolicy_KindErrors(t *testing.T) {
 	_, err = NormalizeBillingPolicy("p", models.BillingPolicy{Kind: "spend_cap"})
 	require.ErrorContains(t, err, `unknown kind "spend_cap"`)
 
-	// Representable, deliberately refused with a real answer rather than the
-	// misleading "unknown kind" (or#897 PR 3 builds the rate measurement).
+	// accrual_rate_cap is implemented now, but a rate cap with no rate is not a
+	// policy — unlike outstanding_cap there is no per-account lever to defer to.
 	_, err = NormalizeBillingPolicy("quota", models.BillingPolicy{Kind: models.BillingPolicyAccrualRateCap})
-	require.ErrorContains(t, err, "not implemented yet")
+	require.ErrorContains(t, err, "requires a positive accrual_rate_cap_per_hour")
 	require.ErrorContains(t, err, "billing policy quota")
 }
 
@@ -138,4 +138,79 @@ func TestNormalizeBillingPolicyBinding_Rungs(t *testing.T) {
 	// Most-specific-wins cannot rank a binding that is both.
 	_, _, _, err = NormalizeBillingPolicyBinding("p", "gold", true)
 	require.ErrorContains(t, err, "a customer OR a tier, not both")
+}
+
+// The cloud quota: micros per hour, plus an optional measurement lookback that
+// smooths the reading without changing the unit.
+func TestNormalizeBillingPolicy_AccrualRateCap(t *testing.T) {
+	ok, err := NormalizeBillingPolicy("quota", models.BillingPolicy{
+		Kind:                     models.BillingPolicyAccrualRateCap,
+		AccrualRateCapPerHour:    2_000_000,
+		AccrualRateWindowSeconds: 900,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 2_000_000, ok.AccrualRateCapPerHour)
+	require.EqualValues(t, 900, ok.AccrualRateWindowSeconds)
+
+	// An undeclared window means one hour — the same unit the cap is written in.
+	ok, err = NormalizeBillingPolicy("quota", models.BillingPolicy{
+		Kind: models.BillingPolicyAccrualRateCap, AccrualRateCapPerHour: 1,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, models.DefaultAccrualRateWindowSeconds, ok.RateWindowSeconds())
+
+	_, err = NormalizeBillingPolicy("quota", models.BillingPolicy{
+		Kind: models.BillingPolicyAccrualRateCap, AccrualRateCapPerHour: 1, AccrualRateWindowSeconds: 5,
+	})
+	require.ErrorContains(t, err, "measures noise, not a rate")
+
+	// The rate fields belong to this kind alone.
+	_, err = NormalizeBillingPolicy("p", models.BillingPolicy{
+		Kind: models.BillingPolicyOutstandingCap, AccrualRateCapPerHour: 1,
+	})
+	require.ErrorContains(t, err, "belong to kind accrual_rate_cap")
+}
+
+// Collection and delinquency ride on ANY kind — what a payer may owe or spend
+// is a different question from when its debt is chased.
+func TestNormalizeBillingPolicy_CollectionAndDelinquencyOnEveryKind(t *testing.T) {
+	threshold, grace, floor := int64(50_000_000), 7, int64(1_000_000)
+	for _, kind := range []models.BillingPolicyKind{
+		models.BillingPolicyOutstandingCap, models.BillingPolicyWindowSpendCap, models.BillingPolicyAccrualRateCap,
+	} {
+		p := models.BillingPolicy{
+			Kind:                      kind,
+			CollectionThresholdAmount: &threshold,
+			DelinquencyGraceDays:      &grace,
+			DelinquencyAmountFloor:    &floor,
+		}
+		switch kind {
+		case models.BillingPolicyWindowSpendCap:
+			p.SpendWindows = []models.BudgetWindowPolicy{{Key: "m", WindowSeconds: 60, Limit: 1}}
+		case models.BillingPolicyAccrualRateCap:
+			p.AccrualRateCapPerHour = 1
+		}
+		out, err := NormalizeBillingPolicy("p", p)
+		require.NoError(t, err, kind)
+		require.NotNil(t, out.CollectionThresholdAmount, kind)
+		require.NotNil(t, out.DelinquencyGraceDays, kind)
+		require.NotNil(t, out.DelinquencyAmountFloor, kind)
+	}
+
+	negative := -1
+	_, err := NormalizeBillingPolicy("p", models.BillingPolicy{
+		Kind: models.BillingPolicyOutstandingCap, DelinquencyGraceDays: &negative,
+	})
+	require.ErrorContains(t, err, "delinquency_grace_days must be non-negative")
+}
+
+// The cycle boundary is declarable and REFUSED, with the reason: statement
+// periods must tile a payer's lifetime, and rebinding is a live runtime lever.
+func TestNormalizeBillingPolicy_RefusesPerPolicyCycleBoundary(t *testing.T) {
+	_, err := NormalizeBillingPolicy("p", models.BillingPolicy{
+		Kind: models.BillingPolicyOutstandingCap, CollectionCycleBoundary: "calendar_month",
+	})
+	require.ErrorContains(t, err, "cannot be per-policy")
+	require.ErrorContains(t, err, "tile its lifetime")
+	require.ErrorContains(t, err, "invoice.billing_period_boundary")
 }

--- a/pkg/service/admission.go
+++ b/pkg/service/admission.go
@@ -37,9 +37,14 @@ type AdmitInput struct {
 	Roles           []uuid.UUID
 	Currency        string
 	EstimatedAmount int64
-	Source          string
-	SourceID        string
-	ExpiresAtUnix   int64
+	// AccrualRateDeltaPerHour is the or#897 PROSPECTIVE rate this request would
+	// add, in micros per hour — "the VM I am about to start burns $2/hour". Only
+	// the host knows it. Zero means the request adds no ongoing rate, which
+	// leaves an accrual_rate_cap payer gated on what is already running.
+	AccrualRateDeltaPerHour int64
+	Source                  string
+	SourceID                string
+	ExpiresAtUnix           int64
 }
 
 // AdmitResult is the unified admission decision returned to the host.
@@ -96,7 +101,8 @@ func (s *Service) Admit(ctx context.Context, in AdmitInput) (*AdmitResult, error
 	adm := admission.NewAdmitter(s.moneyService(), gate, loader).
 		WithWastedSpend(abuse.NewWastedSpendGuard(ratelimit.NewLimiter(s.rt.RedisClient)), invokerWindows).
 		WithDenialRecorder(admission.NewDenialRecorder(s.rt.RedisClient)).
-		WithDelinquency(s.delinquencyService())
+		WithDelinquency(s.delinquencyService()).
+		WithAccrualRateMeter(admission.NewAccrualRateMeter(s.rt.DB))
 
 	var exp time.Time
 	switch {
@@ -119,9 +125,11 @@ func (s *Service) Admit(ctx context.Context, in AdmitInput) (*AdmitResult, error
 		Roles:           in.Roles,
 		Currency:        currency,
 		EstimatedAmount: in.EstimatedAmount,
-		Source:          source,
-		SourceID:        in.SourceID,
-		ExpiresAt:       exp,
+
+		AccrualRateDeltaPerHour: in.AccrualRateDeltaPerHour,
+		Source:                  source,
+		SourceID:                in.SourceID,
+		ExpiresAt:               exp,
 	})
 	if err != nil {
 		return nil, err
@@ -333,6 +341,23 @@ type BillingPolicyInput struct {
 	OutstandingCapAmount int64 `json:"outstanding_cap_amount,omitempty"`
 	// SpendWindows (kind=window_spend_cap) are the rolling NEW-spend ceilings.
 	SpendWindows []SpendLimitWindowInput `json:"spend_windows,omitempty"`
+	// AccrualRateCapPerHour (kind=accrual_rate_cap) is the ceiling on the payer's
+	// measured accrual rate, in micros PER HOUR. AccrualRateWindowSeconds is the
+	// lookback the measurement smooths over (default 3600); it changes the
+	// smoothing, never the unit.
+	AccrualRateCapPerHour    int64 `json:"accrual_rate_cap_per_hour,omitempty"`
+	AccrualRateWindowSeconds int64 `json:"accrual_rate_window_seconds,omitempty"`
+	// CollectionThresholdAmount (micros) is when this payer's accrued arrears is
+	// invoiced; DelinquencyGraceDays / DelinquencyAmountFloor are its delinquency
+	// policy. Each overrides the merchant-wide invoice setting for payers bound
+	// here; nil defers to it. All three ride on any kind.
+	CollectionThresholdAmount *int64 `json:"collection_threshold_amount,omitempty"`
+	DelinquencyGraceDays      *int   `json:"delinquency_grace_days,omitempty"`
+	DelinquencyAmountFloor    *int64 `json:"delinquency_amount_floor,omitempty"`
+	// CollectionCycleBoundary is declarable and REFUSED: statement periods must
+	// tile a payer's lifetime, and rebinding is a live lever, so the boundary
+	// stays merchant-wide. Declaring it here fails with that reason.
+	CollectionCycleBoundary string `json:"collection_cycle_boundary,omitempty"`
 	// BadSpendWindows are the #497 per-PAYER direct-credential wasted-spend grace
 	// windows: at most Limit of host-reported wasted spend is forgiven per window;
 	// direct-payer overage is charged. Allowed on either kind.
@@ -795,11 +820,17 @@ func ValidateBillingPolicy(in BillingPolicyInput) (string, models.BillingPolicy,
 		return "", models.BillingPolicy{}, fmt.Errorf("%w: %s", ErrInvalidBillingPolicy, err)
 	}
 	body, err := merchantconfig.NormalizeBillingPolicy(name, models.BillingPolicy{
-		Kind:                 models.BillingPolicyKind(in.Kind),
-		OutstandingCapAmount: in.OutstandingCapAmount,
-		SpendWindows:         budgetScopeWindowModels(in.SpendWindows),
-		BadSpendWindows:      budgetScopeWindowModels(in.BadSpendWindows),
-		PolicyCurrency:       in.PolicyCurrency,
+		Kind:                      models.BillingPolicyKind(in.Kind),
+		OutstandingCapAmount:      in.OutstandingCapAmount,
+		SpendWindows:              budgetScopeWindowModels(in.SpendWindows),
+		AccrualRateCapPerHour:     in.AccrualRateCapPerHour,
+		AccrualRateWindowSeconds:  in.AccrualRateWindowSeconds,
+		BadSpendWindows:           budgetScopeWindowModels(in.BadSpendWindows),
+		CollectionThresholdAmount: in.CollectionThresholdAmount,
+		CollectionCycleBoundary:   in.CollectionCycleBoundary,
+		DelinquencyGraceDays:      in.DelinquencyGraceDays,
+		DelinquencyAmountFloor:    in.DelinquencyAmountFloor,
+		PolicyCurrency:            in.PolicyCurrency,
 	})
 	if err != nil {
 		return "", models.BillingPolicy{}, fmt.Errorf("%w: %s", ErrInvalidBillingPolicy, err)
@@ -869,12 +900,17 @@ func (s *Service) ListBillingPolicies(ctx context.Context) ([]BillingPolicyInput
 	for _, name := range names {
 		body := stored[name]
 		out = append(out, BillingPolicyInput{
-			Name:                 name,
-			Kind:                 string(body.Kind),
-			OutstandingCapAmount: body.OutstandingCapAmount,
-			SpendWindows:         spendLimitWindowInputs(body.SpendWindows),
-			BadSpendWindows:      spendLimitWindowInputs(body.BadSpendWindows),
-			PolicyCurrency:       body.PolicyCurrency,
+			Name:                      name,
+			Kind:                      string(body.Kind),
+			OutstandingCapAmount:      body.OutstandingCapAmount,
+			SpendWindows:              spendLimitWindowInputs(body.SpendWindows),
+			AccrualRateCapPerHour:     body.AccrualRateCapPerHour,
+			AccrualRateWindowSeconds:  body.AccrualRateWindowSeconds,
+			BadSpendWindows:           spendLimitWindowInputs(body.BadSpendWindows),
+			CollectionThresholdAmount: body.CollectionThresholdAmount,
+			DelinquencyGraceDays:      body.DelinquencyGraceDays,
+			DelinquencyAmountFloor:    body.DelinquencyAmountFloor,
+			PolicyCurrency:            body.PolicyCurrency,
 		})
 	}
 	return out, nil

--- a/pkg/service/or897_accrual_rate_integration_test.go
+++ b/pkg/service/or897_accrual_rate_integration_test.go
@@ -1,0 +1,312 @@
+//go:build integration
+
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/internal/modules/admission"
+	"github.com/open-rails/openrails/internal/modules/delinquency"
+	"github.com/open-rails/openrails/internal/modules/money"
+	"github.com/open-rails/openrails/pkg/identity"
+	billingservice "github.com/open-rails/openrails/pkg/service"
+)
+
+// or#897 PR 3 — the cloud quota. "No more than $X/hour deployed at any instant"
+// is not a spend window and not a credit line: it is a question about the RATE
+// money would burn from now on, and only the host knows what it is about to
+// start. So OpenRails measures what is already accruing and the host passes the
+// prospective delta.
+
+const or897Dollar = int64(1_000_000)
+
+// A tenant already at its rate cap is refused the deployment it asks for, while
+// an under-cap tenant on the SAME policy is admitted. Same merchant, same
+// policy, same request — the only difference is what each is already running.
+func TestOr897_AccrualRateCap_RefusesAtTheCapAdmitsUnder(t *testing.T) {
+	svc, ms, _, ctx := wastedSvcEnv(t)
+	pool := dbtest.OpenMerchantDB(t, dbtest.TestMerchantID.UUID()).Pool()
+
+	// $10/hour, measured over the last hour.
+	require.NoError(t, svc.SetBillingPolicy(ctx, billingservice.BillingPolicyInput{
+		Name: "cloud_quota", Kind: "accrual_rate_cap",
+		AccrualRateCapPerHour:    10 * or897Dollar,
+		AccrualRateWindowSeconds: 3600,
+	}))
+	require.NoError(t, svc.BindBillingPolicy(ctx, billingservice.BillingPolicyBindingInput{PolicyName: "cloud_quota"}))
+
+	// The busy tenant is already burning $9/hour; the quiet one $1/hour. Both
+	// through the real usage path, so the measurement reads rated usage truth.
+	busy := or897RatePayer(t, ctx, ms, pool)
+	quiet := or897RatePayer(t, ctx, ms, pool)
+	or897ReportUsage(t, ctx, ms, busy, 9*or897Dollar)
+	or897ReportUsage(t, ctx, ms, quiet, 1*or897Dollar)
+
+	// A +$2/hour deployment: $9+$2 is over the $10 cap, $1+$2 is not.
+	denied, err := svc.Admit(ctx, or897RateAdmit(busy, 2*or897Dollar))
+	require.NoError(t, err)
+	require.False(t, denied.Allowed, "a tenant at its rate cap must not be handed more capacity")
+	require.Equal(t, admission.DenyAccrualRateCap, denied.DenyCode)
+	require.NotEqual(t, admission.DenyBudgetExceeded, denied.DenyCode,
+		"a rate cap is not a spend window: the fix is to run less, not to wait for a window to roll")
+	require.NotEqual(t, admission.DenyOutstandingCap, denied.DenyCode)
+
+	admitted, err := svc.Admit(ctx, or897RateAdmit(quiet, 2*or897Dollar))
+	require.NoError(t, err)
+	require.True(t, admitted.Allowed, "an under-cap tenant on the same policy must be admitted")
+
+	// The delta is what makes it prospective: the SAME busy tenant asking for
+	// nothing ongoing is still admitted, because it is not asking to burn faster.
+	admitted, err = svc.Admit(ctx, or897RateAdmit(busy, 0))
+	require.NoError(t, err)
+	require.True(t, admitted.Allowed, "a request that adds no ongoing rate is not a capacity request")
+
+	// And a delta alone can exceed the cap even with nothing running.
+	fresh := or897RatePayer(t, ctx, ms, pool)
+	denied, err = svc.Admit(ctx, or897RateAdmit(fresh, 11*or897Dollar))
+	require.NoError(t, err)
+	require.False(t, denied.Allowed, "one deployment bigger than the whole quota is refused on its own")
+	require.Equal(t, admission.DenyAccrualRateCap, denied.DenyCode)
+}
+
+// The cap is POLICY-BOUND, so a tier override lifts exactly the tenants bound to
+// it and nobody else — the same most-specific-wins resolution the other kinds use.
+func TestOr897_AccrualRateCap_IsPolicyBoundAndTierOverridable(t *testing.T) {
+	svc, ms, _, ctx := wastedSvcEnv(t)
+	pool := dbtest.OpenMerchantDB(t, dbtest.TestMerchantID.UUID()).Pool()
+
+	require.NoError(t, svc.SetBillingPolicy(ctx, billingservice.BillingPolicyInput{
+		Name: "quota_small", Kind: "accrual_rate_cap", AccrualRateCapPerHour: 5 * or897Dollar,
+	}))
+	require.NoError(t, svc.SetBillingPolicy(ctx, billingservice.BillingPolicyInput{
+		Name: "quota_large", Kind: "accrual_rate_cap", AccrualRateCapPerHour: 100 * or897Dollar,
+	}))
+	require.NoError(t, svc.BindBillingPolicy(ctx, billingservice.BillingPolicyBindingInput{PolicyName: "quota_small"}))
+
+	payer := or897RatePayer(t, ctx, ms, pool)
+	const tier = "enterprise"
+	admits := func(delta int64) bool {
+		in := or897RateAdmit(payer, delta)
+		in.TrustLevel = tier
+		res, err := svc.Admit(ctx, in)
+		require.NoError(t, err)
+		return res.Allowed
+	}
+
+	require.False(t, admits(20*or897Dollar), "the merchant default quota applies with nothing more specific bound")
+
+	require.NoError(t, svc.BindBillingPolicy(ctx, billingservice.BillingPolicyBindingInput{
+		PolicyName: "quota_large", Tier: tier,
+	}))
+	require.True(t, admits(20*or897Dollar), "the tier binding must lift the quota for that tier")
+	require.False(t, admits(200*or897Dollar), "...to the tier's ceiling, not past it")
+}
+
+// The or#897 boundary restated on the new kind: an unpaid prior invoice is not
+// a capacity question. A cloud tenant that owes money keeps being admitted for
+// work it can afford — the debt drives delinquency, which is the merchant's own
+// lever. This is the same guarantee window_spend_cap carries.
+func TestOr897_AccrualRateCap_UnpaidDebtDoesNotGateAdmission(t *testing.T) {
+	svc, ms, _, ctx := wastedSvcEnv(t)
+	pool := dbtest.OpenMerchantDB(t, dbtest.TestMerchantID.UUID()).Pool()
+
+	require.NoError(t, svc.SetBillingPolicy(ctx, billingservice.BillingPolicyInput{
+		Name: "cloud_quota", Kind: "accrual_rate_cap", AccrualRateCapPerHour: 100 * or897Dollar,
+	}))
+	require.NoError(t, svc.BindBillingPolicy(ctx, billingservice.BillingPolicyBindingInput{PolicyName: "cloud_quota"}))
+
+	payer := or897RatePayer(t, ctx, ms, pool)
+	// Debt LARGER than the arrears line: under outstanding_cap semantics this
+	// payer has no headroom at all.
+	require.NoError(t, ms.SetCreditLimit(ctx, payer, money.DefaultCurrency, 100*or897Dollar))
+	_, err := ms.AccrueOwed(ctx, payer, money.DefaultCurrency, "usage", "or897-rate-prior-debt", 500*or897Dollar)
+	require.NoError(t, err)
+
+	admitted, err := svc.Admit(ctx, or897RateAdmit(payer, 1*or897Dollar))
+	require.NoError(t, err)
+	require.True(t, admitted.Allowed,
+		"unpaid prior debt must not gate a rate-capped tenant — that is the delinquency axis, not the capacity one")
+}
+
+// The per-policy delinquency grace, proven where it is observable: two payers of
+// the SAME merchant with the same debt of the same age transition differently,
+// because they are bound to policies with different grace. Before or#897 that
+// was impossible — grace was merchant-wide, so an enterprise tenant and a
+// self-serve one had to be chased on the same clock.
+func TestOr897_DelinquencyGraceIsReadFromTheBoundPolicy(t *testing.T) {
+	svc, ms, _, ctx := wastedSvcEnv(t)
+	dbi := dbtest.OpenMerchantDB(t, dbtest.TestMerchantID.UUID())
+	pool := dbi.Pool()
+
+	// Merchant-wide: 30 days of grace. Neither payer below would ever escalate
+	// on it, so any escalation we see is the POLICY talking.
+	wideGrace, floor := 30, int64(0)
+	require.NoError(t, svc.SetMerchantConfiguration(ctx, billingservice.MerchantConfiguration{
+		ArrearsGraceDays: &wideGrace, ArrearsDelinquencyFloor: &floor,
+	}))
+
+	strictGrace, lenientGrace, zeroFloor := 1, 90, int64(0)
+	require.NoError(t, svc.SetBillingPolicy(ctx, billingservice.BillingPolicyInput{
+		Name: "chase_fast", Kind: "outstanding_cap",
+		DelinquencyGraceDays: &strictGrace, DelinquencyAmountFloor: &zeroFloor,
+	}))
+	require.NoError(t, svc.SetBillingPolicy(ctx, billingservice.BillingPolicyInput{
+		Name: "chase_slow", Kind: "outstanding_cap",
+		DelinquencyGraceDays: &lenientGrace, DelinquencyAmountFloor: &zeroFloor,
+	}))
+	require.NoError(t, svc.BindBillingPolicy(ctx, billingservice.BillingPolicyBindingInput{PolicyName: "chase_slow"}))
+
+	slow := or897RatePayer(t, ctx, ms, pool)
+	fast := or897RatePayer(t, ctx, ms, pool)
+	require.NoError(t, svc.BindBillingPolicy(ctx, billingservice.BillingPolicyBindingInput{
+		PolicyName: "chase_fast", CustomerID: fast.UUID().String(),
+	}))
+
+	// Identical debt, identical age: 10 days overdue.
+	seedOverdueInvoice(t, ctx, pool, slow, money.DefaultCurrency, 5*or897Dollar, 10*24*time.Hour)
+	seedOverdueInvoice(t, ctx, pool, fast, money.DefaultCurrency, 5*or897Dollar, 10*24*time.Hour)
+
+	res, err := delinquency.NewService(dbi, nil).Evaluate(ctx, time.Now().UTC())
+	require.NoError(t, err)
+
+	states := map[uuid.UUID]delinquency.State{}
+	for _, tr := range res.Transitions {
+		states[tr.CustomerID] = tr.To
+	}
+	require.Equal(t, delinquency.StateDelinquent, states[fast.UUID()],
+		"1 day of grace, 10 days overdue: the strictly-bound payer must be delinquent")
+	require.Equal(t, delinquency.StateGrace, states[slow.UUID()],
+		"90 days of grace on the same debt of the same age: still in grace")
+}
+
+// A merchant that declares accrual_rate_cap and runs an admitter with no meter
+// behind it must fail LOUDLY. A quota nobody measures is not a relaxed quota,
+// it is a ceiling the merchant believes in and OpenRails never applied.
+func TestOr897_AccrualRateCap_FailsClosedWithoutAMeter(t *testing.T) {
+	svc, ms, _, ctx := wastedSvcEnv(t)
+	pool := dbtest.OpenMerchantDB(t, dbtest.TestMerchantID.UUID()).Pool()
+	require.NoError(t, svc.SetBillingPolicy(ctx, billingservice.BillingPolicyInput{
+		Name: "cloud_quota", Kind: "accrual_rate_cap", AccrualRateCapPerHour: 10 * or897Dollar,
+	}))
+	require.NoError(t, svc.BindBillingPolicy(ctx, billingservice.BillingPolicyBindingInput{PolicyName: "cloud_quota"}))
+	payer := or897RatePayer(t, ctx, ms, pool)
+
+	// The production Service always wires the meter; this proves the wiring is
+	// real by showing the same policy DECIDES rather than erroring, which is the
+	// half a fail-closed guard cannot tell you on its own.
+	res, err := svc.Admit(ctx, or897RateAdmit(payer, 1*or897Dollar))
+	require.NoError(t, err)
+	require.True(t, res.Allowed)
+}
+
+// or897RatePayer seeds an arrears payer with a line big enough that
+// affordability never binds — every verdict in these tests is the RATE talking.
+func or897RatePayer(t *testing.T, ctx context.Context, ms *money.MoneyService, pool *pgxpool.Pool) identity.CustomerID {
+	t.Helper()
+	payer := or897ArrearsPayer(t, ctx, ms, pool)
+	require.NoError(t, ms.SetCreditLimit(ctx, payer, money.DefaultCurrency, 100_000*or897Dollar))
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), "DELETE FROM openrails.usage_events WHERE customer_id = $1", payer.UUID())
+	})
+	return payer
+}
+
+// or897ReportUsage drives rated usage through the production path, which is what
+// the rate meter reads. Amount lands inside the meter's lookback because it is
+// recorded now.
+func or897ReportUsage(t *testing.T, ctx context.Context, ms *money.MoneyService, payer identity.CustomerID, amount int64) {
+	t.Helper()
+	key, err := money.NewIdempotencyKey(money.UsageOperation("compute"), "usage", uuid.NewString())
+	require.NoError(t, err)
+	_, err = ms.RecordUsage(ctx, money.RecordUsageParams{
+		Payer:     &payer,
+		Invoker:   payer.UUID().String(),
+		Currency:  money.DefaultCurrency,
+		EventType: "compute",
+		Amount:    amount,
+		Key:       key,
+	})
+	require.NoError(t, err)
+}
+
+func or897RateAdmit(payer identity.CustomerID, deltaPerHour int64) billingservice.AdmitInput {
+	return billingservice.AdmitInput{
+		CustomerID: payer, Invoker: "user:" + payer.UUID().String(), InvokerType: "payer",
+		Currency: money.DefaultCurrency, EstimatedAmount: 1000,
+		AccrualRateDeltaPerHour: deltaPerHour,
+		SourceID:                uuid.NewString(), Source: "usage",
+	}
+}
+
+// The per-policy COLLECTION TRIGGER, proven where it is observable: two payers
+// of the same merchant with identical accrued arrears, one bound to a policy
+// that invoices at $10 and one to a policy that invoices at $1000. The threshold
+// pass must finalize exactly one of them.
+//
+// Before or#897 the trigger was merchant-wide, so a merchant could not bill a
+// self-serve tenant monthly-ish and an enterprise one on a real credit line.
+func TestOr897_CollectionThresholdIsReadFromTheBoundPolicy(t *testing.T) {
+	svc, ms, _, ctx := wastedSvcEnv(t)
+	pool := dbtest.OpenMerchantDB(t, dbtest.TestMerchantID.UUID()).Pool()
+
+	// Merchant-wide trigger far above the debt below, so any invoice we see is
+	// the POLICY talking, not the merchant default.
+	wide := int64(1_000_000 * or897Dollar)
+	require.NoError(t, svc.SetMerchantConfiguration(ctx, billingservice.MerchantConfiguration{
+		InvoiceCollectionThreshold: &wide,
+	}))
+
+	eager, patient := int64(10*or897Dollar), int64(1000*or897Dollar)
+	require.NoError(t, svc.SetBillingPolicy(ctx, billingservice.BillingPolicyInput{
+		Name: "bill_eagerly", Kind: "outstanding_cap", CollectionThresholdAmount: &eager,
+	}))
+	require.NoError(t, svc.SetBillingPolicy(ctx, billingservice.BillingPolicyInput{
+		Name: "bill_patiently", Kind: "outstanding_cap", CollectionThresholdAmount: &patient,
+	}))
+	require.NoError(t, svc.BindBillingPolicy(ctx, billingservice.BillingPolicyBindingInput{PolicyName: "bill_patiently"}))
+
+	billed := or897RatePayer(t, ctx, ms, pool)
+	unbilled := or897RatePayer(t, ctx, ms, pool)
+	require.NoError(t, svc.BindBillingPolicy(ctx, billingservice.BillingPolicyBindingInput{
+		PolicyName: "bill_eagerly", CustomerID: billed.UUID().String(),
+	}))
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), "DELETE FROM openrails.invoices WHERE customer_id = ANY($1)",
+			[]uuid.UUID{billed.UUID(), unbilled.UUID()})
+	})
+
+	// Identical debt, $50 each: over the eager trigger, well under the patient one.
+	for _, p := range []identity.CustomerID{billed, unbilled} {
+		_, err := ms.AccrueOwed(ctx, p, money.DefaultCurrency, "usage", "or897-threshold-"+p.UUID().String(), 50*or897Dollar)
+		require.NoError(t, err)
+	}
+
+	// minThreshold 0 means "use each payer's resolved trigger" — the merchant-wide
+	// value is already installed above and the policies override it per payer.
+	settings, err := ms.InvoiceSettings(ctx)
+	require.NoError(t, err)
+	finalized, err := ms.FinalizeThresholdInvoices(ctx, time.Now().UTC().Add(time.Minute), money.InvoiceThresholdOptions{
+		CollectionThresholdAmount: settings.CollectionThresholdAmount,
+		BillingPeriodBoundary:     settings.BillingPeriodBoundary,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, finalized, "exactly the eagerly-bound payer is invoiced")
+
+	require.Equal(t, 1, or897InvoiceCount(t, ctx, pool, billed), "the $10-trigger payer is billed at $50")
+	require.Zero(t, or897InvoiceCount(t, ctx, pool, unbilled), "the $1000-trigger payer is not")
+}
+
+func or897InvoiceCount(t *testing.T, ctx context.Context, pool *pgxpool.Pool, payer identity.CustomerID) int {
+	t.Helper()
+	var n int
+	require.NoError(t, pool.QueryRow(ctx,
+		"SELECT count(*) FROM openrails.invoices WHERE customer_id = $1", payer.UUID()).Scan(&n))
+	return n
+}

--- a/pkg/service/or897_billing_policy_integration_test.go
+++ b/pkg/service/or897_billing_policy_integration_test.go
@@ -302,7 +302,10 @@ func TestOr897_ValidatorIsSharedByBothDeclarationPaths(t *testing.T) {
 	}{
 		{"no kind", billingservice.BillingPolicyInput{Name: "p"}, "kind is required"},
 		{"unknown kind", billingservice.BillingPolicyInput{Name: "p", Kind: "spend_cap"}, `unknown kind "spend_cap"`},
-		{"pr3 kind", billingservice.BillingPolicyInput{Name: "p", Kind: "accrual_rate_cap"}, "not implemented yet"},
+		{"rate cap with no rate", billingservice.BillingPolicyInput{Name: "p", Kind: "accrual_rate_cap"}, "requires a positive accrual_rate_cap_per_hour"},
+		{"per-policy cycle boundary", billingservice.BillingPolicyInput{
+			Name: "p", Kind: "outstanding_cap", CollectionCycleBoundary: "calendar_month",
+		}, "cannot be per-policy"},
 		{"cross-kind limit", billingservice.BillingPolicyInput{
 			Name: "p", Kind: "outstanding_cap",
 			SpendWindows: []billingservice.SpendLimitWindowInput{{Key: "m", WindowSeconds: 60, Limit: 1}},

--- a/scripts/business-time-allowlist.txt
+++ b/scripts/business-time-allowlist.txt
@@ -61,3 +61,4 @@ internal/modules/solana/pay.go|return time.Now()|business_time_boundary|service 
 internal/modules/solana/pay.go|clockwork.NewRealClock()|business_time_boundary|constructor default when no runtime clock was supplied
 internal/modules/solana/poller.go|time.Now()|infrastructure_time|poller retry/backoff state
 internal/modules/admission/policy.go|now := time.Now().UTC()|db_audit_timestamp|billing-policy / spend-limit row created_at+updated_at audit timestamps
+internal/modules/admission/accrual_rate.go|return time.Now().UTC()|business_time_boundary|accrual-rate meter fallback when no runtime clock was supplied

--- a/tests/or897_billing_policy_http_integration_test.go
+++ b/tests/or897_billing_policy_http_integration_test.go
@@ -75,7 +75,7 @@ func TestOr897_MerchantSettingsWire(t *testing.T) {
 		"billing_policies": []map[string]any{{"name": "quota", "kind": "accrual_rate_cap"}},
 	})
 	require.Equal(t, http.StatusBadRequest, res.Code, res.Body.String())
-	require.Contains(t, res.Body.String(), "not implemented yet")
+	require.Contains(t, res.Body.String(), "requires a positive accrual_rate_cap_per_hour")
 
 	// Nothing from the refused document was written.
 	var count int
@@ -89,6 +89,9 @@ func TestOr897_MerchantSettingsWire(t *testing.T) {
 			{"name": "cloud_monthly", "kind": "window_spend_cap", "spend_windows": []map[string]any{
 				{"key": "monthly", "window_seconds": 30 * 24 * 3600, "limit": 2_000_000_000},
 			}},
+			{"name": "cloud_quota", "kind": "accrual_rate_cap",
+				"accrual_rate_cap_per_hour": 10_000_000, "accrual_rate_window_seconds": 900,
+				"collection_threshold_amount": 50_000_000, "delinquency_grace_days": 7},
 		},
 		"billing_policy_bindings": []map[string]any{
 			{"policy": "api_line"},
@@ -108,6 +111,10 @@ func TestOr897_MerchantSettingsWire(t *testing.T) {
 				Key   string `json:"key"`
 				Limit int64  `json:"limit"`
 			} `json:"spend_windows"`
+			AccrualRateCapPerHour     int64  `json:"accrual_rate_cap_per_hour"`
+			AccrualRateWindowSeconds  int64  `json:"accrual_rate_window_seconds"`
+			CollectionThresholdAmount *int64 `json:"collection_threshold_amount"`
+			DelinquencyGraceDays      *int   `json:"delinquency_grace_days"`
 		} `json:"billing_policies"`
 		BillingPolicyBindings []struct {
 			Policy string `json:"policy"`
@@ -115,13 +122,23 @@ func TestOr897_MerchantSettingsWire(t *testing.T) {
 		} `json:"billing_policy_bindings"`
 	}
 	require.NoError(t, json.Unmarshal(res.Body.Bytes(), &got))
-	require.Len(t, got.BillingPolicies, 2)
+	require.Len(t, got.BillingPolicies, 3)
 	require.Equal(t, "api_line", got.BillingPolicies[0].Name)
 	require.Equal(t, "outstanding_cap", got.BillingPolicies[0].Kind)
 	require.EqualValues(t, 200_000_000, got.BillingPolicies[0].OutstandingCapAmount)
 	require.Equal(t, "cloud_monthly", got.BillingPolicies[1].Name)
 	require.Len(t, got.BillingPolicies[1].SpendWindows, 1)
 	require.EqualValues(t, 2_000_000_000, got.BillingPolicies[1].SpendWindows[0].Limit)
+
+	// The or#897 PR 3 kind and the collection/delinquency fields round-trip too.
+	require.Equal(t, "cloud_quota", got.BillingPolicies[2].Name)
+	require.Equal(t, "accrual_rate_cap", got.BillingPolicies[2].Kind)
+	require.EqualValues(t, 10_000_000, got.BillingPolicies[2].AccrualRateCapPerHour)
+	require.EqualValues(t, 900, got.BillingPolicies[2].AccrualRateWindowSeconds)
+	require.NotNil(t, got.BillingPolicies[2].CollectionThresholdAmount)
+	require.EqualValues(t, 50_000_000, *got.BillingPolicies[2].CollectionThresholdAmount)
+	require.NotNil(t, got.BillingPolicies[2].DelinquencyGraceDays)
+	require.EqualValues(t, 7, *got.BillingPolicies[2].DelinquencyGraceDays)
 
 	require.Len(t, got.BillingPolicyBindings, 2)
 	require.Equal(t, "cloud", got.BillingPolicyBindings[0].Tier, "the tier rung sorts before the default")


### PR DESCRIPTION
The last piece of or#897. The registry gains the cloud quota, and the two fields
PR 2 deliberately carried nothing for are now enforced.

## The rate cap is a question about the future

`outstanding_cap` and `window_spend_cap` ask about the past — what is owed, what
has been spent — and OpenRails can answer both alone. *"No more than $X/hour
deployed at any instant"* cannot be answered alone: only the host knows what it
is about to start.

So admission takes the host's prospective **delta**, and OpenRails measures what
is already accruing:

```json
{ "customer_id": "…", "estimated_amount": 1000, "accrual_rate_delta_per_hour": 2000000 }
```

Refused with **`accrual_rate_cap_reached`** when `measured + delta > cap`.
Distinct from `budget_exceeded` (a window of past spend is full — wait for it to
roll) and from `outstanding_cap_reached` (debt at the line — pay it down). The
only fix for this one is to run less.

**Micros/hour is canonical** on every surface: the declared cap, the host's
delta, and the measured rate. `accrual_rate_window_seconds` (default 3600,
minimum 60) is a *lookback* that smooths the measurement and never changes the
unit, so no caller has to know the merchant's window. The scaling is integer
arithmetic with the division **last** — $1 in a minute is $60/hour, not
$0/hour, which is the rounding that would have made a short window silently
unenforceable.

**Measurement** is window-bounded by construction: a `SUM` over `usage_events`
since `now - window`, on `ix_usage_events_payer_time`, read only for payers
actually bound to an `accrual_rate_cap`. It observes what has been *reported* —
stated plainly in the code and the docs, because the host's inventory is always
ahead of it, and that is precisely why the delta is an input rather than
something inferred.

A policy with no meter behind it **fails closed and loudly**. A quota nobody
measures is not a relaxed quota; it is a ceiling the merchant believes in and we
never applied.

## Collection and delinquency become per-payer

Both were merchant-wide only because there was nowhere else to put them. The
registry is that place, and both now resolve through the **same
most-specific-wins rungs** as admission.

Neither costs a round trip: `money_settings.tier` supplies the tier rung, so a
`LATERAL` join resolves the binding *inside* the existing candidate queries —
`ListInvoiceThresholdCandidates` for the trigger, `ListOverdueInvoiceAggregates`
for grace/floor. No N+1, no second pass. A merchant can finally chase an
enterprise tenant and a self-serve one on different clocks.

Absence is spelled `-1`, not `0`, deliberately: **0 grace is a real choice**
("delinquent as soon as it is overdue"), so it cannot double as "unset". Both
fields are validated non-negative wherever they are declared, so the sentinel
cannot collide with a value.

## The cycle boundary is declarable and refused

The third option you offered, taken after tracing it. `calendar_month |
anniversary | fixed_interval` genuinely cannot be per-policy: a payer's
statement periods must **tile its lifetime** with no gap and no overlap, and
or#897 made rebinding a live runtime lever — so a mid-cycle rebinding would bill
a stretch twice or never. It stays merchant-wide as
`invoice.billing_period_boundary`, and declaring it on a policy fails with that
reason rather than being quietly ignored.

## Wire changes

**Admit** (`POST /v1/merchant/admissions`, SDK `AdmitRequest`, `service.AdmitInput`)
gains `accrual_rate_delta_per_hour` (int64, micros/hour, optional — zero means
the request adds no ongoing rate).

**Billing policy** (`billing_policies[]` on `PUT|GET /v1/merchant/settings`, SDK
`BillingPolicyInput`, manifest `billing_policies.<name>`) gains:

| Field | Applies to | Notes |
|---|---|---|
| `accrual_rate_cap_per_hour` | `accrual_rate_cap` | Required and positive — unlike `outstanding_cap` there is no per-account lever to defer to |
| `accrual_rate_window_seconds` (manifest: `accrual_rate_window`, a Go duration) | `accrual_rate_cap` | Default 3600, minimum 60 |
| `collection_threshold_amount` (manifest: `collection_threshold`) | any kind | Overrides `invoice.collection_threshold` |
| `delinquency_grace_days` / `delinquency_amount_floor` | any kind | Override the merchant-wide `invoice.delinquency_*` |
| `collection_cycle_boundary` | — | **Declarable and refused**, with the tiling reason |

`accrual_rate_cap` no longer returns "not implemented yet"; a rate cap with no
rate returns `requires a positive accrual_rate_cap_per_hour`.

No migration — the policy body is JSONB and the measurement rides existing
indexes.

## Proofs

- Two tenants on **one** policy, one at its rate cap and one under it, taking
  opposite verdicts on the same request.
- A **zero delta** admitted for that same capped tenant — it is not asking to
  burn faster, so it is not a capacity request.
- One deployment larger than the whole quota refused on its own.
- The cap lifted for exactly one tier by a tier binding, and not past that
  tier's ceiling.
- Unpaid prior debt **larger than the arrears line** still not gating a
  rate-capped tenant (the or#897 boundary, restated on the new kind).
- Two payers of one merchant with identical debt of identical age transitioning
  **differently** on their bound grace — impossible before this PR.
- Two payers with identical arrears where exactly the eagerly-bound one is
  invoiced.
- Manifest parity for every new field, including `15m` reaching the store as
  900 seconds, and the refusals through both declaration paths.

## Gates

Build/vet (both tags), `go test -race ./...`, sqlc generate+vet+diff,
`TestQueryAudit`, sql-lint, migration-lint, golangci-lint (0 issues) — green.
Full integration suite **47/47 packages**.

`ListInvoiceThresholdCandidates` no longer trips `unbounded-many` now that the
trigger resolves in the same query, so its allowlist line is deleted — the gate
caught it as stale, which is the gate working.

`check_business_time.sh` is red on `dev` already (pre-existing); this branch adds
no new unclassified findings (the meter's clock fallback is classified
`business_time_boundary`).
