### PR TITLE
or#823 quiet window: drop the write-only columns, plus the or#871 and or#887 tails

### DIFF
--- a/internal/db/gen/admission_support.sql.go
+++ b/internal/db/gen/admission_support.sql.go
@@ -34,7 +34,7 @@ func (q *Queries) DeleteAllInvokerSpendLimits(ctx context.Context, arg DeleteAll
 }
 
 const getEffectiveTierSchedule = `-- name: GetEffectiveTierSchedule :one
-SELECT id, merchant_id, customer_id, currency, rungs, schedule_version, created_at, updated_at FROM openrails.tier_schedules
+SELECT id, merchant_id, customer_id, currency, rungs, created_at, updated_at FROM openrails.tier_schedules
 WHERE merchant_id = $1
   AND currency = $3
   AND (customer_id = $2 OR customer_id IS NULL)
@@ -60,7 +60,6 @@ func (q *Queries) GetEffectiveTierSchedule(ctx context.Context, arg GetEffective
 		&i.CustomerID,
 		&i.Currency,
 		&i.Rungs,
-		&i.ScheduleVersion,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -141,7 +140,7 @@ func (q *Queries) ListDeclarativeBillingPolicyBindings(ctx context.Context, merc
 }
 
 const listInvokerSpendLimits = `-- name: ListInvokerSpendLimits :many
-SELECT id, merchant_id, customer_id, scope, scope_key, windows, policy_version, created_at, updated_at FROM openrails.invoker_spend_limits
+SELECT id, merchant_id, customer_id, scope, scope_key, windows, created_at, updated_at FROM openrails.invoker_spend_limits
 WHERE merchant_id = $1 AND customer_id = $2
 `
 
@@ -168,7 +167,6 @@ func (q *Queries) ListInvokerSpendLimits(ctx context.Context, arg ListInvokerSpe
 			&i.Scope,
 			&i.ScopeKey,
 			&i.Windows,
-			&i.PolicyVersion,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -348,23 +346,22 @@ func (q *Queries) UpsertBillingPolicyBindingTier(ctx context.Context, arg Upsert
 
 const upsertInvokerSpendLimit = `-- name: UpsertInvokerSpendLimit :exec
 INSERT INTO openrails.invoker_spend_limits (
-    id, merchant_id, customer_id, scope, scope_key, windows, policy_version, created_at, updated_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+    id, merchant_id, customer_id, scope, scope_key, windows, created_at, updated_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 ON CONFLICT (merchant_id, customer_id, scope, scope_key) DO UPDATE SET
     windows = EXCLUDED.windows,
     updated_at = EXCLUDED.updated_at
 `
 
 type UpsertInvokerSpendLimitParams struct {
-	ID            uuid.UUID
-	MerchantID    uuid.UUID
-	CustomerID    uuid.UUID
-	Scope         string
-	ScopeKey      string
-	Windows       []byte
-	PolicyVersion int64
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
+	ID         uuid.UUID
+	MerchantID uuid.UUID
+	CustomerID uuid.UUID
+	Scope      string
+	ScopeKey   string
+	Windows    []byte
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
 }
 
 // Per-invoker spend-limit upsert (#473/#517): the payer's cap on a delegated
@@ -377,7 +374,6 @@ func (q *Queries) UpsertInvokerSpendLimit(ctx context.Context, arg UpsertInvoker
 		arg.Scope,
 		arg.ScopeKey,
 		arg.Windows,
-		arg.PolicyVersion,
 		arg.CreatedAt,
 		arg.UpdatedAt,
 	)
@@ -386,11 +382,10 @@ func (q *Queries) UpsertInvokerSpendLimit(ctx context.Context, arg UpsertInvoker
 
 const upsertTierScheduleDefault = `-- name: UpsertTierScheduleDefault :exec
 INSERT INTO openrails.tier_schedules (
-    id, merchant_id, customer_id, currency, rungs, schedule_version, created_at, updated_at
-) VALUES ($1, $2, NULL, $6, $3, 1, $4, $5)
+    id, merchant_id, customer_id, currency, rungs, created_at, updated_at
+) VALUES ($1, $2, NULL, $6, $3, $4, $5)
 ON CONFLICT (merchant_id, currency) WHERE (customer_id IS NULL) DO UPDATE SET
     rungs = EXCLUDED.rungs,
-    schedule_version = openrails.tier_schedules.schedule_version + 1,
     updated_at = EXCLUDED.updated_at
 `
 
@@ -419,11 +414,10 @@ func (q *Queries) UpsertTierScheduleDefault(ctx context.Context, arg UpsertTierS
 
 const upsertTierScheduleSubject = `-- name: UpsertTierScheduleSubject :exec
 INSERT INTO openrails.tier_schedules (
-    id, merchant_id, customer_id, currency, rungs, schedule_version, created_at, updated_at
-) VALUES ($1, $2, $3, $7, $4, 1, $5, $6)
+    id, merchant_id, customer_id, currency, rungs, created_at, updated_at
+) VALUES ($1, $2, $3, $7, $4, $5, $6)
 ON CONFLICT (merchant_id, customer_id, currency) WHERE (customer_id IS NOT NULL) DO UPDATE SET
     rungs = EXCLUDED.rungs,
-    schedule_version = openrails.tier_schedules.schedule_version + 1,
     updated_at = EXCLUDED.updated_at
 `
 

--- a/internal/db/gen/alerting.sql.go
+++ b/internal/db/gen/alerting.sql.go
@@ -54,7 +54,7 @@ const createAlertRule = `-- name: CreateAlertRule :one
 
 INSERT INTO openrails.alert_rules (merchant_id, name, template, params, severity, channels, enabled)
 VALUES ($7::uuid, $1, $2, $3, $4, $5, $6)
-RETURNING id, merchant_id, name, template, params, severity, channels, enabled, fired_at, cleared_at, last_evaluated_at, last_value, last_detail, created_at, updated_at
+RETURNING id, merchant_id, name, template, params, severity, channels, enabled, fired_at, cleared_at, last_evaluated_at, last_value, created_at, updated_at
 `
 
 type CreateAlertRuleParams struct {
@@ -98,7 +98,6 @@ func (q *Queries) CreateAlertRule(ctx context.Context, arg CreateAlertRuleParams
 		&i.ClearedAt,
 		&i.LastEvaluatedAt,
 		&i.LastValue,
-		&i.LastDetail,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -216,7 +215,7 @@ func (q *Queries) DeleteMerchantWebhook(ctx context.Context, id uuid.UUID) (int6
 }
 
 const getAlertRule = `-- name: GetAlertRule :one
-SELECT id, merchant_id, name, template, params, severity, channels, enabled, fired_at, cleared_at, last_evaluated_at, last_value, last_detail, created_at, updated_at FROM openrails.alert_rules WHERE id = $1
+SELECT id, merchant_id, name, template, params, severity, channels, enabled, fired_at, cleared_at, last_evaluated_at, last_value, created_at, updated_at FROM openrails.alert_rules WHERE id = $1
 `
 
 func (q *Queries) GetAlertRule(ctx context.Context, id uuid.UUID) (OpenrailsAlertRule, error) {
@@ -235,7 +234,6 @@ func (q *Queries) GetAlertRule(ctx context.Context, id uuid.UUID) (OpenrailsAler
 		&i.ClearedAt,
 		&i.LastEvaluatedAt,
 		&i.LastValue,
-		&i.LastDetail,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -263,7 +261,7 @@ func (q *Queries) GetMerchantWebhook(ctx context.Context, id uuid.UUID) (Openrai
 }
 
 const listAlertRules = `-- name: ListAlertRules :many
-SELECT id, merchant_id, name, template, params, severity, channels, enabled, fired_at, cleared_at, last_evaluated_at, last_value, last_detail, created_at, updated_at FROM openrails.alert_rules ORDER BY created_at DESC, id
+SELECT id, merchant_id, name, template, params, severity, channels, enabled, fired_at, cleared_at, last_evaluated_at, last_value, created_at, updated_at FROM openrails.alert_rules ORDER BY created_at DESC, id
 `
 
 func (q *Queries) ListAlertRules(ctx context.Context) ([]OpenrailsAlertRule, error) {
@@ -288,7 +286,6 @@ func (q *Queries) ListAlertRules(ctx context.Context) ([]OpenrailsAlertRule, err
 			&i.ClearedAt,
 			&i.LastEvaluatedAt,
 			&i.LastValue,
-			&i.LastDetail,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -334,7 +331,7 @@ func (q *Queries) ListArmedAlertMerchants(ctx context.Context) ([]*uuid.UUID, er
 }
 
 const listEnabledAlertRules = `-- name: ListEnabledAlertRules :many
-SELECT id, merchant_id, name, template, params, severity, channels, enabled, fired_at, cleared_at, last_evaluated_at, last_value, last_detail, created_at, updated_at FROM openrails.alert_rules WHERE enabled ORDER BY created_at, id
+SELECT id, merchant_id, name, template, params, severity, channels, enabled, fired_at, cleared_at, last_evaluated_at, last_value, created_at, updated_at FROM openrails.alert_rules WHERE enabled ORDER BY created_at, id
 `
 
 // Evaluator's per-merchant rule set (RLS-scoped; partial index backs it).
@@ -360,7 +357,6 @@ func (q *Queries) ListEnabledAlertRules(ctx context.Context) ([]OpenrailsAlertRu
 			&i.ClearedAt,
 			&i.LastEvaluatedAt,
 			&i.LastValue,
-			&i.LastDetail,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -484,7 +480,6 @@ SET fired_at = $2::timestamptz,
     cleared_at = NULL,
     last_evaluated_at = $3::timestamptz,
     last_value = $4,
-    last_detail = $5,
     updated_at = now()
 WHERE id = $1
 `
@@ -494,17 +489,15 @@ type MarkAlertRuleFiredParams struct {
 	FiredAt     time.Time
 	EvaluatedAt time.Time
 	Value       *float64
-	Detail      []byte
 }
 
-// Edge transition: open a new active alert. Records the crossing value/detail.
+// Edge transition: open a new active alert. Records the crossing value.
 func (q *Queries) MarkAlertRuleFired(ctx context.Context, arg MarkAlertRuleFiredParams) error {
 	_, err := q.db.Exec(ctx, markAlertRuleFired,
 		arg.ID,
 		arg.FiredAt,
 		arg.EvaluatedAt,
 		arg.Value,
-		arg.Detail,
 	)
 	return err
 }
