### PR TITLE
Log payment method save timings

### DIFF
--- a/internal/modules/paymentmethods/vault_service.go
+++ b/internal/modules/paymentmethods/vault_service.go
@@ -162,6 +162,21 @@ func NewVaultService(pm *PaymentMethodService, sub subscriptionReader, dbx *db.D
 // vault is created IN that PSP's account, and the row's rail comes from the
 // resolved scope.
 func (s *VaultService) CreateVault(ctx context.Context, userID string, req *CreateVaultRequest) (*models.PaymentMethod, error) {
+	startedAt := time.Now()
+	var providerDuration time.Duration
+	var databaseDuration time.Duration
+	outcome := "failed"
+	defer func() {
+		log.WithFields(log.Fields{
+			"operation":            "payment_method_create",
+			"provider":             strings.TrimSpace(strings.ToLower(req.Provider)),
+			"provider_duration_ms": providerDuration.Milliseconds(),
+			"database_duration_ms": databaseDuration.Milliseconds(),
+			"total_duration_ms":    time.Since(startedAt).Milliseconds(),
+			"outcome":              outcome,
+		}).Info("Payment method create timing")
+	}()
+
 	psp := strings.TrimSpace(strings.ToLower(req.Provider))
 	if psp == "" {
 		return nil, errors.New("provider is required")
@@ -197,7 +212,9 @@ func (s *VaultService) CreateVault(ctx context.Context, userID string, req *Crea
 		Address2:     req.Address2,
 	}
 
+	providerStartedAt := time.Now()
 	nmiResponse, err := client.CreateCustomerVault(vaultData)
+	providerDuration = time.Since(providerStartedAt)
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{"user_id": userID}).Error("Failed to create vault in NMI")
 		var nmiErr *nmi.CustomerVaultError
@@ -236,7 +253,9 @@ func (s *VaultService) CreateVault(ctx context.Context, userID string, req *Crea
 		pm.PspID = pspID
 	}
 
+	databaseStartedAt := time.Now()
 	if err := s.PaymentMethodService.Create(ctx, pm); err != nil {
+		databaseDuration = time.Since(databaseStartedAt)
 		log.WithError(err).WithFields(log.Fields{"user_id": userID, "vault_id": nmiResponse.CustomerVaultID}).Error("Failed to store vault locally")
 		// Best-effort direct remote cleanup — deliberately NOT intent-routed
 		// (#674 tail): the vault was created milliseconds ago and is referenced
@@ -244,7 +263,9 @@ func (s *VaultService) CreateVault(ctx context.Context, userID string, req *Crea
 		_ = client.DeleteCustomerVault(nmi.DeleteCustomerVaultData{CustomerVaultID: nmiResponse.CustomerVaultID})
 		return nil, fmt.Errorf("failed to store vault locally: %w", err)
 	}
+	databaseDuration = time.Since(databaseStartedAt)
 
+	outcome = "success"
 	log.WithFields(log.Fields{"user_id": userID, "vault_id": pm.RailCustomerRef}).Info("Successfully created payment vault")
 	return pm, nil
 }

--- a/internal/modules/paymentmethods/vault_service_test.go
+++ b/internal/modules/paymentmethods/vault_service_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/open-rails/openrails/config"
@@ -16,6 +17,7 @@ import (
 	"github.com/open-rails/openrails/internal/integrations/nmi"
 	"github.com/open-rails/openrails/internal/merchants"
 	"github.com/open-rails/openrails/pkg/merchant"
+	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -84,6 +86,8 @@ func TestApplyUpdatedCardMetadataClearsOmittedCardDetails(t *testing.T) {
 }
 
 func TestCreateVaultUsesMerchantSecretMobiusKeyWithoutStaticClient(t *testing.T) {
+	hook := logtest.NewGlobal()
+	t.Cleanup(hook.Reset)
 	ctx := merchant.WithID(context.Background(), dbtest.TestMerchantID)
 	store := merchants.NewMemorySecretStore()
 	secretName, err := merchants.PSPSecretName("nmi", "live", "mobius-account", "security_key")
@@ -102,6 +106,7 @@ func TestCreateVaultUsesMerchantSecretMobiusKeyWithoutStaticClient(t *testing.T)
 		var body map[string]any
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 		seen <- v5CreateSeen{auth: r.Header.Get("Authorization"), body: body}
+		time.Sleep(5 * time.Millisecond)
 		_, _ = io.WriteString(w, `{"object":"customer","id":"vault_123","billing":[{"object":"billing","id":"billing_456","priority":1}]}`)
 	}))
 	defer server.Close()
@@ -154,6 +159,21 @@ func TestCreateVaultUsesMerchantSecretMobiusKeyWithoutStaticClient(t *testing.T)
 	require.Equal(t, "Visa", *pm.CardType)
 	require.Equal(t, "12/30", *pm.ExpiryDate)
 	require.Equal(t, "Ada Lovelace", pm.Metadata["name_on_card"])
+
+	var timingFields map[string]any
+	for _, entry := range hook.AllEntries() {
+		if entry.Message == "Payment method create timing" {
+			timingFields = entry.Data
+			break
+		}
+	}
+	require.NotNil(t, timingFields)
+	require.Equal(t, "payment_method_create", timingFields["operation"])
+	require.Equal(t, "nmi", timingFields["provider"])
+	require.Equal(t, "success", timingFields["outcome"])
+	require.GreaterOrEqual(t, timingFields["provider_duration_ms"], int64(5))
+	require.GreaterOrEqual(t, timingFields["database_duration_ms"], int64(0))
+	require.GreaterOrEqual(t, timingFields["total_duration_ms"], timingFields["provider_duration_ms"])
 }
 
 // #788: the boot-config plane is gone — a vault create with no armed rail


### PR DESCRIPTION
Adds provider, database, and total durations to payment-method creation logs.

Tested: `go test ./...` and focused `go vet`.