### PR TITLE
or#823: close the last two residuals — the dead `round` knob goes, `imported_dunning_history` stays

### DIFF
--- a/config/catalog.example.yaml
+++ b/config/catalog.example.yaml
@@ -359,7 +359,6 @@ catalogs:
             psps: [stripe]
             input_min: 5_000_000
             input_max: 500_000_000
-            round: down
             model: tiered
             tiered:
               mode: graduated

--- a/docs/merchant-guide.md
+++ b/docs/merchant-guide.md
@@ -111,7 +111,6 @@ or credits → $):
             psps: [stripe]
             input_min: 5_000_000        # $5 minimum spend
             input_max: 500_000_000
-            round: down
             model: tiered
             tiered:
               mode: graduated
@@ -126,7 +125,7 @@ or credits → $):
 | Model | Cost | Use for |
 |---|---|---|
 | `flat` | fixed amount | base fees ("$5/mo includes…") |
-| `per_unit` | `round(qty × unit_amount / divide_by)` | linear rates; `divide_by` keeps integer micros exact (e.g. micros/hour rated per second: `divide_by: 3_600`); optional `maximum_amount` cap, `matrix` for per-SKU cells on a meter dimension |
+| `per_unit` | `round(qty × unit_amount / divide_by)` | linear rates; `divide_by` keeps integer micros exact (e.g. micros/hour rated per second: `divide_by: 3_600`); `round: up\|down\|half_up` (default `half_up`) picks the mode, declared inside `per_unit` — the one place it is read; optional `maximum_amount` cap, `matrix` for per-SKU cells on a meter dimension |
 | `tiered` | `graduated` (bands stack) or `volume` (final band prices everything) | volume discounts; prefer graduated — volume has price cliffs and doesn't invert |
 | `package` | `ceil((qty − free_units)/package_size) × amount` | block pricing, round-up-to-next-unit |
 