@@ -548,7 +541,7 @@ const updateAlertRule = `-- name: UpdateAlertRule :one
 UPDATE openrails.alert_rules
 SET name = $2, params = $3, severity = $4, channels = $5, enabled = $6, updated_at = now()
 WHERE id = $1
-RETURNING id, merchant_id, name, template, params, severity, channels, enabled, fired_at, cleared_at, last_evaluated_at, last_value, last_detail, created_at, updated_at
+RETURNING id, merchant_id, name, template, params, severity, channels, enabled, fired_at, cleared_at, last_evaluated_at, last_value, created_at, updated_at
 `
 
 type UpdateAlertRuleParams struct {
@@ -584,7 +577,6 @@ func (q *Queries) UpdateAlertRule(ctx context.Context, arg UpdateAlertRuleParams
 		&i.ClearedAt,
 		&i.LastEvaluatedAt,
 		&i.LastValue,
-		&i.LastDetail,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/internal/db/gen/grants.sql.go
+++ b/internal/db/gen/grants.sql.go
@@ -40,13 +40,12 @@ func (q *Queries) AdminGrantExistsForSource(ctx context.Context, arg AdminGrantE
 const createProductUsageLimitBinding = `-- name: CreateProductUsageLimitBinding :exec
 INSERT INTO openrails.product_usage_limit_bindings (
     id, merchant_id, customer_id, usage_limit_key, measure, windows,
-    source_type, source_id, product_key, grant_id, starts_at, ends_at, policy_version
+    grant_id, starts_at, ends_at
 ) VALUES (
     $1::uuid, $2::uuid, $3::uuid,
     $4::text, $5::text, $6::jsonb,
-    $7::text, $8::uuid, $9::text,
-    $10::uuid, $11::timestamptz,
-    $12::timestamptz, $13::bigint
+    $7::uuid, $8::timestamptz,
+    $9::timestamptz
 )
 `
 
@@ -57,13 +56,9 @@ type CreateProductUsageLimitBindingParams struct {
 	UsageLimitKey string
 	Measure       string
 	Windows       []byte
-	SourceType    string
-	SourceID      *uuid.UUID
-	ProductKey    *string
 	GrantID       *uuid.UUID
 	StartsAt      time.Time
 	EndsAt        *time.Time
-	PolicyVersion int64
 }
 
 func (q *Queries) CreateProductUsageLimitBinding(ctx context.Context, arg CreateProductUsageLimitBindingParams) error {
@@ -74,13 +69,9 @@ func (q *Queries) CreateProductUsageLimitBinding(ctx context.Context, arg Create
 		arg.UsageLimitKey,
 		arg.Measure,
 		arg.Windows,
-		arg.SourceType,
-		arg.SourceID,
-		arg.ProductKey,
 		arg.GrantID,
 		arg.StartsAt,
 		arg.EndsAt,
-		arg.PolicyVersion,
 	)
 	return err
 }
@@ -1482,8 +1473,7 @@ func (q *Queries) RevokeEntitlementsByGrant(ctx context.Context, arg RevokeEntit
 const revokeProductUsageLimitBindingsByGrant = `-- name: RevokeProductUsageLimitBindingsByGrant :exec
 UPDATE openrails.product_usage_limit_bindings
 SET revoked_at = $1::timestamptz,
-    updated_at = now(),
-    policy_version = policy_version + 1
+    updated_at = now()
 WHERE merchant_id = $2::uuid
   AND grant_id = $3::uuid
   AND revoked_at IS NULL

--- a/internal/db/gen/merchant_configurations.sql.go
+++ b/internal/db/gen/merchant_configurations.sql.go
@@ -13,7 +13,7 @@ import (
 )
 
 const getMerchantConfiguration = `-- name: GetMerchantConfiguration :one
-SELECT merchant_id, config, config_version, created_at, updated_at FROM openrails.merchant_configurations
+SELECT merchant_id, config, created_at, updated_at FROM openrails.merchant_configurations
 WHERE merchant_id = $1
 LIMIT 1
 `
@@ -24,7 +24,6 @@ func (q *Queries) GetMerchantConfiguration(ctx context.Context, merchantID uuid.
 	err := row.Scan(
 		&i.MerchantID,
 		&i.Config,
-		&i.ConfigVersion,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -33,11 +32,10 @@ func (q *Queries) GetMerchantConfiguration(ctx context.Context, merchantID uuid.
 
 const upsertMerchantConfiguration = `-- name: UpsertMerchantConfiguration :exec
 INSERT INTO openrails.merchant_configurations (
-    merchant_id, config, config_version, created_at, updated_at
-) VALUES ($1, $2, 1, $3, $4)
+    merchant_id, config, created_at, updated_at
+) VALUES ($1, $2, $3, $4)
 ON CONFLICT (merchant_id) DO UPDATE SET
     config = EXCLUDED.config,
-    config_version = openrails.merchant_configurations.config_version + 1,
     updated_at = EXCLUDED.updated_at
 `
 

--- a/internal/db/gen/models.go
+++ b/internal/db/gen/models.go
@@ -138,7 +138,6 @@ type OpenrailsAlertRule struct {
 	ClearedAt       *time.Time
 	LastEvaluatedAt *time.Time
 	LastValue       *float64
-	LastDetail      []byte
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 }
@@ -617,11 +616,10 @@ type OpenrailsInvokerSpendLimit struct {
 	CustomerID uuid.UUID
 	Scope      string
 	// Immutable scope discriminator: role uuid (scope=role), invoker string (scope=invoker), or tier key (scope=invoker_tier).
-	ScopeKey      string
-	Windows       []byte
-	PolicyVersion int64
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
+	ScopeKey  string
+	Windows   []byte
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 // #512 double-entry ledger accounts. One account belongs to exactly one (merchant, currency) ledger; TB-style posted/pending counters are maintained from immutable ledger_transfers and verified by reconciliation. account_type identifies its role (customer_balance, platform_revenue, processor_clearing, arrears_liability, expired_credits, fx_liquidity, world).
@@ -689,10 +687,9 @@ type OpenrailsMerchant struct {
 type OpenrailsMerchantConfiguration struct {
 	MerchantID uuid.UUID
 	// JSONB merchant config. delegated_invoker_wasted_spend_windows is an array of {key, window_seconds, limit}; amount values use the request currency internal precision.
-	Config        []byte
-	ConfigVersion int64
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
+	Config    []byte
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 // Wrapped per-merchant Data Encryption Keys for envelope encryption-at-rest (issue #227). wrapped_dek = merchant DEK sealed with the master key (AES-256-GCM, nonce||ct||tag). Master key lives in config/env (self-hosted) or KMS (production), never in the DB. Merchant-owned and RLS protected.
@@ -700,7 +697,6 @@ type OpenrailsMerchantDek struct {
 	MerchantID uuid.UUID
 	// AES-256-GCM(master_key, merchant_dek): nonce(12) || ciphertext(32) || tag(16).
 	WrappedDek []byte
-	KeyVersion int32
 	CreatedAt  time.Time
 	UpdatedAt  time.Time
 }
@@ -792,7 +788,6 @@ type OpenrailsMoneySetting struct {
 	AutoTopupPaymentMethodID *uuid.UUID
 	// per-account default credit-grant expiry in HOURS; NULL = no default.
 	DefaultCreditExpiryHours *int32
-	LastAlertAt              *time.Time
 	LastTopupAt              *time.Time
 	CreatedAt                time.Time
 	UpdatedAt                time.Time
@@ -1033,15 +1028,10 @@ type OpenrailsProductUsageLimitBinding struct {
 	UsageLimitKey string
 	Measure       string
 	Windows       []byte
-	SourceType    string
-	SourceID      *uuid.UUID
-	// Catalog product key/slug whose current benefits were materialized at grant time.
-	ProductKey    *string
 	GrantID       *uuid.UUID
 	StartsAt      time.Time
 	EndsAt        *time.Time
 	RevokedAt     *time.Time
-	PolicyVersion int64
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
 }
@@ -1138,7 +1128,7 @@ type OpenrailsRailMutationLog struct {
 	CreatedAt time.Time
 }
 
-// Durable Provider Refresh watermarks. A failed or partial provider read records last_error but never advances watermark_at.
+// Durable Provider Refresh watermarks: the exclusive lower bound for the next bounded event window, per (merchant, rail, PSP, domain). A failed or partial provider read simply never advances watermark_at — the failure itself is recorded by the job, not here.
 type OpenrailsRailRefreshWatermark struct {
 	ID         uuid.UUID
 	MerchantID uuid.UUID
@@ -1148,12 +1138,9 @@ type OpenrailsRailRefreshWatermark struct {
 	// Refresh domain. events currently covers provider transaction/subscription event windows.
 	EventDomain string
 	// Exclusive lower bound for the next successful bounded provider event refresh window.
-	WatermarkAt     time.Time
-	LastAttemptedAt *time.Time
-	LastSucceededAt *time.Time
-	LastError       *string
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
+	WatermarkAt time.Time
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
 }
 
 // Durable reconciliation findings ledger. Stable identity per (merchant, finding_type, subject_key); provider/account context lives in evidence for pull.* findings. Statuses: reconcile_required, requires_review, auto_fixed, fixed, ignored (#573).
@@ -1207,7 +1194,6 @@ type OpenrailsReconciliationState struct {
 	MerchantID      uuid.UUID
 	SourceDomain    string
 	FullyReconciled bool
-	LastFullPullAt  *time.Time
 	UpdatedAt       time.Time
 }
 
@@ -1332,10 +1318,9 @@ type OpenrailsTierSchedule struct {
 	// Currency whose cumulative paid amount is compared to this ladder.
 	Currency string
 	// Ordered JSONB array of {tier, min_cumulative_paid_amount}; a payer's tier = highest rung whose min_cumulative_paid_amount <= same-currency cumulative_paid.
-	Rungs           []byte
-	ScheduleVersion int64
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
+	Rungs     []byte
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 // Append-only multi-dimensional metered usage (issue #289). Source of truth for usage reporting + #303 invoice line items. Host-priced (amount sent by the host); event + ledger debit commit in one tx. The hot admission path (#298) never reads this table.
@@ -1344,8 +1329,7 @@ type OpenrailsUsageEvent struct {
 	MerchantID uuid.UUID
 	CustomerID uuid.UUID
 	// Caller-supplied principal string that fired this metered usage event. Opaque to OpenRails; attribution + grouping only, not a FK. Joins use source/source_id.
-	InvokerID   string
-	InvokerType *string
+	InvokerID string
 	// Native OpenRails currency code; amount uses this currency internal precision.
 	Currency string
 	// Caller-supplied free-form string for what was metered (tensorhub: endpoint slug; doujins: plan/item slug). Opaque to OpenRails; nullable, not a FK.
@@ -1377,15 +1361,9 @@ type OpenrailsWebhookHealth struct {
 	Rail       string
 	// last signature-VERIFIED webhook for this rail; silence age is measured from here (or created_at when nothing was ever accepted).
 	LastAcceptedAt *time.Time
-	AcceptedCount  int64
-	LastRejectedAt *time.Time
-	RejectedCount  int64
-	LastDriftAt    *time.Time
-	// pull-derived corrections applied while last_accepted_at predated the previous pull — changes a webhook should have announced.
-	DriftCount int64
-	LastPullAt *time.Time
-	CreatedAt  time.Time
-	UpdatedAt  time.Time
+	LastPullAt     *time.Time
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
 }
 
 // #786 UTC-day webhook counter buckets backing the #733 webhook_rejects / webhook_drift_events windowed metrics.
@@ -1393,7 +1371,6 @@ type OpenrailsWebhookHealthDaily struct {
 	MerchantID uuid.UUID
 	Rail       string
 	DayAt      time.Time
-	Accepted   int64
 	Rejected   int64
 	Drift      int64
 }

--- a/internal/db/gen/money_accounts.sql.go
+++ b/internal/db/gen/money_accounts.sql.go
@@ -103,7 +103,7 @@ func (q *Queries) GetAdmissionCapacity(ctx context.Context, arg GetAdmissionCapa
 }
 
 const getMoneyAccountSettings = `-- name: GetMoneyAccountSettings :one
-SELECT merchant_id, customer_id, billing_mode, low_balance_threshold, auto_topup_enabled, auto_topup_amount, auto_topup_payment_method_id, default_credit_expiry_hours, last_alert_at, last_topup_at, created_at, updated_at, tier, tier_source, currency, credit_limit_amount, collection_payment_method_id FROM openrails.money_settings
+SELECT merchant_id, customer_id, billing_mode, low_balance_threshold, auto_topup_enabled, auto_topup_amount, auto_topup_payment_method_id, default_credit_expiry_hours, last_topup_at, created_at, updated_at, tier, tier_source, currency, credit_limit_amount, collection_payment_method_id FROM openrails.money_settings
 WHERE merchant_id = $1 AND customer_id = $2 AND currency = $3
 LIMIT 1
 `
@@ -126,7 +126,6 @@ func (q *Queries) GetMoneyAccountSettings(ctx context.Context, arg GetMoneyAccou
 		&i.AutoTopupAmount,
 		&i.AutoTopupPaymentMethodID,
 		&i.DefaultCreditExpiryHours,
-		&i.LastAlertAt,
 		&i.LastTopupAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -170,7 +169,7 @@ const listBelowThresholdMoneyAccounts = `-- name: ListBelowThresholdMoneyAccount
 WITH avail AS (
     SELECT s.merchant_id, s.customer_id, s.currency,
            s.low_balance_threshold, s.auto_topup_enabled, s.auto_topup_amount,
-           s.auto_topup_payment_method_id, s.last_alert_at, s.last_topup_at,
+           s.auto_topup_payment_method_id, s.last_topup_at,
            COALESCE((
                SELECT a.credits_posted - a.debits_posted
                FROM openrails.ledger_accounts a
@@ -183,7 +182,7 @@ WITH avail AS (
 SELECT merchant_id, customer_id, currency, available,
        COALESCE(low_balance_threshold, 0)::bigint AS threshold,
        auto_topup_enabled, auto_topup_amount, auto_topup_payment_method_id,
-       last_alert_at, last_topup_at
+       last_topup_at
 FROM avail
 WHERE available < low_balance_threshold
 `
@@ -197,7 +196,6 @@ type ListBelowThresholdMoneyAccountsRow struct {
 	AutoTopupEnabled         bool
 	AutoTopupAmount          *int64
 	AutoTopupPaymentMethodID *uuid.UUID
-	LastAlertAt              *time.Time
 	LastTopupAt              *time.Time
 }
 
@@ -222,7 +220,6 @@ func (q *Queries) ListBelowThresholdMoneyAccounts(ctx context.Context, merchantI
 			&i.AutoTopupEnabled,
 			&i.AutoTopupAmount,
 			&i.AutoTopupPaymentMethodID,
-			&i.LastAlertAt,
 			&i.LastTopupAt,
 		); err != nil {
 			return nil, err
@@ -277,7 +274,7 @@ func (q *Queries) ListMoneyAccountPairs(ctx context.Context, merchantID uuid.UUI
 }
 
 const lockMoneyAccountSettings = `-- name: LockMoneyAccountSettings :one
-SELECT merchant_id, customer_id, billing_mode, low_balance_threshold, auto_topup_enabled, auto_topup_amount, auto_topup_payment_method_id, default_credit_expiry_hours, last_alert_at, last_topup_at, created_at, updated_at, tier, tier_source, currency, credit_limit_amount, collection_payment_method_id FROM openrails.money_settings
+SELECT merchant_id, customer_id, billing_mode, low_balance_threshold, auto_topup_enabled, auto_topup_amount, auto_topup_payment_method_id, default_credit_expiry_hours, last_topup_at, created_at, updated_at, tier, tier_source, currency, credit_limit_amount, collection_payment_method_id FROM openrails.money_settings
 WHERE merchant_id = $1 AND customer_id = $2 AND currency = $3
 FOR UPDATE
 `
@@ -300,7 +297,6 @@ func (q *Queries) LockMoneyAccountSettings(ctx context.Context, arg LockMoneyAcc
 		&i.AutoTopupAmount,
 		&i.AutoTopupPaymentMethodID,
 		&i.DefaultCreditExpiryHours,
-		&i.LastAlertAt,
 		&i.LastTopupAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -395,29 +391,6 @@ func (q *Queries) SetMoneyAccountTier(ctx context.Context, arg SetMoneyAccountTi
 		arg.CustomerID,
 		arg.Tier,
 		arg.TierSource,
-		arg.Now,
-		arg.Currency,
-	)
-	return err
-}
-
-const stampMoneyAccountAlertAt = `-- name: StampMoneyAccountAlertAt :exec
-UPDATE openrails.money_settings
-SET last_alert_at = $3, updated_at = $3
-WHERE merchant_id = $1 AND customer_id = $2 AND currency = $4
-`
-
-type StampMoneyAccountAlertAtParams struct {
-	MerchantID uuid.UUID
-	CustomerID uuid.UUID
-	Now        *time.Time
-	Currency   string
-}
-
-func (q *Queries) StampMoneyAccountAlertAt(ctx context.Context, arg StampMoneyAccountAlertAtParams) error {
-	_, err := q.db.Exec(ctx, stampMoneyAccountAlertAt,
-		arg.MerchantID,
-		arg.CustomerID,
 		arg.Now,
 		arg.Currency,
 	)

--- a/internal/db/gen/reconciliation.sql.go
+++ b/internal/db/gen/reconciliation.sql.go
@@ -1063,7 +1063,7 @@ func (q *Queries) ListDunningStalledSubscriptions(ctx context.Context, arg ListD
 
 const listLapsedSubscriptionsWithEvidence = `-- name: ListLapsedSubscriptionsWithEvidence :many
 SELECT s.id, s.status, s.rail,
-       (s.payment_method_id IS NOT NULL)::bool AS vaulted,
+       (s.payment_method_id IS NOT NULL)::bool AS has_payment_method,
        s.rail_subscription_id,
        s.current_period_ends_at, s.grace_ends_at, s.next_retry_at, s.retry_attempts,
        (s.current_period_starts_at IS NOT NULL AND EXISTS (
@@ -1112,7 +1112,7 @@ type ListLapsedSubscriptionsWithEvidenceRow struct {
 	ID                          uuid.UUID
 	Status                      OpenrailsSubscriptionStatus
 	Rail                        string
-	Vaulted                     bool
+	HasPaymentMethod            bool
 	RailSubscriptionID          string
 	CurrentPeriodEndsAt         *time.Time
 	GraceEndsAt                 *time.Time
@@ -1158,7 +1158,7 @@ func (q *Queries) ListLapsedSubscriptionsWithEvidence(ctx context.Context, arg L
 			&i.ID,
 			&i.Status,
 			&i.Rail,
-			&i.Vaulted,
+			&i.HasPaymentMethod,
 			&i.RailSubscriptionID,
 			&i.CurrentPeriodEndsAt,
 			&i.GraceEndsAt,
@@ -1860,7 +1860,7 @@ func (q *Queries) ReconcileGrantSubscriptionEntitlement(ctx context.Context, arg
 }
 
 const reconcileListPaymentMethodsByRails = `-- name: ReconcileListPaymentMethodsByRails :many
-SELECT id, customer_id, rail, rail_customer_ref AS vault_id, last_four, card_type,
+SELECT id, customer_id, rail, rail_customer_ref, last_four, card_type,
        expiry_date
 FROM openrails.payment_methods
 WHERE rail = ANY ($1::text[])
@@ -1873,17 +1873,18 @@ type ReconcileListPaymentMethodsByRailsParams struct {
 }
 
 type ReconcileListPaymentMethodsByRailsRow struct {
-	ID         uuid.UUID
-	CustomerID uuid.UUID
-	Rail       string
-	VaultID    string
-	LastFour   *string
-	CardType   *string
-	ExpiryDate *string
+	ID              uuid.UUID
+	CustomerID      uuid.UUID
+	Rail            string
+	RailCustomerRef string
+	LastFour        *string
+	CardType        *string
+	ExpiryDate      *string
 }
 
-// Reconcile is NMI-vault-specific: rail_customer_ref IS the NMI customer_vault_id
-// here, aliased to vault_id so the reconcile matcher keeps its NMI-vault vocabulary.
+// rail_customer_ref is the rail's handle on the stored instrument (on NMI it is
+// the customer_vault_id). or#871: no `AS vault_id` alias — `vault` is reserved
+// for HashiCorp Vault, and the column already carries the right name.
 func (q *Queries) ReconcileListPaymentMethodsByRails(ctx context.Context, arg ReconcileListPaymentMethodsByRailsParams) ([]ReconcileListPaymentMethodsByRailsRow, error) {
 	rows, err := q.db.Query(ctx, reconcileListPaymentMethodsByRails, arg.Rails, arg.PspID)
 	if err != nil {
@@ -1897,7 +1898,7 @@ func (q *Queries) ReconcileListPaymentMethodsByRails(ctx context.Context, arg Re
 			&i.ID,
 			&i.CustomerID,
 			&i.Rail,
-			&i.VaultID,
+			&i.RailCustomerRef,
 			&i.LastFour,
 			&i.CardType,
 			&i.ExpiryDate,
@@ -2451,23 +2452,21 @@ func (q *Queries) UpsertReconciliationFinding(ctx context.Context, arg UpsertRec
 const upsertReconciliationState = `-- name: UpsertReconciliationState :one
 
 INSERT INTO openrails.reconciliation_state (
-    merchant_id, source_domain, fully_reconciled, last_full_pull_at, updated_at
+    merchant_id, source_domain, fully_reconciled, updated_at
 ) VALUES (
     $1::uuid, $2::text,
-    $3::boolean, $4::timestamptz, now()
+    $3::boolean, now()
 )
 ON CONFLICT (merchant_id, source_domain) DO UPDATE SET
     fully_reconciled = EXCLUDED.fully_reconciled,
-    last_full_pull_at = COALESCE(EXCLUDED.last_full_pull_at, openrails.reconciliation_state.last_full_pull_at),
     updated_at = now()
-RETURNING id, merchant_id, source_domain, fully_reconciled, last_full_pull_at, updated_at
+RETURNING id, merchant_id, source_domain, fully_reconciled, updated_at
 `
 
 type UpsertReconciliationStateParams struct {
 	MerchantID      uuid.UUID
 	SourceDomain    string
 	FullyReconciled bool
-	LastFullPullAt  *time.Time
 }
 
 // #511 Convergence Engine: per-(merchant, source_domain) confirmed-absence gate.
@@ -2477,22 +2476,16 @@ type UpsertReconciliationStateParams struct {
 // configured provider account whose rail could hold that domain's sources.
 // `grants` is admin/local-sourced, so no pull ever proves it — it stays a
 // manual/bulk-import decision. The flag is a ratchet: never auto-unset.
-// Mark a source domain's reconciliation watermark. Pass fully_reconciled=true +
-// last_full_pull_at after a completed authoritative pull/import for that domain.
+// Mark a source domain's reconciliation watermark: pass fully_reconciled=true
+// after a completed authoritative pull/import for that domain.
 func (q *Queries) UpsertReconciliationState(ctx context.Context, arg UpsertReconciliationStateParams) (OpenrailsReconciliationState, error) {
-	row := q.db.QueryRow(ctx, upsertReconciliationState,
-		arg.MerchantID,
-		arg.SourceDomain,
-		arg.FullyReconciled,
-		arg.LastFullPullAt,
-	)
+	row := q.db.QueryRow(ctx, upsertReconciliationState, arg.MerchantID, arg.SourceDomain, arg.FullyReconciled)
 	var i OpenrailsReconciliationState
 	err := row.Scan(
 		&i.ID,
 		&i.MerchantID,
 		&i.SourceDomain,
 		&i.FullyReconciled,
-		&i.LastFullPullAt,
 		&i.UpdatedAt,
 	)
 	return i, err

--- a/internal/db/gen/usage_events.sql.go
+++ b/internal/db/gen/usage_events.sql.go
@@ -119,7 +119,7 @@ func (q *Queries) AggregateUsageTotals(ctx context.Context, arg AggregateUsageTo
 }
 
 const getUsageEventByCoords = `-- name: GetUsageEventByCoords :one
-SELECT id, merchant_id, customer_id, invoker_id, invoker_type, currency, resource, event_type, dimensions, amount, source, source_id, ledger_transfer_id, metadata, occurred_at, created_at FROM openrails.usage_events
+SELECT id, merchant_id, customer_id, invoker_id, currency, resource, event_type, dimensions, amount, source, source_id, ledger_transfer_id, metadata, occurred_at, created_at FROM openrails.usage_events
 WHERE merchant_id = $1 AND customer_id = $2 AND currency = $6
   AND event_type = $3 AND source = $4 AND source_id = $5
 LIMIT 1
@@ -149,7 +149,6 @@ func (q *Queries) GetUsageEventByCoords(ctx context.Context, arg GetUsageEventBy
 		&i.MerchantID,
 		&i.CustomerID,
 		&i.InvokerID,
-		&i.InvokerType,
 		&i.Currency,
 		&i.Resource,
 		&i.EventType,

--- a/internal/db/gen/webhook_health.sql.go
+++ b/internal/db/gen/webhook_health.sql.go
@@ -59,18 +59,11 @@ func (q *Queries) ListWebhookExpectedRails(ctx context.Context) ([]ListWebhookEx
 
 const recordWebhookAccepted = `-- name: RecordWebhookAccepted :exec
 
-WITH health AS (
-    INSERT INTO openrails.webhook_health (merchant_id, rail, last_accepted_at, accepted_count)
-    VALUES ($1::uuid, $2::text, $3::timestamptz, 1)
-    ON CONFLICT (merchant_id, rail) DO UPDATE SET
-        last_accepted_at = EXCLUDED.last_accepted_at,
-        accepted_count = openrails.webhook_health.accepted_count + 1,
-        updated_at = now()
-)
-INSERT INTO openrails.webhook_health_daily (merchant_id, rail, day_at, accepted)
-VALUES ($1::uuid, $2::text, date_trunc('day', $3::timestamptz AT TIME ZONE 'UTC') AT TIME ZONE 'UTC', 1)
-ON CONFLICT (merchant_id, rail, day_at) DO UPDATE SET
-    accepted = openrails.webhook_health_daily.accepted + 1
+INSERT INTO openrails.webhook_health (merchant_id, rail, last_accepted_at)
+VALUES ($1::uuid, $2::text, $3::timestamptz)
+ON CONFLICT (merchant_id, rail) DO UPDATE SET
+    last_accepted_at = EXCLUDED.last_accepted_at,
+    updated_at = now()
 `
 
 type RecordWebhookAcceptedParams struct {
@@ -81,7 +74,9 @@ type RecordWebhookAcceptedParams struct {
 
 // #786 webhook-health recording. All statements run merchant-scoped (MerchantTx
 // or a pinned merchant connection); INSERTs pass merchant_id for RLS WITH CHECK.
-// Verified-accepted webhook: stamp the silence watermark + bump counters.
+// Verified-accepted webhook: stamp the silence watermark. The lifetime tallies
+// this used to bump were dropped in or#823 — a monotonic total answers no
+// windowed question, which is what webhook_health_daily is for.
 func (q *Queries) RecordWebhookAccepted(ctx context.Context, arg RecordWebhookAcceptedParams) error {
 	_, err := q.db.Exec(ctx, recordWebhookAccepted, arg.MerchantID, arg.Rail, arg.At)
 	return err
@@ -90,9 +85,7 @@ func (q *Queries) RecordWebhookAccepted(ctx context.Context, arg RecordWebhookAc
 const recordWebhookDrift = `-- name: RecordWebhookDrift :execrows
 WITH gate AS (
     UPDATE openrails.webhook_health
-    SET last_drift_at = $1::timestamptz,
-        drift_count = drift_count + $2::bigint,
-        updated_at = now()
+    SET updated_at = now()
     WHERE merchant_id = $3::uuid
       AND rail = $4::text
       AND last_pull_at IS NOT NULL
@@ -133,11 +126,9 @@ func (q *Queries) RecordWebhookDrift(ctx context.Context, arg RecordWebhookDrift
 
 const recordWebhookRejected = `-- name: RecordWebhookRejected :exec
 WITH health AS (
-    INSERT INTO openrails.webhook_health (merchant_id, rail, last_rejected_at, rejected_count)
-    VALUES ($1::uuid, $2::text, $3::timestamptz, 1)
+    INSERT INTO openrails.webhook_health (merchant_id, rail)
+    VALUES ($1::uuid, $2::text)
     ON CONFLICT (merchant_id, rail) DO UPDATE SET
-        last_rejected_at = EXCLUDED.last_rejected_at,
-        rejected_count = openrails.webhook_health.rejected_count + 1,
         updated_at = now()
 )
 INSERT INTO openrails.webhook_health_daily (merchant_id, rail, day_at, rejected)
@@ -152,8 +143,10 @@ type RecordWebhookRejectedParams struct {
 	At         time.Time
 }
 
-// Failed signature verification: bump reject counters. NEVER touches
-// last_accepted_at — rejects must not look like liveness.
+// Failed signature verification: bump the daily reject bucket. NEVER touches
+// last_accepted_at — rejects must not look like liveness. The snapshot row is
+// still upserted so a rail that has ONLY ever rejected still has a created_at
+// for the silence age to measure from.
 func (q *Queries) RecordWebhookRejected(ctx context.Context, arg RecordWebhookRejectedParams) error {
 	_, err := q.db.Exec(ctx, recordWebhookRejected, arg.MerchantID, arg.Rail, arg.At)
 	return err

--- a/internal/db/models/money.go
+++ b/internal/db/models/money.go
@@ -68,7 +68,6 @@ type MoneyAccount struct {
 	// denies insufficient_credit when a new hold would exceed it. 0 = off. NOT
 	// self-serve (set via SetCreditLimit, never UpsertAccountSettings).
 	CreditLimitAmount int64      `json:"credit_limit_amount"`
-	LastAlertAt       *time.Time `json:"last_alert_at,omitempty"`
 	LastTopupAt       *time.Time `json:"last_topup_at,omitempty"`
 
 	TrustLevel *string `json:"trust_level,omitempty"`

--- a/internal/db/queries/EXEMPTIONS.md
+++ b/internal/db/queries/EXEMPTIONS.md
@@ -181,8 +181,8 @@ production writes. Deliberately not started.
 
 ### The inline exemptions
 
-Fifteen statements, twenty-one rule instances, all classified
-**PERMANENT**. All but `0048` are **history** —
+Twenty-seven statements, forty-two rule instances, all classified
+**PERMANENT**. All but `0048` and `0061` are **history** —
 rewriting them changes no live database and the honest record is what actually
 ran. The rules stay armed for new migrations.
 
@@ -198,6 +198,7 @@ ran. The rules stay armed for new migrations.
 | `0031` payments token_type CHECK | `constraint-missing-not-valid` | The two `UPDATE`s immediately above rewrite every row the re-added CHECK then validates, in the same transaction — the constraint is dropped and restored only to move `provider_vault`/`pan_via_vault` to their new names. |
 | `0044` host_lifecycle_events.currency | `adding-not-nullable-field` | The rule's own suggested fix — stay nullable, add a `CHECK` — provably cannot satisfy the invariant it exists for: CUR-1 reads `information_schema.columns.is_nullable`, so only the column attribute counts. The scan is inherent to `SET NOT NULL`, not the constraint two-step the sibling rule covers, so no file split reduces it. The table is a delivery feed created in `0037` and pruned after delivery, so the scan is over a small, short-lived table. |
 | `0060` rail_refresh_watermarks PSP cut | `ban-drop-column`, `adding-not-nullable-field`, `disallowed-unique-constraint`, `adding-foreign-key-constraint`, `constraint-missing-not-valid` | or#893 deletes the table's NULL/global lane. `psp_key` is a generated column that existed only to key that lane; the `DELETE … WHERE psp_id IS NULL` two statements earlier removes every row the `SET NOT NULL` and the re-keyed UNIQUE then validate. The table is a resumable cursor — one row per (merchant, rail, PSP, domain) — so every scan here is over a handful of rows, and `NOT VALID` buys nothing inside a single-transaction migrator (see `0014`). |
+| `0061` ×12 write-only column drops | `ban-drop-column` (×21) | **Deliberate hard cut, not history.** or#823 drops the columns that are written and read by nothing — the rule's concern is breaking a client that reads them, and the verified fact that qualified each column is that no such client exists (no sqlc query, no generated reader, no raw SQL). Prelaunch: no deployment holds rows, and a column kept "just in case" reads to the next person as evidence something consumes it. The lock is `ACCESS EXCLUSIVE` either way and `DROP COLUMN` is metadata-only in Postgres, so there is no cheaper shape to split this into. |
 | `0048` DROP payer_spend_limits | `ban-drop-table` | **Deliberate hard cut, not history.** or#897 replaces the table with `billing_policies` + `billing_policy_bindings`; the rule's concern (breaking existing clients) is the intended effect, and prelaunch there is no deployment holding rows worth keeping. Leaving the table alongside its replacement would be the two-substrate disease or#878 removed from exposure. |
 
 A new migration that genuinely needs one of these must add the constraint

--- a/internal/db/queries/admission_support.sql
+++ b/internal/db/queries/admission_support.sql
@@ -77,8 +77,8 @@ LIMIT 1;
 -- Per-invoker spend-limit upsert (#473/#517): the payer's cap on a delegated
 -- invoker/role. Payer-set only (no owner discriminator).
 INSERT INTO openrails.invoker_spend_limits (
-    id, merchant_id, customer_id, scope, scope_key, windows, policy_version, created_at, updated_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+    id, merchant_id, customer_id, scope, scope_key, windows, created_at, updated_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 ON CONFLICT (merchant_id, customer_id, scope, scope_key) DO UPDATE SET
     windows = EXCLUDED.windows,
     updated_at = EXCLUDED.updated_at;
@@ -100,22 +100,20 @@ WHERE merchant_id = $1 AND customer_id = $2;
 -- Tenant-wide tier schedule upsert (#476): customer_id IS NULL is the
 -- tenant's default ladder. Schedules are platform-owned.
 INSERT INTO openrails.tier_schedules (
-    id, merchant_id, customer_id, currency, rungs, schedule_version, created_at, updated_at
-) VALUES ($1, $2, NULL, sqlc.arg(currency), $3, 1, $4, $5)
+    id, merchant_id, customer_id, currency, rungs, created_at, updated_at
+) VALUES ($1, $2, NULL, sqlc.arg(currency), $3, $4, $5)
 ON CONFLICT (merchant_id, currency) WHERE (customer_id IS NULL) DO UPDATE SET
     rungs = EXCLUDED.rungs,
-    schedule_version = openrails.tier_schedules.schedule_version + 1,
     updated_at = EXCLUDED.updated_at;
 
 -- name: UpsertTierScheduleSubject :exec
 -- Per-subject tier schedule override upsert (#476): takes precedence over the
 -- tenant-wide default for that subject.
 INSERT INTO openrails.tier_schedules (
-    id, merchant_id, customer_id, currency, rungs, schedule_version, created_at, updated_at
-) VALUES ($1, $2, $3, sqlc.arg(currency), $4, 1, $5, $6)
+    id, merchant_id, customer_id, currency, rungs, created_at, updated_at
+) VALUES ($1, $2, $3, sqlc.arg(currency), $4, $5, $6)
 ON CONFLICT (merchant_id, customer_id, currency) WHERE (customer_id IS NOT NULL) DO UPDATE SET
     rungs = EXCLUDED.rungs,
-    schedule_version = openrails.tier_schedules.schedule_version + 1,
     updated_at = EXCLUDED.updated_at;
 
 -- name: GetEffectiveTierSchedule :one

--- a/internal/db/queries/alerting.sql
+++ b/internal/db/queries/alerting.sql
@@ -33,13 +33,12 @@ RETURNING *;
 DELETE FROM openrails.alert_rules WHERE id = $1;
 
 -- name: MarkAlertRuleFired :exec
--- Edge transition: open a new active alert. Records the crossing value/detail.
+-- Edge transition: open a new active alert. Records the crossing value.
 UPDATE openrails.alert_rules
 SET fired_at = sqlc.arg(fired_at)::timestamptz,
     cleared_at = NULL,
     last_evaluated_at = sqlc.arg(evaluated_at)::timestamptz,
     last_value = sqlc.narg(value),
-    last_detail = sqlc.narg(detail),
     updated_at = now()
 WHERE id = $1;
 

--- a/internal/db/queries/grants.sql
+++ b/internal/db/queries/grants.sql
@@ -68,20 +68,18 @@ SELECT EXISTS (
 -- name: CreateProductUsageLimitBinding :exec
 INSERT INTO openrails.product_usage_limit_bindings (
     id, merchant_id, customer_id, usage_limit_key, measure, windows,
-    source_type, source_id, product_key, grant_id, starts_at, ends_at, policy_version
+    grant_id, starts_at, ends_at
 ) VALUES (
     sqlc.arg(id)::uuid, sqlc.arg(merchant_id)::uuid, sqlc.arg(customer_id)::uuid,
     sqlc.arg(usage_limit_key)::text, sqlc.arg(measure)::text, sqlc.arg(windows)::jsonb,
-    sqlc.arg(source_type)::text, sqlc.narg(source_id)::uuid, sqlc.narg(product_key)::text,
     sqlc.narg(grant_id)::uuid, sqlc.arg(starts_at)::timestamptz,
-    sqlc.narg(ends_at)::timestamptz, sqlc.arg(policy_version)::bigint
+    sqlc.narg(ends_at)::timestamptz
 );
 
 -- name: RevokeProductUsageLimitBindingsByGrant :exec
 UPDATE openrails.product_usage_limit_bindings
 SET revoked_at = sqlc.arg(revoked_at)::timestamptz,
-    updated_at = now(),
-    policy_version = policy_version + 1
+    updated_at = now()
 WHERE merchant_id = sqlc.arg(merchant_id)::uuid
   AND grant_id = sqlc.arg(grant_id)::uuid
   AND revoked_at IS NULL;

--- a/internal/db/queries/merchant_configurations.sql
+++ b/internal/db/queries/merchant_configurations.sql
@@ -2,11 +2,10 @@
 -- One merchant-scoped config row. Missing JSON keys are interpreted by service
 -- defaults, not stored as extra rows.
 INSERT INTO openrails.merchant_configurations (
-    merchant_id, config, config_version, created_at, updated_at
-) VALUES ($1, $2, 1, $3, $4)
+    merchant_id, config, created_at, updated_at
+) VALUES ($1, $2, $3, $4)
 ON CONFLICT (merchant_id) DO UPDATE SET
     config = EXCLUDED.config,
-    config_version = openrails.merchant_configurations.config_version + 1,
     updated_at = EXCLUDED.updated_at;
 
 -- name: GetMerchantConfiguration :one

--- a/internal/db/queries/money_accounts.sql
+++ b/internal/db/queries/money_accounts.sql
@@ -93,11 +93,6 @@ WHERE merchant_id = $1
   AND customer_id = $2
   AND currency = sqlc.arg(currency);
 
--- name: StampMoneyAccountAlertAt :exec
-UPDATE openrails.money_settings
-SET last_alert_at = sqlc.arg(now), updated_at = sqlc.arg(now)
-WHERE merchant_id = $1 AND customer_id = $2 AND currency = sqlc.arg(currency);
-
 -- name: StampMoneyAccountTopupAt :exec
 UPDATE openrails.money_settings
 SET last_topup_at = sqlc.arg(now), updated_at = sqlc.arg(now)
@@ -127,7 +122,7 @@ WHERE merchant_id = $1 AND customer_id = $2 AND currency = sqlc.arg(currency)
 WITH avail AS (
     SELECT s.merchant_id, s.customer_id, s.currency,
            s.low_balance_threshold, s.auto_topup_enabled, s.auto_topup_amount,
-           s.auto_topup_payment_method_id, s.last_alert_at, s.last_topup_at,
+           s.auto_topup_payment_method_id, s.last_topup_at,
            COALESCE((
                SELECT a.credits_posted - a.debits_posted
                FROM openrails.ledger_accounts a
@@ -140,6 +135,6 @@ WITH avail AS (
 SELECT merchant_id, customer_id, currency, available,
        COALESCE(low_balance_threshold, 0)::bigint AS threshold,
        auto_topup_enabled, auto_topup_amount, auto_topup_payment_method_id,
-       last_alert_at, last_topup_at
+       last_topup_at
 FROM avail
 WHERE available < low_balance_threshold;

--- a/internal/db/queries/reconciliation.sql
+++ b/internal/db/queries/reconciliation.sql
@@ -359,9 +359,10 @@ WHERE rail::text = ANY (sqlc.arg(rails)::text[])
   AND psp_id = sqlc.arg(psp_id)::uuid;
 
 -- name: ReconcileListPaymentMethodsByRails :many
--- Reconcile is NMI-vault-specific: rail_customer_ref IS the NMI customer_vault_id
--- here, aliased to vault_id so the reconcile matcher keeps its NMI-vault vocabulary.
-SELECT id, customer_id, rail, rail_customer_ref AS vault_id, last_four, card_type,
+-- rail_customer_ref is the rail's handle on the stored instrument (on NMI it is
+-- the customer_vault_id). or#871: no `AS vault_id` alias — `vault` is reserved
+-- for HashiCorp Vault, and the column already carries the right name.
+SELECT id, customer_id, rail, rail_customer_ref, last_four, card_type,
        expiry_date
 FROM openrails.payment_methods
 WHERE rail = ANY (sqlc.arg(rails)::text[])
@@ -514,17 +515,16 @@ WHERE id = sqlc.arg(id)
 -- manual/bulk-import decision. The flag is a ratchet: never auto-unset.
 
 -- name: UpsertReconciliationState :one
--- Mark a source domain's reconciliation watermark. Pass fully_reconciled=true +
--- last_full_pull_at after a completed authoritative pull/import for that domain.
+-- Mark a source domain's reconciliation watermark: pass fully_reconciled=true
+-- after a completed authoritative pull/import for that domain.
 INSERT INTO openrails.reconciliation_state (
-    merchant_id, source_domain, fully_reconciled, last_full_pull_at, updated_at
+    merchant_id, source_domain, fully_reconciled, updated_at
 ) VALUES (
     sqlc.arg(merchant_id)::uuid, sqlc.arg(source_domain)::text,
-    sqlc.arg(fully_reconciled)::boolean, sqlc.narg(last_full_pull_at)::timestamptz, now()
+    sqlc.arg(fully_reconciled)::boolean, now()
 )
 ON CONFLICT (merchant_id, source_domain) DO UPDATE SET
     fully_reconciled = EXCLUDED.fully_reconciled,
-    last_full_pull_at = COALESCE(EXCLUDED.last_full_pull_at, openrails.reconciliation_state.last_full_pull_at),
     updated_at = now()
 RETURNING *;
 
@@ -551,7 +551,7 @@ SELECT COALESCE((
 --                              and saw no renewal (ownership)
 -- name: ListLapsedSubscriptionsWithEvidence :many
 SELECT s.id, s.status, s.rail,
-       (s.payment_method_id IS NOT NULL)::bool AS vaulted,
+       (s.payment_method_id IS NOT NULL)::bool AS has_payment_method,
        s.rail_subscription_id,
        s.current_period_ends_at, s.grace_ends_at, s.next_retry_at, s.retry_attempts,
        (s.current_period_starts_at IS NOT NULL AND EXISTS (

--- a/internal/db/queries/webhook_health.sql
+++ b/internal/db/queries/webhook_health.sql
@@ -2,29 +2,24 @@
 -- or a pinned merchant connection); INSERTs pass merchant_id for RLS WITH CHECK.
 
 -- name: RecordWebhookAccepted :exec
--- Verified-accepted webhook: stamp the silence watermark + bump counters.
-WITH health AS (
-    INSERT INTO openrails.webhook_health (merchant_id, rail, last_accepted_at, accepted_count)
-    VALUES (sqlc.arg(merchant_id)::uuid, sqlc.arg(rail)::text, sqlc.arg(at)::timestamptz, 1)
-    ON CONFLICT (merchant_id, rail) DO UPDATE SET
-        last_accepted_at = EXCLUDED.last_accepted_at,
-        accepted_count = openrails.webhook_health.accepted_count + 1,
-        updated_at = now()
-)
-INSERT INTO openrails.webhook_health_daily (merchant_id, rail, day_at, accepted)
-VALUES (sqlc.arg(merchant_id)::uuid, sqlc.arg(rail)::text, date_trunc('day', sqlc.arg(at)::timestamptz AT TIME ZONE 'UTC') AT TIME ZONE 'UTC', 1)
-ON CONFLICT (merchant_id, rail, day_at) DO UPDATE SET
-    accepted = openrails.webhook_health_daily.accepted + 1;
+-- Verified-accepted webhook: stamp the silence watermark. The lifetime tallies
+-- this used to bump were dropped in or#823 — a monotonic total answers no
+-- windowed question, which is what webhook_health_daily is for.
+INSERT INTO openrails.webhook_health (merchant_id, rail, last_accepted_at)
+VALUES (sqlc.arg(merchant_id)::uuid, sqlc.arg(rail)::text, sqlc.arg(at)::timestamptz)
+ON CONFLICT (merchant_id, rail) DO UPDATE SET
+    last_accepted_at = EXCLUDED.last_accepted_at,
+    updated_at = now();
 
 -- name: RecordWebhookRejected :exec
--- Failed signature verification: bump reject counters. NEVER touches
--- last_accepted_at — rejects must not look like liveness.
+-- Failed signature verification: bump the daily reject bucket. NEVER touches
+-- last_accepted_at — rejects must not look like liveness. The snapshot row is
+-- still upserted so a rail that has ONLY ever rejected still has a created_at
+-- for the silence age to measure from.
 WITH health AS (
-    INSERT INTO openrails.webhook_health (merchant_id, rail, last_rejected_at, rejected_count)
-    VALUES (sqlc.arg(merchant_id)::uuid, sqlc.arg(rail)::text, sqlc.arg(at)::timestamptz, 1)
+    INSERT INTO openrails.webhook_health (merchant_id, rail)
+    VALUES (sqlc.arg(merchant_id)::uuid, sqlc.arg(rail)::text)
     ON CONFLICT (merchant_id, rail) DO UPDATE SET
-        last_rejected_at = EXCLUDED.last_rejected_at,
-        rejected_count = openrails.webhook_health.rejected_count + 1,
         updated_at = now()
 )
 INSERT INTO openrails.webhook_health_daily (merchant_id, rail, day_at, rejected)
@@ -40,9 +35,7 @@ ON CONFLICT (merchant_id, rail, day_at) DO UPDATE SET
 -- import is not drift. Returns rows affected (0 = gate closed).
 WITH gate AS (
     UPDATE openrails.webhook_health
-    SET last_drift_at = sqlc.arg(at)::timestamptz,
-        drift_count = drift_count + sqlc.arg(n)::bigint,
-        updated_at = now()
+    SET updated_at = now()
     WHERE merchant_id = sqlc.arg(merchant_id)::uuid
       AND rail = sqlc.arg(rail)::text
       AND last_pull_at IS NOT NULL

--- a/internal/invariantaudit/deployment_scans_rls_integration_test.go
+++ b/internal/invariantaudit/deployment_scans_rls_integration_test.go
@@ -18,8 +18,16 @@ import (
 //
 // This test asserts BOTH halves on the enforcing role: the retired base-pool
 // shape still lies (that is the regression pin — it is what a superuser-backed
-// harness can never show), and migration 0021's SECURITY DEFINER reader tells
-// the truth across merchants.
+// harness can never show), and the SECURITY DEFINER readers the ceiling
+// ACTUALLY calls tell the truth.
+//
+// or#887 narrowed which truth that is. The ceiling's budget is PER-MERCHANT —
+// a shared deployment-wide wall let one busy tenant deny service to every
+// other — so the readers under test are the per-merchant leg and the per-actor
+// leg. The anti-theft property survives the narrowing: a forged-identity burst
+// is still walled inside the merchant it targets, and one credential operating
+// across merchants is still visible as ONE actor, which is what the second
+// assertion below pins.
 func TestOR860_DestructiveRateCeilingCountsAcrossMerchantsUnderRLS(t *testing.T) {
 	ctx, super, app := pools(t)
 
@@ -46,9 +54,8 @@ func TestOR860_DestructiveRateCeilingCountsAcrossMerchantsUnderRLS(t *testing.T)
 			require.NoError(t, err)
 		}
 	}
-	_ = merchants
-
 	types := []string{intentType}
+	origins := []string{"user", "admin"}
 
 	// The retired shape: a GUC-less count on the app role. Zero, no error.
 	var basePool int64
@@ -60,14 +67,22 @@ func TestOR860_DestructiveRateCeilingCountsAcrossMerchantsUnderRLS(t *testing.T)
 	require.EqualValues(t, 0, basePool,
 		"if this ever becomes non-zero the base pool has gained RLS bypass — re-read or#824 before 'fixing' this test")
 
-	// The fix: the definer reader sees all six.
-	var global, byActor int64
-	require.NoError(t, app.QueryRow(ctx,
-		`SELECT openrails.count_destructive_intents_since($1::text[], now() - interval '1 hour')`,
-		types).Scan(&global))
-	require.GreaterOrEqual(t, global, int64(6),
-		"or#860: the deployment-wide destructive count must span merchants, or the ceiling never trips")
+	// The fix, leg 1 (or#887): the per-merchant definer reader — the one the
+	// ceiling actually calls — sees each merchant's own three, from a pool that
+	// carries no app.merchant_id and would otherwise have counted zero.
+	for _, mid := range merchants {
+		var perMerchant int64
+		require.NoError(t, app.QueryRow(ctx,
+			`SELECT openrails.count_destructive_intents_for_merchant_since($1, $2::text[], $3::text[], now() - interval '1 hour')`,
+			mid, origins, types).Scan(&perMerchant))
+		require.EqualValues(t, 3, perMerchant,
+			"or#887: the ceiling's per-merchant count must see the merchant's own destructive intents, or the wall never trips")
+	}
 
+	// Leg 2: the per-actor reader still spans merchants. This is the anti-theft
+	// half — the budget is per-merchant, but ONE stolen credential must not be
+	// six invisible ones.
+	var byActor int64
 	require.NoError(t, app.QueryRow(ctx,
 		`SELECT openrails.count_destructive_intents_by_actor_since($1, $2::text[], now() - interval '1 hour')`,
 		actor, types).Scan(&byActor))
@@ -123,23 +138,25 @@ func TestOR861_ArmedMerchantScansSeeMerchantsUnderRLS(t *testing.T) {
 func TestCrossMerchantReadersRefuseAWeakDefiner(t *testing.T) {
 	ctx, super, app := pools(t)
 
+	const fn = `openrails.count_destructive_intents_for_merchant_since(uuid, text[], text[], timestamptz)`
+
 	role := "or860_weak_" + uuid.NewString()[:8]
 	_, err := super.Exec(ctx, `CREATE ROLE `+role+` NOLOGIN`)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		bg := stdcontext.Background()
-		_, _ = super.Exec(bg, `ALTER FUNCTION openrails.count_destructive_intents_since(text[], timestamptz) OWNER TO CURRENT_USER`)
+		_, _ = super.Exec(bg, `ALTER FUNCTION `+fn+` OWNER TO CURRENT_USER`)
 		_, _ = super.Exec(bg, `DROP ROLE IF EXISTS `+role)
 	})
 	_, err = super.Exec(ctx, `GRANT USAGE ON SCHEMA openrails TO `+role)
 	require.NoError(t, err)
-	_, err = super.Exec(ctx,
-		`ALTER FUNCTION openrails.count_destructive_intents_since(text[], timestamptz) OWNER TO `+role)
+	_, err = super.Exec(ctx, `ALTER FUNCTION `+fn+` OWNER TO `+role)
 	require.NoError(t, err)
 
 	var n int64
 	err = app.QueryRow(ctx,
-		`SELECT openrails.count_destructive_intents_since(ARRAY['nmi_delete_subscription']::text[], now() - interval '1 hour')`).
+		`SELECT openrails.count_destructive_intents_for_merchant_since($1, ARRAY['user','admin']::text[], ARRAY['nmi_delete_subscription']::text[], now() - interval '1 hour')`,
+		uuid.New()).
 		Scan(&n)
 	require.Error(t, err,
 		"a definer that cannot bypass RLS must RAISE — returning 0 is how the ceiling silently stopped protecting anything")

--- a/internal/modules/admission/policy.go
+++ b/internal/modules/admission/policy.go
@@ -495,7 +495,6 @@ func (s *InvokerSpendLimitStore) upsert(ctx context.Context, tenantID uuid.UUID,
 		Scope:         budgets.NormalizeScope(p.Scope), // #491: store canonical invoker
 		ScopeKey:      p.ScopeKey,
 		Windows:       windowsJSON,
-		PolicyVersion: 1,
 		CreatedAt:     now,
 		UpdatedAt:     now,
 	})

--- a/internal/modules/admission/spendgate/policy.go
+++ b/internal/modules/admission/spendgate/policy.go
@@ -23,8 +23,7 @@
 //     invokers a window applies to; it never creates a shared pool across those
 //     invokers. Only payer scope is aggregate across the whole payer account.
 //
-// Policy is read-mostly config (cached in memory, invalidated on policy_version
-// bump); the Lua scripts + client live in gate.go.
+// Policy is read-mostly config; the Lua scripts + client live in gate.go.
 package spendgate
 
 import (
@@ -64,8 +63,12 @@ type ScopedWindows struct {
 }
 
 // Policy is the full cached cap config for one payer+currency (all scopes). It is
-// read-mostly config loaded from Postgres and cached in memory, invalidated on the
-// existing policy_version bump — never read from Postgres on the hot path.
+// read-mostly config loaded from Postgres — never read from Postgres on the hot
+// path. There is no invalidation signal: or#823 dropped the policy_version
+// column this comment used to claim one from, because nothing ever read it and
+// the cache-invalidation mechanism it described was never built. A cache that
+// needs invalidating must grow a real one (future #687's revision counter is the
+// obvious substrate) rather than point at a bigint nobody increments for it.
 type Policy struct {
 	Scopes []ScopedWindows `json:"scopes"`
 }

--- a/internal/modules/alerting/evaluator.go
+++ b/internal/modules/alerting/evaluator.go
@@ -93,7 +93,7 @@ func (s *Service) evaluateRule(ctx context.Context, rule Rule, now time.Time, st
 	case outcome.Crossed && !firing:
 		s.deliverer.dispatch(ctx, rule, s.buildAlert(rule, outcome, now))
 		stats.Fired++
-		return s.store.markFired(ctx, rule.ID, now, now, outcome.Value, outcome.Dims)
+		return s.store.markFired(ctx, rule.ID, now, now, outcome.Value)
 	case !outcome.Crossed && firing:
 		stats.Cleared++
 		return s.store.markCleared(ctx, rule.ID, now, now, outcome.Value)

--- a/internal/modules/alerting/store.go
+++ b/internal/modules/alerting/store.go
@@ -112,10 +112,12 @@ func (s *store) deleteRule(ctx context.Context, id uuid.UUID) (int64, error) {
 	return s.db.Gen(ctx).DeleteAlertRule(ctx, id)
 }
 
-func (s *store) markFired(ctx context.Context, id uuid.UUID, firedAt, evaluatedAt time.Time, value float64, dims map[string]string) error {
-	detail, _ := json.Marshal(map[string]any{"dimensions": dims})
+// markFired opens the active alert. The crossing DIMENSIONS ride the dispatched
+// alert, which is the surface an operator sees; or#823 dropped the last_detail
+// column that also stored them, because nothing ever read it back.
+func (s *store) markFired(ctx context.Context, id uuid.UUID, firedAt, evaluatedAt time.Time, value float64) error {
 	return s.db.Gen(ctx).MarkAlertRuleFired(ctx, gen.MarkAlertRuleFiredParams{
-		ID: id, FiredAt: firedAt, EvaluatedAt: evaluatedAt, Value: &value, Detail: detail,
+		ID: id, FiredAt: firedAt, EvaluatedAt: evaluatedAt, Value: &value,
 	})
 }
 

--- a/internal/modules/alerting/webhook_health_integration_test.go
+++ b/internal/modules/alerting/webhook_health_integration_test.go
@@ -39,11 +39,21 @@ func countRuleNotifications(t *testing.T, pool *pgxpool.Pool, mid, ruleID uuid.U
 	return n
 }
 
-func webhookHealthRow(t *testing.T, pool *pgxpool.Pool, mid uuid.UUID, rail string) (lastAccepted *time.Time, acceptedCount, rejectedCount, driftCount int64) {
+// webhookHealthRow reads the two substrates #786 actually has: the silence
+// watermark on the snapshot row, and the daily counter buckets the metrics read.
+// or#823 dropped webhook_health's lifetime tallies — they were incremented on
+// every event and consulted by nothing, so asserting on them proved only that
+// the write happened.
+func webhookHealthRow(t *testing.T, pool *pgxpool.Pool, mid uuid.UUID, rail string) (lastAccepted *time.Time, rejected, drift int64) {
 	t.Helper()
-	require.NoError(t, pool.QueryRow(context.Background(),
-		`SELECT last_accepted_at, accepted_count, rejected_count, drift_count FROM openrails.webhook_health WHERE merchant_id=$1 AND rail=$2`,
-		mid, rail).Scan(&lastAccepted, &acceptedCount, &rejectedCount, &driftCount))
+	ctx := context.Background()
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT last_accepted_at FROM openrails.webhook_health WHERE merchant_id=$1 AND rail=$2`,
+		mid, rail).Scan(&lastAccepted))
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT COALESCE(SUM(rejected),0)::bigint, COALESCE(SUM(drift),0)::bigint
+		   FROM openrails.webhook_health_daily WHERE merchant_id=$1 AND rail=$2`,
+		mid, rail).Scan(&rejected, &drift))
 	return
 }
 
@@ -98,9 +108,8 @@ func TestWebhookHealthAlertCycle(t *testing.T) {
 
 	// 1. Verified-accepted ingest stamps the watermark; nothing fires.
 	rec.Accepted(mctx(mid), "nmi")
-	firstAccepted, acceptedCount, _, _ := webhookHealthRow(t, pool, mid, "nmi")
+	firstAccepted, _, _ := webhookHealthRow(t, pool, mid, "nmi")
 	require.NotNil(t, firstAccepted)
-	require.Equal(t, int64(1), acceptedCount)
 	stats := evaluate()
 	require.Equal(t, 0, stats.Fired)
 	require.Equal(t, 0, countNotifications(t, pool, mid))
@@ -126,11 +135,11 @@ func TestWebhookHealthAlertCycle(t *testing.T) {
 	// stamped watermark is detectable) bump the reject counter but NEVER the
 	// accepted watermark; the third reject crosses the webhook_rejects threshold.
 	clk.Advance(time.Hour)
-	acceptedBefore, _, _, _ := webhookHealthRow(t, pool, mid, "nmi")
+	acceptedBefore, _, _ := webhookHealthRow(t, pool, mid, "nmi")
 	for i := 0; i < 3; i++ {
 		rec.Rejected(mctx(mid), "nmi")
 	}
-	acceptedAfter, _, rejectedCount, _ := webhookHealthRow(t, pool, mid, "nmi")
+	acceptedAfter, rejectedCount, _ := webhookHealthRow(t, pool, mid, "nmi")
 	require.Equal(t, int64(3), rejectedCount)
 	require.Equal(t, acceptedBefore.UTC(), acceptedAfter.UTC(), "a rejected webhook must not stamp the accepted watermark")
 	stats = evaluate()
@@ -157,7 +166,7 @@ func TestWebhookHealthAlertCycle(t *testing.T) {
 		require.True(t, admitted, "correction with stale accepted watermark must count as drift")
 		require.NoError(t, webhookhealth.StampPull(ctx, appDB, "nmi", clk.Now()))
 	})
-	_, _, _, driftCount := webhookHealthRow(t, pool, mid, "nmi")
+	_, _, driftCount := webhookHealthRow(t, pool, mid, "nmi")
 	require.Equal(t, int64(2), driftCount)
 	stats = evaluate()
 	require.Equal(t, 1, stats.Fired)
@@ -171,7 +180,7 @@ func TestWebhookHealthAlertCycle(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, admitted, "webhook-announced change must not count as drift")
 	})
-	_, _, _, driftCount = webhookHealthRow(t, pool, mid, "nmi")
+	_, _, driftCount = webhookHealthRow(t, pool, mid, "nmi")
 	require.Equal(t, int64(2), driftCount)
 }
 

--- a/internal/modules/catalog/catalog_platform_sidecars_integration_test.go
+++ b/internal/modules/catalog/catalog_platform_sidecars_integration_test.go
@@ -92,8 +92,8 @@ func TestCatalogBenefitAndMeteringSidecars_AppRoleRLS(t *testing.T) {
 		require.NoError(t, err)
 		_, err = tx.Exec(ctx,
 			`INSERT INTO openrails.product_usage_limit_bindings
-			 (id, merchant_id, customer_id, usage_limit_key, measure, windows, source_type, product_key)
-			 VALUES ($1, $2, $3, $4, 'api_requests', '[{"period":"day","limit":1000}]'::jsonb, 'catalog_product', 'pro')`,
+			 (id, merchant_id, customer_id, usage_limit_key, measure, windows)
+			 VALUES ($1, $2, $3, $4, 'api_requests', '[{"period":"day","limit":1000}]'::jsonb)`,
 			uuid.New(), tA.UUID(), customerA, usageKey,
 		)
 		require.NoError(t, err)

--- a/internal/modules/grants/grants.go
+++ b/internal/modules/grants/grants.go
@@ -369,11 +369,6 @@ func (l *Ledger) materializeUsageLimitBindings(ctx context.Context, g gen.Openra
 		if exists {
 			continue
 		}
-		sourceID := g.ID
-		if parsed, perr := uuid.Parse(g.SourceID); perr == nil {
-			sourceID = parsed
-		}
-		productKey := spec.ProductKey
 		grantID := g.ID
 		if err := l.q.CreateProductUsageLimitBinding(ctx, gen.CreateProductUsageLimitBindingParams{
 			ID:            uuidutil.NewV7(),
@@ -382,13 +377,9 @@ func (l *Ledger) materializeUsageLimitBindings(ctx context.Context, g gen.Openra
 			UsageLimitKey: spec.UsageLimitKey,
 			Measure:       spec.Measure,
 			Windows:       spec.Windows,
-			SourceType:    g.SourceType,
-			SourceID:      &sourceID,
-			ProductKey:    &productKey,
 			GrantID:       &grantID,
 			StartsAt:      g.StartsAt,
 			EndsAt:        g.EndsAt,
-			PolicyVersion: 1,
 		}); err != nil {
 			return fmt.Errorf("grants: materialize usage-limit binding %q: %w", spec.UsageLimitKey, err)
 		}

--- a/internal/modules/money/genmap.go
+++ b/internal/modules/money/genmap.go
@@ -95,7 +95,6 @@ func settingsFromGen(r gen.OpenrailsMoneySetting) *models.MoneyAccount {
 		CollectionPaymentMethod:  r.CollectionPaymentMethodID,
 		DefaultCreditExpiryHours: expiry,
 		CreditLimitAmount:        r.CreditLimitAmount,
-		LastAlertAt:              r.LastAlertAt,
 		LastTopupAt:              r.LastTopupAt,
 		TrustLevel:               r.Tier,
 		TrustLevelSource:         r.TierSource,

--- a/internal/modules/money/money_in.go
+++ b/internal/modules/money/money_in.go
@@ -62,7 +62,6 @@ type moneyInAccount struct {
 	AutoTopup       bool
 	TopupAmount     *int64
 	PaymentMethodID *uuid.UUID
-	LastAlertAt     *time.Time
 	LastTopupAt     *time.Time
 }
 
@@ -89,7 +88,6 @@ func (s *MoneyService) belowThresholdAccounts(ctx context.Context) ([]moneyInAcc
 			AutoTopup:       r.AutoTopupEnabled,
 			TopupAmount:     r.AutoTopupAmount,
 			PaymentMethodID: r.AutoTopupPaymentMethodID,
-			LastAlertAt:     r.LastAlertAt,
 			LastTopupAt:     r.LastTopupAt,
 		})
 	}
@@ -217,18 +215,3 @@ func (s *MoneyService) StampAutoTopupAttempt(ctx context.Context, customerID uui
 	})
 }
 
-// stampMoneyInTimestamp sets a single timestamp column on the settings row.
-func (s *MoneyService) stampMoneyInTimestamp(ctx context.Context, r moneyInAccount, column string, now time.Time) error {
-	switch column {
-	case "last_alert_at":
-		return s.db.Gen(ctx).StampMoneyAccountAlertAt(ctx, gen.StampMoneyAccountAlertAtParams{
-			MerchantID: r.MerchantID, CustomerID: r.CustomerID, Currency: normalizeCurrency(r.Currency), Now: &now,
-		})
-	case "last_topup_at":
-		return s.db.Gen(ctx).StampMoneyAccountTopupAt(ctx, gen.StampMoneyAccountTopupAtParams{
-			MerchantID: r.MerchantID, CustomerID: r.CustomerID, Currency: normalizeCurrency(r.Currency), Now: &now,
-		})
-	default:
-		return fmt.Errorf("money: unknown money-in timestamp column %q", column)
-	}
-}

--- a/internal/reconcile/converge/converge_gate_integration_test.go
+++ b/internal/reconcile/converge/converge_gate_integration_test.go
@@ -77,7 +77,7 @@ func TestConverge_ConfirmedAbsenceGateFlipsOnExhaustivePull(t *testing.T) {
 
 		// A NON-exhaustive pull proves nothing.
 		flipped, err := reconcile.MarkReconciledSourceDomains(ctx, q, gateMerchant.UUID(),
-			reconcile.PullProofs{reconcile.ProviderNMI: {}}, time.Now().UTC())
+			reconcile.PullProofs{reconcile.ProviderNMI: {}})
 		require.NoError(t, err)
 		require.Empty(t, flipped, "non-exhaustive coverage must not flip any domain")
 		require.False(t, isReconciled(ctx, q, "subscriptions"))
@@ -89,7 +89,7 @@ func TestConverge_ConfirmedAbsenceGateFlipsOnExhaustivePull(t *testing.T) {
 			reconcile.PullProofs{reconcile.ProviderNMI: {Coverage: reconcile.SnapshotCoverage{
 				SubscriptionsExhaustive: true, TransactionsExhaustive: true,
 				TransactionsPaginatedComplete: true, TransactionWindowSince: &since,
-			}}}, time.Now().UTC())
+			}}})
 		require.NoError(t, err)
 		require.Equal(t, []string{"subscriptions"}, flipped)
 		require.True(t, isReconciled(ctx, q, "subscriptions"))
@@ -111,7 +111,7 @@ func TestConverge_ConfirmedAbsenceGateFlipsOnExhaustivePull(t *testing.T) {
 		flipped, err = reconcile.MarkReconciledSourceDomains(ctx, q, gateMerchant.UUID(),
 			reconcile.PullProofs{reconcile.ProviderNMI: {Coverage: reconcile.SnapshotCoverage{
 				SubscriptionsExhaustive: true, TransactionsExhaustive: true, TransactionsPaginatedComplete: true,
-			}}}, time.Now().UTC())
+			}}})
 		require.NoError(t, err)
 		require.Empty(t, flipped, "multi-account rail is unprovable by one pull")
 		require.True(t, isReconciled(ctx, q, "subscriptions"), "ratchet: proven domains never unset")
@@ -177,8 +177,7 @@ func TestConverge_EmptyStripeRosterNeverOpensTheAbsenceGate(t *testing.T) {
 		require.NoError(t, err)
 
 		flipped, err := reconcile.MarkReconciledSourceDomains(ctx, q, gateMerchant.UUID(),
-			reconcile.PullProofs{reconcile.ProviderStripe: {Coverage: snap.Coverage, PspID: psp.ID.String()}},
-			time.Now().UTC())
+			reconcile.PullProofs{reconcile.ProviderStripe: {Coverage: snap.Coverage, PspID: psp.ID.String()}})
 		require.NoError(t, err)
 		require.Empty(t, flipped,
 			"an empty Stripe roster proved absence — the confirmed-absence gate is a ratchet, so this opens every retraction for this merchant permanently")

--- a/internal/reconcile/converge/converge_life_more_integration_test.go
+++ b/internal/reconcile/converge/converge_life_more_integration_test.go
@@ -78,8 +78,8 @@ func TestConverge_LifeSubscriptionPendingStaleWaitsForSourceProof(t *testing.T) 
 	// repair proceeds.
 	require.NoError(t, appDB.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
 		_, err := appDB.Qx(ctx).Exec(ctx,
-			`INSERT INTO openrails.reconciliation_state (merchant_id, source_domain, fully_reconciled, last_full_pull_at)
-			 VALUES ($1,'subscriptions',true,now())
+			`INSERT INTO openrails.reconciliation_state (merchant_id, source_domain, fully_reconciled)
+			 VALUES ($1,'subscriptions',true)
 			 ON CONFLICT (merchant_id, source_domain) DO UPDATE SET fully_reconciled = true`, merchantID)
 		return err
 	}))

--- a/internal/reconcile/converge/converge_passes.go
+++ b/internal/reconcile/converge/converge_passes.go
@@ -490,7 +490,7 @@ func (p *lifePass) Run(ctx context.Context, scope Scope) ([]ConvergeFinding, err
 		state := reconcile.SubscriptionState{
 			Status:             string(row.Status),
 			Rail:               row.Rail,
-			HasPaymentMethod:   row.Vaulted,
+			HasPaymentMethod:   row.HasPaymentMethod,
 			RailSubscriptionID: row.RailSubscriptionID,
 			PeriodEnd:          row.CurrentPeriodEndsAt,
 			GraceEndsAt:        row.GraceEndsAt,

--- a/internal/reconcile/converge/convergence_phase_a_integration_test.go
+++ b/internal/reconcile/converge/convergence_phase_a_integration_test.go
@@ -5,7 +5,6 @@ package converge
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -125,14 +124,12 @@ func TestConvergenceState_ConfirmedAbsenceGate(t *testing.T) {
 			require.False(t, *got, "domain %s defaults to not-reconciled", d)
 		}
 
-		// Mark subscriptions fully reconciled with a pull watermark.
-		now := time.Now().UTC().Truncate(time.Second)
+		// Mark subscriptions fully reconciled.
 		st, err := q.UpsertReconciliationState(ctx, gen.UpsertReconciliationStateParams{
-			MerchantID: merchantID, SourceDomain: "subscriptions", FullyReconciled: true, LastFullPullAt: &now,
+			MerchantID: merchantID, SourceDomain: "subscriptions", FullyReconciled: true,
 		})
 		require.NoError(t, err)
 		require.True(t, st.FullyReconciled)
-		require.NotNil(t, st.LastFullPullAt)
 
 		got, err := q.IsSourceDomainReconciled(ctx, gen.IsSourceDomainReconciledParams{
 			MerchantID: merchantID, SourceDomain: "subscriptions",
@@ -147,13 +144,12 @@ func TestConvergenceState_ConfirmedAbsenceGate(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, *got, "payments still not reconciled")
 
-		// Re-upsert with nil watermark preserves the prior last_full_pull_at (COALESCE).
+		// Re-upsert updates in place rather than adding a second row.
 		st2, err := q.UpsertReconciliationState(ctx, gen.UpsertReconciliationStateParams{
-			MerchantID: merchantID, SourceDomain: "subscriptions", FullyReconciled: false, LastFullPullAt: nil,
+			MerchantID: merchantID, SourceDomain: "subscriptions", FullyReconciled: false,
 		})
 		require.NoError(t, err)
 		require.False(t, st2.FullyReconciled)
-		require.NotNil(t, st2.LastFullPullAt, "watermark preserved across upsert")
 
 		var stateCount int
 		require.NoError(t, appDB.Qx(ctx).QueryRow(ctx,

--- a/internal/reconcile/coverage.go
+++ b/internal/reconcile/coverage.go
@@ -74,7 +74,7 @@ func (r *RunResult) PullProofs() PullProofs {
 // Callers run it merchant-scoped (RLS) after mirror writes were applied
 // (enforce insert+overwrite) — an advisory dry-run proves nothing about the
 // LOCAL mirror.
-func MarkReconciledSourceDomains(ctx context.Context, q *gen.Queries, merchantID uuid.UUID, proofs PullProofs, now time.Time) ([]string, error) {
+func MarkReconciledSourceDomains(ctx context.Context, q *gen.Queries, merchantID uuid.UUID, proofs PullProofs) ([]string, error) {
 	accounts, err := q.ListPSPsForMerchant(ctx, gen.ListPSPsForMerchantParams{
 		MerchantID: merchantID,
 	})
@@ -108,9 +108,8 @@ func MarkReconciledSourceDomains(ctx context.Context, q *gen.Queries, merchantID
 		if !proven {
 			continue
 		}
-		ts := now.UTC()
 		if _, err := q.UpsertReconciliationState(ctx, gen.UpsertReconciliationStateParams{
-			MerchantID: merchantID, SourceDomain: domain, FullyReconciled: true, LastFullPullAt: &ts,
+			MerchantID: merchantID, SourceDomain: domain, FullyReconciled: true,
 		}); err != nil {
 			return flipped, fmt.Errorf("reconcile: mark %s reconciled: %w", domain, err)
 		}

--- a/internal/reconcile/local.go
+++ b/internal/reconcile/local.go
@@ -236,7 +236,7 @@ func (l *PGLocalStateLoader) Load(ctx context.Context, provider Provider, pspID 
 			ID:              row.ID,
 			CustomerID:      row.CustomerID,
 			Rail:            row.Rail,
-			RailCustomerRef: row.VaultID,
+			RailCustomerRef: row.RailCustomerRef,
 		}
 		if row.LastFour != nil {
 			pm.LastFour = *row.LastFour

--- a/internal/river/jobs_provider_refresh.go
+++ b/internal/river/jobs_provider_refresh.go
@@ -375,7 +375,7 @@ func (w *ProviderRefreshWorker) refreshMerchant(ctx context.Context, mid uuid.UU
 		// PROVES a source domain — flip reconciliation_state before the
 		// convergence pass so held EXCESS repairs can proceed.
 		if len(res.Proofs) > 0 {
-			if flipped, err := reconcile.MarkReconciledSourceDomains(tctx, w.DB.Gen(tctx), mid, res.Proofs, w.now()); err != nil {
+			if flipped, err := reconcile.MarkReconciledSourceDomains(tctx, w.DB.Gen(tctx), mid, res.Proofs); err != nil {
 				stats.LaneErrors++
 				logger.WithError(err).WithField("merchant_id", mid).Warn("Provider Refresh: mark reconciled domains failed")
 			} else if len(flipped) > 0 {
@@ -555,10 +555,10 @@ func (w *ProviderRefreshWorker) runProviderEventWindows(ctx context.Context, mid
 		res, err := engine.Run(ctx, params)
 		if err != nil {
 			out.ProviderErrors++
-			if werr := w.recordWatermarkFailure(ctx, mid, provider, pspID, since, now, err); werr != nil {
-				out.WatermarkErrors++
-				log.WithContext(ctx).WithError(werr).WithField("provider", provider).Warn("Provider Refresh: record failed provider attempt failed")
-			}
+			// or#823: the failure is recorded by the job (log + River's own error
+			// record), not by a watermark column nothing surfaced. The row is
+			// deliberately left alone: an unadvanced watermark IS the durable
+			// statement that this window still needs reading.
 			log.WithContext(ctx).WithError(err).WithFields(log.Fields{
 				"provider": provider,
 				"since":    since,
@@ -583,7 +583,7 @@ func (w *ProviderRefreshWorker) runProviderEventWindows(ctx context.Context, mid
 				log.WithContext(ctx).WithError(derr).WithField("provider", provider).Warn("Provider Refresh: record webhook drift failed")
 			}
 		}
-		if err := w.recordWatermarkSuccess(ctx, mid, provider, pspID, until, now); err != nil {
+		if err := w.recordWatermarkSuccess(ctx, mid, provider, pspID, until); err != nil {
 			out.WatermarkErrors++
 			log.WithContext(ctx).WithError(err).WithField("provider", provider).Warn("Provider Refresh: advance watermark failed")
 			break
@@ -619,36 +619,16 @@ SELECT watermark_at
 	return watermark.UTC(), nil
 }
 
-func (w *ProviderRefreshWorker) recordWatermarkSuccess(ctx context.Context, mid uuid.UUID, provider reconcile.Provider, pspID uuid.UUID, watermark, attemptedAt time.Time) error {
+func (w *ProviderRefreshWorker) recordWatermarkSuccess(ctx context.Context, mid uuid.UUID, provider reconcile.Provider, pspID uuid.UUID, watermark time.Time) error {
 	_, err := w.DB.Qx(ctx).Exec(ctx, `
 INSERT INTO openrails.rail_refresh_watermarks (
-    merchant_id, rail, psp_id, event_domain, watermark_at,
-    last_attempted_at, last_succeeded_at, last_error
-) VALUES ($1::uuid, $2::text, $3::uuid, $4::text, $5::timestamptz, $6::timestamptz, $6::timestamptz, NULL)
+    merchant_id, rail, psp_id, event_domain, watermark_at
+) VALUES ($1::uuid, $2::text, $3::uuid, $4::text, $5::timestamptz)
 ON CONFLICT ON CONSTRAINT rail_refresh_watermarks_identity_key
 DO UPDATE SET
     watermark_at = EXCLUDED.watermark_at,
-    last_attempted_at = EXCLUDED.last_attempted_at,
-    last_succeeded_at = EXCLUDED.last_succeeded_at,
-    last_error = NULL,
     updated_at = now()
-`, mid, string(provider), pspID, providerRefreshDomainEvents, watermark.UTC(), attemptedAt.UTC())
-	return err
-}
-
-func (w *ProviderRefreshWorker) recordWatermarkFailure(ctx context.Context, mid uuid.UUID, provider reconcile.Provider, pspID uuid.UUID, watermark, attemptedAt time.Time, cause error) error {
-	errText := cause.Error()
-	_, err := w.DB.Qx(ctx).Exec(ctx, `
-INSERT INTO openrails.rail_refresh_watermarks (
-    merchant_id, rail, psp_id, event_domain, watermark_at,
-    last_attempted_at, last_succeeded_at, last_error
-) VALUES ($1::uuid, $2::text, $3::uuid, $4::text, $5::timestamptz, $6::timestamptz, NULL, $7::text)
-ON CONFLICT ON CONSTRAINT rail_refresh_watermarks_identity_key
-DO UPDATE SET
-    last_attempted_at = EXCLUDED.last_attempted_at,
-    last_error = EXCLUDED.last_error,
-    updated_at = now()
-`, mid, string(provider), pspID, providerRefreshDomainEvents, watermark.UTC(), attemptedAt.UTC(), errText)
+`, mid, string(provider), pspID, providerRefreshDomainEvents, watermark.UTC())
 	return err
 }
 

--- a/internal/river/jobs_provider_refresh_integration_test.go
+++ b/internal/river/jobs_provider_refresh_integration_test.go
@@ -47,24 +47,23 @@ func TestProviderRefreshWatermarkAdvancesOnlyOnSuccessfulWindow(t *testing.T) {
 		require.Equal(t, 2, res.Windows)
 		require.Zero(t, res.ProviderErrors)
 		require.Len(t, successFetcher.calls, 2)
-		watermark, lastErr := loadProviderRefreshWatermarkForTest(t, ctx, dbi, merchantID, pspID)
-		require.Equal(t, successFetcher.calls[1].Until.UTC(), watermark)
-		require.Nil(t, lastErr)
+		require.Equal(t, successFetcher.calls[1].Until.UTC(), loadProviderRefreshWatermarkForTest(t, ctx, dbi, merchantID, pspID))
 		return nil
 	}))
 
 	failingFetcher := &providerRefreshRecordingFetcher{provider: reconcile.ProviderStripe, err: errors.New("provider offline")}
 	require.NoError(t, dbi.RunInMerchantConn(baseCtx, func(ctx context.Context) error {
-		before, _ := loadProviderRefreshWatermarkForTest(t, ctx, dbi, merchantID, pspID)
+		before := loadProviderRefreshWatermarkForTest(t, ctx, dbi, merchantID, pspID)
 		res := worker.runProviderEventWindows(ctx, merchantID, reconcile.ProviderStripe, reconcile.ModeEnforce, nil, reconcile.RailMerchantAccountBinding{ID: pspID, Rail: "stripe"}, map[reconcile.Provider]reconcile.RailFetcher{
 			reconcile.ProviderStripe: failingFetcher,
 		})
 		require.Zero(t, res.Windows)
 		require.Equal(t, 1, res.ProviderErrors)
-		after, lastErr := loadProviderRefreshWatermarkForTest(t, ctx, dbi, merchantID, pspID)
-		require.Equal(t, before, after)
-		require.NotNil(t, lastErr)
-		require.Contains(t, *lastErr, "provider offline")
+		// or#823: a failed window leaves the watermark exactly where it was — that
+		// unadvanced cursor IS the durable record that the window still needs
+		// reading. The failure itself surfaces through the job's error, not through
+		// a last_error column nothing read.
+		require.Equal(t, before, loadProviderRefreshWatermarkForTest(t, ctx, dbi, merchantID, pspID))
 		return nil
 	}))
 }
@@ -214,20 +213,19 @@ func (f *providerRefreshRecordingFetcher) Fetch(_ context.Context, params reconc
 	}, nil
 }
 
-func loadProviderRefreshWatermarkForTest(t *testing.T, ctx context.Context, dbi *db.DB, merchantID, pspID uuid.UUID) (time.Time, *string) {
+func loadProviderRefreshWatermarkForTest(t *testing.T, ctx context.Context, dbi *db.DB, merchantID, pspID uuid.UUID) time.Time {
 	t.Helper()
 	var watermark time.Time
-	var lastErr *string
 	err := dbi.Qx(ctx).QueryRow(ctx, `
-SELECT watermark_at, last_error
+SELECT watermark_at
   FROM openrails.rail_refresh_watermarks
  WHERE merchant_id = $1::uuid
    AND rail = 'stripe'
    AND event_domain = 'events'
    AND psp_id = $2::uuid
-`, merchantID, pspID).Scan(&watermark, &lastErr)
+`, merchantID, pspID).Scan(&watermark)
 	require.NoError(t, err)
-	return watermark.UTC(), lastErr
+	return watermark.UTC()
 }
 
 // seedRefreshPSPForTest declares one PSP on a rail — or#893 makes a pull refuse
@@ -288,8 +286,8 @@ func TestProviderRefreshWatermarksAreScopedPerPSP(t *testing.T) {
 		require.Equal(t, fetcherA.calls[0].Since.UTC(), fetcherB.calls[0].Since.UTC(),
 			"PSP B's first window must start at the initial lookback, not where PSP A's pull left off")
 
-		wmA, _ := loadProviderRefreshWatermarkForTest(t, ctx, dbi, merchantID, pspA)
-		wmB, _ := loadProviderRefreshWatermarkForTest(t, ctx, dbi, merchantID, pspB)
+		wmA := loadProviderRefreshWatermarkForTest(t, ctx, dbi, merchantID, pspA)
+		wmB := loadProviderRefreshWatermarkForTest(t, ctx, dbi, merchantID, pspB)
 		require.Equal(t, fetcherA.calls[1].Until.UTC(), wmA)
 		require.Equal(t, fetcherB.calls[1].Until.UTC(), wmB)
 

--- a/internal/river/jobs_provider_refresh_pull_integration_test.go
+++ b/internal/river/jobs_provider_refresh_pull_integration_test.go
@@ -4,6 +4,7 @@ package riverjobs
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jonboulle/clockwork"
 	"github.com/riverqueue/river"
 	log "github.com/sirupsen/logrus"
@@ -235,8 +237,10 @@ func newStorePullWorker(dbi *db.DB, svc *merchants.Service, nmiSrv *fakeNMIPullS
 	return w
 }
 
-// loadPullWatermark returns the SUCCESSFUL watermark: a failure row (last_error
-// set, never succeeded) does not count as an advanced watermark.
+// loadPullWatermark returns the SUCCESSFUL watermark. or#823 dropped the
+// last_succeeded_at/last_error diagnostics this used to filter on, and the
+// filter is no longer needed: only a COMPLETED window writes a row, so the row's
+// existence is the success signal it was approximating.
 func loadPullWatermark(t *testing.T, dbi *db.DB, mid merchant.ID, provider string) (time.Time, bool) {
 	t.Helper()
 	var watermark time.Time
@@ -245,12 +249,14 @@ func loadPullWatermark(t *testing.T, dbi *db.DB, mid merchant.ID, provider strin
 	// helper reports "no watermark" for a watermark that exists.
 	err := dbtest.SharedMerchantPool(t, mid.UUID()).QueryRow(context.Background(), `
 		SELECT watermark_at FROM openrails.rail_refresh_watermarks
-		 WHERE merchant_id = $1 AND rail = $2 AND event_domain = 'events'
-		   AND last_succeeded_at IS NOT NULL AND last_error IS NULL`,
+		 WHERE merchant_id = $1 AND rail = $2 AND event_domain = 'events'`,
 		mid.UUID(), provider).Scan(&watermark)
-	if err != nil {
+	if errors.Is(err, pgx.ErrNoRows) {
 		return time.Time{}, false
 	}
+	// Anything else (a renamed column, a broken pool) must fail the test loudly:
+	// swallowing it would report "no watermark" for every schema drift.
+	require.NoError(t, err)
 	return watermark.UTC(), true
 }
 

--- a/migrations/postgres/0061_drop_write_only_columns.down.sql
+++ b/migrations/postgres/0061_drop_write_only_columns.down.sql
@@ -1,0 +1,67 @@
+-- Restore the write-only columns in their 0001 shape (types, nullability,
+-- defaults, comments). Values are NOT recoverable and none ever mattered: every
+-- column here was written and never read, so re-adding the defaults restores
+-- exactly the information content the deployment had.
+
+SET LOCAL statement_timeout = '60s';
+SET LOCAL lock_timeout = '10s';
+
+ALTER TABLE openrails.invoker_spend_limits
+    ADD COLUMN policy_version bigint DEFAULT 1 NOT NULL;
+
+ALTER TABLE openrails.merchant_configurations
+    ADD COLUMN config_version bigint DEFAULT 1 NOT NULL;
+
+ALTER TABLE openrails.tier_schedules
+    ADD COLUMN schedule_version bigint DEFAULT 1 NOT NULL;
+
+ALTER TABLE openrails.product_usage_limit_bindings
+    ADD COLUMN source_type text NOT NULL DEFAULT '',
+    ADD COLUMN source_id uuid,
+    ADD COLUMN product_key text,
+    ADD COLUMN policy_version bigint DEFAULT 1 NOT NULL;
+
+-- 0001 declared source_type NOT NULL with no default; the default above exists
+-- only so the ADD succeeds against existing rows. Drop it so the restored shape
+-- matches (new writers must supply the value, as they did before).
+ALTER TABLE openrails.product_usage_limit_bindings
+    ALTER COLUMN source_type DROP DEFAULT;
+
+COMMENT ON COLUMN openrails.product_usage_limit_bindings.product_key IS
+    'Catalog product key/slug whose current benefits were materialized at grant time.';
+
+ALTER TABLE openrails.webhook_health
+    ADD COLUMN accepted_count bigint DEFAULT 0 NOT NULL,
+    ADD COLUMN last_rejected_at timestamp with time zone,
+    ADD COLUMN rejected_count bigint DEFAULT 0 NOT NULL,
+    ADD COLUMN last_drift_at timestamp with time zone,
+    ADD COLUMN drift_count bigint DEFAULT 0 NOT NULL;
+
+COMMENT ON COLUMN openrails.webhook_health.drift_count IS
+    'pull-derived corrections applied while last_accepted_at predated the previous pull — changes a webhook should have announced.';
+
+ALTER TABLE openrails.webhook_health_daily
+    ADD COLUMN accepted bigint DEFAULT 0 NOT NULL;
+
+ALTER TABLE openrails.rail_refresh_watermarks
+    ADD COLUMN last_attempted_at timestamp with time zone,
+    ADD COLUMN last_succeeded_at timestamp with time zone,
+    ADD COLUMN last_error text;
+
+COMMENT ON TABLE openrails.rail_refresh_watermarks IS
+    'Durable Provider Refresh watermarks. A failed or partial provider read records last_error but never advances watermark_at.';
+
+ALTER TABLE openrails.usage_events
+    ADD COLUMN invoker_type text;
+
+ALTER TABLE openrails.merchant_deks
+    ADD COLUMN key_version integer DEFAULT 1 NOT NULL;
+
+ALTER TABLE openrails.money_settings
+    ADD COLUMN last_alert_at timestamp with time zone;
+
+ALTER TABLE openrails.alert_rules
+    ADD COLUMN last_detail jsonb;
+
+ALTER TABLE openrails.reconciliation_state
+    ADD COLUMN last_full_pull_at timestamp with time zone;

--- a/migrations/postgres/0061_drop_write_only_columns.up.sql
+++ b/migrations/postgres/0061_drop_write_only_columns.up.sql
@@ -1,0 +1,174 @@
+-- or#823: drop the columns that are written and never read.
+--
+-- Each one below was re-verified against current dev, not inherited from the
+-- audit: a column qualifies only when no sqlc query, no generated reader, and no
+-- raw SQL in the app consults it. A test-only reader does not save a column —
+-- it only means a test asserts on a value nothing acts on, so the test moves to
+-- whatever the app actually reads.
+--
+-- Three classes:
+--   * counters and diagnostics superseded by a live substrate that IS read
+--     (webhook_health's lifetime totals vs webhook_health_daily's buckets);
+--   * provenance and version stamps written at insert and never consulted;
+--   * columns with no writer at all, so every reader saw the default forever.
+--
+-- Prelaunch: dropped, not deprecated. There is no deployment holding rows and
+-- no stable API contract over these names, and a column kept "just in case"
+-- reads to the next person as a signal that something consumes it.
+--
+-- squawk fires ban-drop-column on every statement here. That is the operation
+-- this migration exists to perform; the exemption is recorded in
+-- internal/db/queries/EXEMPTIONS.md.
+
+SET LOCAL statement_timeout = '60s';
+SET LOCAL lock_timeout = '10s';
+
+-- --------------------------------------------------------------------------
+-- The *_version optimistic-concurrency stamps
+-- --------------------------------------------------------------------------
+
+-- Four surviving columns of a five-column pattern (payer_spend_limits went with
+-- its table in 0048). Every one is incremented on write and read by nothing;
+-- spendgate/policy.go documented a policy cache "invalidated on policy_version
+-- bump" that was never built, and that claim is corrected alongside this drop.
+--
+-- These are NOT groundwork for future #687. That issue specifies a `revision`
+-- column with a CAS write path (`SET revision = revision + 1 WHERE id = $1 AND
+-- revision = $expected`), a conflict error at every call site, and the counter
+-- on API responses. None of that exists here: these bump unconditionally, are
+-- never compared, and never leave the database. #687 would add its own column
+-- to its own scope list (which includes checkout_sessions, provider_intents and
+-- invoices, none of which carry a version column today) — it would not adopt
+-- four unread bigints under three different names.
+
+ALTER TABLE openrails.invoker_spend_limits
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN policy_version;
+
+ALTER TABLE openrails.merchant_configurations
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN config_version;
+
+ALTER TABLE openrails.tier_schedules
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN schedule_version;
+
+-- --------------------------------------------------------------------------
+-- product_usage_limit_bindings: version + provenance
+-- --------------------------------------------------------------------------
+
+-- The table's ONLY reader (admission/policy.go) selects `usage_limit_key,
+-- windows`; everything else is EXISTS-by-grant. So the grant-time provenance
+-- stamps answer no question anyone asks. grant_id stays — it IS the key the
+-- revoke path and the existence check use.
+
+ALTER TABLE openrails.product_usage_limit_bindings
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN policy_version,
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN source_type,
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN source_id,
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN product_key;
+
+-- --------------------------------------------------------------------------
+-- webhook_health: lifetime counters superseded by webhook_health_daily
+-- --------------------------------------------------------------------------
+
+-- #786 shipped both a lifetime tally and a daily bucket table. The metrics
+-- registry reads the buckets (`whd.rejected`, `whd.drift`) and, from the
+-- snapshot table, only `last_accepted_at`/`created_at` for the silence age. A
+-- monotonic lifetime total cannot answer a windowed question anyway, which is
+-- why the daily table was added.
+--
+-- last_accepted_at and last_pull_at STAY: the first is the silence watermark
+-- the alert template ages, the second is the drift gate's comparison point.
+
+ALTER TABLE openrails.webhook_health
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN accepted_count,
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN rejected_count,
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN drift_count,
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN last_rejected_at,
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN last_drift_at;
+
+-- The daily bucket nobody measures. `rejected` and `drift` back the
+-- webhook_rejects / webhook_drift_events measures; there is no accepted-volume
+-- measure, and the silence watermark already answers "are webhooks arriving".
+ALTER TABLE openrails.webhook_health_daily
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN accepted;
+
+-- --------------------------------------------------------------------------
+-- rail_refresh_watermarks: the operator diagnostics with no operator surface
+-- --------------------------------------------------------------------------
+
+-- The table comment advertised last_error as a failure signal. Nothing surfaces
+-- it: the only app reader (ProviderRefreshWorker.loadWatermark) selects
+-- watermark_at alone, and a failed pass already logs and raises through River's
+-- own retry/error record — which IS an operator surface. Keeping a second,
+-- invisible copy of the same fact just made the schema claim a capability the
+-- deployment does not have.
+
+ALTER TABLE openrails.rail_refresh_watermarks
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN last_attempted_at,
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN last_succeeded_at,
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN last_error;
+
+COMMENT ON TABLE openrails.rail_refresh_watermarks IS
+    'Durable Provider Refresh watermarks: the exclusive lower bound for the next bounded event window, per (merchant, rail, PSP, domain). A failed or partial provider read simply never advances watermark_at — the failure itself is recorded by the job, not here.';
+
+-- --------------------------------------------------------------------------
+-- Columns with no writer at all
+-- --------------------------------------------------------------------------
+
+-- usage_events.invoker_type: both INSERT statements omit it, so every row has
+-- carried NULL since the table existed. The invoker's TYPE is a property of the
+-- admit request (identity.InvokerType), decided before the event is recorded and
+-- not part of what a usage event means; invoker_id is the column that identifies
+-- who consumed the units.
+ALTER TABLE openrails.usage_events
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN invoker_type;
+
+-- merchant_deks.key_version: dbDEKStore writes (merchant_id, wrapped_dek) and
+-- reads wrapped_dek. Nothing has ever set or consulted a version, so it has been
+-- 1 on every row. DEK rotation, when it is built, needs a rotation state machine
+-- and a re-wrap path, not a counter that predates the design.
+ALTER TABLE openrails.merchant_deks
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN key_version;
+
+-- money_settings.last_alert_at: the low-balance alerter was deleted with the
+-- rest of #240, and its stamp went with it — stampMoneyInTimestamp, the only
+-- caller of the write, now has no callers of its own. The column is still
+-- projected onto the money-account API response, where it has always been null.
+-- last_topup_at STAYS: it is the durable auto-top-up episode anchor.
+ALTER TABLE openrails.money_settings
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN last_alert_at;
+
+-- alert_rules.last_detail: written on the fired edge beside last_value, which IS
+-- read. Nothing reads the detail — not the API model, not the notification
+-- payload, not the digest. The detail that matters travels in the notification
+-- the crossing emits.
+ALTER TABLE openrails.alert_rules
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN last_detail;
+
+-- reconciliation_state.last_full_pull_at: the gate this table exists for
+-- (IsSourceDomainReconciled) reads fully_reconciled, a ratchet. The timestamp
+-- beside it was never consulted — freshness of a pull lives in
+-- rail_refresh_watermarks, which is the cursor the next pull actually resumes
+-- from.
+ALTER TABLE openrails.reconciliation_state
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN last_full_pull_at;

--- a/migrations/postgres/0062_drop_deployment_wide_destructive_count.down.sql
+++ b/migrations/postgres/0062_drop_deployment_wide_destructive_count.down.sql
@@ -1,0 +1,33 @@
+-- Restore 0021's deployment-wide destructive-intent reader and its index.
+
+SET LOCAL statement_timeout = '60s';
+SET LOCAL lock_timeout = '10s';
+
+CREATE FUNCTION openrails.count_destructive_intents_since(
+    p_intent_types text[], p_since timestamptz)
+    RETURNS bigint
+    LANGUAGE plpgsql STABLE SECURITY DEFINER
+    SET search_path TO 'openrails', 'pg_catalog'
+    AS $$
+DECLARE
+    n bigint;
+BEGIN
+    PERFORM openrails.assert_cross_merchant_reader();
+    SELECT count(*) INTO n
+      FROM openrails.rail_intents
+     WHERE origin IN ('user', 'admin')
+       AND intent_type = ANY (p_intent_types)
+       AND created_at >= p_since;
+    RETURN n;
+END;
+$$;
+
+COMMENT ON FUNCTION openrails.count_destructive_intents_since(text[], timestamptz) IS
+    'Deployment-wide count of destructive user/admin intents created since a cutoff — the #732 rate ceiling''s global wall. A scalar, never rows. Replaces a base-pool count that returned 0 under RLS and so never tripped (or#860).';
+
+REVOKE ALL ON FUNCTION openrails.count_destructive_intents_since(text[], timestamptz) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION openrails.count_destructive_intents_since(text[], timestamptz) TO openrails_app;
+
+CREATE INDEX idx_rail_intents_destructive_window
+    ON openrails.rail_intents USING btree (created_at, intent_type)
+    WHERE (origin IN ('user', 'admin'));

--- a/migrations/postgres/0062_drop_deployment_wide_destructive_count.up.sql
+++ b/migrations/postgres/0062_drop_deployment_wide_destructive_count.up.sql
@@ -1,0 +1,33 @@
+-- or#887 tail: retire the deployment-wide destructive-intent reader 0028 orphaned.
+--
+-- 0028 replaced the shared, cross-tenant budget with a PER-MERCHANT one
+-- (count_destructive_intents_for_merchant_since) precisely because one budget
+-- spanning every merchant is a cross-tenant denial of service. It dropped 0024's
+-- system-origin function and index at the time, but 0021's deployment-wide
+-- count_destructive_intents_since survived with no caller: the #732 ceiling now
+-- reads the per-merchant leg and the per-actor leg, and nothing asks for a
+-- global total any more.
+--
+-- Leaving it in place is not neutral. It is a SECURITY DEFINER cross-merchant
+-- reader granted to openrails_app, and the surviving function/index pair reads
+-- to the next person as evidence that a deployment-wide wall still exists. It
+-- does not, and or#887 decided it must not.
+--
+-- What STAYS:
+--   * count_destructive_intents_by_actor_since — live. One compromised
+--     credential operating across merchants is exactly what it must see, and
+--     that is a property OF the actor, not a shared budget between tenants.
+--   * count_destructive_intents_for_merchant_since (0028) — the ceiling's
+--     merchant-scoped reader for both origin legs.
+--   * idx_rail_intents_destructive_actor_window — serves the actor leg.
+
+SET LOCAL statement_timeout = '60s';
+SET LOCAL lock_timeout = '10s';
+
+DROP FUNCTION openrails.count_destructive_intents_since(text[], timestamptz);
+
+-- 0021 built this partial index solely for the function above: leading on
+-- created_at with no merchant column, it can serve no other predicate in the
+-- codebase. The actor leg has its own (actor, created_at, intent_type) index and
+-- the per-merchant leg has 0028's (merchant_id, origin, created_at, intent_type).
+DROP INDEX openrails.idx_rail_intents_destructive_window;

--- a/pkg/embedded/pull_provider.go
+++ b/pkg/embedded/pull_provider.go
@@ -243,7 +243,7 @@ func PullProvider(ctx context.Context, opts PullProviderOptions) error {
 			// rail account), never blindly. A full-head --insert --overwrite pull
 			// remains the manual bulk-import way to establish the gate.
 			if opts.Insert && opts.Overwrite {
-				if _, err := reconcile.MarkReconciledSourceDomains(ctx, rt.DB.Gen(ctx), merchantID.UUID(), res.PullProofs(), time.Now().UTC()); err != nil {
+				if _, err := reconcile.MarkReconciledSourceDomains(ctx, rt.DB.Gen(ctx), merchantID.UUID(), res.PullProofs()); err != nil {
 					return fmt.Errorf("mark reconciled domains: %w", err)
 				}
 			}


### PR DESCRIPTION
The or#823 quiet-window batch: three schema jobs that all needed the same
whole-tree `sqlc generate`, which is why they waited for a window with no other
lane writing `internal/db/gen`.

## 1. or#823 — drop the write-only columns (migration 0061)

Each candidate was re-verified against current `dev`, not inherited from the
2026-07-28 audit. A column qualifies only when **no sqlc query, no generated
reader, and no raw SQL in the app** consults it. A test-only reader does not
save a column — it means a test asserts on a value nothing acts on, so the test
moves onto whatever the app actually reads.

| column | verdict | evidence |
|---|---|---|
| `invoker_spend_limits.policy_version` | **dropped** | bumped on write, compared nowhere |
| `merchant_configurations.config_version` | **dropped** | same |
| `tier_schedules.schedule_version` | **dropped** | same |
| `product_usage_limit_bindings.policy_version` | **dropped** | same |
| `product_usage_limit_bindings.source_type` / `source_id` / `product_key` | **dropped** | the table's only reader (`admission/policy.go`) selects `usage_limit_key, windows`; everything else is EXISTS-by-grant |
| `webhook_health.accepted_count` / `rejected_count` / `drift_count` / `last_rejected_at` / `last_drift_at` | **dropped** | metrics read `webhook_health_daily`; only a test read these |
| `webhook_health_daily.accepted` | **dropped** | `rejected`/`drift` back the two measures; there is no accepted-volume measure |
| `rail_refresh_watermarks.last_attempted_at` / `last_succeeded_at` / `last_error` | **dropped** | `loadWatermark` selects `watermark_at` alone; the table comment advertised `last_error` as an operator signal with no operator surface |
| `usage_events.invoker_type` | **dropped** | *never written* — both INSERTs omit it |
| `merchant_deks.key_version` | **dropped** | never written, never read |
| `money_settings.last_alert_at` | **dropped** | the #240 alerter went; `stampMoneyInTimestamp`, its only writer, had no callers of its own |
| `alert_rules.last_detail` | **dropped** | the crossing dimensions ride the dispatched alert |
| `reconciliation_state.last_full_pull_at` | **dropped** | the gate reads `fully_reconciled` |
| `invoice_payments.psp_id` | **kept** | or#893 task 1 / #235 are making payment provenance total — a column to be stamped, not deleted |
| `metered_rating_watermarks.rated_through` | **kept** | the audit's "write-only" claim is **false** on current dev: `GREATEST(rated_through, $n)` reads it and `metered_watermark_integration_test.go` pins its monotonicity |
| `payer_spend_limits.policy_version` | already gone | table dropped by 0048 (or#897) |
| `merchant_exports.row_counts` | already gone | 0027 renamed it to `merchant_purge_inventories.manifest`, which IS read at purge time |
| `rail_refresh_watermarks.psp_key` | already gone | dropped by 0060 (or#893) |

**The `*_version` decision, made explicitly.** Future #687 specifies a
`revision` column with a CAS write path (`SET revision = revision + 1 WHERE id =
$1 AND revision = $expected`), a conflict error per call site, and the counter on
API responses — over a scope list that includes `checkout_sessions`,
`provider_intents` and `invoices`, none of which carry a version column today.
These four bump unconditionally, are never compared, and never leave the
database. #687 would add its own column to its own scope; it would not adopt four
unread bigints under three different names. `spendgate/policy.go` documented a
policy cache "invalidated on policy_version bump" that was never built — that
claim is corrected, not left describing a fiction.

**Behaviour changes worth naming.** The provider-refresh failure path no longer
writes a row: the unadvanced watermark IS the durable statement that the window
still needs reading (previously it wrote `watermark_at = since`, which is
identical to what `loadWatermark`'s fallback already returns), and the failure
reaches operators through the job's own error record. `MarkReconciledSourceDomains`
lost its now-unused `now` parameter rather than keeping one that does nothing.

## 2. or#871 tail — the surviving sqlc aliases

`rail_customer_ref AS vault_id` → `rail_customer_ref` (no alias; the column
already carries the right name), and `(payment_method_id IS NOT NULL) AS vaulted`
→ `AS has_payment_method`. Generated fields become `RailCustomerRef` /
`HasPaymentMethod`; both call sites were already assigning into fields with those
names, so the mappings are now identities. Reading surface only, per or#871's
settled rule — the `nmi_vault_delete` job kind and NMI's `customer_vault_id` wire
field are untouched.

## 3. or#887 tail — the dead 0021 reader (migration 0062)

0028 replaced the #732 ceiling's shared cross-tenant budget with a per-merchant
one and dropped 0024's system-origin pair, but 0021's deployment-wide
`count_destructive_intents_since` and `idx_rail_intents_destructive_window`
survived with no app caller. A `SECURITY DEFINER` cross-merchant reader granted to
`openrails_app` that nothing calls is not inert — it reads as evidence that a
deployment-wide wall still exists, which or#887 decided it must not.

Its only caller was the or#860 RLS proof, whose rationale comment ("the
deployment-wide destructive count must span merchants, or the ceiling never
trips") had become false. Retargeted onto the two readers the ceiling actually
calls. `count_destructive_intents_by_actor_since` and its index STAY: the budget
is per-merchant, but one stolen credential must not be six invisible ones.

## Gates

`sqlc generate` is idempotent (byte-identical on re-run) and `sqlc vet`,
`TestQueryAudit`, `sql-lint` (40 exemptions), `migration-lint` (42 files) and
`golangci-lint` (0 issues) are all clean. squawk's `ban-drop-column` fires 21
times on 0061 — inline `squawk-ignore` at each statement, recorded in
`EXEMPTIONS.md` as PERMANENT/deliberate-hard-cut alongside 0048.

Full unit suite green. **All 49 integration packages green**, serially
(`-p 1 -parallel 1 -count=1`). Four test surfaces were retargeted onto live
substrate rather than deleted: the webhook-health assertions moved to
`webhook_health_daily`, the provider-refresh watermark helpers dropped their
`last_error` filter (only a completed window writes a row, so existence is the
success signal) and now fail loudly on a schema error instead of silently
reporting "no watermark", and the reconciliation-state and catalog-sidecar
inserts dropped the removed columns.

Both migrations ship a `down` restoring the prior shape (types, nullability,
defaults, comments). Values are not recoverable and none ever mattered.
