### PR TITLE
or#893/or#795: an intent names a PSP or a custodian — the custodian-addressed class

### DIFF
--- a/cmd/openrails/intents.go
+++ b/cmd/openrails/intents.go
@@ -231,7 +231,8 @@ func runIntentsList(cmd *cobra.Command, status, provider, intentType, format, me
 			if row.LastFailureReason != nil {
 				reason = *row.LastFailureReason
 			}
-			account := row.PspID.String()
+			// or#893/or#795: an intent is addressed to a PSP or to a custodian.
+			account := intentAddress(row.PspID, row.CustodianID)
 			if row.Status == intents.StatusPending {
 				byMode[executesUnder(row.Origin)]++
 			}
@@ -349,7 +350,8 @@ func runIntentsMutationLog(cmd *cobra.Command, provider, intentID, providerAccou
 		w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 		fmt.Fprintln(w, "CREATED\tPROVIDER\tACCOUNT\tINTENT\tTYPE\tATTEMPT\tPHASE\tREASON")
 		for _, row := range rows {
-			account := row.PspID.String()
+			// or#893/or#795: an intent is addressed to a PSP or to a custodian.
+			account := intentAddress(row.PspID, row.CustodianID)
 			intent := ""
 			if row.RailIntentID != nil {
 				intent = row.RailIntentID.String()
@@ -388,4 +390,15 @@ func withIntentsListDB(cmd *cobra.Command, merchantSlug string, fn func(ctx cont
 	return database.RunInMerchantConn(ctx, func(ctx context.Context) error {
 		return fn(ctx, database)
 	})
+}
+
+// intentAddress renders whichever account an intent or mutation log names.
+func intentAddress(psp, custodian *uuid.UUID) string {
+	if psp != nil {
+		return psp.String()
+	}
+	if custodian != nil {
+		return "custodian:" + custodian.String()
+	}
+	return ""
 }

--- a/internal/db/gen/destructive_run_undo.sql.go
+++ b/internal/db/gen/destructive_run_undo.sql.go
@@ -128,8 +128,15 @@ SELECT
     -- payment_methods carries no soft-delete column; every row is live.
     (SELECT count(*) FROM openrails.payment_methods
       WHERE merchant_id = $1::uuid AND psp_id IS NULL)::bigint AS payment_methods,
+    -- rail_intents excludes the CUSTODIAN-addressed lane (or#795's batch
+    -- account updater): those rows carry no psp_id because the write goes to a
+    -- custodian that backs many PSPs, so no PSP-scoped operation was ever
+    -- supposed to reach them. rail_intents_addressed guarantees they name a
+    -- custodian instead, which is what makes the exclusion safe rather than a
+    -- second blind spot.
     (SELECT count(*) FROM openrails.rail_intents
       WHERE merchant_id = $1::uuid AND psp_id IS NULL
+        AND custodian_id IS NULL
         AND status IN ('pending', 'failed_retryable'))::bigint AS unfired_intents
 `
 

--- a/internal/db/gen/models.go
+++ b/internal/db/gen/models.go
@@ -1155,10 +1155,12 @@ type OpenrailsRailIntent struct {
 	CreatedAt      time.Time
 	ExecutedAt     *time.Time
 	UpdatedAt      time.Time
-	// PSP the outbound intent was enqueued against. Required (or#893).
-	PspID uuid.UUID
+	// PSP the outbound intent was enqueued against. Required unless the intent is custodian-addressed (rail_intents_addressed) — or#893/or#795.
+	PspID *uuid.UUID
 	// or#859: the destructive run whose pass enqueued this intent. The reverse of that run supersedes the ones still pending/failed_retryable and reports the rest — succeeded ones as irreversible provider-side divergence, in_flight/unknown_needs_verify ones as ambiguous. Attribution only: never cleared, never used to delete a row.
 	DestructiveRunID *uuid.UUID
+	// or#893/or#795: the custodian this outbound write is addressed to, for intents that target a custodian rather than a gateway account (the batch account updater). NULL for the ordinary PSP-addressed intent. Composite FK: an intent can only reference ITS OWN merchant's custodian.
+	CustodianID *uuid.UUID
 }
 
 // Append-only operator history for external provider mutations executed from provider intents/convergence (#533). or#859 Class A: the record of what we did to the outside world — INSERT plus the whole-merchant purge DELETE only, never UPDATE, and never rolled back.
@@ -1166,8 +1168,8 @@ type OpenrailsRailMutationLog struct {
 	ID         uuid.UUID
 	MerchantID uuid.UUID
 	Rail       string
-	// PSP the logged mutation was addressed to. Required (or#893).
-	PspID          uuid.UUID
+	// PSP the logged mutation was addressed to. Required unless the mutation is custodian-addressed (rail_mutation_logs_addressed) — or#893/or#795.
+	PspID          *uuid.UUID
 	RailIntentID   *uuid.UUID
 	IntentType     *string
 	IdempotencyKey *string
@@ -1178,6 +1180,8 @@ type OpenrailsRailMutationLog struct {
 	// Scrubbed structured metadata only. Never store API keys, authorization headers, card data, private keys, or unsanitized provider bodies.
 	Evidence  []byte
 	CreatedAt time.Time
+	// or#893/or#795: the custodian the logged mutation was addressed to, for custodian-addressed intents. NULL for the ordinary PSP-addressed mutation.
+	CustodianID *uuid.UUID
 }
 
 // Durable Provider Refresh watermarks: the exclusive lower bound for the next bounded event window, per (merchant, rail, PSP, domain). A failed or partial provider read simply never advances watermark_at — the failure itself is recorded by the job, not here.

--- a/internal/db/gen/rail_intents.sql.go
+++ b/internal/db/gen/rail_intents.sql.go
@@ -32,7 +32,7 @@ SET status = 'in_flight',
     updated_at = now()
 FROM due
 WHERE pi.id = due.id
-RETURNING pi.id, pi.merchant_id, pi.rail, pi.intent_type, pi.subscription_id, pi.payment_id, pi.price_id, pi.payload, pi.idempotency_key, pi.status, pi.attempts, pi.next_attempt_at, pi.claimed_until, pi.origin, pi.origin_reason, pi.actor, pi.last_failure_reason, pi.expires_at, pi.result_evidence, pi.created_at, pi.executed_at, pi.updated_at, pi.psp_id, pi.destructive_run_id
+RETURNING pi.id, pi.merchant_id, pi.rail, pi.intent_type, pi.subscription_id, pi.payment_id, pi.price_id, pi.payload, pi.idempotency_key, pi.status, pi.attempts, pi.next_attempt_at, pi.claimed_until, pi.origin, pi.origin_reason, pi.actor, pi.last_failure_reason, pi.expires_at, pi.result_evidence, pi.created_at, pi.executed_at, pi.updated_at, pi.psp_id, pi.destructive_run_id, pi.custodian_id
 `
 
 type ClaimDueRailIntentsParams struct {
@@ -83,6 +83,7 @@ func (q *Queries) ClaimDueRailIntents(ctx context.Context, arg ClaimDueRailInten
 			&i.UpdatedAt,
 			&i.PspID,
 			&i.DestructiveRunID,
+			&i.CustodianID,
 		); err != nil {
 			return nil, err
 		}
@@ -109,7 +110,7 @@ SET claimed_until = $1::timestamptz,
     updated_at = now()
 FROM due
 WHERE pi.id = due.id
-RETURNING pi.id, pi.merchant_id, pi.rail, pi.intent_type, pi.subscription_id, pi.payment_id, pi.price_id, pi.payload, pi.idempotency_key, pi.status, pi.attempts, pi.next_attempt_at, pi.claimed_until, pi.origin, pi.origin_reason, pi.actor, pi.last_failure_reason, pi.expires_at, pi.result_evidence, pi.created_at, pi.executed_at, pi.updated_at, pi.psp_id, pi.destructive_run_id
+RETURNING pi.id, pi.merchant_id, pi.rail, pi.intent_type, pi.subscription_id, pi.payment_id, pi.price_id, pi.payload, pi.idempotency_key, pi.status, pi.attempts, pi.next_attempt_at, pi.claimed_until, pi.origin, pi.origin_reason, pi.actor, pi.last_failure_reason, pi.expires_at, pi.result_evidence, pi.created_at, pi.executed_at, pi.updated_at, pi.psp_id, pi.destructive_run_id, pi.custodian_id
 `
 
 type ClaimDueVerifyRailIntentsParams struct {
@@ -155,6 +156,7 @@ func (q *Queries) ClaimDueVerifyRailIntents(ctx context.Context, arg ClaimDueVer
 			&i.UpdatedAt,
 			&i.PspID,
 			&i.DestructiveRunID,
+			&i.CustodianID,
 		); err != nil {
 			return nil, err
 		}
@@ -178,7 +180,7 @@ WHERE pi.id = $2
         OR (pi.status = 'in_flight' AND pi.claimed_until IS NOT NULL AND pi.claimed_until <= $3::timestamptz)
       )
   AND (pi.expires_at IS NULL OR pi.expires_at > $3::timestamptz)
-RETURNING pi.id, pi.merchant_id, pi.rail, pi.intent_type, pi.subscription_id, pi.payment_id, pi.price_id, pi.payload, pi.idempotency_key, pi.status, pi.attempts, pi.next_attempt_at, pi.claimed_until, pi.origin, pi.origin_reason, pi.actor, pi.last_failure_reason, pi.expires_at, pi.result_evidence, pi.created_at, pi.executed_at, pi.updated_at, pi.psp_id, pi.destructive_run_id
+RETURNING pi.id, pi.merchant_id, pi.rail, pi.intent_type, pi.subscription_id, pi.payment_id, pi.price_id, pi.payload, pi.idempotency_key, pi.status, pi.attempts, pi.next_attempt_at, pi.claimed_until, pi.origin, pi.origin_reason, pi.actor, pi.last_failure_reason, pi.expires_at, pi.result_evidence, pi.created_at, pi.executed_at, pi.updated_at, pi.psp_id, pi.destructive_run_id, pi.custodian_id
 `
 
 type ClaimRailIntentByIDParams struct {
@@ -221,6 +223,7 @@ func (q *Queries) ClaimRailIntentByID(ctx context.Context, arg ClaimRailIntentBy
 		&i.UpdatedAt,
 		&i.PspID,
 		&i.DestructiveRunID,
+		&i.CustodianID,
 	)
 	return i, err
 }
@@ -380,14 +383,14 @@ const enqueueRailIntent = `-- name: EnqueueRailIntent :one
 INSERT INTO openrails.rail_intents (
     merchant_id, rail, intent_type, subscription_id, payment_id, price_id,
     payload, idempotency_key, status, next_attempt_at, origin, origin_reason,
-    actor, expires_at, psp_id
+    actor, expires_at, psp_id, custodian_id
 ) VALUES (
     $1, $2, $3,
     $4, $5, $6,
     $7, $8, 'pending',
     $9::timestamptz, $10,
     $11, $12, $13,
-    $14::uuid
+    $14::uuid, $15::uuid
 )
 ON CONFLICT (merchant_id, idempotency_key) DO UPDATE SET
     status = CASE
@@ -431,7 +434,7 @@ ON CONFLICT (merchant_id, idempotency_key) DO UPDATE SET
         ELSE openrails.rail_intents.last_failure_reason
     END,
     updated_at = now()
-RETURNING id, merchant_id, rail, intent_type, subscription_id, payment_id, price_id, payload, idempotency_key, status, attempts, next_attempt_at, claimed_until, origin, origin_reason, actor, last_failure_reason, expires_at, result_evidence, created_at, executed_at, updated_at, psp_id, destructive_run_id
+RETURNING id, merchant_id, rail, intent_type, subscription_id, payment_id, price_id, payload, idempotency_key, status, attempts, next_attempt_at, claimed_until, origin, origin_reason, actor, last_failure_reason, expires_at, result_evidence, created_at, executed_at, updated_at, psp_id, destructive_run_id, custodian_id
 `
 
 type EnqueueRailIntentParams struct {
@@ -448,7 +451,8 @@ type EnqueueRailIntentParams struct {
 	OriginReason   *string
 	Actor          *string
 	ExpiresAt      *time.Time
-	PspID          uuid.UUID
+	PspID          *uuid.UUID
+	CustodianID    *uuid.UUID
 }
 
 // #358 phase A: provider intent ledger queries — idempotent enqueue, the
@@ -490,6 +494,7 @@ func (q *Queries) EnqueueRailIntent(ctx context.Context, arg EnqueueRailIntentPa
 		arg.Actor,
 		arg.ExpiresAt,
 		arg.PspID,
+		arg.CustodianID,
 	)
 	var i OpenrailsRailIntent
 	err := row.Scan(
@@ -517,6 +522,7 @@ func (q *Queries) EnqueueRailIntent(ctx context.Context, arg EnqueueRailIntentPa
 		&i.UpdatedAt,
 		&i.PspID,
 		&i.DestructiveRunID,
+		&i.CustodianID,
 	)
 	return i, err
 }
@@ -559,7 +565,7 @@ func (q *Queries) ExpireOverdueRailIntents(ctx context.Context, arg ExpireOverdu
 
 const getRailIntent = `-- name: GetRailIntent :one
 
-SELECT id, merchant_id, rail, intent_type, subscription_id, payment_id, price_id, payload, idempotency_key, status, attempts, next_attempt_at, claimed_until, origin, origin_reason, actor, last_failure_reason, expires_at, result_evidence, created_at, executed_at, updated_at, psp_id, destructive_run_id FROM openrails.rail_intents WHERE id = $1
+SELECT id, merchant_id, rail, intent_type, subscription_id, payment_id, price_id, payload, idempotency_key, status, attempts, next_attempt_at, claimed_until, origin, origin_reason, actor, last_failure_reason, expires_at, result_evidence, created_at, executed_at, updated_at, psp_id, destructive_run_id, custodian_id FROM openrails.rail_intents WHERE id = $1
 `
 
 // ============================================================================
@@ -593,6 +599,7 @@ func (q *Queries) GetRailIntent(ctx context.Context, id uuid.UUID) (OpenrailsRai
 		&i.UpdatedAt,
 		&i.PspID,
 		&i.DestructiveRunID,
+		&i.CustodianID,
 	)
 	return i, err
 }
@@ -715,7 +722,7 @@ func (q *Queries) ListDueVerifyRailIntentMerchants(ctx context.Context, arg List
 }
 
 const listRailIntents = `-- name: ListRailIntents :many
-SELECT id, merchant_id, rail, intent_type, subscription_id, payment_id, price_id, payload, idempotency_key, status, attempts, next_attempt_at, claimed_until, origin, origin_reason, actor, last_failure_reason, expires_at, result_evidence, created_at, executed_at, updated_at, psp_id, destructive_run_id FROM openrails.rail_intents
+SELECT id, merchant_id, rail, intent_type, subscription_id, payment_id, price_id, payload, idempotency_key, status, attempts, next_attempt_at, claimed_until, origin, origin_reason, actor, last_failure_reason, expires_at, result_evidence, created_at, executed_at, updated_at, psp_id, destructive_run_id, custodian_id FROM openrails.rail_intents
 WHERE ($1::text IS NULL OR status = $1::text)
   AND ($2::text IS NULL OR rail = $2::text)
   AND ($3::text IS NULL OR intent_type = $3::text)
@@ -774,6 +781,7 @@ func (q *Queries) ListRailIntents(ctx context.Context, arg ListRailIntentsParams
 			&i.UpdatedAt,
 			&i.PspID,
 			&i.DestructiveRunID,
+			&i.CustodianID,
 		); err != nil {
 			return nil, err
 		}
@@ -787,7 +795,7 @@ func (q *Queries) ListRailIntents(ctx context.Context, arg ListRailIntentsParams
 
 const listStuckRailIntents = `-- name: ListStuckRailIntents :many
 
-SELECT id, merchant_id, rail, intent_type, subscription_id, payment_id, price_id, payload, idempotency_key, status, attempts, next_attempt_at, claimed_until, origin, origin_reason, actor, last_failure_reason, expires_at, result_evidence, created_at, executed_at, updated_at, psp_id, destructive_run_id FROM openrails.rail_intents
+SELECT id, merchant_id, rail, intent_type, subscription_id, payment_id, price_id, payload, idempotency_key, status, attempts, next_attempt_at, claimed_until, origin, origin_reason, actor, last_failure_reason, expires_at, result_evidence, created_at, executed_at, updated_at, psp_id, destructive_run_id, custodian_id FROM openrails.rail_intents
 WHERE (status IN ('pending', 'failed_retryable') AND created_at <= $1::timestamptz)
    OR (status IN ('in_flight', 'unknown_needs_verify') AND created_at <= $2::timestamptz)
 ORDER BY created_at, id
@@ -841,6 +849,7 @@ func (q *Queries) ListStuckRailIntents(ctx context.Context, arg ListStuckRailInt
 			&i.UpdatedAt,
 			&i.PspID,
 			&i.DestructiveRunID,
+			&i.CustodianID,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/gen/rail_mutation_logs.sql.go
+++ b/internal/db/gen/rail_mutation_logs.sql.go
@@ -46,6 +46,7 @@ INSERT INTO openrails.rail_mutation_logs (
     merchant_id,
     rail,
     psp_id,
+    custodian_id,
     rail_intent_id,
     intent_type,
     idempotency_key,
@@ -54,14 +55,15 @@ INSERT INTO openrails.rail_mutation_logs (
     reason,
     evidence
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 )
 `
 
 type InsertRailMutationLogParams struct {
 	MerchantID     uuid.UUID
 	Rail           string
-	PspID          uuid.UUID
+	PspID          *uuid.UUID
+	CustodianID    *uuid.UUID
 	RailIntentID   *uuid.UUID
 	IntentType     *string
 	IdempotencyKey *string
@@ -76,6 +78,7 @@ func (q *Queries) InsertRailMutationLog(ctx context.Context, arg InsertRailMutat
 		arg.MerchantID,
 		arg.Rail,
 		arg.PspID,
+		arg.CustodianID,
 		arg.RailIntentID,
 		arg.IntentType,
 		arg.IdempotencyKey,
@@ -89,7 +92,7 @@ func (q *Queries) InsertRailMutationLog(ctx context.Context, arg InsertRailMutat
 
 const listRailMutationLogs = `-- name: ListRailMutationLogs :many
 
-SELECT id, merchant_id, rail, psp_id, rail_intent_id, intent_type, idempotency_key, attempt, phase, reason, evidence, created_at FROM openrails.rail_mutation_logs
+SELECT id, merchant_id, rail, psp_id, rail_intent_id, intent_type, idempotency_key, attempt, phase, reason, evidence, created_at, custodian_id FROM openrails.rail_mutation_logs
 WHERE merchant_id = $1::uuid
   AND ($2::text IS NULL OR rail = $2::text)
   AND ($3::uuid IS NULL OR rail_intent_id = $3::uuid)
@@ -139,6 +142,7 @@ func (q *Queries) ListRailMutationLogs(ctx context.Context, arg ListRailMutation
 			&i.Reason,
 			&i.Evidence,
 			&i.CreatedAt,
+			&i.CustodianID,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/provider_account_stamp.go
+++ b/internal/db/provider_account_stamp.go
@@ -42,3 +42,24 @@ func RequirePSPID(ctx context.Context) (uuid.UUID, error) {
 	}
 	return id, nil
 }
+
+type custodianIDCtxKey struct{}
+
+// WithCustodianID pins the custodian a write is addressed to. or#893/or#795:
+// the batch account updater uploads one token batch to a custodian that backs
+// MANY PSPs, so its provenance is the custodian, not a gateway account.
+func WithCustodianID(ctx context.Context, id uuid.UUID) context.Context {
+	if id == uuid.Nil {
+		return ctx
+	}
+	return context.WithValue(ctx, custodianIDCtxKey{}, id)
+}
+
+// CustodianIDFromContext returns the pinned custodian, or uuid.Nil.
+func CustodianIDFromContext(ctx context.Context) uuid.UUID {
+	v, ok := ctx.Value(custodianIDCtxKey{}).(uuid.UUID)
+	if !ok {
+		return uuid.Nil
+	}
+	return v
+}

--- a/internal/db/queries/EXEMPTIONS.md
+++ b/internal/db/queries/EXEMPTIONS.md
@@ -181,8 +181,8 @@ production writes. Deliberately not started.
 
 ### The inline exemptions
 
-Thirty-nine statements, fifty-six rule instances, all classified
-**PERMANENT**. All but `0048`, `0061` and `0063` are **history** —
+Forty-five statements, sixty-four rule instances, all classified
+**PERMANENT**. All but `0048`, `0061`, `0063` and `0077` are **history** —
 rewriting them changes no live database and the honest record is what actually
 ran. The rules stay armed for new migrations.
 
@@ -203,6 +203,9 @@ ran. The rules stay armed for new migrations.
 | `0063` payments + invoice_payments `psp_required_on_rail` CHECKs | `constraint-missing-not-valid` | These are the two tables where a CHECK is the RIGHT shape (both also record off-rail money), so only the lock argument applies: `NOT VALID` buys nothing inside a single-transaction migrator — see `0014`. The rows it validates were just rewritten by the same transaction. |
 | `0063` rail_mutation_logs + rail_customer_accounts psp FKs | `adding-foreign-key-constraint`, `constraint-missing-not-valid` | Both re-point at `openrails.psps` after the column closed: the mutation-log FK moves `ON DELETE SET NULL` → `CASCADE` (SET NULL is unrepresentable against NOT NULL — the same choice `0060` made for the watermark cursor), and rail_customer_accounts' is a brand-new column whose rows were attributed or deleted three statements earlier. Same single-transaction argument as `0014`. |
 | `0063` ×2 rail-transaction unique rebuilds | `disallowed-unique-constraint` | The rule wants a `UNIQUE` constraint rather than a unique index; every equivalent invariant in this schema is a PARTIAL unique index (`WHERE deleted_at IS NULL`, `WHERE rail_subscription_id <> ''`), which a table constraint cannot express at all. Dropping the partial predicate to satisfy the rule would change the invariant. |
+| `0077` ×2 rail_intents/rail_mutation_logs custodian FKs | `adding-foreign-key-constraint`, `constraint-missing-not-valid` | Composite `(custodian_id, merchant_id)` FKs, the same shape `psps_custodian_fk` carries, so the reference cannot cross a merchant boundary. The column is added in the statement above each, so every existing row is NULL and the validating scan is over an all-NULL column — the case `0018` records squawk cannot see. `NOT VALID` buys nothing inside a single-transaction migrator (`0014`). |
+| `0077` ×2 psp_id `DROP NOT NULL` | `ban-drop-not-null` | **Deliberate, and not a weakening.** or#795's batch account updater is addressed to a CUSTODIAN — one custodian backs many PSPs, so no single `psp_id` names the write. The `rail_intents_addressed` / `rail_mutation_logs_addressed` CHECKs added two lines below each restate `0063`'s actual invariant (*an outbound write names the account it will execute against*) over both kinds of account, so nothing becomes unattributable. The rule's concern is a client that assumes non-NULL; the readers were changed in the same PR and the CHECK is what they now rely on. |
+| `0077` ×2 addressed CHECKs | `constraint-missing-not-valid` | Every existing row has `psp_id` NOT NULL — it was the column attribute until two statements earlier — so the scan validates rows already known to satisfy the constraint. Same single-transaction argument as `0014`. |
 | `0048` DROP payer_spend_limits | `ban-drop-table` | **Deliberate hard cut, not history.** or#897 replaces the table with `billing_policies` + `billing_policy_bindings`; the rule's concern (breaking existing clients) is the intended effect, and prelaunch there is no deployment holding rows worth keeping. Leaving the table alongside its replacement would be the two-substrate disease or#878 removed from exposure. |
 
 A new migration that genuinely needs one of these must add the constraint

--- a/internal/db/queries/destructive_run_undo.sql
+++ b/internal/db/queries/destructive_run_undo.sql
@@ -83,6 +83,13 @@ SELECT
     -- payment_methods carries no soft-delete column; every row is live.
     (SELECT count(*) FROM openrails.payment_methods
       WHERE merchant_id = sqlc.arg(merchant_id)::uuid AND psp_id IS NULL)::bigint AS payment_methods,
+    -- rail_intents excludes the CUSTODIAN-addressed lane (or#795's batch
+    -- account updater): those rows carry no psp_id because the write goes to a
+    -- custodian that backs many PSPs, so no PSP-scoped operation was ever
+    -- supposed to reach them. rail_intents_addressed guarantees they name a
+    -- custodian instead, which is what makes the exclusion safe rather than a
+    -- second blind spot.
     (SELECT count(*) FROM openrails.rail_intents
       WHERE merchant_id = sqlc.arg(merchant_id)::uuid AND psp_id IS NULL
+        AND custodian_id IS NULL
         AND status IN ('pending', 'failed_retryable'))::bigint AS unfired_intents;

--- a/internal/db/queries/rail_intents.sql
+++ b/internal/db/queries/rail_intents.sql
@@ -25,14 +25,14 @@
 INSERT INTO openrails.rail_intents (
     merchant_id, rail, intent_type, subscription_id, payment_id, price_id,
     payload, idempotency_key, status, next_attempt_at, origin, origin_reason,
-    actor, expires_at, psp_id
+    actor, expires_at, psp_id, custodian_id
 ) VALUES (
     sqlc.arg(merchant_id), sqlc.arg(rail), sqlc.arg(intent_type),
     sqlc.narg(subscription_id), sqlc.narg(payment_id), sqlc.narg(price_id),
     sqlc.narg(payload), sqlc.arg(idempotency_key), 'pending',
     sqlc.arg(next_attempt_at)::timestamptz, sqlc.arg(origin),
     sqlc.narg(origin_reason), sqlc.narg(actor), sqlc.narg(expires_at),
-    sqlc.arg(psp_id)::uuid
+    sqlc.narg(psp_id)::uuid, sqlc.narg(custodian_id)::uuid
 )
 ON CONFLICT (merchant_id, idempotency_key) DO UPDATE SET
     status = CASE

--- a/internal/db/queries/rail_mutation_logs.sql
+++ b/internal/db/queries/rail_mutation_logs.sql
@@ -3,6 +3,7 @@ INSERT INTO openrails.rail_mutation_logs (
     merchant_id,
     rail,
     psp_id,
+    custodian_id,
     rail_intent_id,
     intent_type,
     idempotency_key,
@@ -11,7 +12,7 @@ INSERT INTO openrails.rail_mutation_logs (
     reason,
     evidence
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 );
 
 -- Operator read surface (#735: replaced the ClickHouse mirror; this table is

--- a/internal/db/querytest/contracts_test.go
+++ b/internal/db/querytest/contracts_test.go
@@ -329,7 +329,7 @@ func TestQueryContractsHighValueBillingDomains(t *testing.T) {
 		IdempotencyKey: "intent-" + subscriptionID.String(),
 		NextAttemptAt:  now,
 		Origin:         "system",
-		PspID:          account.ID,
+		PspID:          &account.ID,
 	})
 	require.NoError(t, err)
 	claimed, err := q.ClaimRailIntentByID(ctx, gen.ClaimRailIntentByIDParams{

--- a/internal/http/handlers/webhook.go
+++ b/internal/http/handlers/webhook.go
@@ -453,7 +453,12 @@ func resolveWebhookCustodianAccount(r *httprequest.Request, kind, environment, t
 		r.ErrorJSON(http.StatusNotFound, "Unknown custodian account")
 		return merchants.CustodianIdentity{}, noop, false
 	}
-	r.Request = r.Request.WithContext(merchant.WithID(r.Request.Context(), custodian.MerchantID))
+	// or#893/or#795: pin the custodian the event demonstrably came from, the way
+	// the PSP routes pin theirs. Nothing on this plane enqueues an intent today,
+	// but anything that starts to is custodian-addressed by construction — the
+	// event identifies a custodian that backs many PSPs, never one of them.
+	ctx := merchant.WithID(r.Request.Context(), custodian.MerchantID)
+	r.Request = r.Request.WithContext(db.WithCustodianID(ctx, custodian.ID))
 	release, ok := pinWebhookMerchantConn(r, custodian.MerchantID)
 	if !ok {
 		return merchants.CustodianIdentity{}, noop, false

--- a/internal/intents/mutation_log.go
+++ b/internal/intents/mutation_log.go
@@ -26,6 +26,7 @@ type MutationLogParams struct {
 	MerchantID       uuid.UUID
 	Provider         string
 	PspID            uuid.UUID
+	CustodianID      uuid.UUID
 	ProviderIntentID *uuid.UUID
 	IntentType       string
 	IdempotencyKey   string
@@ -48,7 +49,9 @@ func (s *Store) LogExternalMutation(ctx context.Context, p MutationLogParams) er
 	if p.MerchantID == uuid.Nil || p.Provider == "" || p.Phase == "" {
 		return fmt.Errorf("intents: mutation log requires merchant_id, provider, and phase")
 	}
-	if p.PspID == uuid.Nil {
+	// rail_mutation_logs_addressed: the log records which account the attempt was
+	// sent to, and a custodian-addressed attempt names a custodian.
+	if p.PspID == uuid.Nil && p.CustodianID == uuid.Nil {
 		return fmt.Errorf("intents: mutation log for %s: %w", p.Provider, db.ErrNoPSPInContext)
 	}
 	var reason *string
@@ -69,7 +72,8 @@ func (s *Store) LogExternalMutation(ctx context.Context, p MutationLogParams) er
 	return s.db.Gen(ctx).InsertRailMutationLog(ctx, gen.InsertRailMutationLogParams{
 		MerchantID:     p.MerchantID,
 		Rail:           p.Provider,
-		PspID:          p.PspID,
+		PspID:          uuidPtrOrNil(p.PspID),
+		CustodianID:    uuidPtrOrNil(p.CustodianID),
 		RailIntentID:   p.ProviderIntentID,
 		IntentType:     intentType,
 		IdempotencyKey: idempotencyKey,

--- a/internal/intents/nmi_payment_method_delete.go
+++ b/internal/intents/nmi_payment_method_delete.go
@@ -287,7 +287,7 @@ func (h *NMIPaymentMethodDeleteHandler) loadPaymentMethod(ctx context.Context, i
 		Rail:            models.Rail(strings.ToLower(intent.Rail)),
 		RailCustomerRef: p.RailCustomerRef,
 		RailMethodRef:   p.RailMethodRef,
-		PspID:           intent.PspID,
+		PspID:           derefUUID(intent.PspID),
 	}, nil
 }
 

--- a/internal/intents/rail_clients.go
+++ b/internal/intents/rail_clients.go
@@ -23,7 +23,7 @@ func resolveIntentNMIClient(ctx context.Context, r money.NMIClientResolver, inte
 	if r == nil {
 		return nil, false, errors.New("nmi client resolver is not configured")
 	}
-	return r.ResolveNMIClient(ctx, intent.MerchantID, &intent.PspID)
+	return r.ResolveNMIClient(ctx, intent.MerchantID, intent.PspID)
 }
 
 // ccbillDataLinkForMerchant arms the ctx merchant's CCBill DataLink client

--- a/internal/intents/runner.go
+++ b/internal/intents/runner.go
@@ -159,7 +159,7 @@ func (r *Runner) executeOne(ctx context.Context, intent gen.OpenrailsRailIntent,
 	// addressed to, so every mirror row the handler creates — the charge, the
 	// subscription, the vaulted method — inherits that provenance instead of
 	// having to re-resolve (or fail to).
-	ctx = db.WithPSPID(ctx, intent.PspID)
+	ctx = pinIntentAddress(ctx, intent)
 
 	handler := r.Registry.Lookup(intent.IntentType)
 	if handler == nil {
@@ -286,7 +286,7 @@ func (r *Runner) RunVerifyOnce(ctx context.Context) (Stats, error) {
 		// (#336) and its PSP for their provenance (or#893) — a verifier's repair
 		// writes the same mirror rows the executor would have.
 		ctx := merchant.WithID(ctx, merchant.ID(intent.MerchantID))
-		ctx = db.WithPSPID(ctx, intent.PspID)
+		ctx = pinIntentAddress(ctx, intent)
 		logEntry := log.WithContext(ctx).WithFields(log.Fields{
 			"intent_id":   intent.ID,
 			"intent_type": intent.IntentType,
@@ -421,7 +421,8 @@ func (r *Runner) logExternalMutation(ctx context.Context, intent gen.OpenrailsRa
 	return logger.LogExternalMutation(ctx, MutationLogParams{
 		MerchantID:       intent.MerchantID,
 		Provider:         intent.Rail,
-		PspID:            intent.PspID,
+		PspID:            derefUUID(intent.PspID),
+		CustodianID:      derefUUID(intent.CustodianID),
 		ProviderIntentID: &intentID,
 		IntentType:       intent.IntentType,
 		IdempotencyKey:   intent.IdempotencyKey,
@@ -469,4 +470,21 @@ type DestructiveGate interface {
 	// AllowDestructive reports whether destructive provider writes may execute
 	// for a merchant. It must FAIL CLOSED: an unreadable policy denies.
 	AllowDestructive(ctx context.Context, merchantID uuid.UUID) (bool, string)
+}
+
+// pinIntentAddress puts the account the intent is addressed to on the context,
+// so every mirror row a handler or verifier writes inherits the provenance the
+// intent row already recorded instead of re-resolving it (or#893). An intent
+// names a PSP, a custodian, or — for a custodian-proxy write — both;
+// rail_intents_addressed guarantees at least one.
+func pinIntentAddress(ctx context.Context, intent gen.OpenrailsRailIntent) context.Context {
+	ctx = db.WithPSPID(ctx, derefUUID(intent.PspID))
+	return db.WithCustodianID(ctx, derefUUID(intent.CustodianID))
+}
+
+func derefUUID(id *uuid.UUID) uuid.UUID {
+	if id == nil {
+		return uuid.Nil
+	}
+	return *id
 }

--- a/internal/intents/store.go
+++ b/internal/intents/store.go
@@ -54,10 +54,15 @@ type EnqueueParams struct {
 	SubscriptionID *uuid.UUID
 	PaymentID      *uuid.UUID
 	PriceID        *uuid.UUID
-	// PspID is the PSP the outbound write is addressed to. Required (or#893):
-	// rail_intents.psp_id is NOT NULL, and an intent nobody can attribute cannot
-	// be executed against the right credentials.
-	PspID          uuid.UUID
+	// PspID is the PSP the outbound write is addressed to. Required (or#893)
+	// unless the intent is CUSTODIAN-addressed: an intent nobody can attribute
+	// cannot be executed against the right credentials.
+	PspID uuid.UUID
+	// CustodianID addresses the write to a custodian instead (or#795's batch
+	// account updater uploads one token batch to a custodian that backs many
+	// PSPs, so no single psp_id names it). Exactly the rail_intents_addressed
+	// constraint: one of the two must be set.
+	CustodianID    uuid.UUID
 	Payload        any
 	IdempotencyKey string
 	NextAttemptAt  time.Time
@@ -77,11 +82,16 @@ func (s *Store) Enqueue(ctx context.Context, p EnqueueParams) (gen.OpenrailsRail
 	if p.IntentType == "" || p.IdempotencyKey == "" {
 		return gen.OpenrailsRailIntent{}, fmt.Errorf("intents: enqueue requires intent_type and idempotency_key")
 	}
-	// or#893: rail_intents.psp_id is NOT NULL. An explicit PspID wins; otherwise
-	// the PSP the caller already routed to and pinned on ctx (checkout's
-	// stampPSP, the webhook plane) is the answer. Nothing else is: an intent
-	// nobody can attribute cannot be executed against the right credentials.
-	if p.PspID == uuid.Nil {
+	// or#893/or#795 (rail_intents_addressed): the intent names the account it
+	// will execute against — a PSP, or a custodian for the writes addressed to
+	// one. An explicit value wins; otherwise the PSP the caller already routed
+	// to and pinned on ctx (checkout's stampPSP, the webhook plane) is the
+	// answer. Nothing else is: an intent nobody can attribute cannot be executed
+	// against the right credentials.
+	if p.CustodianID == uuid.Nil {
+		p.CustodianID = db.CustodianIDFromContext(ctx)
+	}
+	if p.PspID == uuid.Nil && p.CustodianID == uuid.Nil {
 		psp, err := db.RequirePSPID(ctx)
 		if err != nil {
 			return gen.OpenrailsRailIntent{}, fmt.Errorf("intents: enqueue %s: %w", p.IntentType, err)
@@ -141,7 +151,8 @@ func (s *Store) Enqueue(ctx context.Context, p EnqueueParams) (gen.OpenrailsRail
 		OriginReason:   originReason,
 		Actor:          actorPtr,
 		ExpiresAt:      p.ExpiresAt,
-		PspID:          p.PspID,
+		PspID:          uuidPtrOrNil(p.PspID),
+		CustodianID:    uuidPtrOrNil(p.CustodianID),
 	})
 }
 
@@ -426,4 +437,14 @@ func one(rows int64, err error) error {
 		return err
 	}
 	return nil
+}
+
+// uuidPtrOrNil maps the zero uuid to a NULL column: the two addressing columns
+// are nullable and constrained as a pair, so "unset" must reach the DB as NULL
+// rather than as a zero uuid no row could ever reference.
+func uuidPtrOrNil(id uuid.UUID) *uuid.UUID {
+	if id == uuid.Nil {
+		return nil
+	}
+	return &id
 }

--- a/internal/river/jobs_account_updater.go
+++ b/internal/river/jobs_account_updater.go
@@ -445,7 +445,11 @@ func (w AccountUpdaterBatchWorker) submitMerchant(ctx context.Context, mid uuid.
 		intent, err := w.Intents.EnqueueAndExecute(ctx, intents.EnqueueParams{
 			MerchantID: mid,
 			Provider:   models.CustodianBasisTheory,
-			IntentType: intents.TypeAccountUpdaterBatchSubmit,
+			// or#893/or#795: this write is addressed to the CUSTODIAN, not to a
+			// gateway account — one custodian backs many PSPs, so no single
+			// psp_id names it. rail_intents_addressed accepts either.
+			CustodianID: row.ID,
+			IntentType:  intents.TypeAccountUpdaterBatchSubmit,
 			Payload: intents.AccountUpdaterBatchPayload{
 				BatchID:            batch.ID,
 				CustodianKind:      row.Kind,

--- a/internal/river/jobs_account_updater_integration_test.go
+++ b/internal/river/jobs_account_updater_integration_test.go
@@ -247,6 +247,16 @@ func (fx *auFixture) seedMerchant(declareCustodian, armed bool, lookaheadDays in
 	exec(`INSERT INTO openrails.merchants (id, slug, status) VALUES ($1, $2, 'active')`,
 		m.id, "or795-"+m.id.String()[:8])
 
+	// Every merchant charges through a PSP whether or not it declares a
+	// custodian — "NULL custodian = this PSP holds its own instruments" is the
+	// common case (0053), not the absence of an account. The instruments seeded
+	// below carry psp_id, so the row has to exist for all four fixtures, and
+	// only custodian_id is conditional.
+	m.pspID = uuid.New()
+	exec(`INSERT INTO openrails.psps (id, merchant_id, rail, environment, account_id)
+	      VALUES ($1, $2, 'nmi', 'live', $3)`,
+		m.pspID, m.id, "gw-"+m.id.String()[:6])
+
 	if declareCustodian {
 		m.custID = uuid.New()
 		settings := map[string]any{"public_api_key": "key_pub_test"}
@@ -262,10 +272,7 @@ func (fx *auFixture) seedMerchant(declareCustodian, armed bool, lookaheadDays in
 		      VALUES ($1, $2, $3, 'basis_theory', 'live', $4, $5)`,
 			m.custID, m.id, "bt-"+m.id.String()[:8], m.tenantID, raw)
 
-		m.pspID = uuid.New()
-		exec(`INSERT INTO openrails.psps (id, merchant_id, rail, environment, account_id, custodian_id)
-		      VALUES ($1, $2, 'nmi', 'live', $3, $4)`,
-			m.pspID, m.id, "gw-"+m.id.String()[:6], m.custID)
+		exec(`UPDATE openrails.psps SET custodian_id = $2 WHERE id = $1`, m.pspID, m.custID)
 
 		days := lookaheadDays
 		if days <= 0 {
@@ -738,4 +745,39 @@ func auResultCSV(rows ...auResult) string {
 			r.token, r.newToken, r.expYear, r.expMonth, r.code, r.fingerprint, r.brand, r.last4)
 	}
 	return b.String()
+}
+
+// or#893 × or#795: the submit intent is CUSTODIAN-addressed. or#893 made
+// rail_intents.psp_id NOT NULL and taught the runner to refuse a provider write
+// it cannot attribute — correct for every intent aimed at a gateway account,
+// and wrong for this one: a custodian backs many PSPs, so there is no single
+// psp_id to name. This pins the row the submit actually writes (custodian named,
+// psp NULL) and the mutation log that records the attempt, so a future
+// tightening cannot quietly re-break the class.
+func TestAccountUpdaterSubmitIsCustodianAddressedNotPSPAddressed(t *testing.T) {
+	fx := newAUFixture(t)
+	m := fx.seedMerchant(true, true, 14)
+	fx.build()
+	fx.seedInstrument(m, instrumentOpts{renewsIn: 5 * 24 * time.Hour})
+
+	_, err := fx.worker.RunPass(fx.ctx)
+	require.NoError(t, err)
+
+	var pspID, custodianID *uuid.UUID
+	require.NoError(t, fx.super.QueryRow(fx.ctx,
+		`SELECT psp_id, custodian_id FROM openrails.rail_intents
+		  WHERE merchant_id = $1 AND intent_type = $2`,
+		m.id, intents.TypeAccountUpdaterBatchSubmit).Scan(&pspID, &custodianID))
+	require.Nil(t, pspID, "the batch is not sent to a gateway account, so it must not claim one")
+	require.NotNil(t, custodianID, "rail_intents_addressed: the write names the custodian it goes to")
+	require.Equal(t, m.custID, *custodianID)
+
+	var logPSP, logCustodian *uuid.UUID
+	require.NoError(t, fx.super.QueryRow(fx.ctx,
+		`SELECT psp_id, custodian_id FROM openrails.rail_mutation_logs
+		  WHERE merchant_id = $1 AND intent_type = $2 ORDER BY created_at LIMIT 1`,
+		m.id, intents.TypeAccountUpdaterBatchSubmit).Scan(&logPSP, &logCustodian))
+	require.Nil(t, logPSP)
+	require.NotNil(t, logCustodian, "the attempt is recorded against the custodian it was sent to")
+	require.Equal(t, m.custID, *logCustodian)
 }

--- a/migrations/postgres/0077_custodian_addressed_intents.down.sql
+++ b/migrations/postgres/0077_custodian_addressed_intents.down.sql
@@ -1,0 +1,27 @@
+-- Structural reverse of 0077. Custodian-addressed rows are DELETED rather than
+-- forced back into a psp_id they never had: re-imposing NOT NULL means the
+-- class that migration exists for is unrepresentable again, and a fabricated
+-- gateway account is worse than no row.
+
+SET LOCAL statement_timeout = '60s';
+SET LOCAL lock_timeout = '10s';
+
+DELETE FROM openrails.rail_mutation_logs WHERE psp_id IS NULL;
+DELETE FROM openrails.rail_intents WHERE psp_id IS NULL;
+
+ALTER TABLE openrails.rail_mutation_logs DROP CONSTRAINT rail_mutation_logs_addressed;
+ALTER TABLE openrails.rail_mutation_logs ALTER COLUMN psp_id SET NOT NULL;
+DROP INDEX openrails.idx_rail_mutation_logs_custodian;
+ALTER TABLE openrails.rail_mutation_logs DROP CONSTRAINT rail_mutation_logs_custodian_fk;
+ALTER TABLE openrails.rail_mutation_logs DROP COLUMN custodian_id;
+
+ALTER TABLE openrails.rail_intents DROP CONSTRAINT rail_intents_addressed;
+ALTER TABLE openrails.rail_intents ALTER COLUMN psp_id SET NOT NULL;
+DROP INDEX openrails.idx_rail_intents_custodian;
+ALTER TABLE openrails.rail_intents DROP CONSTRAINT rail_intents_custodian_fk;
+ALTER TABLE openrails.rail_intents DROP COLUMN custodian_id;
+
+COMMENT ON COLUMN openrails.rail_intents.psp_id IS
+    'PSP the outbound intent was enqueued against. Required (or#893).';
+COMMENT ON COLUMN openrails.rail_mutation_logs.psp_id IS
+    'PSP the logged mutation was addressed to. Required (or#893).';

--- a/migrations/postgres/0077_custodian_addressed_intents.up.sql
+++ b/migrations/postgres/0077_custodian_addressed_intents.up.sql
@@ -1,0 +1,83 @@
+-- or#893 × or#795. 0063 made PSP provenance total on the intent plane:
+-- rail_intents.psp_id and rail_mutation_logs.psp_id are NOT NULL, and the
+-- runner refuses a provider write it cannot attribute. That is right for every
+-- intent addressed to a GATEWAY ACCOUNT — which was all of them when 0063 was
+-- written.
+--
+-- or#795's batch account updater is not. `bt_account_updater_batch` is addressed
+-- to a CUSTODIAN: the write uploads one token batch to Basis Theory, and a
+-- custodian backs MANY PSPs (0053: "one custodian can back many PSPs"). There is
+-- no single psp_id to name, and inventing one would claim the batch belongs to a
+-- gateway account it was never sent to.
+--
+-- Same doctrine as 0063's off-rail payments lane: classify the genuinely
+-- different class EXPLICITLY rather than weakening the invariant for everyone.
+-- An intent must still name the account it will execute against — the CHECK
+-- below says exactly that, and now admits the second kind of account. It is
+-- "at least one" rather than "exactly one" deliberately: a custodian-proxy sale
+-- is addressed to a PSP whose card happens to sit at a custodian, so an intent
+-- knowing BOTH is more provenance, not less, and must not be forbidden.
+
+SET LOCAL statement_timeout = '60s';
+SET LOCAL lock_timeout = '10s';
+
+-- ------------------------------------------------------------ rail_intents ---
+
+ALTER TABLE openrails.rail_intents ADD COLUMN custodian_id uuid;
+
+COMMENT ON COLUMN openrails.rail_intents.custodian_id IS
+    'or#893/or#795: the custodian this outbound write is addressed to, for intents that target a custodian rather than a gateway account (the batch account updater). NULL for the ordinary PSP-addressed intent. Composite FK: an intent can only reference ITS OWN merchant''s custodian.';
+
+-- Composite, exactly like psps_custodian_fk (0053): the reference cannot cross
+-- a merchant boundary.
+ALTER TABLE ONLY openrails.rail_intents
+    -- squawk-ignore adding-foreign-key-constraint, constraint-missing-not-valid
+    ADD CONSTRAINT rail_intents_custodian_fk FOREIGN KEY (custodian_id, merchant_id)
+    REFERENCES openrails.custodians(id, merchant_id) ON DELETE RESTRICT;
+
+CREATE INDEX idx_rail_intents_custodian ON openrails.rail_intents USING btree (custodian_id) WHERE (custodian_id IS NOT NULL);
+
+-- squawk-ignore ban-drop-not-null
+ALTER TABLE openrails.rail_intents ALTER COLUMN psp_id DROP NOT NULL;
+
+-- The invariant 0063 actually meant: an outbound write names the account it
+-- will execute against. Dropping NOT NULL above does not weaken it — this
+-- restates it over both kinds of account. Every existing row has psp_id NOT
+-- NULL (it was the column attribute until two statements ago), so the scan
+-- validates rows already known to satisfy it, and NOT VALID buys nothing inside
+-- a single-transaction migrator (see 0014).
+ALTER TABLE openrails.rail_intents
+    -- squawk-ignore constraint-missing-not-valid
+    ADD CONSTRAINT rail_intents_addressed
+    CHECK (psp_id IS NOT NULL OR custodian_id IS NOT NULL);
+
+COMMENT ON COLUMN openrails.rail_intents.psp_id IS
+    'PSP the outbound intent was enqueued against. Required unless the intent is custodian-addressed (rail_intents_addressed) — or#893/or#795.';
+
+-- ------------------------------------------------------ rail_mutation_logs ---
+-- The runner logs one mutation row per attempt for EVERY intent, so the log
+-- needs the same two-address vocabulary or a custodian-addressed attempt could
+-- not be recorded at all.
+
+ALTER TABLE openrails.rail_mutation_logs ADD COLUMN custodian_id uuid;
+
+COMMENT ON COLUMN openrails.rail_mutation_logs.custodian_id IS
+    'or#893/or#795: the custodian the logged mutation was addressed to, for custodian-addressed intents. NULL for the ordinary PSP-addressed mutation.';
+
+ALTER TABLE ONLY openrails.rail_mutation_logs
+    -- squawk-ignore adding-foreign-key-constraint, constraint-missing-not-valid
+    ADD CONSTRAINT rail_mutation_logs_custodian_fk FOREIGN KEY (custodian_id, merchant_id)
+    REFERENCES openrails.custodians(id, merchant_id) ON DELETE CASCADE;
+
+CREATE INDEX idx_rail_mutation_logs_custodian ON openrails.rail_mutation_logs USING btree (custodian_id) WHERE (custodian_id IS NOT NULL);
+
+-- squawk-ignore ban-drop-not-null
+ALTER TABLE openrails.rail_mutation_logs ALTER COLUMN psp_id DROP NOT NULL;
+
+ALTER TABLE openrails.rail_mutation_logs
+    -- squawk-ignore constraint-missing-not-valid
+    ADD CONSTRAINT rail_mutation_logs_addressed
+    CHECK (psp_id IS NOT NULL OR custodian_id IS NOT NULL);
+
+COMMENT ON COLUMN openrails.rail_mutation_logs.psp_id IS
+    'PSP the logged mutation was addressed to. Required unless the mutation is custodian-addressed (rail_mutation_logs_addressed) — or#893/or#795.';

--- a/migrations/postgres/custodian_addressed_intents_integration_test.go
+++ b/migrations/postgres/custodian_addressed_intents_integration_test.go
@@ -1,0 +1,97 @@
+//go:build integration
+
+package postgresmigrations_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// insertIntent writes one rail_intents row addressed however the caller says.
+// Both address columns are nullable and constrained as a pair, so the test can
+// exercise every combination the schema is supposed to admit or refuse.
+func (f pspFixture) insertIntent(t *testing.T, key string, psp, custodian *uuid.UUID) error {
+	t.Helper()
+	_, err := f.pool.Exec(context.Background(),
+		`INSERT INTO openrails.rail_intents
+		   (merchant_id, rail, intent_type, idempotency_key, status, next_attempt_at,
+		    origin, psp_id, custodian_id)
+		 VALUES ($1, 'nmi', 'bt_account_updater_batch', $2, 'pending', now(), 'system', $3, $4)`,
+		f.merchant, key, psp, custodian)
+	return err
+}
+
+func (f pspFixture) newCustodian(t *testing.T) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	_, err := f.pool.Exec(context.Background(),
+		`INSERT INTO openrails.custodians (id, merchant_id, key, kind, environment, account_id)
+		 VALUES ($1, $2, $3, 'basis_theory', 'live', $4)`,
+		id, f.merchant, "bt-"+uuid.NewString()[:8], "tnt_"+uuid.NewString()[:8])
+	require.NoError(t, err)
+	return id
+}
+
+// or#893 × or#795. 0063 made psp_id NOT NULL on rail_intents because every
+// intent then in existence was addressed to a gateway account. The batch
+// account updater is addressed to a CUSTODIAN — one custodian backs many PSPs,
+// so no single psp_id names the write. 0077 admits that class explicitly
+// instead of weakening the invariant: an intent still has to name the account
+// it will execute against, and now there are two kinds of account.
+func TestAnIntentMustNameTheAccountItExecutesAgainst(t *testing.T) {
+	f := newPSPFixture(t)
+	cust := f.newCustodian(t)
+
+	require.NoError(t, f.insertIntent(t, "psp-addressed-"+uuid.NewString()[:8], &f.pspA, nil),
+		"the ordinary PSP-addressed intent")
+	require.NoError(t, f.insertIntent(t, "custodian-addressed-"+uuid.NewString()[:8], nil, &cust),
+		"or#795: a batch account-updater submit names its custodian, not a PSP")
+	// A custodian-proxy write is addressed to a PSP whose card sits at a
+	// custodian; knowing both is more provenance, not less.
+	require.NoError(t, f.insertIntent(t, "both-"+uuid.NewString()[:8], &f.pspA, &cust))
+
+	err := f.insertIntent(t, "unaddressed-"+uuid.NewString()[:8], nil, nil)
+	require.Error(t, err, "an intent addressed to nothing is not representable")
+	require.Contains(t, strings.ToLower(err.Error()), "rail_intents_addressed",
+		"the refusal names the invariant, not a bare NOT NULL")
+}
+
+// The custodian reference cannot cross a merchant boundary — the same composite
+// FK psps.custodian_id carries (0053).
+func TestAnIntentCannotNameAnotherMerchantsCustodian(t *testing.T) {
+	f := newPSPFixture(t)
+	other := newPSPFixture(t)
+	foreign := other.newCustodian(t)
+
+	err := f.insertIntent(t, "cross-merchant-"+uuid.NewString()[:8], nil, &foreign)
+	require.Error(t, err, "a custodian belonging to another merchant is unreferenceable")
+	require.Contains(t, strings.ToLower(err.Error()), "rail_intents_custodian_fk")
+}
+
+// The mutation log records one row per attempt for EVERY intent, so it needs
+// the same two-address vocabulary — otherwise a custodian-addressed attempt
+// could not be recorded at all.
+func TestAMutationLogCarriesEitherAddress(t *testing.T) {
+	f := newPSPFixture(t)
+	cust := f.newCustodian(t)
+	ctx := context.Background()
+
+	insert := func(psp, custodian *uuid.UUID) error {
+		_, err := f.pool.Exec(ctx,
+			`INSERT INTO openrails.rail_mutation_logs
+			   (merchant_id, rail, psp_id, custodian_id, intent_type, attempt, phase, created_at)
+			 VALUES ($1, 'nmi', $2, $3, 'bt_account_updater_batch', 1, 'attempting', $4)`,
+			f.merchant, psp, custodian, time.Now().UTC())
+		return err
+	}
+	require.NoError(t, insert(&f.pspA, nil))
+	require.NoError(t, insert(nil, &cust))
+	err := insert(nil, nil)
+	require.Error(t, err, "a mutation nobody can attribute is not recordable")
+	require.Contains(t, strings.ToLower(err.Error()), "rail_mutation_logs_addressed")
+}


### PR DESCRIPTION
Reconciles or#893's intent-plane provenance hardening (PR #243) with or#795's batch account updater. Both merged; the collision is semantic, not textual.

## The collision

PR #243 made `rail_intents.psp_id` NOT NULL and taught the runner to refuse a provider write it cannot attribute. That is right for every intent addressed to a **gateway account** — which was all of them when it was written.

`bt_account_updater_batch` is not. The submit uploads one token batch to Basis Theory, and **a custodian backs many PSPs** (0053: *"one custodian can back many PSPs"*). There is no single `psp_id` to name, and inventing one would claim the batch belongs to a gateway account it was never sent to. Every AU test failed with `no PSP resolved for this provider write`.

## The fix — same doctrine as the off-rail payments lane

Classify the genuinely different class explicitly; never weaken the invariant for everyone. Migration **0077** adds `custodian_id` to `rail_intents` and `rail_mutation_logs` and restates what 0063 actually meant — *an outbound write names the account it will execute against* — over both kinds of account:

```sql
CHECK (psp_id IS NOT NULL OR custodian_id IS NOT NULL)
```

Both FKs are composite `(custodian_id, merchant_id) REFERENCES custodians(id, merchant_id)`, the shape `psps_custodian_fk` already carries, so a reference cannot cross a merchant boundary.

**At-least-one rather than exactly-one is deliberate.** A custodian-proxy sale is addressed to a PSP whose card happens to sit at a custodian; an intent knowing *both* is more provenance, not less, and forbidding it would be a claim I can't justify.

`rail_mutation_logs` is included because the runner writes one row per attempt for **every** intent — without it a custodian-addressed attempt could not be recorded at all.

## Go plane

- `EnqueueParams` gains `CustodianID`; `Store.Enqueue` accepts either address and reads a ctx-pinned custodian the way it already read a ctx-pinned PSP. Neither set ⇒ still refuses.
- `executeOne` and `RunVerifyOnce` pin whichever address the row names (`pinIntentAddress`), so a handler or verifier inherits the provenance the intent already recorded instead of re-resolving it.
- The AU submit stamps `CustodianID: row.ID`.
- The **Basis Theory webhook route** pins the custodian the event demonstrably came from. Nothing on that plane enqueues an intent today — I checked — but anything that starts to is custodian-addressed by construction, since the event identifies a custodian that backs many PSPs, never one of them.
- The undo's attribution invariant (`CountUnattributedProviderRows`) excludes the custodian-addressed lane: those rows *are* attributed, just not to a PSP, so counting them would report the exemption as a hole.
- The `openrails intents` CLI renders whichever address a row carries.

## The `payment_methods_psp_fk` residual

Not a missing composite key — the FK is single-column `(psp_id)`. The fixture's `seedMerchant` created the `psps` row **only when the merchant declared a custodian**, so `noCustodian := fx.seedMerchant(false, false, 0)` left `m.pspID` at `uuid.Nil` and its instruments referenced a PSP that never existed.

Fixed at the cause rather than the symptom: every merchant charges through a PSP, and a NULL custodian means *that PSP holds its own instruments* (0053) — not that no account exists. The `psps` insert is now unconditional; only `custodian_id` is conditional.

## Proofs

- `migrations/postgres/custodian_addressed_intents_integration_test.go` — PSP-addressed, custodian-addressed and both-addressed all insert; addressed-to-nothing is refused **by name** (`rail_intents_addressed`, not a bare NOT NULL); another merchant's custodian is unreferenceable; the mutation log carries either address.
- `TestAccountUpdaterSubmitIsCustodianAddressedNotPSPAddressed` — drives the real worker pass and pins the row the submit actually writes (custodian named, `psp_id` NULL) plus the mutation log recording the attempt, so a future tightening cannot quietly re-break the class.

## Gates

`go build`, `go vet` (both tags), unit suite, `golangci-lint` (0 issues), `sqlc generate`+`vet`+`git diff --exit-code -- internal/db/gen` byte-identical, `TestQueryAudit`, `sql-lint` clean, `migration-lint` clean with 0077's six statements recorded in `internal/db/queries/EXEMPTIONS.md`, 0077 down/up round-trip schema-identical, and the **full integration suite green — 49/49 packages, exit 0** (`scripts/test_integration.sh ./...`, `-p 1`, serial).

The four suites called out specifically — `internal/river`, `internal/intents`, `internal/custodymigration`, `internal/modules/webhooks` — are green, as is everything else.