--- a/internal/db/gen/models.go
+++ b/internal/db/gen/models.go
@@ -202,7 +202,6 @@ type OpenrailsCatalogCreditPurchasePrice struct {
 	Rails      []string
 	InputMin   int64
 	InputMax   int64
-	Round      *string
 	Price      []byte
 	CreatedAt  time.Time
 	UpdatedAt  time.Time

--- a/internal/db/queries/EXEMPTIONS.md
+++ b/internal/db/queries/EXEMPTIONS.md
@@ -183,15 +183,25 @@ production writes. Deliberately not started.
 
 ### The inline exemptions
 
-None. or#893 squashed the migration chain into `0001`, and every inline
+or#893 squashed the migration chain into `0001`, and every inline
 `-- squawk-ignore` lived in a file that squash deleted. Those exemptions were
 records of what one-time rename/backfill/hard-cut migrations actually did; the
-baseline states the result instead, so there is nothing left to excuse. The
-invariants they protected survive as constraints, indexes and COMMENTs on the
-objects themselves.
+baseline states the result instead. The invariants they protected survive as
+constraints, indexes and COMMENTs on the objects themselves. What follows is
+what has been earned since.
 
-The next inline exemption is written when a new migration earns one, at the
-statement, with its reason, and recorded here.
+**`0002_drop_credit_purchase_round.up.sql` — `ban-drop-column`.** or#823 drops
+`catalog_credit_purchase_prices.round`, a column written and never read: the
+runtime credit-purchase quote (`money.loadCatalogCreditPurchase`) lists its
+columns explicitly and this was not among them. The rule guards against a client
+that still names a dropped column, and squawk cannot see who reads what — every
+client that named this one is in this repo and stops naming it in the same
+commit (the sidecar INSERT, and the embedded manifest dump that echoed it back
+out). The residual case the rule really covers, an older binary INSERTing it
+against the new schema, is a catalog-apply/dump path rather than the money path,
+and migratekit applies at boot ahead of the binary that needs it. The rounding
+that IS read lives inside the offer's `price` jsonb as `per_unit.round` and is
+untouched.
 
 Because the baseline is the only file and the only excluded path, squawk has
 nothing to check and exits non-zero on the empty glob. `scripts/migration-lint.sh`

--- a/internal/modules/money/catalog_ratecard_integration_test.go
+++ b/internal/modules/money/catalog_ratecard_integration_test.go
@@ -305,3 +305,63 @@ VALUES ($1, $2, 1, 'image-credit', 'USD', 1000000, '{
 	require.Equal(t, int64(50_000_000), quote.PaidAmount)
 }
 
+// or#823 money-boundary pin: the ONE rounding knob a credit purchase actually
+// reads is per_unit.round, carried in the offer's `price` jsonb. Two offers
+// differing in nothing else must quote different micros for the same credits,
+// at the exact values below — otherwise the mode is decorative and the doctrine
+// that a declared knob is read has no proof. (The retired top-level
+// catalog_credit_purchase_prices.round column is dropped in 0002; it was never
+// selected here.)
+func TestCatalogCreditPurchase_PerUnitRoundModeChangesTheQuote(t *testing.T) {
+	svc, pool, _, _, ctx := moneyInEnv(t)
+	merchantID := dbtest.TestMerchantID.UUID()
+
+	_, err := pool.Exec(ctx, `
+INSERT INTO openrails.custom_credit_types (id, merchant_id, name, decimals, active)
+VALUES (uuidv7(), $1, 'image-credit', 0, true)
+ON CONFLICT (merchant_id, name) DO UPDATE SET active = true`, merchantID)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, `
+INSERT INTO openrails.catalog_credit_balances (merchant_id, key, unit)
+VALUES ($1, 'image-credit', 'image-credit')
+ON CONFLICT (merchant_id, key) DO UPDATE SET unit = EXCLUDED.unit`, merchantID)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, "DELETE FROM openrails.catalog_credit_balances WHERE merchant_id = $1 AND key = $2", merchantID, "image-credit")
+	})
+
+	// 1000 credits at 10_000 micros / 3 = 3_333_333.33 micros — a quantity whose
+	// exact cost is not an integer, so the mode is the only thing that can decide
+	// the last micro.
+	for _, c := range []struct {
+		mode string
+		want int64
+	}{
+		{"up", 3_333_334},
+		{"down", 3_333_333},
+		{"half_up", 3_333_333},
+	} {
+		productID := uuid.New()
+		productKey := "image-credit-topup-" + uuid.NewString()
+		t.Cleanup(func() {
+			_, _ = pool.Exec(ctx, "DELETE FROM openrails.catalog_credit_purchase_prices WHERE merchant_id = $1 AND product_id = $2", merchantID, productID)
+			_, _ = pool.Exec(ctx, "DELETE FROM openrails.products WHERE id = $1", productID)
+		})
+		_, err = pool.Exec(ctx, `INSERT INTO openrails.products (id, key, display_name, merchant_id) VALUES ($1, $2, 'Topup', $3)`, productID, productKey, merchantID)
+		require.NoError(t, err)
+		_, err = pool.Exec(ctx, `
+INSERT INTO openrails.catalog_credit_purchase_prices (merchant_id, product_id, ordinal, credit_key, currency, price)
+VALUES ($1, $2, 1, 'image-credit', 'USD', $3::jsonb)`, merchantID, productID,
+			`{"model":"per_unit","per_unit":{"unit_amount":10000,"divide_by":3,"round":"`+c.mode+`"}}`)
+		require.NoError(t, err)
+
+		quote, err := svc.QuoteCatalogCreditPurchase(ctx, money.CatalogCreditPurchaseQuoteInput{
+			ProductKey: productKey,
+			Credits:    1_000,
+		})
+		require.NoError(t, err, "round %q", c.mode)
+		require.Equal(t, int64(1_000), quote.TotalCredits, "round %q", c.mode)
+		require.Equal(t, c.want, quote.PaidAmount, "round %q quoted the wrong micros", c.mode)
+	}
+}
+

