### PR TITLE
feat(checkout): resolve hosted customer identity

### DIFF
--- a/internal/integrations/nmi/client.go
+++ b/internal/integrations/nmi/client.go
@@ -19,6 +19,8 @@ import (
 const (
 	DefaultDirectPostURL = "https://secure.networkmerchants.com/api/transact.php"
 	DefaultQueryAPIURL   = "https://secure.nmi.com/api/query.php"
+	SandboxDirectPostURL = "https://sandbox.nmi.com/api/transact.php"
+	SandboxQueryAPIURL   = "https://sandbox.nmi.com/api/query.php"
 )
 
 type NMIClient struct {
@@ -192,21 +194,30 @@ func NewClient(provider string, cfg *config.NMIProviderSettings, testMode bool) 
 		log.WithField("provider", provider).Warn("NMI security_key not configured - NMI API calls will be disabled")
 	}
 
+	directPostURL := DefaultDirectPostURL
+	queryURL := DefaultQueryAPIURL
+	v5BaseURL := DefaultV5BaseURL
+	if testMode {
+		directPostURL = SandboxDirectPostURL
+		queryURL = SandboxQueryAPIURL
+		v5BaseURL = SandboxV5BaseURL
+	}
+
 	log.WithFields(log.Fields{
 		"provider":    provider,
 		"test_mode":   testMode,
-		"v5":          DefaultV5BaseURL,
-		"direct_post": DefaultDirectPostURL,
-		"query":       DefaultQueryAPIURL,
+		"v5":          v5BaseURL,
+		"direct_post": directPostURL,
+		"query":       queryURL,
 	}).Info("NMI endpoint selection")
 
 	return &NMIClient{
 		providerName:  provider,
 		SecurityKey:   securityKey,
 		WebhookSecret: webhookSecret,
-		DirectPostURL: DefaultDirectPostURL,
-		QueryURL:      DefaultQueryAPIURL,
-		V5BaseURL:     DefaultV5BaseURL,
+		DirectPostURL: directPostURL,
+		QueryURL:      queryURL,
+		V5BaseURL:     v5BaseURL,
 		TestMode:      testMode,
 		httpClient: &http.Client{
 			// Backstop only; the real bound is the per-request context

--- a/internal/integrations/nmi/collectjs_live_integration_test.go
+++ b/internal/integrations/nmi/collectjs_live_integration_test.go
@@ -108,7 +108,7 @@ waitToken:
 	// gateway — the exact production vault-creation wire shape.
 	client, err := NewClient("live-collectjs", &config.NMIProviderSettings{SecurityKey: securityKey}, true)
 	require.NoError(t, err)
-	require.Equal(t, DefaultV5BaseURL, client.V5BaseURL, "must hit the real v5 gateway, not a stub")
+	require.Equal(t, SandboxV5BaseURL, client.V5BaseURL, "must hit the real sandbox v5 gateway, not a stub")
 
 	created, err := client.CreateCustomerVault(ctx, CreateCustomerVaultData{
 		PaymentToken: token,

--- a/internal/integrations/nmi/live_sandbox_integration_test.go
+++ b/internal/integrations/nmi/live_sandbox_integration_test.go
@@ -33,7 +33,7 @@ func TestLiveSandboxClientSurface(t *testing.T) {
 
 	client, err := NewClient("live-sandbox", &config.NMIProviderSettings{SecurityKey: key}, true)
 	require.NoError(t, err)
-	require.Equal(t, DefaultV5BaseURL, client.V5BaseURL, "must hit the real v5 gateway, not a stub")
+	require.Equal(t, SandboxV5BaseURL, client.V5BaseURL, "must hit the real sandbox v5 gateway, not a stub")
 
 	runID := fmt.Sprintf("%d", time.Now().UnixNano())
 
@@ -181,7 +181,9 @@ func TestLiveSandboxClientSurface(t *testing.T) {
 	require.NotEmpty(t, entry2)
 
 	// Billing-TARGETED sale (classic lane) must charge the SECOND card.
-	targetAmount := moneyutil.Cents(110 + (time.Now().UnixNano()/13)%80)
+	// Keep this amount in a disjoint range from amountCents above. NMI's
+	// duplicate guard keys on card + amount even when the order id differs.
+	targetAmount := moneyutil.Cents(210 + (time.Now().UnixNano()/13)%80)
 	targeted, err := client.RunSale(context.Background(), SaleParams{
 		CustomerVaultID:  vaultID,
 		BillingID:        entry2,

--- a/internal/integrations/nmi/nmi_test.go
+++ b/internal/integrations/nmi/nmi_test.go
@@ -21,11 +21,12 @@ func TestNewClient_EndpointSelection(t *testing.T) {
 		SecurityKey: "test-security-key",
 	}
 
-	t.Run("test mode uses fixed endpoints", func(t *testing.T) {
+	t.Run("test mode uses sandbox endpoints", func(t *testing.T) {
 		client, err := NewClient("mobius", baseCfg, true)
 		require.NoError(t, err)
-		assert.Equal(t, DefaultDirectPostURL, client.DirectPostURL, "should use fixed direct post URL")
-		assert.Equal(t, DefaultQueryAPIURL, client.QueryURL, "should use fixed query URL")
+		assert.Equal(t, SandboxDirectPostURL, client.DirectPostURL)
+		assert.Equal(t, SandboxQueryAPIURL, client.QueryURL)
+		assert.Equal(t, SandboxV5BaseURL, client.V5BaseURL)
 		assert.True(t, client.TestMode)
 	})
 
@@ -34,6 +35,7 @@ func TestNewClient_EndpointSelection(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, DefaultDirectPostURL, client.DirectPostURL, "should use production direct post URL")
 		assert.Equal(t, DefaultQueryAPIURL, client.QueryURL, "should use production query URL")
+		assert.Equal(t, DefaultV5BaseURL, client.V5BaseURL, "should use production v5 URL")
 		assert.False(t, client.TestMode)
 	})
 

--- a/internal/integrations/nmi/stored_credential_sandbox_integration_test.go
+++ b/internal/integrations/nmi/stored_credential_sandbox_integration_test.go
@@ -37,7 +37,7 @@ func TestLiveSandboxStoredCredentialCITThenMIT(t *testing.T) {
 
 	client, err := NewClient("live-sandbox", &config.NMIProviderSettings{SecurityKey: key}, true)
 	require.NoError(t, err)
-	require.Equal(t, DefaultDirectPostURL, client.DirectPostURL, "must hit the real gateway, not a stub")
+	require.Equal(t, SandboxDirectPostURL, client.DirectPostURL, "must hit the real sandbox gateway, not a stub")
 
 	// Vault the standard test card (raw-PAN classic shortcut — production
 	// vaulting takes a Collect.js token; see TestLiveSandboxClientSurface).

--- a/internal/integrations/nmi/v5.go
+++ b/internal/integrations/nmi/v5.go
@@ -27,7 +27,10 @@ import (
 // Auth: the classic security key IS the v5 credential ("no need to generate new
 // API keys"), sent as the ENTIRE Authorization header value — no Bearer/scheme.
 
-const DefaultV5BaseURL = "https://secure.nmi.com/api/v5"
+const (
+	DefaultV5BaseURL = "https://secure.nmi.com/api/v5"
+	SandboxV5BaseURL = "https://sandbox.nmi.com/api/v5"
+)
 
 // ErrV5NotFound marks a v5 404 — the resource does not exist at NMI.
 var ErrV5NotFound = errors.New("nmi: resource not found")

--- a/pkg/service/checkout_identity.go
+++ b/pkg/service/checkout_identity.go
@@ -1,0 +1,54 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// CheckoutCustomerIdentityResolver lets an embedded host resolve verified
+// customer attributes from its own server-side identity system. Browser form
+// values are billing input, not authoritative identity. The returned identity
+// must retain customerRef as its ID; OpenRails rejects mismatches before
+// creating a checkout session.
+type CheckoutCustomerIdentityResolver interface {
+	ResolveCheckoutCustomerIdentity(ctx context.Context, customerRef string) (CheckoutCustomerIdentity, error)
+}
+
+// CheckoutCustomerIdentityResolverFunc adapts a function to
+// CheckoutCustomerIdentityResolver.
+type CheckoutCustomerIdentityResolverFunc func(ctx context.Context, customerRef string) (CheckoutCustomerIdentity, error)
+
+// ResolveCheckoutCustomerIdentity implements CheckoutCustomerIdentityResolver.
+func (f CheckoutCustomerIdentityResolverFunc) ResolveCheckoutCustomerIdentity(
+	ctx context.Context,
+	customerRef string,
+) (CheckoutCustomerIdentity, error) {
+	if f == nil {
+		return CheckoutCustomerIdentity{}, fmt.Errorf("checkout customer identity resolver required")
+	}
+	return f(ctx, customerRef)
+}
+
+func resolveCheckoutCustomerIdentity(
+	ctx context.Context,
+	customerRef string,
+	resolver CheckoutCustomerIdentityResolver,
+) (CheckoutCustomerIdentity, error) {
+	customerRef = strings.TrimSpace(customerRef)
+	if customerRef == "" {
+		return CheckoutCustomerIdentity{}, fmt.Errorf("customer_ref required")
+	}
+	if resolver == nil {
+		return CheckoutCustomerIdentity{}, fmt.Errorf("checkout customer identity resolver required")
+	}
+	identity, err := resolver.ResolveCheckoutCustomerIdentity(ctx, customerRef)
+	if err != nil {
+		return CheckoutCustomerIdentity{}, fmt.Errorf("resolve checkout customer identity: %w", err)
+	}
+	if strings.TrimSpace(identity.ID) != customerRef {
+		return CheckoutCustomerIdentity{}, fmt.Errorf("resolved checkout customer id does not match customer_ref")
+	}
+	identity.ID = customerRef
+	return identity, nil
+}

--- a/pkg/service/checkout_identity_test.go
+++ b/pkg/service/checkout_identity_test.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,4 +28,58 @@ func TestCheckoutUserIdentityRequiresID(t *testing.T) {
 
 	_, err := checkoutUserIdentity(CheckoutCustomerIdentity{})
 	require.EqualError(t, err, "user_id required")
+}
+
+func TestResolveCheckoutCustomerIdentity(t *testing.T) {
+	t.Parallel()
+
+	resolver := CheckoutCustomerIdentityResolverFunc(func(_ context.Context, customerRef string) (CheckoutCustomerIdentity, error) {
+		return CheckoutCustomerIdentity{
+			ID:            customerRef,
+			VerifiedEmail: "jane@example.com",
+			Username:      "jane",
+		}, nil
+	})
+
+	identity, err := resolveCheckoutCustomerIdentity(t.Context(), "  f2cd32df-d987-4c2f-942b-99e7232a0e05  ", resolver)
+	require.NoError(t, err)
+	require.Equal(t, "f2cd32df-d987-4c2f-942b-99e7232a0e05", identity.ID)
+	require.Equal(t, "jane@example.com", identity.VerifiedEmail)
+	require.Equal(t, "jane", identity.Username)
+}
+
+func TestCreateCheckoutSessionWithCustomerResolverRejectsInvalidResolution(t *testing.T) {
+	t.Parallel()
+
+	resolverErr := errors.New("identity store unavailable")
+	tests := []struct {
+		name     string
+		ref      string
+		resolver CheckoutCustomerIdentityResolver
+		wantErr  string
+	}{
+		{name: "missing customer ref", resolver: CheckoutCustomerIdentityResolverFunc(func(context.Context, string) (CheckoutCustomerIdentity, error) {
+			return CheckoutCustomerIdentity{}, nil
+		}), wantErr: "customer_ref required"},
+		{name: "missing resolver", ref: "f2cd32df-d987-4c2f-942b-99e7232a0e05", wantErr: "checkout customer identity resolver required"},
+		{name: "typed nil resolver", ref: "f2cd32df-d987-4c2f-942b-99e7232a0e05", resolver: CheckoutCustomerIdentityResolverFunc(nil), wantErr: "resolve checkout customer identity: checkout customer identity resolver required"},
+		{name: "resolver failure", ref: "f2cd32df-d987-4c2f-942b-99e7232a0e05", resolver: CheckoutCustomerIdentityResolverFunc(func(context.Context, string) (CheckoutCustomerIdentity, error) {
+			return CheckoutCustomerIdentity{}, resolverErr
+		}), wantErr: "resolve checkout customer identity: identity store unavailable"},
+		{name: "customer mismatch", ref: "f2cd32df-d987-4c2f-942b-99e7232a0e05", resolver: CheckoutCustomerIdentityResolverFunc(func(context.Context, string) (CheckoutCustomerIdentity, error) {
+			return CheckoutCustomerIdentity{ID: "09d397cf-015f-41a3-8bad-685220b9b4fc"}, nil
+		}), wantErr: "resolved checkout customer id does not match customer_ref"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := (&Service{}).CreateCheckoutSessionWithCustomerResolver(
+				t.Context(),
+				test.ref,
+				test.resolver,
+				CreateCheckoutSessionRequest{},
+			)
+			require.EqualError(t, err, test.wantErr)
+		})
+	}
 }

--- a/pkg/service/checkout_identity_test.go
+++ b/pkg/service/checkout_identity_test.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckoutUserIdentity(t *testing.T) {
+	t.Parallel()
+
+	identity, err := checkoutUserIdentity(CheckoutCustomerIdentity{
+		ID:            "  f2cd32df-d987-4c2f-942b-99e7232a0e05  ",
+		VerifiedEmail: "  jane@example.com  ",
+		Username:      "  jane  ",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "f2cd32df-d987-4c2f-942b-99e7232a0e05", identity.ID)
+	require.NotNil(t, identity.Email)
+	require.Equal(t, "jane@example.com", *identity.Email)
+	require.Equal(t, "jane", identity.Username)
+}
+
+func TestCheckoutUserIdentityRequiresID(t *testing.T) {
+	t.Parallel()
+
+	_, err := checkoutUserIdentity(CheckoutCustomerIdentity{})
+	require.EqualError(t, err, "user_id required")
+}

--- a/pkg/service/service_user.go
+++ b/pkg/service/service_user.go
@@ -173,13 +173,19 @@ func (s *Service) ListCheckoutRailOptions(ctx context.Context, priceRef string) 
 
 // CreateCheckoutSession creates a new checkout session.
 func (s *Service) CreateCheckoutSession(ctx context.Context, userID string, req CreateCheckoutSessionRequest) (*CheckoutSession, error) {
+	return s.CreateCheckoutSessionForCustomer(ctx, CheckoutCustomerIdentity{ID: userID}, req)
+}
+
+// CreateCheckoutSessionForCustomer creates a checkout session with host-resolved
+// identity attributes for rails that require them.
+func (s *Service) CreateCheckoutSessionForCustomer(ctx context.Context, customer CheckoutCustomerIdentity, req CreateCheckoutSessionRequest) (*CheckoutSession, error) {
 	checkoutSessions, err := s.requireCheckoutSessionService()
 	if err != nil {
 		return nil, err
 	}
-	userID = strings.TrimSpace(userID)
-	if userID == "" {
-		return nil, fmt.Errorf("user_id required")
+	user, err := checkoutUserIdentity(customer)
+	if err != nil {
+		return nil, err
 	}
 
 	svcReq := &checkout.CheckoutSessionCreateRequest{
@@ -210,7 +216,6 @@ func (s *Service) CreateCheckoutSession(ctx context.Context, userID string, req 
 		},
 	}
 
-	user := &checkout.UserIdentity{ID: userID}
 	rt, err := s.runtime()
 	if err != nil {
 		return nil, err
@@ -229,6 +234,23 @@ func (s *Service) CreateCheckoutSession(ctx context.Context, userID string, req 
 	}
 
 	return checkoutSessionFromResponse(resp), nil
+}
+
+func checkoutUserIdentity(customer CheckoutCustomerIdentity) (*checkout.UserIdentity, error) {
+	customer.ID = strings.TrimSpace(customer.ID)
+	if customer.ID == "" {
+		return nil, fmt.Errorf("user_id required")
+	}
+
+	var email *string
+	if verifiedEmail := strings.TrimSpace(customer.VerifiedEmail); verifiedEmail != "" {
+		email = &verifiedEmail
+	}
+	return &checkout.UserIdentity{
+		ID:       customer.ID,
+		Email:    email,
+		Username: strings.TrimSpace(customer.Username),
+	}, nil
 }
 
 // GetCheckoutSession retrieves a checkout session by ID.

--- a/pkg/service/service_user.go
+++ b/pkg/service/service_user.go
@@ -173,6 +173,12 @@ func (s *Service) ListCheckoutRailOptions(ctx context.Context, priceRef string) 
 
 // CreateCheckoutSession creates a new checkout session.
 func (s *Service) CreateCheckoutSession(ctx context.Context, userID string, req CreateCheckoutSessionRequest) (*CheckoutSession, error) {
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
 	return s.CreateCheckoutSessionForCustomer(ctx, CheckoutCustomerIdentity{ID: userID}, req)
 }
 
@@ -234,6 +240,27 @@ func (s *Service) CreateCheckoutSessionForCustomer(ctx context.Context, customer
 	}
 
 	return checkoutSessionFromResponse(resp), nil
+}
+
+// CreateCheckoutSessionWithCustomerResolver resolves the customer through the
+// embedding host's identity system before creating the checkout session.
+func (s *Service) CreateCheckoutSessionWithCustomerResolver(
+	ctx context.Context,
+	customerRef string,
+	resolver CheckoutCustomerIdentityResolver,
+	req CreateCheckoutSessionRequest,
+) (*CheckoutSession, error) {
+	customer, err := resolveCheckoutCustomerIdentity(ctx, customerRef, resolver)
+	if err != nil {
+		return nil, err
+	}
+	ctx, release, pinErr := s.pin(ctx)
+	if pinErr != nil {
+		return nil, pinErr
+	}
+	defer release()
+
+	return s.CreateCheckoutSessionForCustomer(ctx, customer, req)
 }
 
 func checkoutUserIdentity(customer CheckoutCustomerIdentity) (*checkout.UserIdentity, error) {

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -98,6 +98,15 @@ type CheckoutRailOption struct {
 	Mode     string
 }
 
+// CheckoutCustomerIdentity is the host-resolved customer identity used by
+// checkout rails that require verified account attributes in addition to the
+// stable customer ID.
+type CheckoutCustomerIdentity struct {
+	ID            string
+	VerifiedEmail string
+	Username      string
+}
+
 // CreateCheckoutSessionRequest specifies checkout session creation parameters.
 type CreateCheckoutSessionRequest struct {
 	PriceID        string


### PR DESCRIPTION
## Summary
- let embedded hosts provide verified checkout customer identity through a narrow resolver interface
- preserve the direct customer-identity checkout seam while rejecting resolver ID mismatches
- route sandbox NMI clients to the sandbox API endpoints

## Verification
- `go test ./...`