### PR TITLE
feat(embed): expose active merchant pages

### DIFF
--- a/internal/controlplane/merchant_directory.go
+++ b/internal/controlplane/merchant_directory.go
@@ -1,0 +1,41 @@
+package controlplane
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/open-rails/openrails/internal/db/gen"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+const maxActiveMerchantPageSize = 200
+
+// ListActiveMerchantIDs returns one directory page for privileged host
+// orchestration that must enter each merchant's RLS scope independently.
+func (c *ControlPlane) ListActiveMerchantIDs(ctx context.Context, limit, offset int) ([]merchant.ID, error) {
+	if c == nil || c.pool == nil {
+		return nil, errors.New("controlplane: pgx pool unavailable for merchant enumeration")
+	}
+	if limit <= 0 || limit > maxActiveMerchantPageSize {
+		limit = maxActiveMerchantPageSize
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	status := "active"
+	rows, err := gen.New(c.pool).ListPlatformMerchants(ctx, gen.ListPlatformMerchantsParams{
+		Status:     &status,
+		PageOffset: int64(offset),
+		PageLimit:  int64(limit),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("controlplane: list active merchant ids: %w", err)
+	}
+
+	ids := make([]merchant.ID, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, merchant.ID(row.ID))
+	}
+	return ids, nil
+}

--- a/internal/controlplane/merchant_directory_integration_test.go
+++ b/internal/controlplane/merchant_directory_integration_test.go
@@ -1,0 +1,44 @@
+//go:build integration
+
+package controlplane
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+func TestListActiveMerchantIDs(t *testing.T) {
+	ctx := context.Background()
+	super := dbtest.SharedSuperuserPGXPool(t)
+	cp, err := New(ctx, &config.Config{
+		Env:  "test",
+		DB:   &config.DBConfig{},
+		Auth: &config.AuthConfig{Issuer: "https://openrails.test", MintDisabled: true},
+	}, super)
+	require.NoError(t, err)
+
+	suffix := strings.ReplaceAll(uuid.NewString(), "-", "")[:10]
+	activeA, activeB, deleted := uuid.New(), uuid.New(), uuid.New()
+	_, err = super.Exec(ctx, `
+		INSERT INTO openrails.merchants (id, slug, status, deleted_at)
+		VALUES ($1, $2, 'active', NULL), ($3, $4, 'active', NULL), ($5, $6, 'deleted', now())`,
+		activeA, "host-page-a-"+suffix,
+		activeB, "host-page-b-"+suffix,
+		deleted, "host-page-deleted-"+suffix,
+	)
+	require.NoError(t, err)
+
+	ids, err := cp.ListActiveMerchantIDs(ctx, 200, 0)
+	require.NoError(t, err)
+	require.Contains(t, ids, merchant.ID(activeA))
+	require.Contains(t, ids, merchant.ID(activeB))
+	require.NotContains(t, ids, merchant.ID(deleted))
+}

--- a/pkg/embedded/controlplane/merchant_directory.go
+++ b/pkg/embedded/controlplane/merchant_directory.go
@@ -1,0 +1,21 @@
+package controlplane
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-rails/openrails/internal/app"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// ListActiveMerchantIDs returns one page of active merchant IDs for an
+// embedding host that must perform explicitly merchant-scoped background work.
+// This is a privileged host seam; callers are responsible for authorizing and
+// auditing its use.
+func ListActiveMerchantIDs(ctx context.Context, a *app.App, limit, offset int) ([]merchant.ID, error) {
+	cp := Get(a)
+	if cp == nil {
+		return nil, fmt.Errorf("control plane: no control plane attached (call Attach first)")
+	}
+	return cp.ListActiveMerchantIDs(ctx, limit, offset)
+}


### PR DESCRIPTION
## Summary
- expose a bounded active-merchant ID page for embedded host background orchestration
- keep merchant-scoped work explicit instead of encouraging direct schema access
- prove active merchants are returned while deleted merchants are excluded

## Verification
- `go test ./internal/controlplane ./pkg/embedded/controlplane`
- `go test -tags=integration ./internal/controlplane -run '^TestListActiveMerchantIDs$' -count=1`