--- a/migrations/postgres/0002_drop_credit_purchase_round.down.sql
+++ b/migrations/postgres/0002_drop_credit_purchase_round.down.sql
@@ -1,0 +1,10 @@
+-- Restore catalog_credit_purchase_prices.round in its 0001 shape (nullable
+-- text, no default). Values are NOT recoverable and none ever mattered: the
+-- column was written and never read, so an empty column restores exactly the
+-- information content the deployment had.
+
+SET LOCAL statement_timeout = '60s';
+SET LOCAL lock_timeout = '10s';
+
+ALTER TABLE openrails.catalog_credit_purchase_prices
+    ADD COLUMN round text;

--- a/migrations/postgres/0002_drop_credit_purchase_round.up.sql
+++ b/migrations/postgres/0002_drop_credit_purchase_round.up.sql
@@ -1,0 +1,38 @@
+-- or#823: drop catalog_credit_purchase_prices.round — a declared knob nothing
+-- reads.
+--
+-- The column was written by the catalog sidecar push (syncCreditPurchases) and
+-- read by nothing: the one runtime SELECT, money.loadCatalogCreditPurchase,
+-- lists its columns explicitly and `round` is not among them, and
+-- catalogCreditPurchaseRow has no field for it. It never even reached the
+-- column with meaning attached — catalog.Price.ratePrice() builds the RatePrice
+-- that becomes the `price` jsonb WITHOUT Round, so the top-level manifest
+-- `round:` was validated and then dropped on the floor.
+--
+-- The rounding that IS applied to a credit-purchase quote lives inside the
+-- `price` jsonb as per_unit.round, which RatePrice.ToChargeModel() carries into
+-- ChargeModel.Round and mulDivRound honours. That path stays, now pinned by an
+-- integration test that a non-default mode changes the quoted micros.
+--
+-- Not load-bearing for invertibility either: QuoteUnitsForSpend binary-searches
+-- Rate(), so it inverts any MONOTONE model. Monotonicity is what the doctrine
+-- requires and what graduated-only enforces (volume has tier cliffs); every
+-- rounding mode preserves it.
+
+SET LOCAL statement_timeout = '60s';
+SET LOCAL lock_timeout = '10s';
+
+-- squawk ban-drop-column: "may break existing clients" is the right default and
+-- the wrong verdict here, and squawk cannot tell the difference — it sees a
+-- column name, not who reads it. Every client that named this column is in this
+-- repo and stops naming it in this same commit: the sidecar INSERT
+-- (service.syncCreditPurchases) and the embedded manifest dump
+-- (dumpCatalogCreditPurchasePrices, which echoed it straight back out). No
+-- query outside them ever selected it, so no read loses an answer and no write
+-- loses a value. The one client the rule really protects — an older binary
+-- still INSERTing the column against the new schema — is a catalog-apply /
+-- dump path, not the money path, and migratekit runs at boot ahead of the
+-- binary that needs it.
+ALTER TABLE openrails.catalog_credit_purchase_prices
+    -- squawk-ignore ban-drop-column
+    DROP COLUMN round;

--- a/pkg/catalog/applier_service.go
+++ b/pkg/catalog/applier_service.go
@@ -119,7 +119,6 @@ func (a serviceApplier) SyncCatalogSidecars(ctx context.Context, m *Manifest) er
 						PSPs:       append([]string(nil), price.PSPs...),
 						InputMin:   price.InputMin,
 						InputMax:   price.InputMax,
-						Round:      price.Round,
 						Price:      priceJSON,
 					})
 				}

