### PR TITLE
feat(embedded): expose PSP declaration seam

### DIFF
--- a/pkg/embedded/psp_declaration.go
+++ b/pkg/embedded/psp_declaration.go
@@ -1,0 +1,84 @@
+package embedded
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/db/gen"
+	"github.com/open-rails/openrails/internal/merchants"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// PSPDeclaration identifies a payment-service-provider account without
+// configuring credentials. Embedded hosts use this before importing billing
+// facts that came from a host-owned or synthetic provider.
+type PSPDeclaration struct {
+	Key       string
+	Rail      string
+	AccountID string
+}
+
+// DeclarePSP idempotently records a PSP identity for an embedded host. It does
+// not write secrets or arm the PSP for checkout; those remain the payment-
+// provider configuration boundary's responsibility.
+//
+// The PSP environment is derived from the engine's credential posture, and
+// the row receives the same deterministic natural-key ID as every other PSP
+// writer. This is the public precursor to ImportBilling when the declared book
+// attributes its rows with a PSPRef.
+func (e *Embedded) DeclarePSP(ctx context.Context, merchantID merchant.ID, declaration PSPDeclaration) (uuid.UUID, error) {
+	if e == nil || e.app == nil || e.app.Runtime == nil || e.app.Runtime.DB == nil {
+		return uuid.Nil, fmt.Errorf("embedded billing: runtime not initialized")
+	}
+	if merchantID.IsZero() {
+		return uuid.Nil, fmt.Errorf("embedded billing: DeclarePSP requires a merchant")
+	}
+
+	key := strings.ToLower(strings.TrimSpace(declaration.Key))
+	rail := strings.ToLower(strings.TrimSpace(declaration.Rail))
+	accountID := strings.TrimSpace(declaration.AccountID)
+	switch {
+	case key == "":
+		return uuid.Nil, fmt.Errorf("embedded billing: DeclarePSP requires a key")
+	case rail == "":
+		return uuid.Nil, fmt.Errorf("embedded billing: DeclarePSP requires a rail")
+	case accountID == "":
+		return uuid.Nil, fmt.Errorf("embedded billing: DeclarePSP requires an account ID")
+	}
+
+	environment := config.ExpectedProviderEnvironment(e.app.Runtime.Config.IsTestMode())
+	database := e.app.Runtime.DB
+	if err := merchants.AssertPSPUnowned(
+		ctx,
+		gen.New(database.DataPool()),
+		merchantID.UUID(),
+		rail,
+		environment,
+		accountID,
+	); err != nil {
+		return uuid.Nil, fmt.Errorf("embedded billing: declare PSP: %w", err)
+	}
+
+	pspID, normalizedRail, normalizedEnvironment, normalizedAccountID := merchants.PSPNaturalKey(rail, environment, accountID)
+	archived := false
+	err := database.RunInMerchantConn(merchant.WithID(ctx, merchantID), func(ctx context.Context) error {
+		_, err := database.Gen(ctx).UpsertPSP(ctx, gen.UpsertPSPParams{
+			ID:          pspID,
+			MerchantID:  merchantID.UUID(),
+			Rail:        normalizedRail,
+			Environment: &normalizedEnvironment,
+			AccountID:   normalizedAccountID,
+			Key:         &key,
+			Archived:    &archived,
+		})
+		return err
+	})
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("embedded billing: declare PSP %s: %w", key, err)
+	}
+	return pspID, nil
+}

--- a/pkg/embedded/psp_declaration_integration_test.go
+++ b/pkg/embedded/psp_declaration_integration_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+
+package embedded
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/db/gen"
+	"github.com/open-rails/openrails/internal/dbtest"
+	embcp "github.com/open-rails/openrails/pkg/embedded/controlplane"
+)
+
+func TestEmbedded_DeclarePSP(t *testing.T) {
+	_, appDSN := dbtest.SharedRLSPostgres(t)
+	pool, err := pgxpool.New(context.Background(), appDSN)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	suffix := strings.ToLower(uuid.NewString()[:8])
+	cfg := &config.Config{
+		Env:               "development",
+		TestMode:          config.CredentialPostureSandbox,
+		ProviderWriteMode: config.ProviderWriteModeReadOnly,
+		MerchantSource:    config.MerchantSourceAPI,
+		SecretBackend:     config.SecretBackendDB,
+		DB:                &config.DBConfig{URL: appDSN},
+		Auth:              &config.AuthConfig{Issuer: "https://declare-psp-" + suffix + ".openrails.test"},
+	}
+	engine, err := New(Options{Config: cfg, PGXPool: pool, River: RiverManagedByOpenRails()})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = engine.Close(context.Background()) })
+
+	ctx := context.Background()
+	require.NoError(t, embcp.Attach(ctx, engine.App(), cfg, pool))
+	merchantResult, err := embcp.ProvisionMerchant(ctx, engine.App(), embcp.ProvisionMerchantRequest{Slug: "declare-psp-" + suffix})
+	require.NoError(t, err)
+
+	declaration := PSPDeclaration{
+		Key:       " Platform ",
+		Rail:      " PLATFORM ",
+		AccountID: " internal-platform-" + suffix,
+	}
+	firstID, err := engine.DeclarePSP(ctx, merchantResult.MerchantID, declaration)
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, firstID)
+	secondID, err := engine.DeclarePSP(ctx, merchantResult.MerchantID, declaration)
+	require.NoError(t, err)
+	require.Equal(t, firstID, secondID, "re-declaration must preserve the natural-key identity")
+
+	err = engine.RunInMerchantConn(ctx, merchantResult.MerchantID, func(ctx context.Context) error {
+		rows, queryErr := engine.App().Runtime.DB.Gen(ctx).ListPSPsForMerchant(ctx, gen.ListPSPsForMerchantParams{
+			MerchantID: merchantResult.MerchantID.UUID(),
+		})
+		require.NoError(t, queryErr)
+		require.Len(t, rows, 1, "re-declaration must not create a duplicate")
+		require.Equal(t, firstID, rows[0].ID)
+		require.Equal(t, "platform", rows[0].Rail)
+		require.Equal(t, config.ProviderEnvironmentTest, rows[0].Environment)
+		require.Equal(t, strings.TrimSpace(declaration.AccountID), rows[0].AccountID)
+		require.NotNil(t, rows[0].Key)
+		require.Equal(t, "platform", *rows[0].Key)
+		return nil
+	})
+	require.NoError(t, err)
+
+	otherMerchant, err := embcp.ProvisionMerchant(ctx, engine.App(), embcp.ProvisionMerchantRequest{Slug: "declare-psp-other-" + suffix})
+	require.NoError(t, err)
+	_, err = engine.DeclarePSP(ctx, otherMerchant.MerchantID, declaration)
+	require.ErrorContains(t, err, "owned by another merchant")
+}


### PR DESCRIPTION
## Summary
- add an idempotent embedded-host API for declaring PSP identities without credentials
- derive PSP environment from deployment posture and preserve deterministic natural-key IDs
- prove normalization, idempotency, RLS visibility, and cross-merchant ownership rejection

## Verification
- `go test ./...`
- `go test -tags integration ./pkg/embedded -run '^TestEmbedded_DeclarePSP$' -count=1`\n- `go vet ./pkg/embedded`