### PR TITLE
or#893: Docker smoke test uses run-server

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -103,7 +103,7 @@ jobs:
             -e DB_PASSWORD=openrails_app_password \
             -e DB_SSLMODE=disable \
             -e REDIS_ADDR=127.0.0.1:6380 \
-            openrails-smoke:${GITHUB_SHA} server --no-workers)"
+            openrails-smoke:${GITHUB_SHA} run-server --no-workers)"
           trap 'docker logs "$cid"; docker rm -f "$cid"' EXIT
           for i in $(seq 1 60); do
             if curl -fsS http://127.0.0.1:3053/health/ready; then


### PR DESCRIPTION
The master Docker workflow's smoke test invoked the retired `server` alias; phase 8's refusal stub answered with the rename error and the boot never happened — the guard working exactly as designed, on a surface the sweep missed. One-word fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)