--- a/pkg/catalog/load.go
+++ b/pkg/catalog/load.go
@@ -483,10 +483,6 @@ func validateCreditTopUpOffer(productKey string, price *Price, idx int) error {
 	if price.InputMax > 0 && price.InputMin > price.InputMax {
 		return fmt.Errorf("%s input_min %d exceeds input_max %d", where, price.InputMin, price.InputMax)
 	}
-	price.Round = strings.ToLower(strings.TrimSpace(price.Round))
-	if _, ok := validRoundModes[price.Round]; !ok {
-		return fmt.Errorf("%s round must be up, down or half_up, got %q", where, price.Round)
-	}
 	rp := price.ratePrice()
 	if err := validateRatePrice(where, &rp); err != nil {
 		return err

--- a/pkg/catalog/manifest.go
+++ b/pkg/catalog/manifest.go
@@ -204,10 +204,11 @@ type Price struct {
 	Trial *PriceTrial `json:"trial,omitempty" yaml:"trial,omitempty"`
 
 	// Variable credit top-up offer fields. Fixed catalog prices keep using the
-	// UnitAmount/Duration shape above.
+	// UnitAmount/Duration shape above. Rounding is declared where it applies —
+	// per_unit.round — not here (or#823: a top-level `round:` was validated and
+	// then never carried into the price, so it is retired and now fails to load).
 	InputMin int64         `json:"input_min,omitempty" yaml:"input_min,omitempty"`
 	InputMax int64         `json:"input_max,omitempty" yaml:"input_max,omitempty"`
-	Round    string        `json:"round,omitempty" yaml:"round,omitempty"`
 	Model    string        `json:"model,omitempty" yaml:"model,omitempty"`
 	Flat     *FlatPrice    `json:"flat,omitempty" yaml:"flat,omitempty"`
 	PerUnit  *PerUnitPrice `json:"per_unit,omitempty" yaml:"per_unit,omitempty"`

--- a/pkg/catalog/ratecard_test.go
+++ b/pkg/catalog/ratecard_test.go
@@ -212,7 +212,6 @@ products:
       - currency: usd
         psps: [stripe]
         input_min: 5_000_000
-        round: down
         model: tiered
         tiered:
           mode: graduated
@@ -258,6 +257,78 @@ products:
 	_, err := Load(writeManifest(t, body))
 	if err == nil || !strings.Contains(err.Error(), "graduated mode") {
 		t.Fatalf("want volume-mode rejection, got %v", err)
+	}
+}
+
+// or#823: the top-level `round:` on a credit top-up price was validated and
+// then dropped — ratePrice() never carried it, and the column it reached was
+// read by nothing. It is retired, and a manifest still declaring it must fail
+// to load rather than be silently ignored. Rounding is declared where it is
+// read: inside per_unit.
+func TestCreditPurchase_RejectsRetiredTopLevelRound(t *testing.T) {
+	body := `
+version: 1
+credit_balances:
+  - {key: ai-image-gen, unit: ai-image-credit}
+products:
+  - key: topup
+    display_name: Topup
+    credits: [{key: ai-image-gen}]
+    prices:
+      - currency: usd
+        round: down
+        model: per_unit
+        per_unit: {unit_amount: 10_000}
+`
+	_, err := Load(writeManifest(t, body))
+	if err == nil || !strings.Contains(err.Error(), "round") {
+		t.Fatalf("want the retired top-level round to fail the load, got %v", err)
+	}
+}
+
+// The rounding that IS read: per_unit.round reaches ChargeModel through
+// ratePrice()/ToChargeModel(), so a non-default mode changes the quoted micros.
+// Pinned here at the manifest boundary; the runtime quote path is pinned by
+// money's TestCatalogCreditPurchase_PerUnitRoundModeChangesTheQuote.
+func TestCreditPurchase_PerUnitRoundModeReachesTheChargeModel(t *testing.T) {
+	manifest := func(mode string) string {
+		return `
+version: 1
+credit_balances:
+  - {key: ai-image-gen, unit: ai-image-credit}
+products:
+  - key: topup
+    display_name: Topup
+    credits: [{key: ai-image-gen}]
+    prices:
+      - currency: usd
+        model: per_unit
+        per_unit: {unit_amount: 10_000, divide_by: 3, round: ` + mode + `}
+`
+	}
+	for _, c := range []struct {
+		mode string
+		want int64
+	}{
+		{"up", 3_333_334},
+		{"down", 3_333_333},
+		{"half_up", 3_333_333},
+	} {
+		m, err := Load(writeManifest(t, manifest(c.mode)))
+		if err != nil {
+			t.Fatalf("round %q: Load: %v", c.mode, err)
+		}
+		cm := productByKey(t, m, "topup").Prices[0].ratePrice().ToChargeModel()
+		if cm.Round != c.mode {
+			t.Fatalf("round %q did not reach the charge model, got %q", c.mode, cm.Round)
+		}
+		got, err := cm.Rate(1_000)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != c.want {
+			t.Fatalf("round %q rated 1000 units at %d micros, want %d", c.mode, got, c.want)
+		}
 	}
 }
 

--- a/pkg/embedded/catalog_dump.go
+++ b/pkg/embedded/catalog_dump.go
@@ -397,7 +397,7 @@ ORDER BY product_id, ordinal`, merchantID)
 
 func dumpCatalogCreditPurchasePrices(ctx context.Context, database *db.DB, merchantID uuid.UUID, byID map[uuid.UUID]*catalog.Product) error {
 	rows, err := database.Qx(ctx).Query(ctx, `
-SELECT product_id, credit_key, currency, rails, input_min, input_max, COALESCE(round, ''), price
+SELECT product_id, credit_key, currency, rails, input_min, input_max, price
 FROM openrails.catalog_credit_purchase_prices
 WHERE merchant_id = $1
 ORDER BY product_id, ordinal`, merchantID)
@@ -412,7 +412,7 @@ ORDER BY product_id, ordinal`, merchantID)
 			price     catalog.Price
 			priceRaw  []byte
 		)
