### PR TITLE
or#900: host-sweep findings — unpinned facade reads under RLS, plus the two SDK gaps

### DIFF
--- a/client.go
+++ b/client.go
@@ -246,6 +246,12 @@ type CreditTransaction struct {
 	Description     *string
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
+	// Replayed reports that this write's idempotency key had ALREADY committed,
+	// so nothing moved in THIS call — the row described here is the movement
+	// that landed earlier (or#892). Serialized by the engine on both transports;
+	// a consumer that needs applied-vs-replayed reads it here instead of keeping
+	// its own claim table.
+	Replayed bool
 }
 
 // AdmitRequest is one item in POST /v1/merchant/admissions. It checks payer money

--- a/docs/embedded-integration.md
+++ b/docs/embedded-integration.md
@@ -359,6 +359,13 @@ no wire counterpart) — reach it via type assertion. `embed.WithCurrency` /
 opt one back in with `openrails.WithTimeout`). `rt.Service()` is the escape hatch for
 engine-native types (`identity.CustomerID` etc.) instead of wire types.
 
+Every `rt.Service()` method pins its own merchant-scoped connection, so a bare Go
+call reads the merchant's rows without ceremony — and one with no merchant on the
+context fails loudly instead of answering an empty result. Wrapping a *block* of
+calls in `emb.RunInMerchant(ctx, …)` is still worth it (one connection for the
+whole block instead of one per call), but it is an optimization, not a
+prerequisite.
+
 ### 8. Acting on delinquency
 
 For arrears billing, OpenRails decides when a payer's unpaid debt has outlived

--- a/embed/or900_sdk_gaps_integration_test.go
+++ b/embed/or900_sdk_gaps_integration_test.go
@@ -1,0 +1,133 @@
+//go:build integration
+
+// or#900 items 2 and 3: two answers the engine already gives that the SDK
+// dropped on the floor.
+//
+//	item 2 — CreditTransaction.Replayed. or#892 made every money write report
+//	         applied-vs-replayed and the handlers serialize it, but the SDK type
+//	         had no field, so a consumer could not read it and kept its own
+//	         claim table to re-derive it.
+//	item 3 — ErrIdempotencyKeyReused. The refusal ("this key already committed a
+//	         DIFFERENT amount") lived in internal/ with no exported name and no
+//	         wire mapping, so a host saw an opaque 4xx/5xx and could not tell its
+//	         own bug from an engine fault.
+//
+// Both are asserted on BOTH transports — the REMOTE client against the real
+// standalone server, and the in-process transport of the embedded host — because
+// a fix on one transport and not the other is the drift the unified SDK exists
+// to prevent.
+package embed_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails"
+	"github.com/open-rails/openrails/embed"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/internal/integrationharness"
+	"github.com/open-rails/openrails/internal/modules/money"
+	billingservice "github.com/open-rails/openrails/pkg/service"
+)
+
+func TestOr900_ReplayedAndIdempotencyConflictCrossBothTransports(t *testing.T) {
+	ctx := context.Background()
+	currency := money.DefaultCurrency
+
+	h := integrationharness.New(t, ctx)
+	embedded := h.StartEmbeddedHost(currency)
+	standalone := h.StartStandalone(currency)
+	pool := h.Pool()
+
+	newPayer := func() uuid.UUID {
+		id := uuid.New()
+		_, err := pool.Exec(ctx, `
+			INSERT INTO openrails.customers (id, merchant_id, issuer, subject, created_at, last_seen_at)
+			VALUES ($1, $2, 'or900', $3, now(), now())`,
+			id, dbtest.TestMerchantID.UUID(), id.String())
+		require.NoError(t, err)
+		return id
+	}
+
+	transports := []struct {
+		name   string
+		client openrails.Client
+	}{
+		{"in-process", embedded.Runtime().Client(embed.WithCurrency(currency))},
+		{"remote", standalone.Client()},
+	}
+
+	for _, tr := range transports {
+		t.Run(tr.name, func(t *testing.T) {
+			payer := newPayer()
+			pid := openrails.CustomerID(payer)
+			invoker := "user:or900-" + uuid.NewString()
+
+			// --- item 2: applied vs replayed on the SDK type ------------------
+			depositSrc := uuid.New()
+			req := openrails.DepositCreditsRequest{
+				CustomerID: &pid,
+				Invoker:    invoker,
+				Currency:   currency,
+				Amount:     1_000_000,
+				Source:     "or900",
+				SourceID:   &depositSrc,
+			}
+			first, err := tr.client.DepositCredits(ctx, req)
+			require.NoError(t, err)
+			require.False(t, first.Replayed, "a first deposit APPLIES — money moved in this call")
+
+			again, err := tr.client.DepositCredits(ctx, req)
+			require.NoError(t, err, "a replayed deposit is answered, not rejected")
+			require.True(t, again.Replayed,
+				"or#900: the engine reports the replay and the SDK must surface it, or a consumer double-counts")
+			require.Equal(t, first.Amount, again.Amount, "the replay describes the movement that already landed")
+
+			// --- item 3: the reused-key refusal reaches the host --------------
+			usageSourceID := uuid.NewString()
+			usage := openrails.UsageReport{
+				CustomerID: payer.String(),
+				Invoker:    invoker,
+				Currency:   currency,
+				EventType:  "or900_event",
+				Amount:     50_000,
+				Source:     "or900",
+				SourceID:   usageSourceID,
+			}
+			require.NoError(t, tr.client.RecordUsage(ctx, usage), "first usage charge applies")
+
+			// Same key, DIFFERENT charging terms: a caller bug, and it must be
+			// named as one rather than answered with the original amount.
+			conflicting := usage
+			conflicting.Amount = 90_000
+			err = tr.client.RecordUsage(ctx, conflicting)
+			require.Error(t, err, "replaying a key with a changed amount must refuse")
+			require.ErrorIs(t, err, openrails.ErrIdempotencyKeyReused,
+				"or#900: the wire error must map back to the exported sentinel on this transport")
+
+			var se *openrails.StatusError
+			require.ErrorAs(t, err, &se)
+			require.Equal(t, http.StatusConflict, se.Status, "a reused key is a conflict, not a 500")
+			require.Contains(t, se.Message, "idempotency_key_reused")
+			require.Contains(t, se.Message, "90000", "the detail names what the retry asked for")
+			require.Contains(t, se.Message, "50000", "and what the key already committed")
+
+			// Replaying it UNCHANGED is still fine — the refusal is about the
+			// changed terms, not about retrying.
+			require.NoError(t, tr.client.RecordUsage(ctx, usage), "an unchanged retry is still idempotent")
+		})
+	}
+}
+
+// TestOr900_ServiceFacadeExportsTheIdempotencySentinel is the in-process half of
+// item 3: a host that holds *service.Service (not the SDK client) must be able
+// to name the same refusal without importing internal/.
+func TestOr900_ServiceFacadeExportsTheIdempotencySentinel(t *testing.T) {
+	require.True(t, errors.Is(billingservice.ErrIdempotencyKeyReused, money.ErrIdempotencyKeyReused),
+		"pkg/service must re-export the money sentinel itself, not a look-alike")
+}

--- a/errors.go
+++ b/errors.go
@@ -45,6 +45,14 @@ var (
 	// ErrInsufficientCredits is the payer-balance deny (HTTP 402 /
 	// "insufficient_credits"). Message kept identical to go-client's sentinel.
 	ErrInsufficientCredits = errors.New("insufficient_credits")
+
+	// ErrIdempotencyKeyReused is the money-write refusal (HTTP 409 /
+	// "idempotency_key_reused"): the key already committed and THIS retry
+	// carries different charging terms (or#891). A caller bug, not an engine
+	// fault — retrying it unchanged will refuse again. The engine-side twin is
+	// pkg/service.ErrIdempotencyKeyReused; the StatusError's Message carries the
+	// detail (which field, committed vs retried).
+	ErrIdempotencyKeyReused = errors.New("idempotency_key_reused")
 )
 
 // StatusError is the concrete error both transports return for any non-OK
@@ -90,9 +98,11 @@ func newStatusError(status int, code, message string, extra ...error) *StatusErr
 	// Code/message-specific sentinels first: the handlers signal these as
 	// payload strings ("insufficient_credits" on 402 — see
 	// internal/http/handlers/service_credits.go).
-	switch pickCode(code, message) {
-	case "insufficient_credits":
+	switch {
+	case signals(code, message, "insufficient_credits"):
 		e.sentinels = append(e.sentinels, ErrInsufficientCredits)
+	case signals(code, message, "idempotency_key_reused"):
+		e.sentinels = append(e.sentinels, ErrIdempotencyKeyReused)
 	}
 
 	// Status-class sentinel.
@@ -119,16 +129,18 @@ func newStatusError(status int, code, message string, extra ...error) *StatusErr
 	return e
 }
 
