### PR TITLE
or#899: cmd/openrails' boot test provisions its own Redis; post-squash DB reset gets a recipe

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -70,6 +70,16 @@ tasks:
       # --profile all: without it, profiled services (openrails) are left running.
       - docker compose -f docker-compose.yaml --profile all --profile e2e-sandbox down
 
+  docker-reset:
+    desc: "Recreate the local stack from EMPTY: down + delete volumes (Postgres data) + up + migrate"
+    prompt: This DELETES the local Postgres and Garnet volumes. Continue?
+    cmds:
+      # -v drops the named volumes (postgres_data, redis_data, spool, runtime keys);
+      # the external go_mod_cache is left alone. `docker-down` deliberately does NOT
+      # do this — a schema reset has to be asked for.
+      - docker compose -f docker-compose.yaml --profile all --profile e2e-sandbox down -v
+      - task: docker-up
+
   docker-logs:
     desc: Tail openrails logs from docker compose stack
     cmds:

--- a/cmd/openrails/runserver_mode1_integration_test.go
+++ b/cmd/openrails/runserver_mode1_integration_test.go
@@ -76,6 +76,11 @@ func testSigningKeyPEM(t *testing.T) string {
 
 func writeMode1Config(t *testing.T, dir, dsn string, port int, merchantSource, keyPEM string) string {
 	t.Helper()
+	// or#899: config's Redis default is the compose-published localhost:6380, and
+	// /readyz FAILS on a configured-but-unreachable Redis — so leaving it default
+	// makes this package pass only where the repo stack is up. Point it at the
+	// suite's own Redis (testcontainer or OPENRAILS_TEST_REDIS_ADDR).
+	redisAddr := dbtest.SharedRedisAddr(t)
 	// or#893: merchant_source=api must declare where secrets live. MODE 1 never
 	// consults it, so declaring db is inert there and honest here.
 	cfgYAML := fmt.Sprintf(`env: development
@@ -87,12 +92,14 @@ host: 127.0.0.1
 port: %d
 db:
   url: %s
+redis:
+  addr: %s
 auth:
   issuer: https://controlplane.openrails.test
   active_key_id: mode1-test-key
   active_private_key_pem: |
 %s
-`, merchantSource, port, dsn, indentPEM(keyPEM))
+`, merchantSource, port, dsn, redisAddr, indentPEM(keyPEM))
 	path := filepath.Join(dir, "config.yaml")
 	require.NoError(t, os.WriteFile(path, []byte(cfgYAML), 0o600))
 	return path

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -16,6 +16,7 @@ Everything routine goes through [Task](https://taskfile.dev) (`Taskfile.yaml`):
 | `task run` | Build + run the server |
 | `task dev` | Hot-reload dev server (Air, `.air.toml`) |
 | `task docker-up` / `task docker-down` | Start/stop the local compose stack (openrails + Postgres + Garnet) |
+| `task docker-reset` | Recreate the stack from empty — deletes the Postgres volume, then re-migrates ([why you'd need this](#migrations)) |
 | `task docker-logs` | Tail the openrails container |
 | `task sqlc` / `task sqlc-check` | Regenerate + vet `internal/db/gen` (see below); `sqlc-check` is the CI staleness gate |
 | `task test` | Business-time guardrail + unit tests (`-race`) + core integration tier |
@@ -86,8 +87,20 @@ next to the migrations.
 The baseline was re-squashed (or#893). migratekit tracks applied migrations by
 FILENAME, so a database whose ledger holds the pre-squash names will skip the
 new baseline and sit on a schema nothing describes: **drop and recreate any
-database created before the re-squash.** Prelaunch, every database is
-disposable, which is the whole reason the squash is allowed.
+database created before the re-squash — do not try to migrate it forward.**
+Prelaunch, every database is disposable, which is the whole reason the squash
+is allowed.
+
+Recreating one:
+
+| Database | How |
+|---|---|
+| Local compose stack | `task docker-reset` — `down -v` (deletes the `postgres_data` volume) then `docker-up`, which re-runs `openrails-migrate` against an empty server. Plain `task docker-down` keeps the volume and therefore keeps the stale ledger. |
+| A dev/staging server you can't drop the volume of | `DROP DATABASE` + `CREATE DATABASE`, then `openrails migrate up`. |
+| A long-lived hand-rolled test pool | Drop `public.migrations` along with the schema — migratekit reads its ledger there, and a surviving ledger makes it *skip* re-applying the baseline. (The integration suite is unaffected: it creates a fresh per-run database every time.) |
+
+The symptom if you skip this is not a migration error — it is a schema that
+silently lacks whatever the squash folded in.
 
 ## Repo layout
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -34,7 +34,10 @@ Postgres specifics worth knowing:
   migrations (`migrations/postgres/`, baseline `0001_schema.up.sql`, new ones
   start at `0002`). The server validates at boot and refuses to start behind.
 - Local zero-config stack: `task docker-up` (Postgres 18 + Redis + OpenRails on
-  `:3053`), `task docker-down` to tear down.
+  `:3053`), `task docker-down` to tear down, `task docker-reset` to recreate the
+  database from empty (the baseline was re-squashed prelaunch, so a database
+  created before that must be dropped rather than migrated forward — see the
+  [contributor guide](dev/README.md#migrations)).
 
 ### The safety levers
 

--- a/internal/dbtest/containers.go
+++ b/internal/dbtest/containers.go
@@ -82,6 +82,19 @@ func NewSharedRedisClient(t testing.TB) *redis.Client {
 	return rdb
 }
 
+// SharedRedisAddr returns the host:port of the shared integration Redis,
+// provisioning it on first use exactly like NewSharedRedisClient
+// (OPENRAILS_TEST_REDIS_ADDR, else a testcontainer). For tests that must hand an
+// ADDRESS to the code under test — a written config file, a spawned server —
+// instead of a client. Never let such a test fall back to a config default port:
+// that makes it pass only where the compose stack happens to be up.
+func SharedRedisAddr(t testing.TB) string {
+	t.Helper()
+	rdb := NewSharedRedisClient(t)
+	defer func() { _ = rdb.Close() }()
+	return rdb.Options().Addr
+}
+
 func TerminateSharedRedis() {
 	if redisContainer == nil {
 		return


### PR DESCRIPTION
Two P3 hygiene items from the board audit closing pass.

## 1. The mode-1 boot test's undeclared Redis dependency

`cmd/openrails`'s `writeMode1Config` emitted no `redis:` block, so the booted
server inherited the config default `localhost:6380` — the port the repo's
`docker-compose.yaml` publishes. Redis is optional everywhere else in OpenRails,
but `Runtime.Ready` probes it *when configured*, and the default always
configures it. So on a testcontainers-only machine the server never went ready,
the test burned its full 90s deadline, and the failure read
`run-server did not become ready in time` — naming neither Redis nor the
assumption. Exactly the fail-quietly-on-ambient-state shape or#865 removed.

`dbtest.SharedRedisAddr(t)` returns the host:port of the shared integration
Redis, provisioned through the same `sync.Once` as `NewSharedRedisClient`
(`OPENRAILS_TEST_REDIS_ADDR`, else a testcontainer, terminated by `RunMain`).
The written config points at it, so all three tests in the file are
self-sufficient.

**Class check, not just the file:** `config.go:1858` is the only hardcoded
`6380` in the tree, and `internal/integrationharness/harness.go:481` already did
the right thing (`cfg.Redis = &config.RedisConfig{Addr: h.Redis.Options().Addr}`).
`cmd/openrails/rls_posture_integration_test.go` builds `config.Config` literals
with `Redis` nil, so no client is created. This was the last reach for a config
default.

**Proof.** Bare machine, no compose stack, every `OPENRAILS_TEST_*` unset:

```
--- PASS: TestRunServerMode1BootArmsNMIPSPFromManifest (2.66s)
--- PASS: TestRunServerRefusesMissingExplicitMerchantManifest (0.21s)
--- PASS: TestRunServerAPIModeRefusesMerchantManifest (0.26s)
ok  github.com/open-rails/openrails/cmd/openrails  24.074s
```

A naive before/after was contaminated — another agent's container happened to
be bound to `:6380` on the dev box, which is the bug in the flesh. Reproducing
the bare-machine condition faithfully (pre-fix test, config redis pointed at a
dead port) gives the documented failure:

```
--- FAIL: TestRunServerMode1BootArmsNMIPSPFromManifest (99.01s)
    run-server did not become ready in time
```

## 2. Post-squash dev-DB recreation

`docs/dev/README.md` already stated WHY (migratekit tracks by filename, so a
pre-squash ledger skips the new baseline). It stopped at "drop and recreate",
which is the part people get wrong: `task docker-down` keeps `postgres_data`, so
the obvious teardown preserves the stale ledger, and the symptom is a silently
incomplete schema rather than a migration error.

No reset target existed, so this adds `task docker-reset` (`down -v` + `up`,
which re-runs the unprofiled `openrails-migrate` service against an empty
server; confirm-prompted since it deletes volumes) and a table covering the
three cases — compose volume, a server you can only `DROP DATABASE` on, and a
long-lived hand-rolled test pool whose `public.migrations` ledger must go too.
The integration suite needs nothing: it builds a fresh per-run database.
`docs/operator-guide.md`'s local-stack bullet now points at it; no other doc
walks a dev through DB setup in a way that disagrees.

## Gates

`gofmt`, `go build ./...`, `go vet -tags=integration ./...` (whole tree), `task
lint` (0 issues), `golangci-lint --build-tags=integration` on both touched
packages — one pre-existing `SA1019 cfg.BeforeAcquire` in untouched
`dbtest/postgres.go:436`. Integration run above with `-p 1 -parallel 1`,
`nice -n 10`, stale env unset; testcontainers torn down by `RunMain`.