-		if err := rows.Scan(&productID, &creditKey, &price.Currency, &price.PSPs, &price.InputMin, &price.InputMax, &price.Round, &priceRaw); err != nil {
+		if err := rows.Scan(&productID, &creditKey, &price.Currency, &price.PSPs, &price.InputMin, &price.InputMax, &priceRaw); err != nil {
 			return err
 		}
 		if err := json.Unmarshal(priceRaw, &price); err != nil {

--- a/pkg/service/catalog_sidecars.go
+++ b/pkg/service/catalog_sidecars.go
@@ -67,7 +67,6 @@ type CatalogCreditPurchasePriceSpec struct {
 	PSPs       []string        `json:"psps,omitempty"`
 	InputMin   int64           `json:"input_min,omitempty"`
 	InputMax   int64           `json:"input_max,omitempty"`
-	Round      string          `json:"round,omitempty"`
 	Price      json.RawMessage `json:"price"`
 }
 
@@ -291,10 +290,10 @@ func syncCreditPurchases(ctx context.Context, tx pgx.Tx, merchantID uuid.UUID, p
 		}
 		if _, err := tx.Exec(ctx, `
 INSERT INTO openrails.catalog_credit_purchase_prices
-    (merchant_id, product_id, ordinal, credit_key, currency, rails, input_min, input_max, round, price)
-VALUES ($1, $2, $3, $4, $5, $6::text[], $7, $8, NULLIF($9, ''), $10::jsonb)`,
+    (merchant_id, product_id, ordinal, credit_key, currency, rails, input_min, input_max, price)
+VALUES ($1, $2, $3, $4, $5, $6::text[], $7, $8, $9::jsonb)`,
 			merchantID, productID, spec.Ordinal, strings.TrimSpace(spec.CreditKey), strings.TrimSpace(spec.Currency),
-			providers, spec.InputMin, spec.InputMax, strings.TrimSpace(spec.Round), string(spec.Price)); err != nil {
+			providers, spec.InputMin, spec.InputMax, string(spec.Price)); err != nil {
 			return fmt.Errorf("insert credit purchase %q #%d: %w", spec.ProductKey, spec.Ordinal, err)
 		}
 	}


### PR DESCRIPTION
The two residuals left on or#823. One is a deletion, one is a correction to the
audit — both were re-derived from current `dev` rather than inherited.

## 1. `imported_dunning_history` — NOT dead. Kept, no change.

The audit's "zero non-generated callers" is wrong. The table has a live,
production-wired reader:

`internal/river/jobs_provider_refresh.go:527` → `reconcile.NewEngine` →
`wiring.go:35` `e.History = NewPGHistorySource(d)` → `history.go:88`
`ListDunningHistoryEvents`, whose first UNION branch is
`FROM openrails.imported_dunning_history`. Its output is the **history** leg of
the three-source dunning forensics report, documented as operator-facing in
`docs/operations.md` and covered by `internal/reconcile/history_integration_test.go`.
`pkg/embedded/pull_provider.go:188` builds the same engine for embedded hosts.

What the audit actually found is the **writer**: `InsertImportedDunningHistory`
has zero callers, because the wave removed `DeclaredDunningEvent` from
`billingimport`. That is the designed shape, not rot — the table is documented
as a one-time legacy import target (`doujins #387`) populated out-of-band, and
`billingimport` still carries `DunningEvidence`, which lands on the subscription
row's retry fields rather than here. Dropping the table would blind a live
report; dropping it because its in-repo *writer* is unused would delete the read
path over an argument about the write path. Left alone.

## 2. `catalog_credit_purchase_prices.round` — dead knob. Dropped in `0002`.

Written by the sidecar push, read by nothing that prices anything:
`money.loadCatalogCreditPurchase` lists its columns explicitly and `round` is
not among them. It never carried meaning that far regardless —
`catalog.Price.ratePrice()` builds the `RatePrice` that becomes the `price`
jsonb **without** `Round`, so a manifest's top-level `round:` was validated and
then discarded. The single client that did read the column, the embedded
manifest dump, only echoed it back out.

**Not load-bearing for invertibility**, which was the question worth asking:
`QuoteUnitsForSpend` binary-searches `Rate()`, so it inverts any *monotone*
model. Monotonicity is what the doctrine requires and what graduated-only
enforces (volume has the tier cliffs); every rounding mode preserves it.

**The rounding that IS read stays, now pinned.** `per_unit.round` rides inside
the `price` jsonb, reaches `ChargeModel` via `ToChargeModel()` and decides the
last micro in `mulDivRound`. Per the money-boundary standing rule, two tests
hold it to exact values — one at the manifest boundary, one through the live
`QuoteCatalogCreditPurchase` path, where two offers differing in nothing but the
mode quote **3_333_334 vs 3_333_333 micros** for the same 1,000 credits.

The manifest field is retired outright, not aliased: the loader disallows
unknown fields, so a manifest still declaring top-level `round:` now fails to
load rather than being silently ignored.

## Gates

`0002` is the **first migration the or#838 lint has ever checked** — or#893's
baseline is the one excluded path, so until now the script's derived
"nothing to lint" was the whole story. It went red on `ban-drop-column` first,
then clean with an inline `-- squawk-ignore` and the reason recorded in
`EXEMPTIONS.md` (the first inline exemption since the squash).

- `migration-lint`: `clean (1 files checked)` — genuinely running, not the empty-glob early exit
- `sql-lint`: clean (40 reviewed exemptions)
- `sqlc generate` + `vet` + `TestQueryAudit`: green; regen is a 1-line models.go delta
- `go build` / `go vet` / `go vet -tags integration ./...`: clean
- unit suite `./...`: green
- integration (`-p 1`): `internal/modules/money`, `pkg/service`, `pkg/embedded`, `internal/reconcile`, `migrations/postgres`, `internal/integrationharness` — all green

The vet DB is built by applying `migrations/` in order, so `0002` applying
cleanly on top of the baseline is proven by every gate above.