-func pickCode(code, message string) string {
-	if c := strings.TrimSpace(code); c != "" && c != "invalid_param" && c != "internal_error" {
-		// The standalone error envelope's "code" is a coarse api.Code* class; the
-		// discriminating string ("insufficient_credits", ...) is the message. Only
-		// honor a specific code.
-		if c == "insufficient_credits" {
-			return c
-		}
+// signals reports whether the wire payload names `want`. The standalone error
+// envelope's "code" is a coarse api.Code* class (invalid_param,
+// resource_conflict, ...), so the discriminating string is normally the
+// MESSAGE. A message may carry detail after the token
+// ("idempotency_key_reused: spend replayed key (…) with amount=…"), which is
+// worth keeping on the wire, so the token is matched as a prefix too.
+func signals(code, message, want string) bool {
+	if strings.TrimSpace(code) == want {
+		return true
 	}
-	return strings.TrimSpace(message)
+	msg := strings.TrimSpace(message)
+	return msg == want || strings.HasPrefix(msg, want+":")
 }
 
 func errorsContain(errs []error, target error) bool {

--- a/internal/http/handlers/service_admission.go
+++ b/internal/http/handlers/service_admission.go
@@ -259,6 +259,9 @@ func ServiceReportWastedSpend(r *httprequest.Request) {
 		Reason:      req.Reason,
 	})
 	if err != nil {
+		if serviceIdempotencyConflict(r, err) {
+			return
+		}
 		r.ErrorJSON(http.StatusInternalServerError, "report wasted spend failed")
 		return
 	}

--- a/internal/http/handlers/service_credits.go
+++ b/internal/http/handlers/service_credits.go
@@ -15,6 +15,22 @@ import (
 	billingservice "github.com/open-rails/openrails/pkg/service"
 )
 
+// serviceIdempotencyConflict answers a reused-idempotency-key refusal with 409
+// and the money layer's own detail message ("idempotency_key_reused: <op>
+// replayed key (…) with amount=… but that key already committed amount=…").
+// That is the ONE wire shape both SDK transports map back to
+// openrails.ErrIdempotencyKeyReused (errors.go), and pkg/service re-exports the
+// engine-side twin. It is a CALLER bug — the retry changed the charging terms —
+// so it must never be answered 500, which is indistinguishable from an engine
+// fault and invites a retry that will refuse again.
+func serviceIdempotencyConflict(r *httprequest.Request, err error) bool {
+	if !errors.Is(err, billingservice.ErrIdempotencyKeyReused) {
+		return false
+	}
+	r.ErrorJSON(http.StatusConflict, err.Error())
+	return true
+}
+
 type serviceDepositRequest struct {
 	CustomerID  string     `json:"customer_id"`
 	Invoker     string     `json:"invoker"`
@@ -275,6 +291,9 @@ func ServiceRecordUsage(r *httprequest.Request) {
 		Key:        usageKey,
 		OccurredAt: occurredAt,
 	}); err != nil {
+		if serviceIdempotencyConflict(r, err) {
+			return
+		}
 		r.ErrorJSON(http.StatusBadRequest, err.Error())
 		return
 	}
@@ -423,6 +442,9 @@ func ServiceDepositCredits(r *httprequest.Request) {
 			r.ErrorJSON(http.StatusBadRequest, err.Error())
 			return
 		}
+		if serviceIdempotencyConflict(r, err) {
+			return
+		}
 		r.ErrorJSON(http.StatusInternalServerError, "deposit failed")
 		return
 	}
@@ -471,6 +493,9 @@ func ServiceCaptureHold(r *httprequest.Request) {
 		return
 	}
 	if err != nil {
+		if serviceIdempotencyConflict(r, err) {
+			return
+		}
 		r.ErrorJSON(http.StatusInternalServerError, "capture failed")
 		return
 	}

--- a/pkg/embedded/merchant_conn_integration_test.go
+++ b/pkg/embedded/merchant_conn_integration_test.go
@@ -18,14 +18,18 @@ import (
 	billingservice "github.com/open-rails/openrails/pkg/service"
 )
 
-// TestEmbedded_RunInMerchantConn proves the exact failure this seam exists
-// to close: a host calling *service.Service directly (outside any HTTP
-// request or River job) MUST pin a merchant-scoped connection, or the
-// RLS-enforcing openrails_app role rejects the write outright (issue #227),
-// with no distinguishing error from a real permission problem. Found via
-// openrails-saas's own staging build (#10/#26): internal/platform.Bootstrap
-// calls svc.CreateProduct directly at boot and failed exactly this way under
-// the RLS-enforcing role.
+// TestEmbedded_RunInMerchantConn covers the seam a host uses to run merchant-owned
+// Go work outside any HTTP request or River job, under the RLS-enforcing
+// openrails_app role (issue #227). Found via openrails-saas's own staging build
+// (#10/#26): internal/platform.Bootstrap calls svc.CreateProduct directly at boot.
+//
+// or#900 narrowed what this seam is REQUIRED for. Every exported *service.Service
+// method now pins its own merchant connection, so a bare facade call with a
+// merchant on the context works — the split facade (money surfaces pinned,
+// everything else did not) was what made a host's read answer nothing. The seam
+// still earns its place for a BLOCK of calls (one connection instead of one per
+// call) and for engine-native work that is not a facade method, and its guards
+// (unbound engine, mispinned merchant) are unchanged.
 func TestEmbedded_RunInMerchantConn(t *testing.T) {
 	_, appDSN := dbtest.SharedRLSPostgres(t)
 	pool, err := pgxpool.New(context.Background(), appDSN)
@@ -60,15 +64,25 @@ func TestEmbedded_RunInMerchantConn(t *testing.T) {
 	svc, err := e.Service()
 	require.NoError(t, err)
 
-	// Without a pinned merchant connection, a direct write fails closed under
-	// RLS — merchant.WithID alone satisfies merchant.Require but never touches
-	// the app.merchant_id session GUC the table's RLS policy checks.
-	_, err = svc.CreateProduct(merchant.WithID(ctx, res.MerchantID), billingservice.CreateProductRequest{
-		Key: "unpinned-" + sfx, DisplayName: "Unpinned",
+	// or#900: a bare facade call with a merchant on the context now WORKS — the
+	// method pins its own connection, so the caller does not have to know which
+	// half of the facade it is talking to. Before or#900 this write was rejected
+	// by RLS and the matching read answered zero rows and no error.
+	selfPinned, err := svc.CreateProduct(merchant.WithID(ctx, res.MerchantID), billingservice.CreateProductRequest{
+		Key: "selfpinned-" + sfx, DisplayName: "Self-pinned",
 	})
-	require.Error(t, err, "a merchant-owned write without a pinned connection must be rejected by RLS")
+	require.NoError(t, err, "or#900: the facade pins its own merchant connection")
+	require.Equal(t, "selfpinned-"+sfx, selfPinned.Key)
 
-	// The SAME call, wrapped in RunInMerchantConn, succeeds.
+	// With NO merchant at all it still fails, and loudly: silence was the bug.
+	_, err = svc.CreateProduct(ctx, billingservice.CreateProductRequest{
+		Key: "unscoped-" + sfx, DisplayName: "Unscoped",
+	})
+	require.ErrorContains(t, err, "merchant",
+		"an unscoped facade call must name the missing merchant, not answer nothing")
+
+	// The SAME call, wrapped in RunInMerchantConn, succeeds — the seam's value is
+	// now one pinned connection for a whole block instead of one per call.
 	var created *billingservice.CatalogProduct
 	err = e.RunInMerchantConn(ctx, res.MerchantID, func(mctx context.Context) error {
 		created, err = svc.CreateProduct(mctx, billingservice.CreateProductRequest{
@@ -81,8 +95,7 @@ func TestEmbedded_RunInMerchantConn(t *testing.T) {
 	require.Equal(t, "pinned-"+sfx, created.Key)
 
 	// A read is scoped the same way: querying by key inside the pinned
-	// connection finds it; the same query without any pin sees nothing (RLS
-	// filters every row, not just writes).
+	// connection finds it.
 	err = e.RunInMerchantConn(ctx, res.MerchantID, func(mctx context.Context) error {
 		got, gerr := svc.GetProductByKey(mctx, "pinned-"+sfx)
 		require.NoError(t, gerr)

--- a/pkg/service/admission.go
+++ b/pkg/service/admission.go
@@ -64,6 +64,12 @@ type AdmitResult struct {
 // + Postgres→policy loader are built from the runtime per call (both cheap,
 // stateless). #513: no Postgres locks, no per-request budget reservation rows.
 func (s *Service) Admit(ctx context.Context, in AdmitInput) (*AdmitResult, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return nil, fmt.Errorf("service not initialized")
 	}
@@ -258,6 +264,12 @@ func invokerSpendLimitRow(in InvokerSpendLimitInput) admission.InvokerSpendLimit
 // subject's self cap, a role pool, an invoker grant, or an invoker-tier grant.
 // Payer-set: the payer caps how much its delegated invokers/roles may spend.
 func (s *Service) SetInvokerSpendLimits(ctx context.Context, payer identity.CustomerID, in InvokerSpendLimitInput) error {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return fmt.Errorf("service not initialized")
 	}
@@ -273,6 +285,12 @@ func (s *Service) SetInvokerSpendLimits(ctx context.Context, payer identity.Cust
 
 // InvokerSpendLimits returns the payer's per-invoker spend limits (#473/#517).
 func (s *Service) InvokerSpendLimits(ctx context.Context, payer identity.CustomerID) ([]InvokerSpendLimitInput, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return nil, fmt.Errorf("service not initialized")
 	}
@@ -297,6 +315,12 @@ func (s *Service) InvokerSpendLimits(ctx context.Context, payer identity.Custome
 // ReplaceInvokerSpendLimits fully replaces the payer-owned delegated-spend
 // policy document.
 func (s *Service) ReplaceInvokerSpendLimits(ctx context.Context, payer identity.CustomerID, next []InvokerSpendLimitInput) error {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return fmt.Errorf("service not initialized")
 	}
@@ -404,6 +428,12 @@ type MerchantConfiguration struct {
 
 // GetMerchantConfiguration returns the stored merchant-scoped configuration row.
 func (s *Service) GetMerchantConfiguration(ctx context.Context) (MerchantConfiguration, bool, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return MerchantConfiguration{}, false, pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return MerchantConfiguration{}, false, fmt.Errorf("service not initialized")
 	}
@@ -450,6 +480,12 @@ func (s *Service) GetMerchantConfiguration(ctx context.Context) (MerchantConfigu
 // DefaultInvokerWastedWindows fallback. A nil Profile preserves the current
 // profile; a non-nil empty Profile intentionally clears it.
 func (s *Service) SetMerchantConfiguration(ctx context.Context, in MerchantConfiguration) error {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return fmt.Errorf("service not initialized")
 	}
@@ -622,6 +658,12 @@ type WastedSpendResult struct {
 // ledger. No high-volume Postgres event table is written for free/delegated
 // reports.
 func (s *Service) ReportWastedSpend(ctx context.Context, in WastedSpendInput) (*WastedSpendResult, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return nil, fmt.Errorf("service not initialized")
 	}
@@ -827,6 +869,12 @@ func ValidateBillingPolicy(in BillingPolicyInput) (string, models.BillingPolicy,
 // SetBillingPolicy declares (or redeclares) one named billing policy (or#897).
 // Declaring a policy binds nothing — BindBillingPolicy decides who gets it.
 func (s *Service) SetBillingPolicy(ctx context.Context, in BillingPolicyInput) error {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return fmt.Errorf("service not initialized")
 	}
@@ -845,6 +893,12 @@ func (s *Service) SetBillingPolicy(ctx context.Context, in BillingPolicyInput) e
 // declared policy name. This is the merchant's runtime lever: rebinding changes
 // which cap applies to a payer and moves no money.
 func (s *Service) BindBillingPolicy(ctx context.Context, in BillingPolicyBindingInput) error {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return fmt.Errorf("service not initialized")
 	}
@@ -870,6 +924,12 @@ func (s *Service) BindBillingPolicy(ctx context.Context, in BillingPolicyBinding
 
 // ListBillingPolicies returns every declared policy for the config-sync document.
 func (s *Service) ListBillingPolicies(ctx context.Context) ([]BillingPolicyInput, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return nil, fmt.Errorf("service not initialized")
 	}
@@ -906,6 +966,12 @@ func (s *Service) ListBillingPolicies(ctx context.Context) ([]BillingPolicyInput
 // default and the per-tier rungs. Per-customer bindings are runtime segmentation
 // state and are never enumerated (that read would scale with customers).
 func (s *Service) ListBillingPolicyBindings(ctx context.Context) ([]BillingPolicyBindingInput, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return nil, fmt.Errorf("service not initialized")
 	}
@@ -950,6 +1016,12 @@ type TrustLevelScheduleRung struct {
 // payer sets the merchant-wide default schedule; a non-zero payer sets a
 // per-subject override. owner=platform.
 func (s *Service) SetTrustLevelSchedule(ctx context.Context, payer identity.CustomerID, currency string, schedule []TrustLevelScheduleRung) error {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return fmt.Errorf("service not initialized")
 	}
@@ -973,6 +1045,12 @@ func (s *Service) SetTrustLevelSchedule(ctx context.Context, payer identity.Cust
 // against the persisted trust-level schedule (#476), or a manual admin override.
 // Empty means the caller treats it as the lowest/default trust level.
 func (s *Service) GetTrustLevel(ctx context.Context, payer identity.CustomerID, currency string) (string, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return "", pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return "", fmt.Errorf("service not initialized")
 	}

--- a/pkg/service/catalog_drift.go
+++ b/pkg/service/catalog_drift.go
@@ -571,6 +571,12 @@ func fetchNMIPlans(ctx context.Context, lister nmiPlanLister) ([]nmiPlan, error)
 // change inserts zero new rows. Alert-only: it never mutates Stripe, NMI, or the
 // catalog rows.
 func (s *Service) RunCatalogReconciliation(ctx context.Context) (*CatalogDriftReport, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	cfg, err := s.requireConfig()
 	if err != nil {
 		return nil, err
@@ -851,6 +857,12 @@ type CatalogDriftFilter struct {
 // ListCatalogDrift returns open (unresolved) drift events with pagination and
 // optional provider / kind / resource_type filters. Total is the unpaginated count.
 func (s *Service) ListCatalogDrift(ctx context.Context, filter CatalogDriftFilter) (items []CatalogDriftEventView, total int64, err error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, 0, pinErr
+	}
+	defer release()
+
 	dbi, err := s.requireDB()
 	if err != nil {
 		return nil, 0, err
@@ -902,6 +914,12 @@ func (s *Service) listOpenDriftEvents(ctx context.Context, filter CatalogDriftFi
 // price clears its drift from the active list. Safe to call when no events
 // match (no-op). Returns the number of rows closed.
 func (s *Service) ResolveDriftForResource(ctx context.Context, resourceType models.CatalogDriftResourceType, openRailsResourceID string) (int, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return 0, pinErr
+	}
+	defer release()
+
 	openRailsResourceID = strings.TrimSpace(openRailsResourceID)
 	if openRailsResourceID == "" {
 		return 0, nil
@@ -926,6 +944,12 @@ func (s *Service) ResolveDriftForResource(ctx context.Context, resourceType mode
 // for the openrails_catalog_drift_open_count{provider,kind} metric. The map key
 // is "<provider>/<kind>".
 func (s *Service) CountOpenDriftByKind(ctx context.Context) (map[string]int64, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	dbi, err := s.requireDB()
 	if err != nil {
 		return nil, err

--- a/pkg/service/catalog_extras.go
+++ b/pkg/service/catalog_extras.go
@@ -165,6 +165,12 @@ type solanaPlanReader interface {
 // (resp. sunset-needed, for Solana). Read-only; never mutates anything.
 // Providers without a read API (CCBill) contribute notes.
 func (s *Service) DetectCatalogExtras(ctx context.Context) (*CatalogExtrasReport, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	cfg, err := s.requireConfig()
 	if err != nil {
 		return nil, err
@@ -507,6 +513,12 @@ type intentExecutor interface {
 // errors, and the scheduled executor drains them when the mode lifts. The
 // returned error aggregates only TERMINAL failures.
 func (s *Service) ArchiveCatalogExtras(ctx context.Context, extras []CatalogExtra) ([]CatalogExtraArchiveOutcome, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	rt, err := s.runtime()
 	if err != nil {
 		return nil, err

--- a/pkg/service/catalog_sidecars.go
+++ b/pkg/service/catalog_sidecars.go
@@ -81,6 +81,12 @@ type SyncCatalogSidecarsRequest struct {
 }
 
 func (s *Service) SyncCatalogSidecars(ctx context.Context, req SyncCatalogSidecarsRequest) error {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return pinErr
+	}
+	defer release()
+
 	dbi, err := s.requireDB()
 	if err != nil {
 		return err

--- a/pkg/service/delinquency.go
+++ b/pkg/service/delinquency.go
@@ -30,6 +30,12 @@ func (s *Service) delinquencyService() *delinquency.Service {
 // owes in. A payer with no row has never been overdue: absence IS `current`,
 // and the caller reads an empty slice rather than a fabricated state.
 func (s *Service) GetDelinquency(ctx context.Context, payer identity.CustomerID) ([]DelinquencySnapshot, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	svc := s.delinquencyService()
 	if svc == nil {
 		return nil, fmt.Errorf("service not initialized")
@@ -43,6 +49,12 @@ func (s *Service) GetDelinquency(ctx context.Context, payer identity.CustomerID)
 // ListDelinquency returns the merchant's overdue roster — payers in grace or
 // delinquent, oldest debt first. `state` filters to one level ("" = both).
 func (s *Service) ListDelinquency(ctx context.Context, state DelinquencyState, limit int) ([]DelinquencySnapshot, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	svc := s.delinquencyService()
 	if svc == nil {
 		return nil, fmt.Errorf("service not initialized")
@@ -53,6 +65,12 @@ func (s *Service) ListDelinquency(ctx context.Context, state DelinquencyState, l
 // GetDelinquencyPolicy returns the merchant's effective delinquency policy —
 // the declared values, or the defaults/derivations that stand in for them.
 func (s *Service) GetDelinquencyPolicy(ctx context.Context) (DelinquencyPolicy, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return DelinquencyPolicy{}, pinErr
+	}
+	defer release()
+
 	svc := s.delinquencyService()
 	if svc == nil {
 		return DelinquencyPolicy{}, fmt.Errorf("service not initialized")

--- a/pkg/service/enterprise.go
+++ b/pkg/service/enterprise.go
@@ -39,6 +39,12 @@ type InvoiceProfileDTO struct {
 // SetCustomerInvoiceProfile upserts a payer's invoicing profile. Operator
 // surface — a payer must not grant itself credit terms.
 func (s *Service) SetCustomerInvoiceProfile(ctx context.Context, payer identity.CustomerID, p InvoiceProfileDTO) error {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return fmt.Errorf("service not initialized")
 	}
@@ -63,6 +69,12 @@ func (s *Service) SetCustomerInvoiceProfile(ctx context.Context, payer identity.
 // is stored. Existing operator configuration is left unchanged. The returned
 // boolean is true only when this call committed a new profile.
 func (s *Service) EnsureCustomerInvoiceProfile(ctx context.Context, payer identity.CustomerID, p InvoiceProfileDTO) (bool, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return false, pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return false, fmt.Errorf("service not initialized")
 	}
@@ -85,6 +97,12 @@ func (s *Service) EnsureCustomerInvoiceProfile(ctx context.Context, payer identi
 
 // GetCustomerInvoiceProfile returns a payer's invoicing profile (nil = none).
 func (s *Service) GetCustomerInvoiceProfile(ctx context.Context, payer identity.CustomerID) (*InvoiceProfileDTO, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return nil, fmt.Errorf("service not initialized")
 	}
@@ -105,6 +123,12 @@ func (s *Service) GetCustomerInvoiceProfile(ctx context.Context, payer identity.
 // EnsureUsageProduct idempotently ensures a catalog product for host-owned
 // usage rate cards, returning its (deterministic) id.
 func (s *Service) EnsureUsageProduct(ctx context.Context, key, displayName string) (uuid.UUID, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return uuid.UUID{}, pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return uuid.Nil, fmt.Errorf("service not initialized")
 	}
@@ -137,6 +161,12 @@ type UsageMeterSpec struct {
 
 // EnsureUsageMeter idempotently declares a host-owned catalog meter.
 func (s *Service) EnsureUsageMeter(ctx context.Context, spec UsageMeterSpec) error {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return fmt.Errorf("service not initialized")
 	}
@@ -163,6 +193,12 @@ type UsageRateCardInput struct {
 // SetUsageRateCard upserts an in_arrears usage rate card: the merchant
 // default (ProductID set) or a negotiated per-payer override (Payer set).
 func (s *Service) SetUsageRateCard(ctx context.Context, in UsageRateCardInput) error {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return fmt.Errorf("service not initialized")
 	}
@@ -177,6 +213,12 @@ func (s *Service) SetUsageRateCard(ctx context.Context, in UsageRateCardInput) e
 
 // DeletePayerRateCard removes a payer's negotiated override for a meter.
 func (s *Service) DeletePayerRateCard(ctx context.Context, payer identity.CustomerID, meterKey string) error {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return fmt.Errorf("service not initialized")
 	}
@@ -187,6 +229,12 @@ func (s *Service) DeletePayerRateCard(ctx context.Context, payer identity.Custom
 // items (watermarked; safe to repeat) so arrears exposure stays fresh
 // mid-period without finalizing an invoice.
 func (s *Service) SweepUsage(ctx context.Context, payer identity.CustomerID, currency string, from, to time.Time) error {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return fmt.Errorf("service not initialized")
 	}
@@ -212,6 +260,12 @@ type PendingChargeDTO struct {
 // ListPendingCharges returns a payer's accrued-but-uninvoiced owed items —
 // the current-period running spend after a SweepUsage.
 func (s *Service) ListPendingCharges(ctx context.Context, payer identity.CustomerID, currency string) ([]PendingChargeDTO, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return nil, fmt.Errorf("service not initialized")
 	}
@@ -257,6 +311,12 @@ func (s *Service) GetOutstandingOwed(ctx context.Context, payer identity.Custome
 // MarkInvoicesPastDue flips the merchant's overdue open receivables to
 // past_due (the host-visible dunning signal). Returns the number flipped.
 func (s *Service) MarkInvoicesPastDue(ctx context.Context, now time.Time) (int, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return 0, pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return 0, fmt.Errorf("service not initialized")
 	}
@@ -324,6 +384,12 @@ func (s *Service) ResolveUnknownInvoiceCollections(ctx context.Context) (Invoice
 // settle at the provider, unparking can lead to a second charge — confirm
 // provider-side first.
 func (s *Service) UnparkInvoiceCollection(ctx context.Context, payer identity.CustomerID, invoiceID uuid.UUID) error {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return fmt.Errorf("service not initialized")
 	}
@@ -333,6 +399,12 @@ func (s *Service) UnparkInvoiceCollection(ctx context.Context, payer identity.Cu
 // RecordOutOfBandInvoicePayment applies a manual remittance (wire/check) to a
 // send_invoice (or any open) receivable. reference dedups replays.
 func (s *Service) RecordOutOfBandInvoicePayment(ctx context.Context, payer identity.CustomerID, invoiceID uuid.UUID, amount int64, reference string) (*InvoiceDTO, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return nil, fmt.Errorf("service not initialized")
 	}

--- a/pkg/service/merchant_pin.go
+++ b/pkg/service/merchant_pin.go
@@ -1,0 +1,34 @@
+package service
+
+import (
+	"context"
+	"fmt"
+)
+
+// pin puts this call on a merchant-scoped connection for its whole duration, so
+// every read it makes carries `app.merchant_id` and RLS answers with the
+// merchant's rows instead of none.
+//
+// It is on EVERY exported method that reaches the database, not only the ones a
+// host was told to wrap. There is no privileged pool (or#868): under the
+// or#885-mandated `openrails_app` role an unpinned read of a policied table
+// returns ZERO ROWS AND NO ERROR — "source price: no rows" about a price the
+// caller had just written (or#900). Half this facade already pinned itself (the
+// money surfaces, #227) and half relied on the caller, so a host could not tell
+// from the outside which half it was talking to, and the half that did not pin
+// failed by answering nothing rather than by failing.
+//
+// It nests, so there is nothing to weigh: on the HTTP path MerchantDBConnMW has
+// already pinned and this is a no-op; a host that wraps a block of calls in
+// embedded.RunInMerchant keeps ONE connection for the whole block; a River
+// worker inherits its RunInMerchantScope pin. It pins a connection, not a
+// transaction — no BEGIN, no locks held across a rail call.
+//
+// A caller with no merchant on the context gets a loud error here instead of an
+// empty result, which is the whole point.
+func (s *Service) pin(ctx context.Context) (context.Context, func(), error) {
+	if s == nil || s.rt == nil || s.rt.DB == nil {
+		return ctx, func() {}, fmt.Errorf("billing service: not initialized")
+	}
+	return s.rt.DB.WithMerchantConn(ctx)
+}

--- a/pkg/service/merchant_pin_lint_test.go
+++ b/pkg/service/merchant_pin_lint_test.go
@@ -1,0 +1,135 @@
+package service
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// or#900: every exported *Service method that can reach the database must pin a
+// merchant-scoped connection itself.
+//
+// This exists because the failure it prevents is SILENT. There is no privileged
+// pool (or#868): under the or#885-mandated openrails_app role a read of a
+// policied table on an unpinned handle matches `merchant_id = NULL` and returns
+// ZERO ROWS AND NO ERROR. That is how PreviewPlanMigration shipped, passed its
+// tests, and told a host "source price: no rows" about a price the host had just
+// written — the facade half that pinned (the money surfaces, #227) and the half
+// that relied on the caller were indistinguishable from the outside.
+//
+// The rule is deliberately syntactic and local: the method body must call
+// s.pin(ctx) (the prologue) or open a scope itself (RunInMerchantConn /
+// MerchantTx / RunInTx-inside-a-scope …). "The module service handles it" is
+// exactly the belief that produced or#862, so cross-package delegation does not
+// count — an exemption has to be written down here with its reason.
+var facadeMethodsWithoutAPin = map[string]string{
+	"GetCredits":         "returns an error unconditionally (currency is required; use GetCreditsByType) — touches nothing",
+	"GetSupportedTokens": "reads the merchant's Solana rail CONFIG off the runtime, never a table",
+	"HandleWebhook":      "the merchant is not known until the payload is authenticated; the webhook path pins after it resolves one",
+	"ReleaseHold":        "frees a Redis reservation (#513); the durable ledger is untouched",
+}
+
+var pinners = []string{"pin", "RunInMerchantConn", "RunInMerchantScope", "MerchantTx", "WithMerchantConn"}
+
+func TestEveryExportedFacadeMethodPinsAMerchantConnection(t *testing.T) {
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	var unpinned []string
+	seen := map[string]bool{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(".", name), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || fn.Recv == nil || len(fn.Recv.List) == 0 {
+				continue
+			}
+			if facadeReceiver(fn.Recv.List[0].Type) != "Service" || !fn.Name.IsExported() {
+				continue
+			}
+			seen[fn.Name.Name] = true
+			if _, exempt := facadeMethodsWithoutAPin[fn.Name.Name]; exempt {
+				continue
+			}
+			if !callsAPinner(fn.Body) {
+				unpinned = append(unpinned, fn.Name.Name+" ("+name+")")
+			}
+		}
+	}
+
+	if len(unpinned) > 0 {
+		sort.Strings(unpinned)
+		t.Errorf(`or#900: these exported facade methods reach the database without pinning a merchant connection:
+
+  %s
+
+Under openrails_app an unpinned read of a policied table returns ZERO ROWS AND
+NO ERROR — the call appears to succeed and answers nothing.
+
+Fix it by opening the method with the prologue:
+
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return …, pinErr
+	}
+	defer release()
+
+or, if the method genuinely touches no table, add it to
+facadeMethodsWithoutAPin WITH the reason.`, strings.Join(unpinned, "\n  "))
+	}
+
+	for m := range facadeMethodsWithoutAPin {
+		if !seen[m] {
+			t.Errorf("or#900: %q is exempted but is no longer an exported *Service method; delete the exemption", m)
+		}
+	}
+}
+
+func facadeReceiver(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		return facadeReceiver(t.X)
+	}
+	return ""
+}
+
+func callsAPinner(body *ast.BlockStmt) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		var name string
+		switch fun := call.Fun.(type) {
+		case *ast.SelectorExpr:
+			name = fun.Sel.Name
+		case *ast.Ident:
+			name = fun.Name
+		}
+		for _, p := range pinners {
+			if name == p {
+				found = true
+			}
+		}
+		return true
+	})
+	return found
+}

--- a/pkg/service/plan_migration.go
+++ b/pkg/service/plan_migration.go
@@ -14,6 +14,14 @@ import (
 // drive the operator workflow in-process — same service the merchant HTTP
 // routes wrap. Requests/results are the module types re-exported so embedded
 // callers never import internal/.
+//
+// Every method here pins a merchant-scoped connection the way the money
+// surfaces do (spend.go). Without it, a host calling in-process under the
+// or#885-mandated openrails_app role read NOTHING — the reads resolved to the
+// base pool, where `app.merchant_id` is unset, so RLS answered zero rows and no
+// error and Preview reported "source price: no rows" about a price the same
+// host had just written (or#900). RunInMerchantConn reuses an already-pinned
+// connection, so this is correct from a request, a worker, or a bare Go call.
 
 // PlanMigrationRequest re-exports the operator request.
 type PlanMigrationRequest = subscriptions.PlanMigrationRequest
@@ -49,7 +57,13 @@ func (s *Service) PreviewPlanMigration(ctx context.Context, req PlanMigrationReq
 	if err != nil {
 		return nil, err
 	}
-	return pm.Preview(ctx, req)
+	var out *PlanMigrationResult
+	err = s.rt.DB.RunInMerchantConn(ctx, func(ctx context.Context) error {
+		var e error
+		out, e = pm.Preview(ctx, req)
+		return e
+	})
+	return out, err
 }
 
 // PlanMigrate commits a plan migration: batch header + per-subscription rows,
@@ -59,7 +73,13 @@ func (s *Service) PlanMigrate(ctx context.Context, req PlanMigrationRequest) (*P
 	if err != nil {
 		return nil, err
 	}
-	return pm.Migrate(ctx, req)
+	var out *PlanMigrationResult
+	err = s.rt.DB.RunInMerchantConn(ctx, func(ctx context.Context) error {
+		var e error
+		out, e = pm.Migrate(ctx, req)
+		return e
+	})
+	return out, err
 }
 
 // GetPlanMigration returns one migration batch header + its ledger rows.
@@ -68,7 +88,14 @@ func (s *Service) GetPlanMigration(ctx context.Context, batchID uuid.UUID, limit
 	if err != nil {
 		return nil, nil, err
 	}
-	return pm.GetBatch(ctx, batchID, limit, offset)
+	var batch *models.RepriceBatch
+	var rows []*models.SubscriptionReprice
+	err = s.rt.DB.RunInMerchantConn(ctx, func(ctx context.Context) error {
+		var e error
+		batch, rows, e = pm.GetBatch(ctx, batchID, limit, offset)
+		return e
+	})
+	return batch, rows, err
 }
 
 // CancelPlanMigration cancels every still-scheduled row in the batch. The
@@ -79,5 +106,11 @@ func (s *Service) CancelPlanMigration(ctx context.Context, batchID uuid.UUID) (*
 	if err != nil {
 		return nil, err
 	}
-	return pm.CancelBatch(ctx, batchID)
+	var out *PlanMigrationCancelResult
+	err = s.rt.DB.RunInMerchantConn(ctx, func(ctx context.Context) error {
+		var e error
+		out, e = pm.CancelBatch(ctx, batchID)
+		return e
+	})
+	return out, err
 }

--- a/pkg/service/plan_migration_rls_integration_test.go
+++ b/pkg/service/plan_migration_rls_integration_test.go
@@ -1,0 +1,163 @@
+//go:build integration
+
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/app"
+	"github.com/open-rails/openrails/internal/db"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/internal/modules/catalog"
+	"github.com/open-rails/openrails/internal/modules/entitlements"
+	"github.com/open-rails/openrails/internal/modules/merchantconfig"
+	"github.com/open-rails/openrails/internal/modules/money"
+	"github.com/open-rails/openrails/internal/modules/subscriptions"
+	"github.com/open-rails/openrails/pkg/merchant"
+	billingservice "github.com/open-rails/openrails/pkg/service"
+)
+
+// or#900 item 1: the plan-migration facade under the or#885-mandated
+// openrails_app role, called the way an embedding host calls it — a merchant on
+// the context and NOTHING pinned upstream (no HTTP middleware, no
+// embedded.RunInMerchant).
+//
+// Before the fix PreviewPlanMigration/PlanMigrate read on the base pool, where
+// `app.merchant_id` is unset, so every RLS-forced read matched merchant_id =
+// NULL. The price the SAME facade had just written was invisible and Preview
+// answered "plan migration: source price: no rows in result set". This test
+// fails that way without the RunInMerchantConn wrap in plan_migration.go.
+func TestPlanMigrationFacade_RLS_Under_OpenRailsApp(t *testing.T) {
+	ctx := context.Background()
+	superDSN, appRoleDSN := dbtest.SharedRLSPostgres(t)
+
+	merchantID := uuid.NewString()
+	super, err := db.NewDB(&config.DBConfig{URL: superDSN})
+	require.NoError(t, err)
+	defer super.Close()
+	_, err = super.Pool().Exec(ctx,
+		`INSERT INTO openrails.merchants (id, slug) VALUES ($1, $2) ON CONFLICT (id) DO NOTHING`,
+		merchantID, "merchant-pm-"+merchantID[:8])
+	require.NoError(t, err)
+
+	appDB, err := db.NewDB(&config.DBConfig{URL: appRoleDSN})
+	require.NoError(t, err)
+	defer appDB.Close()
+	posture, err := appDB.CheckRLSPosture(ctx)
+	require.NoError(t, err)
+	require.True(t, posture.Enforcing, "the whole point is the role RLS constrains")
+
+	clock := clockwork.NewRealClock()
+	products := catalog.NewProductService(appDB)
+	prices := catalog.NewPriceService(appDB)
+	subs := subscriptions.NewSubscriptionService(appDB, prices, products, nil, clock)
+	reprice := subscriptions.NewRepriceService(
+		appDB,
+		subscriptions.NewRepriceRepo(appDB),
+		prices,
+		subs,
+		subscriptions.NewNotificationService(appDB, nil),
+		merchantconfig.NewStore(appDB),
+		clock,
+	)
+	rt := &app.Runtime{
+		DB:                   appDB,
+		MoneyService:         money.NewMoneyService(appDB),
+		EntitlementService:   entitlements.NewEntitlementService(appDB),
+		ProductService:       products,
+		PriceService:         prices,
+		SubscriptionService:  subs,
+		PlanMigrationService: subscriptions.NewPlanMigrationService(reprice, nil, nil, nil),
+		Clock:                clock,
+	}
+	svc, err := billingservice.New(rt)
+	require.NoError(t, err)
+
+	// A merchant on the context and nothing else — exactly what a host has.
+	mctx := merchant.WithID(ctx, mustMerchantID(t, merchantID))
+
+	sourceProduct, err := svc.CreateProduct(mctx, billingservice.CreateProductRequest{
+		Key: "or900-source", DisplayName: "or900 source",
+	})
+	require.NoError(t, err, "CreateProduct must work under openrails_app")
+	targetProduct, err := svc.CreateProduct(mctx, billingservice.CreateProductRequest{
+		Key: "or900-target", DisplayName: "or900 target",
+	})
+	require.NoError(t, err)
+
+	hours := 720
+	sourcePrice, err := svc.CreatePrice(mctx, billingservice.CreatePriceRequest{
+		ProductID: sourceProduct.ID, UnitAmount: 10_000_000, Currency: "usd",
+		AccessDurationHours: &hours, AutoRenew: true,
+	})
+	require.NoError(t, err, "CreatePrice must work under openrails_app")
+	targetPrice, err := svc.CreatePrice(mctx, billingservice.CreatePriceRequest{
+		ProductID: targetProduct.ID, UnitAmount: 12_000_000, Currency: "usd",
+		AccessDurationHours: &hours, AutoRenew: true,
+	})
+	require.NoError(t, err)
+
+	// The whole defect in one call: a preview of a price this facade wrote a
+	// moment ago, on the same role, with no upstream pin.
+	res, err := svc.PreviewPlanMigration(mctx, billingservice.PlanMigrationRequest{
+		SourcePriceID: sourcePrice.ID,
+		TargetPriceID: targetPrice.ID,
+	})
+	require.NoError(t, err, "PreviewPlanMigration must SEE the price it just wrote (or#900)")
+	require.NotNil(t, res)
+	require.Equal(t, sourcePrice.ID, res.SourcePriceID)
+	require.Equal(t, targetPrice.ID, res.TargetPriceID)
+	require.Equal(t, 0, res.Matched, "no subscriptions on the source price yet")
+
+	// Commit the same migration: the write path resolves the same rows.
+	archive := false
+	committed, err := svc.PlanMigrate(mctx, billingservice.PlanMigrationRequest{
+		SourcePriceID: sourcePrice.ID,
+		TargetPriceID: targetPrice.ID,
+		ArchiveSource: &archive,
+	})
+	require.NoError(t, err, "PlanMigrate must resolve the same prices under openrails_app")
+	require.NotNil(t, committed)
+	require.NotNil(t, committed.BatchID)
+	require.NotEqual(t, uuid.Nil, *committed.BatchID)
+
+	// And the batch is readable back through the facade, still unpinned.
+	batch, rows, err := svc.GetPlanMigration(mctx, *committed.BatchID, 50, 0)
+	require.NoError(t, err, "GetPlanMigration must find the batch it just wrote")
+	require.NotNil(t, batch)
+	require.Empty(t, rows, "empty cohort means no per-subscription ledger rows")
+}
+
+// TestFacadeRefusesWithoutAMerchant proves the OTHER half of the fix: with no
+// merchant on the context the facade now FAILS instead of answering an empty
+// result. Silence was the bug — a host could not tell "nothing matched" from
+// "you read the wrong connection".
+func TestFacadeRefusesWithoutAMerchant(t *testing.T) {
+	ctx := context.Background()
+	_, appRoleDSN := dbtest.SharedRLSPostgres(t)
+
+	appDB, err := db.NewDB(&config.DBConfig{URL: appRoleDSN})
+	require.NoError(t, err)
+	defer appDB.Close()
+
+	rt := &app.Runtime{
+		DB:                 appDB,
+		MoneyService:       money.NewMoneyService(appDB),
+		EntitlementService: entitlements.NewEntitlementService(appDB),
+		ProductService:     catalog.NewProductService(appDB),
+		PriceService:       catalog.NewPriceService(appDB),
+		Clock:              clockwork.NewRealClock(),
+	}
+	svc, err := billingservice.New(rt)
+	require.NoError(t, err)
+
+	_, err = svc.GetProduct(ctx, uuid.New())
+	require.Error(t, err, "an unscoped facade read must fail loudly, not return nothing")
+	require.Contains(t, err.Error(), "merchant")
+}

--- a/pkg/service/price_key.go
+++ b/pkg/service/price_key.go
@@ -56,6 +56,12 @@ func resolvePriceKey(product *models.Product, req CreatePriceRequest) string {
 // row for that key. Used wherever checkout/API accept a price_key alongside a
 // price UUID.
 func (s *Service) GetPriceByKey(ctx context.Context, key string) (*CatalogPrice, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	prices, err := s.requirePriceService()
 	if err != nil {
 		return nil, err
@@ -86,6 +92,12 @@ func (s *Service) GetPriceByKey(ctx context.Context, key string) (*CatalogPrice,
 // repoint invariant CreatePrice/ActivatePrice enforce), so a rename can also
 // double as a manual repoint.
 func (s *Service) SetPriceKey(ctx context.Context, priceID uuid.UUID, key string) (*CatalogPrice, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	prices, err := s.requirePriceService()
 	if err != nil {
 		return nil, err
@@ -148,6 +160,12 @@ type PriceKeyHistoryEntry struct {
 // wrong for a REACTIVATED row: its created_at is its ORIGINAL creation, not
 // the date it most recently became current again).
 func (s *Service) GetPriceKeyHistory(ctx context.Context, key string) ([]PriceKeyHistoryEntry, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	prices, err := s.requirePriceService()
 	if err != nil {
 		return nil, err
@@ -184,6 +202,12 @@ func (s *Service) GetPriceKeyHistory(ctx context.Context, key string) ([]PriceKe
 // does not parse as a UUID, so a key that happens to collide with UUID syntax
 // can never occur (uuid.Parse is total over its own format).
 func (s *Service) ResolvePriceReference(ctx context.Context, ref string) (*CatalogPrice, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	ref = strings.TrimSpace(ref)
 	if ref == "" {
 		return nil, fmt.Errorf("price reference required")

--- a/pkg/service/product_access.go
+++ b/pkg/service/product_access.go
@@ -33,6 +33,12 @@ type ProductAccessRecord struct {
 
 // ListProductAccess lists active product-access grants for a host subject.
 func (s *Service) ListProductAccess(ctx context.Context, userID string) ([]ProductAccessRecord, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	userID = strings.TrimSpace(userID)
 	if userID == "" {
 		return nil, fmt.Errorf("user_id required")
@@ -49,6 +55,12 @@ func (s *Service) ListProductAccess(ctx context.Context, userID string) ([]Produ
 
 // HasProductAccess reports whether a host subject can access a product.
 func (s *Service) HasProductAccess(ctx context.Context, userID string, productID uuid.UUID) (bool, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return false, pinErr
+	}
+	defer release()
+
 	userID = strings.TrimSpace(userID)
 	if userID == "" {
 		return false, fmt.Errorf("user_id required")

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -47,6 +47,14 @@ func (s *Service) now() time.Time {
 
 var ErrInsufficientCredits = money.ErrInsufficientCredits
 
+// ErrIdempotencyKeyReused is the money-write refusal a caller can act on: the
+// key already committed, and THIS retry carries different charging terms
+// (or#891). It is re-exported here because the rule lives in internal/ — a host
+// could see the failure but not name it, so it could not tell a caller bug
+// apart from an engine fault. Wrapped errors carry the detail
+// (money.IdempotencyConflict: which field, committed vs retried).
+var ErrIdempotencyKeyReused = money.ErrIdempotencyKeyReused
+
 type CaptureHoldRequest struct {
 	RequestID string
 	Amount    int64
@@ -115,6 +123,12 @@ type WithdrawCreditsRequest struct {
 }
 
 func (s *Service) WithdrawCredits(ctx context.Context, req WithdrawCreditsRequest) (*CreditTransaction, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	req.Invoker = strings.TrimSpace(req.Invoker)
 	req.Source = strings.TrimSpace(req.Source)
 	if req.CustomerID == nil || req.CustomerID.IsZero() {
@@ -188,6 +202,12 @@ type DepositCreditsRequest struct {
 }
 
 func (s *Service) DepositCredits(ctx context.Context, req DepositCreditsRequest) (*CreditTransaction, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	req.Invoker = strings.TrimSpace(req.Invoker)
 	if req.CustomerID == nil || req.CustomerID.IsZero() {
 		return nil, fmt.Errorf("customer_id required")
@@ -241,6 +261,12 @@ func (s *Service) DepositCredits(ctx context.Context, req DepositCreditsRequest)
 }
 
 func (s *Service) CaptureHold(ctx context.Context, req CaptureHoldRequest) (*CreditTransaction, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	req.RequestID = strings.TrimSpace(req.RequestID)
 	if req.RequestID == "" {
 		return nil, fmt.Errorf("request_id required")
@@ -386,6 +412,12 @@ type ServiceUsageRollupRequest struct {
 // window (#311) — the OpenRails-sourced data behind the platform's
 // /budget-usage + revenue analytics. Service-scoped (operator API key).
 func (s *Service) ServiceUsageRollup(ctx context.Context, req ServiceUsageRollupRequest) ([]ServiceUsageRollupRow, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	if req.CustomerID == nil || req.CustomerID.IsZero() {
 		return nil, fmt.Errorf("customer_id required")
 	}
@@ -415,6 +447,12 @@ type ResourceRevenueDailyRow struct {
 // attribution column) across all payers in the merchant over [from, to) — powers
 // tensorhub endpoint revenue analytics (#410).
 func (s *Service) ResourceRevenueDaily(ctx context.Context, resource, currency string, from, to time.Time) ([]ResourceRevenueDailyRow, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	currency, err := requireCurrency(currency)
 	if err != nil {
 		return nil, err
@@ -465,6 +503,12 @@ func serviceMerchantID(ctx context.Context) (string, error) {
 }
 
 func (s *Service) ListActiveEntitlements(ctx context.Context, userID string, at time.Time) ([]string, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	userID = strings.TrimSpace(userID)
 	if userID == "" {
 		return nil, fmt.Errorf("user_id required")
@@ -476,6 +520,12 @@ func (s *Service) ListActiveEntitlements(ctx context.Context, userID string, at 
 }
 
 func (s *Service) ListActiveEntitlementsForCustomer(ctx context.Context, tenantSubjectID identity.CustomerID, at time.Time) ([]string, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	if tenantSubjectID.IsZero() {
 		return nil, fmt.Errorf("customer_id required")
 	}
@@ -486,6 +536,12 @@ func (s *Service) ListActiveEntitlementsForCustomer(ctx context.Context, tenantS
 }
 
 func (s *Service) IsCustomerEntitled(ctx context.Context, tenantSubjectID identity.CustomerID, entitlement string, at time.Time) (bool, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return false, pinErr
+	}
+	defer release()
+
 	if tenantSubjectID.IsZero() {
 		return false, fmt.Errorf("customer_id required")
 	}
@@ -500,6 +556,12 @@ func (s *Service) IsCustomerEntitled(ctx context.Context, tenantSubjectID identi
 }
 
 func (s *Service) HasActiveIndefiniteEntitlementForCustomer(ctx context.Context, tenantSubjectID identity.CustomerID, entitlement string, at time.Time) (bool, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return false, pinErr
+	}
+	defer release()
+
 	if tenantSubjectID.IsZero() {
 		return false, fmt.Errorf("customer_id required")
 	}
@@ -514,6 +576,12 @@ func (s *Service) HasActiveIndefiniteEntitlementForCustomer(ctx context.Context,
 }
 
 func (s *Service) LatestFiniteEntitlementWindowForCustomer(ctx context.Context, tenantSubjectID identity.CustomerID, entitlement string, at time.Time) (*EntitlementRecord, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	if tenantSubjectID.IsZero() {
 		return nil, fmt.Errorf("customer_id required")
 	}
@@ -548,6 +616,12 @@ type EntitlementRecord struct {
 }
 
 func (s *Service) ListActiveEntitlementRecords(ctx context.Context, userID string, at time.Time) ([]EntitlementRecord, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	userID = strings.TrimSpace(userID)
 	if userID == "" {
 		return nil, fmt.Errorf("user_id required")
@@ -585,6 +659,12 @@ func (s *Service) ListActiveEntitlementRecords(ctx context.Context, userID strin
 }
 
 func (s *Service) ListActiveEntitlementRecordsForCustomer(ctx context.Context, tenantSubjectID identity.CustomerID, at time.Time) ([]EntitlementRecord, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	if tenantSubjectID.IsZero() {
 		return nil, fmt.Errorf("customer_id required")
 	}
@@ -632,6 +712,12 @@ const EntitlementsBatchMaxSubjects = 500
 // an active window of `entitlement` for the merchant, keyset-paginated (afterID
 // exclusive; uuid.Nil starts). A zero `at` means now.
 func (s *Service) ListCustomersWithEntitlement(ctx context.Context, entitlement string, at time.Time, afterID uuid.UUID, limit int) ([]uuid.UUID, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	if at.IsZero() {
 		at = s.now().UTC()
 	}
@@ -639,6 +725,12 @@ func (s *Service) ListCustomersWithEntitlement(ctx context.Context, entitlement 
 }
 
 func (s *Service) ListActiveEntitlementRecordsByExternalSubjects(ctx context.Context, subjects []string, at time.Time) (map[string][]EntitlementRecord, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	if len(subjects) == 0 {
 		return map[string][]EntitlementRecord{}, nil
 	}

--- a/pkg/service/service_admin.go
+++ b/pkg/service/service_admin.go
@@ -23,6 +23,12 @@ import (
 
 // AdminGetSubscriptions returns a paginated list of all subscriptions.
 func (s *Service) AdminGetSubscriptions(ctx context.Context, opts AdminGetSubscriptionsOptions) (*PaginatedResult[Subscription], error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	adminSubscriptions, err := s.requireAdminSubscriptionService()
 	if err != nil {
 		return nil, err
@@ -67,6 +73,12 @@ func (s *Service) AdminGetSubscriptions(ctx context.Context, opts AdminGetSubscr
 
 // AdminGetSubscription returns a single subscription by ID.
 func (s *Service) AdminGetSubscription(ctx context.Context, subscriptionID uuid.UUID) (*Subscription, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	adminSubscriptions, err := s.requireAdminSubscriptionService()
 	if err != nil {
 		return nil, err
@@ -87,6 +99,12 @@ func (s *Service) AdminGetSubscription(ctx context.Context, subscriptionID uuid.
 // AdminCancelSubscription cancels a subscription by ID. revokeAccess controls
 // whether subscription/grace entitlements are revoked immediately.
 func (s *Service) AdminCancelSubscription(ctx context.Context, subscriptionID uuid.UUID, reason string, revokeAccess bool) error {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return pinErr
+	}
+	defer release()
+
 	adminSubscriptions, err := s.requireAdminSubscriptionService()
 	if err != nil {
 		return err
@@ -102,6 +120,12 @@ func (s *Service) AdminCancelSubscription(ctx context.Context, subscriptionID uu
 
 // AdminGetPayments returns a paginated list of all payments.
 func (s *Service) AdminGetPayments(ctx context.Context, opts AdminGetPaymentsOptions) (*PaginatedResult[Payment], error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	paymentsService, err := s.requirePaymentService()
 	if err != nil {
 		return nil, err
@@ -155,6 +179,12 @@ func (s *Service) AdminGetPayments(ctx context.Context, opts AdminGetPaymentsOpt
 
 // AdminGetPayment returns a single payment by ID with refund details.
 func (s *Service) AdminGetPayment(ctx context.Context, paymentID uuid.UUID) (*Payment, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	paymentsService, err := s.requirePaymentService()
 	if err != nil {
 		return nil, err
@@ -180,6 +210,12 @@ func (s *Service) AdminGetPayment(ctx context.Context, paymentID uuid.UUID) (*Pa
 
 // AdminRefundPayment issues a refund for a payment.
 func (s *Service) AdminRefundPayment(ctx context.Context, paymentID uuid.UUID, req RefundPaymentRequest) (*Payment, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	paymentsService, err := s.requirePaymentService()
 	if err != nil {
 		return nil, err
@@ -205,6 +241,12 @@ func (s *Service) AdminRefundPayment(ctx context.Context, paymentID uuid.UUID, r
 
 // AdminGetUserPayments returns payments for a specific user.
 func (s *Service) AdminGetUserPayments(ctx context.Context, userID string, opts AdminGetPaymentsOptions) (*PaginatedResult[Payment], error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	if _, err := s.requirePaymentService(); err != nil {
 		return nil, err
 	}
@@ -219,6 +261,12 @@ func (s *Service) AdminGetUserPayments(ctx context.Context, userID string, opts 
 
 // AdminCreateOffChannelPayment creates a payment record for an off-channel payment.
 func (s *Service) AdminCreateOffChannelPayment(ctx context.Context, req AdminCreateOffChannelPaymentRequest) (*Payment, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	paymentsService, err := s.requirePaymentService()
 	if err != nil {
 		return nil, err
@@ -287,6 +335,12 @@ func (s *Service) AdminCreateOffChannelPayment(ctx context.Context, req AdminCre
 
 // AdminGetUserBillingProfile returns a user's complete billing profile.
 func (s *Service) AdminGetUserBillingProfile(ctx context.Context, userID string) (*AdminUserProfile, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	userID = strings.TrimSpace(userID)
 	if userID == "" {
 		return nil, fmt.Errorf("user_id required")
@@ -336,6 +390,12 @@ func (s *Service) AdminGetUserBillingProfile(ctx context.Context, userID string)
 
 // AdminGetUserEntitlements returns entitlements for a user.
 func (s *Service) AdminGetUserEntitlements(ctx context.Context, userID string, at *time.Time) ([]EntitlementRecord, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	entitlements := s.entitlementService()
 	if entitlements == nil {
 		return nil, fmt.Errorf("billing service: not initialized")
@@ -365,6 +425,12 @@ func (s *Service) AdminGetUserEntitlements(ctx context.Context, userID string, a
 
 // EntitlementGrantEntitlement grants an entitlement to a user.
 func (s *Service) EntitlementGrantEntitlement(ctx context.Context, adminUserID string, req EntitlementGrantEntitlementRequest) (*EntitlementRecord, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	if _, dbErr := s.requireDB(); dbErr != nil {
 		return nil, dbErr
 	}
@@ -429,6 +495,12 @@ func (s *Service) EntitlementGrantEntitlement(ctx context.Context, adminUserID s
 
 // AdminRevokeEntitlement revokes an entitlement.
 func (s *Service) AdminRevokeEntitlement(ctx context.Context, userID string, entitlementID uuid.UUID, req AdminRevokeEntitlementRequest) error {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return pinErr
+	}
+	defer release()
+
 	entitlements := s.entitlementService()
 	if entitlements == nil {
 		return fmt.Errorf("billing service: not initialized")

--- a/pkg/service/service_definition_catalog.go
+++ b/pkg/service/service_definition_catalog.go
@@ -134,6 +134,12 @@ type CreateProductRequest struct {
 }
 
 func (s *Service) CreateProduct(ctx context.Context, req CreateProductRequest) (*CatalogProduct, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	products, err := s.requireProductService()
 	if err != nil {
 		return nil, err
@@ -196,6 +202,12 @@ type UpdateProductRequest struct {
 }
 
 func (s *Service) UpdateProduct(ctx context.Context, productID uuid.UUID, req UpdateProductRequest) (*CatalogProduct, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	products, err := s.requireProductService()
 	if err != nil {
 		return nil, err
@@ -483,6 +495,12 @@ func (req CreatePriceRequest) RecurringCycleDays() *int {
 }
 
 func (s *Service) CreatePrice(ctx context.Context, req CreatePriceRequest) (*CatalogPrice, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	products, prices, err := s.requireCatalogServices()
 	if err != nil {
 		return nil, err
@@ -681,6 +699,12 @@ type UpdatePriceRequest struct {
 }
 
 func (s *Service) UpdatePrice(ctx context.Context, priceID uuid.UUID, req UpdatePriceRequest) (*CatalogPrice, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	prices, err := s.requirePriceService()
 	if err != nil {
 		return nil, err

--- a/pkg/service/service_definition_catalog_admin.go
+++ b/pkg/service/service_definition_catalog_admin.go
@@ -39,6 +39,12 @@ func clampCatalogPage(limit, offset int) (int, int) {
 
 // GetProduct returns a product by ID.
 func (s *Service) GetProduct(ctx context.Context, productID uuid.UUID) (*CatalogProduct, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	products, err := s.requireProductService()
 	if err != nil {
 		return nil, err
@@ -55,6 +61,12 @@ func (s *Service) GetProduct(ctx context.Context, productID uuid.UUID) (*Catalog
 
 // GetProductByKey returns a product by its key.
 func (s *Service) GetProductByKey(ctx context.Context, key string) (*CatalogProduct, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	products, err := s.requireProductService()
 	if err != nil {
 		return nil, err
@@ -87,6 +99,12 @@ type ListProductsOptions struct {
 // ListProducts returns a paginated list of products with optional filters.
 // Total is the unfiltered-by-pagination count.
 func (s *Service) ListProducts(ctx context.Context, opts ListProductsOptions) (items []CatalogProduct, total int64, err error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, 0, pinErr
+	}
+	defer release()
+
 	products, err := s.requireProductService()
 	if err != nil {
 		return nil, 0, err
@@ -120,6 +138,12 @@ func (s *Service) ListProducts(ctx context.Context, opts ListProductsOptions) (i
 
 // ActivateProduct sets status=active on a product.
 func (s *Service) ActivateProduct(ctx context.Context, productID uuid.UUID) (*CatalogProduct, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	products, err := s.requireProductService()
 	if err != nil {
 		return nil, err
@@ -143,6 +167,12 @@ func (s *Service) ActivateProduct(ctx context.Context, productID uuid.UUID) (*Ca
 // DeactivateProduct archives a product. Existing subscriptions on its prices
 // are grandfathered and keep billing.
 func (s *Service) DeactivateProduct(ctx context.Context, productID uuid.UUID) (*CatalogProduct, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	products, err := s.requireProductService()
 	if err != nil {
 		return nil, err
@@ -164,6 +194,12 @@ func (s *Service) DeactivateProduct(ctx context.Context, productID uuid.UUID) (*
 
 // GetPrice returns a price by ID.
 func (s *Service) GetPrice(ctx context.Context, priceID uuid.UUID) (*CatalogPrice, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	prices, err := s.requirePriceService()
 	if err != nil {
 		return nil, err
@@ -180,6 +216,12 @@ func (s *Service) GetPrice(ctx context.Context, priceID uuid.UUID) (*CatalogPric
 
 // ListPricesByProduct returns all prices belonging to a product. Set activeOnly=true to filter inactive.
 func (s *Service) ListPricesByProduct(ctx context.Context, productID uuid.UUID, activeOnly bool) ([]CatalogPrice, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	prices, err := s.requirePriceService()
 	if err != nil {
 		return nil, err
@@ -205,6 +247,12 @@ func (s *Service) ListPricesByProduct(ctx context.Context, productID uuid.UUID, 
 
 // ListPrices returns a paginated list of prices across all products, with filters.
 func (s *Service) ListPrices(ctx context.Context, filter catalog.PriceFilter, limit, offset int) (items []CatalogPrice, total int64, err error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, 0, pinErr
+	}
+	defer release()
+
 	prices, err := s.requirePriceService()
 	if err != nil {
 		return nil, 0, err
@@ -250,6 +298,12 @@ func (s *Service) propagatePriceActiveToStripe(ctx context.Context, price *model
 // this row is un-archived, then one pointer-movement log entry records the
 // move. Activating an already-active row is a no-op (no movement logged).
 func (s *Service) ActivatePrice(ctx context.Context, priceID uuid.UUID) (*CatalogPrice, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	prices, err := s.requirePriceService()
 	if err != nil {
 		return nil, err
@@ -300,6 +354,12 @@ func (s *Service) ActivatePrice(ctx context.Context, priceID uuid.UUID) (*Catalo
 // DeactivatePrice archives a price. Existing subscriptions on this price are
 // grandfathered and keep billing; new purchases are rejected.
 func (s *Service) DeactivatePrice(ctx context.Context, priceID uuid.UUID) (*CatalogPrice, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	prices, err := s.requirePriceService()
 	if err != nil {
 		return nil, err
@@ -324,6 +384,12 @@ func (s *Service) DeactivatePrice(ctx context.Context, priceID uuid.UUID) (*Cata
 // dispatcher merges per-provider drift / missing / configured signals into the
 // uniform ProviderState surface.
 func (s *Service) VerifyPriceSync(ctx context.Context, priceID uuid.UUID) (map[string]ProviderState, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	prices, err := s.requirePriceService()
 	if err != nil {
 		return nil, err
@@ -417,6 +483,12 @@ type ReconcileResult struct {
 // ReconcilePrice walks every attached provider and re-applies OpenRails values
 // to the remote when drift is detected. OpenRails is authoritative.
 func (s *Service) ReconcilePrice(ctx context.Context, priceID uuid.UUID, opts ReconcileOptions) (*ReconcileResult, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	prices, err := s.requirePriceService()
 	if err != nil {
 		return nil, err
@@ -546,6 +618,12 @@ type ProductReconcileResult struct {
 // provider link — the Stripe Product id is discovered via the product's prices.
 // This is the product-level analog of ReconcilePrice.
 func (s *Service) ReconcileProduct(ctx context.Context, productID uuid.UUID, opts ReconcileOptions) (*ProductReconcileResult, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	products, err := s.requireProductService()
 	if err != nil {
 		return nil, err

--- a/pkg/service/service_user.go
+++ b/pkg/service/service_user.go
@@ -34,6 +34,12 @@ import (
 
 // GetProducts returns a paginated list of products.
 func (s *Service) GetProducts(ctx context.Context, opts GetProductsOptions) (*PaginatedResult[Product], error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	publicSubscriptions, err := s.requirePublicSubscriptionService()
 	if err != nil {
 		return nil, err
@@ -70,6 +76,12 @@ func (s *Service) GetProducts(ctx context.Context, opts GetProductsOptions) (*Pa
 
 // GetPrices returns a paginated list of prices.
 func (s *Service) GetPrices(ctx context.Context, opts GetPricesOptions) (*PaginatedResult[Price], error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	prices, err := s.requirePriceService()
 	if err != nil {
 		return nil, err
@@ -301,6 +313,12 @@ func (s *Service) ConfirmCheckoutSession(ctx context.Context, userID string, ses
 
 // GetBillingStatus returns a user's overall billing status.
 func (s *Service) GetBillingStatus(ctx context.Context, userID string) (*BillingStatus, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	userID = strings.TrimSpace(userID)
 	if userID == "" {
 		return nil, fmt.Errorf("user_id required")
@@ -335,6 +353,12 @@ func (s *Service) GetBillingStatus(ctx context.Context, userID string) (*Billing
 
 // GetSubscriptions returns a user's subscriptions.
 func (s *Service) GetSubscriptions(ctx context.Context, userID string, opts GetSubscriptionsOptions) (*PaginatedResult[Subscription], error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	userSubscriptions, err := s.requireUserSubscriptionService()
 	if err != nil {
 		return nil, err
@@ -382,6 +406,12 @@ func (s *Service) GetSubscriptions(ctx context.Context, userID string, opts GetS
 
 // CancelSubscription cancels a user's active subscription.
 func (s *Service) CancelSubscription(ctx context.Context, userID string, req CancelSubscriptionRequest) (*CancelSubscriptionResult, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	userSubscriptions, err := s.requireUserSubscriptionService()
 	if err != nil {
 		return nil, err
@@ -408,6 +438,12 @@ func (s *Service) CancelSubscription(ctx context.Context, userID string, req Can
 // enqueues the same ResumeSubscriptionArgs River job the HTTP handler enqueues —
 // so the library and HTTP entrypoints execute identically.
 func (s *Service) ResumeSubscription(ctx context.Context, userID string) (*ResumeSubscriptionResult, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	userSubscriptions, err := s.requireUserSubscriptionService()
 	if err != nil {
 		return nil, err
@@ -485,6 +521,12 @@ func (s *Service) ResumeSubscription(ctx context.Context, userID string) (*Resum
 
 // UpdateSubscriptionPaymentMethod updates the payment method for a subscription.
 func (s *Service) UpdateSubscriptionPaymentMethod(ctx context.Context, userID string, req UpdateSubscriptionPaymentMethodRequest) (*UpdateSubscriptionPaymentMethodResult, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	subscriptionService, paymentMethods, err := s.requireSubscriptionAndPaymentMethodServices()
 	if err != nil {
 		return nil, err
@@ -575,6 +617,12 @@ func (s *Service) UpdateSubscriptionPaymentMethod(ctx context.Context, userID st
 
 // GetPayments returns a user's payments.
 func (s *Service) GetPayments(ctx context.Context, userID string, opts GetPaymentsOptions) (*PaginatedResult[Payment], error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	userSubscriptions, err := s.requireUserSubscriptionService()
 	if err != nil {
 		return nil, err
@@ -621,6 +669,12 @@ func (s *Service) GetPayments(ctx context.Context, userID string, opts GetPaymen
 
 // GetPaymentMethods returns a user's payment methods.
 func (s *Service) GetPaymentMethods(ctx context.Context, userID string, opts GetPaymentMethodsOptions) (*PaginatedResult[PaymentMethod], error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	paymentMethods, err := s.requirePaymentMethodService()
 	if err != nil {
 		return nil, err
@@ -659,6 +713,12 @@ func (s *Service) GetPaymentMethods(ctx context.Context, userID string, opts Get
 
 // CreatePaymentMethod creates a new payment method.
 func (s *Service) CreatePaymentMethod(ctx context.Context, userID string, req CreatePaymentMethodRequest) (*PaymentMethod, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	vaults, err := s.requireVaultService()
 	if err != nil {
 		return nil, err
@@ -697,6 +757,12 @@ func (s *Service) CreatePaymentMethod(ctx context.Context, userID string, req Cr
 
 // UpdatePaymentMethod updates an existing payment method.
 func (s *Service) UpdatePaymentMethod(ctx context.Context, userID string, paymentMethodID uuid.UUID, req UpdatePaymentMethodRequest) (*PaymentMethod, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	vaults, paymentMethods, err := s.requireVaultAndPaymentMethodServices()
 	if err != nil {
 		return nil, err
@@ -749,6 +815,12 @@ func (s *Service) UpdatePaymentMethod(ctx context.Context, userID string, paymen
 
 // DeletePaymentMethod deletes (deactivates) a payment method.
 func (s *Service) DeletePaymentMethod(ctx context.Context, userID string, paymentMethodID uuid.UUID) error {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return pinErr
+	}
+	defer release()
+
 	vaults, paymentMethods, err := s.requireVaultAndPaymentMethodServices()
 	if err != nil {
 		return err
@@ -776,6 +848,12 @@ func (s *Service) DeletePaymentMethod(ctx context.Context, userID string, paymen
 
 // GetNotifications returns a user's notifications.
 func (s *Service) GetNotifications(ctx context.Context, userID string, opts GetNotificationsOptions) (*PaginatedResult[Notification], error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	userSubscriptions, err := s.requireUserSubscriptionService()
 	if err != nil {
 		return nil, err
@@ -820,6 +898,12 @@ func (s *Service) GetNotifications(ctx context.Context, userID string, opts GetN
 
 // GetUnreadNotificationCount returns the count of unread notifications.
 func (s *Service) GetUnreadNotificationCount(ctx context.Context, userID string) (*UnreadNotificationCount, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	userSubscriptions, err := s.requireUserSubscriptionService()
 	if err != nil {
 		return nil, err
@@ -846,6 +930,12 @@ func (s *Service) GetUnreadNotificationCount(ctx context.Context, userID string)
 
 // MarkNotificationRead marks a notification as read.
 func (s *Service) MarkNotificationRead(ctx context.Context, userID string, notificationID uuid.UUID) error {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return pinErr
+	}
+	defer release()
+
 	userSubscriptions, err := s.requireUserSubscriptionService()
 	if err != nil {
 		return err
@@ -869,6 +959,12 @@ func (s *Service) GetCredits(ctx context.Context, userID string) ([]CreditBalanc
 
 // GetCreditsByType returns the user's money balance for the requested currency.
 func (s *Service) GetCreditsByType(ctx context.Context, userID, currency string) (*CreditBalance, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	userID = strings.TrimSpace(userID)
 	if userID == "" {
 		return nil, fmt.Errorf("user_id required")
@@ -900,6 +996,12 @@ func (s *Service) GetCreditsByType(ctx context.Context, userID, currency string)
 
 // GetCreditTransactions returns money transactions for a user in the requested currency.
 func (s *Service) GetCreditTransactions(ctx context.Context, userID, currency string, opts GetCreditTransactionsOptions) (*PaginatedResult[CreditTransaction], error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	userID = strings.TrimSpace(userID)
 	if userID == "" {
 		return nil, fmt.Errorf("user_id required")
@@ -1008,6 +1110,12 @@ func (s *Service) GetSupportedTokens(ctx context.Context) (*SupportedTokensResul
 
 // CreateStripePortalSession creates a Stripe customer portal session.
 func (s *Service) CreateStripePortalSession(ctx context.Context, userID string, req CreateStripePortalSessionRequest) (*StripePortalSession, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	rt, err := s.runtime()
 	if err != nil {
 		return nil, err

--- a/pkg/service/spend.go
+++ b/pkg/service/spend.go
@@ -488,6 +488,12 @@ func (s *Service) SetCreditLimit(ctx context.Context, payer identity.CustomerID,
 
 // GetCreditLimit returns the admin-set arrears credit line for a payer (#489).
 func (s *Service) GetCreditLimit(ctx context.Context, payer identity.CustomerID, currency string) (int64, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return 0, pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return 0, fmt.Errorf("service not initialized")
 	}
@@ -505,6 +511,12 @@ func (s *Service) GetCreditLimit(ctx context.Context, payer identity.CustomerID,
 // (billing mode prepaid|arrears, spend caps, auto-top-up, expiry default) for the
 // customer billing-account admin surface (issue #242). RLS-scoped.
 func (s *Service) GetCreditAccountSettings(ctx context.Context, payer identity.CustomerID, currency string) (*models.MoneyAccount, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	if payer.IsZero() {
 		return nil, fmt.Errorf("payer required")
 	}

--- a/pkg/service/usage.go
+++ b/pkg/service/usage.go
@@ -49,6 +49,12 @@ type RecordUsageInput struct {
 // (merchant, payer, currency, usage:<event_type>, source, source_id); a replay
 // carrying a different Amount returns money.ErrIdempotencyKeyReused.
 func (s *Service) RecordUsage(ctx context.Context, in RecordUsageInput) error {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return fmt.Errorf("service not initialized")
 	}
@@ -88,6 +94,12 @@ func (s *Service) RecordUsage(ctx context.Context, in RecordUsageInput) error {
 // (allowances + per-period watermarks) and the resulting statement is
 // finalized as an invoice (#797 public export). Idempotent per window.
 func (s *Service) FinalizeInvoice(ctx context.Context, payer identity.CustomerID, currency string, from, to time.Time) (*InvoiceDTO, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	if s == nil || s.rt == nil {
 		return nil, fmt.Errorf("service not initialized")
 	}


### PR DESCRIPTION
Fixes the three defects the cozy-art / tensorhub host sweep exposed (or#900). Item 1 is
the P1 that has to land before dev ships to a host.

## 1 (P1) — plan-migration reads ran unpinned, so they read nothing

`PreviewPlanMigration` / `PlanMigrate` never opened a merchant-scoped connection. Under
the or#885-mandated `openrails_app` role their reads resolved to the base pool, where
`app.merchant_id` is unset, so every RLS-forced read matched `merchant_id = NULL` and
returned **zero rows and no error** — `plan migration: source price: no rows in result
set` about a price the same host had written moments earlier.

Fixed the way the sibling money surfaces on the same facade do (`spend.go`): the whole
call runs inside `s.rt.DB.RunInMerchantConn`. `GetPlanMigration` and
`CancelPlanMigration` had the identical gap and are fixed with it.

**Failing-before proof**: `pkg/service/plan_migration_rls_integration_test.go`
(`TestPlanMigrationFacade_RLS_Under_OpenRailsApp`) writes the products and prices
*through the facade* under the enforcing role with a merchant on the context and nothing
pinned upstream, then previews and commits the migration. Verified failing on the
pre-fix code with exactly the reported error:

```
--- FAIL: TestPlanMigrationFacade_RLS_Under_OpenRailsApp
    Error: plan migration: source price: no rows in result set
```

### The facade sweep — the gap was the class, not the method

Machine-checked every exported `*Service` method with a type-aware cross-package call
graph (go/packages + go/types): does a direct in-process call, with nothing pinned
upstream, reach `(*db.DB).Gen` / `.Qx` / `.Pool` / `.RunInTx` outside a merchant scope?

**81 of 133 did.** The facade was split down the middle: the money surfaces pinned
themselves (#227), everything else silently relied on the caller — and a host has no way
to tell from the outside which half it is talking to.

| file | had the gap | already pinned | touches no table |
|---|---|---|---|
| `admission.go` | 6 | 7 | 0 |
| `catalog_drift.go` | 4 | 0 | 0 |
| `catalog_extras.go` | 2 | 0 | 0 |
| `catalog_sidecars.go` | 1 | 0 | 0 |
| `checkout_routing.go` | 0 | 1 | 0 |
| `delinquency.go` | 0 | 3 | 0 |
| `enterprise.go` | 1 | 14 | 0 |
| `plan_migration.go` | 4 | 0 | 0 |
| `price_key.go` | 4 | 0 | 0 |
| `product_access.go` | 2 | 0 | 0 |
| `service.go` | 10 | 4 | 1 |
| `service_admin.go` | 11 | 1 | 0 |
| `service_definition_catalog.go` | 4 | 0 | 0 |
| `service_definition_catalog_admin.go` | 13 | 0 | 0 |
| `service_user.go` | 18 | 4 | 2 |
| `service_webhooks.go` | 0 | 0 | 1 |
| `spend.go` | 1 | 12 | 0 |
| `usage.go` | 0 | 2 | 0 |
| **total** | **81** | **48** | **4** |

The 81, by file:

- **admission.go** — `Admit`, `GetTrustLevel`, `ReplaceInvokerSpendLimits`,
  `ReportWastedSpend`, `SetInvokerSpendLimits`, `SetTrustLevelSchedule`
- **catalog_drift.go** — `CountOpenDriftByKind`, `ListCatalogDrift`,
  `ResolveDriftForResource`, `RunCatalogReconciliation`
- **catalog_extras.go** — `ArchiveCatalogExtras`, `DetectCatalogExtras`
- **catalog_sidecars.go** — `SyncCatalogSidecars` (opened `RunInTx` on the base pool)
- **enterprise.go** — `EnsureUsageProduct`
- **plan_migration.go** — `PreviewPlanMigration`, `PlanMigrate`, `GetPlanMigration`,
  `CancelPlanMigration` *(the reported defect)*
- **price_key.go** — `GetPriceByKey`, `GetPriceKeyHistory`, `ResolvePriceReference`,
  `SetPriceKey`
- **product_access.go** — `HasProductAccess`, `ListProductAccess`
- **service.go** — `DepositCredits` and the nine entitlement reads
  (`ListActiveEntitlements`, `…ForCustomer`, `…Records`, `…RecordsForCustomer`,
  `…RecordsByExternalSubjects`, `IsCustomerEntitled`,
  `HasActiveIndefiniteEntitlementForCustomer`,
  `LatestFiniteEntitlementWindowForCustomer`, `ListCustomersWithEntitlement`)
- **service_admin.go** — all 11 `AdminGet*` / `AdminCancelSubscription` /
  `AdminCreateOffChannelPayment` / `AdminRefundPayment` / `AdminRevokeEntitlement`
- **service_definition_catalog.go** — `CreateProduct`, `CreatePrice`, `UpdateProduct`,
  `UpdatePrice`
- **service_definition_catalog_admin.go** — `GetProduct`, `GetProductByKey`,
  `ListProducts`, `GetPrice`, `ListPrices`, `ListPricesByProduct`, `ActivateProduct`,
  `DeactivateProduct`, `ActivatePrice`, `DeactivatePrice`, `ReconcileProduct`,
  `ReconcilePrice`, `VerifyPriceSync`
- **service_user.go** — `GetProducts`, `GetPrices`, `GetSubscriptions`,
  `GetBillingStatus`, `CancelSubscription`, `ResumeSubscription`,
  `UpdateSubscriptionPaymentMethod`, `GetPaymentMethods`, `CreatePaymentMethod`,
  `UpdatePaymentMethod`, `DeletePaymentMethod`, `GetPayments`,
  `CreateStripePortalSession`, `GetNotifications`, `GetUnreadNotificationCount`,
  `MarkNotificationRead`, `GetCreditsByType`, `GetCreditTransactions`
- **spend.go** — `GetCreditLimit` (the one sibling in the money file that didn't pin)

All 81 now open with the same prologue:

```go
ctx, release, pinErr := s.pin(ctx)
if pinErr != nil {
	return …, pinErr
}
defer release()
```

`pin` (`pkg/service/merchant_pin.go`) wraps `DB.WithMerchantConn`, which **nests**: on the
HTTP path `MerchantDBConnMW` already pinned and this is a no-op; a host that wraps a
block in `embedded.RunInMerchant` keeps one connection for the whole block; a River
worker inherits its `RunInMerchantScope`. It pins a connection, not a transaction — no
BEGIN, no locks held across a rail call. A call with no merchant on the context now
fails loudly instead of answering an empty result, which is the point.

Four methods are exempt, each with its reason recorded in the lint:

| method | why |
|---|---|
| `GetCredits` | returns an error unconditionally (currency required; use `GetCreditsByType`) |
| `GetSupportedTokens` | reads the Solana rail **config** off the runtime, never a table |
| `HandleWebhook` | the merchant is not known until the payload is authenticated |
| `ReleaseHold` | frees a Redis reservation (#513); the durable ledger is untouched |

`pkg/service/merchant_pin_lint_test.go` keeps this true — a plain unit test (runs on every
`go test ./...`) that fails on any new exported facade method that reaches the DB without
pinning, and also fails on a stale exemption. Same shape as `internal/river`'s FC-16 lint.

`TestFacadeRefusesWithoutAMerchant` pins the other half of the contract: an unscoped
facade read now errors instead of returning nothing.

## 2 — `Replayed bool` on `openrails.CreditTransaction`

or#892 made every money write report applied-vs-replayed and the handlers serialize it,
but the SDK type had no field, so it was dropped on decode — which is why tensorhub still
carries a claim table to re-derive it. Added the field (the wire is Go field names, no
json tags, so it decodes as-is).

## 3 — `ErrIdempotencyKeyReused` is nameable from outside `internal/`

- `pkg/service.ErrIdempotencyKeyReused` re-exports `money.ErrIdempotencyKeyReused` (same
  sentinel object) for hosts holding `*service.Service`.
- The four money-write handlers (`ServiceDepositCredits`, `ServiceCaptureHold`,
  `ServiceRecordUsage`, `ServiceReportWastedSpend`) now answer **409** with the money
  layer's own detail message instead of a 500/400. A reused key is a caller bug, and a 500
  is indistinguishable from an engine fault — it invites a retry that will refuse again.
- The SDK gained `openrails.ErrIdempotencyKeyReused`, mapped from the wire by the same
  mechanism `ErrInsufficientCredits` already used (`newStatusError` code/message
  matching), widened to accept the token as a prefix so the useful detail
  (`…with amount=90000, but that key already committed amount=50000`) stays on the wire.
  The embedded transport dispatches into the same handlers, so both transports get it
  from one change.

`embed/or900_sdk_gaps_integration_test.go` asserts both items on **both** transports (the
remote client against the real standalone server, and the in-process transport of the
embedded host): a replayed deposit surfaces `Replayed: true`, a usage replay with a
changed amount is a 409 that `errors.Is` the exported sentinel, and an *unchanged* retry
is still idempotent.

## cozy-art

ca#265 (`265-openrails-dev-adaptation`, PR cozy-creator/cozy.art#269) skipped a test for
item 1. **The skip can be reverted** once this lands — no host-side change is needed;
cozy-art does not have to wrap its `Service()` calls in `RunInMerchant` (that is now an
optimization for multi-call blocks, documented in `docs/embedded-integration.md` §7).
Not touched here.

## Tests

- `go build ./...`, `go vet ./...`, `go test ./...` (unit) — green.
- Full integration suite, `-tags integration -p 1`, testcontainers (no stale
  `OPENRAILS_TEST_DB_*` / `REDIS_ADDR`) — green.
- `cmd/openrails` needs the compose Redis on `localhost:6380` (or#899 item 1, pre-existing
  and unrelated); run with it up, green.
