### PR TITLE
or#901: catalog reconciliation — a re-squash that can never re-apply, behind a queue that retries structural failures forever

### DIFF
--- a/internal/app/worker_health.go
+++ b/internal/app/worker_health.go
@@ -35,14 +35,18 @@ func (r *Runtime) workerHealthRegistrations() *riverjobs.WorkerRegistrations {
 // healthTrackedWorker wraps an OpenRails worker so its health bookkeeping
 // travels with the worker itself rather than with whoever built the client.
 type healthTrackedWorker[T river.JobArgs] struct {
-	inner  river.Worker[T]
-	health rivertype.WorkerMiddleware
+	inner      river.Worker[T]
+	health     rivertype.WorkerMiddleware
+	structural rivertype.WorkerMiddleware
 }
 
+// Middleware order matters. `health` is OUTERMOST so its bookkeeping records the
+// error the queue actually acts on — i.e. the structural refusal, not the raw
+// driver error underneath it (or#901).
 func (w *healthTrackedWorker[T]) Middleware(job *rivertype.JobRow) []rivertype.WorkerMiddleware {
 	inner := w.inner.Middleware(job)
-	out := make([]rivertype.WorkerMiddleware, 0, len(inner)+1)
-	out = append(out, w.health)
+	out := make([]rivertype.WorkerMiddleware, 0, len(inner)+2)
+	out = append(out, w.health, w.structural)
 	return append(out, inner...)
 }
 
@@ -64,8 +68,9 @@ func addTrackedWorker[T river.JobArgs](r *Runtime, workers *river.Workers, worke
 	var args T
 	r.workerHealthRegistrations().NoteKind(args.Kind())
 	return river.AddWorkerSafely[T](workers, &healthTrackedWorker[T]{
-		inner:  worker,
-		health: riverjobs.NewWorkerHealthMiddleware(r.DB),
+		inner:      worker,
+		health:     riverjobs.NewWorkerHealthMiddleware(r.DB),
+		structural: riverjobs.NewStructuralFailureMiddleware(),
 	})
 }
 

--- a/internal/migrate/migrator.go
+++ b/internal/migrate/migrator.go
@@ -6,6 +6,9 @@ import (
 
 	"fmt"
 	"regexp"
+	"sort"
+	"strconv"
+	"strings"
 
 	_ "github.com/jackc/pgx/v5/stdlib" // database/sql driver "pgx"
 
@@ -84,12 +87,105 @@ func RunPostgres(ctx context.Context, cfg *config.Config) error {
 	// (public.migrations.app), independent of the schema (#471 renamed it from
 	// "billing").
 	m := migratekit.NewPostgres(sqlDB, config.MigratekitApp).WithSchema(schema)
+	// or#901: refuse a database that has run migrations this build no longer
+	// carries, BEFORE applying anything. See assertNoOrphanedMigrations.
+	if err := assertNoOrphanedMigrations(ctx, m, schema, migrations); err != nil {
+		return err
+	}
 	// ApplyMigrations now calls Setup() automatically within the lock
 	if err := m.ApplyMigrations(ctx, migrations); err != nil {
 		return fmt.Errorf("openrails: apply migrations: %w", err)
 	}
 	log.Info("✓ OpenRails migrations completed successfully")
 	return nil
+}
+
+// OrphanedMigrationsError reports that the database has recorded OpenRails
+// migrations this build does not carry. It is always fatal: the schema and the
+// binary describe different databases and nothing downstream can reconcile them.
+type OrphanedMigrationsError struct {
+	Schema   string
+	Orphaned []string
+	Embedded []string
+}
+
+func (e *OrphanedMigrationsError) Error() string {
+	return fmt.Sprintf(
+		"openrails: schema %q has applied migration(s) %s that this build does not carry (it carries %s) — "+
+			"the recorded history is ahead of, or divergent from, the embedded set, so migratekit applies nothing "+
+			"and the schema stays frozen while the binary advances. Rebuild the OpenRails schema from the current "+
+			"baseline (see or#899's post-squash reset recipe); do NOT renumber migrations to paper over this",
+		e.Schema, strings.Join(e.Orphaned, ", "), strings.Join(e.Embedded, ", "))
+}
+
+// assertNoOrphanedMigrations refuses when the database records an applied
+// OpenRails migration that no longer exists in the embedded set.
+//
+// migratekit only ever asks "is every embedded migration applied?"
+// (ApplyMigrations, ValidateAllApplied). It never asks the converse. A database
+// that recorded 1..12 against a chain since re-squashed to {1, 2} therefore sees
+// both remaining names already applied, applies nothing, and keeps the OLD
+// schema — while the binary moves on to code written against the new baseline.
+//
+// That is exactly how or#901 lost the catalog reconciliation loop:
+// psp_rail_merchant_ids was created by a numbered migration that or#893's
+// re-squash absorbed into 0001, so on every already-migrated database the
+// function was simply never created and both money-path reconcile jobs failed
+// with SQLSTATE 42883 — silently, for 15 days, behind 25 retries apiece.
+//
+// The check is one-directional on purpose: PENDING migrations are ApplyMigrations'
+// job, and are normal. ORPHANED ones are never normal.
+func assertNoOrphanedMigrations(ctx context.Context, m *migratekit.Postgres, schema string, migrations []migratekit.Migration) error {
+	applied, err := m.Applied(ctx)
+	if err != nil {
+		return fmt.Errorf("openrails: read applied migrations: %w", err)
+	}
+	embedded := make(map[string]struct{}, len(migrations))
+	embeddedNames := make([]string, 0, len(migrations))
+	for _, mig := range migrations {
+		p := migratekit.Prefix(mig.Name)
+		if _, seen := embedded[p]; seen {
+			continue
+		}
+		embedded[p] = struct{}{}
+		embeddedNames = append(embeddedNames, p)
+	}
+
+	var orphaned []string
+	for _, name := range applied {
+		if _, ok := embedded[name]; !ok {
+			orphaned = append(orphaned, name)
+		}
+	}
+	if len(orphaned) == 0 {
+		return nil
+	}
+	sortMigrationNames(orphaned)
+	sortMigrationNames(embeddedNames)
+	return &OrphanedMigrationsError{
+		Schema:   schema,
+		Orphaned: orphaned,
+		Embedded: embeddedNames,
+	}
+}
+
+// sortMigrationNames orders migratekit prefixes numerically ("2" before "10"),
+// falling back to lexical order for any non-numeric name.
+func sortMigrationNames(names []string) {
+	sort.Slice(names, func(i, j int) bool {
+		ni, erri := strconv.ParseInt(names[i], 10, 64)
+		nj, errj := strconv.ParseInt(names[j], 10, 64)
+		if erri == nil && errj == nil {
+			return ni < nj
+		}
+		if erri == nil {
+			return true
+		}
+		if errj == nil {
+			return false
+		}
+		return names[i] < names[j]
+	})
 }
 
 // schemaWordRe matches the default schema name (config.DefaultSchema) as a whole

--- a/internal/migrate/orphaned_migrations_integration_test.go
+++ b/internal/migrate/orphaned_migrations_integration_test.go
@@ -1,0 +1,92 @@
+//go:build integration
+
+package migrate_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/open-rails/migratekit"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/internal/migrate"
+	postgresmigrations "github.com/open-rails/openrails/migrations/postgres"
+)
+
+// or#901: reproduce, through the REAL migrator entrypoint, the condition that
+// silently killed both money-path reconcile jobs for 15 days.
+//
+// Both e2e stacks recorded openrails migrations 1..12 (from a tensorhub pin
+// whose chain reached 12). or#893's re-squash then folded 0002-0085 into a
+// rewritten 0001 and deleted the rest, leaving the embedded set {0001, 0002}.
+// migratekit only ever asks "is every embedded migration applied?", so names
+// "1" and "2" both read as already done, NOTHING is applied, and the database
+// keeps the old schema — which has no openrails.psp_rail_merchant_ids — while
+// the binary runs code that calls it. Every catalog_reconciliation_pull then
+// failed SQLSTATE 42883, 25 times per job, with no other signal anywhere.
+//
+// RunPostgres must refuse such a database instead of reporting success.
+
+const orphanedSchema = "openrails" // the production default; the stacks' schema
+
+func seedAppliedMigration(t *testing.T, sqlDB *sql.DB, name string) {
+	t.Helper()
+	_, err := sqlDB.ExecContext(context.Background(),
+		`INSERT INTO public.migrations (app, database, name, schema) VALUES ($1, 'postgres', $2, $3)
+		 ON CONFLICT DO NOTHING`,
+		config.MigratekitApp, name, orphanedSchema)
+	require.NoError(t, err)
+}
+
+func TestRunPostgres_RefusesOrphanedMigrations(t *testing.T) {
+	ctx := context.Background()
+	// An isolated, fully-migrated database built by the real migrator.
+	dsn := dbtest.SharedSuperuserDSN(t)
+	sqlDB, err := sql.Open("pgx", dsn)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	orphans := []string{"3", "4", "5", "6", "7", "8", "9", "10", "11", "12"}
+	t.Cleanup(func() {
+		for _, n := range orphans {
+			_, _ = sqlDB.ExecContext(context.Background(),
+				`DELETE FROM public.migrations WHERE app = $1 AND schema = $2 AND name = $3`,
+				config.MigratekitApp, orphanedSchema, n)
+		}
+	})
+
+	cfg := &config.Config{Env: "dev", DB: &config.DBConfig{URL: dsn}}
+
+	// Re-running the migrator over a database it built is a clean no-op.
+	require.NoError(t, migrate.RunPostgres(ctx, cfg),
+		"a database whose applied set matches the embedded set migrates cleanly")
+
+	// Now make it the stacks' database: migrations recorded that this build no
+	// longer carries anywhere.
+	for _, n := range orphans {
+		seedAppliedMigration(t, sqlDB, n)
+	}
+
+	err = migrate.RunPostgres(ctx, cfg)
+	require.Error(t, err, "a re-squash that can never re-apply must refuse, not report success")
+
+	var orphanErr *migrate.OrphanedMigrationsError
+	require.ErrorAs(t, err, &orphanErr, "the refusal is typed")
+	require.Equal(t, orphanedSchema, orphanErr.Schema)
+	require.Equal(t, orphans, orphanErr.Orphaned, "every orphan named, in numeric order")
+	require.Contains(t, orphanErr.Error(), "does not carry")
+
+	// The control that matters most: migratekit itself is still perfectly happy
+	// with this database. Its two checks (ApplyMigrations, ValidateAllApplied)
+	// only ask embedded-subset-of-applied, never the converse — so without the
+	// fence a frozen schema is indistinguishable from an up-to-date one.
+	migrations, err := migratekit.LoadFromFS(postgresmigrations.FS)
+	require.NoError(t, err)
+	m := migratekit.NewPostgres(sqlDB, config.MigratekitApp).WithSchema(orphanedSchema)
+	require.NoError(t, m.ValidateAllApplied(ctx, migrations),
+		"this is the hole or#901 closes: migratekit reports a frozen schema as fully migrated")
+}

--- a/internal/river/structural_failure.go
+++ b/internal/river/structural_failure.go
@@ -1,0 +1,135 @@
+package riverjobs
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// or#901: River retries every returned error the same way — up to max_attempts,
+// with backoff — because at the queue level a structural failure and a provider
+// blip look identical. They are not. A job whose PRECONDITIONS are wrong (the
+// database does not have the function the code calls; the context carries no
+// merchant) will fail exactly the same way on attempt 25 as on attempt 1, and
+// retrying it only buries the defect in noise that reads as transient.
+//
+// That is measured, not hypothetical: openrails.catalog_reconciliation_pull
+// accumulated 578 retryable rows across two stacks and completed ZERO times in
+// 15 days, first on `merchant: no merchant resolved on context` and then on
+// `SQLSTATE 42883 undefined_function`. A release check flagged the backlog twice
+// and both times it read as noise.
+//
+// StructuralFailureMiddleware converts those two classes into river.JobCancel,
+// which is terminal and records the reason on the job row, and logs them at
+// error with a typed event so the queue stops being the only witness.
+
+// StructuralFailureMiddleware terminates jobs that failed on a structural
+// precondition instead of letting them retry to exhaustion.
+type StructuralFailureMiddleware struct {
+	river.MiddlewareDefaults
+}
+
+// NewStructuralFailureMiddleware builds the classifier. It holds no state; one
+// instance is safe to share across every worker.
+func NewStructuralFailureMiddleware() *StructuralFailureMiddleware {
+	return &StructuralFailureMiddleware{}
+}
+
+func (m *StructuralFailureMiddleware) Work(ctx context.Context, job *rivertype.JobRow, doInner func(context.Context) error) error {
+	err := doInner(ctx)
+	if err == nil {
+		return nil
+	}
+	reason, structural := classifyStructural(err)
+	if !structural {
+		return err
+	}
+	// Loud: a terminal refusal that only exists as a job row is the same silence
+	// the retries provided.
+	log.WithContext(ctx).WithError(err).WithFields(log.Fields{
+		"event":       "structural_job_refusal",
+		"worker_kind": job.Kind,
+		"job_id":      job.ID,
+		"attempt":     job.Attempt,
+		"reason":      reason,
+	}).Error("river: refusing job — structural precondition failure is not retryable")
+	return river.JobCancel(&StructuralFailureError{Reason: reason, Kind: job.Kind, Err: err})
+}
+
+// StructuralFailureReason names the class of precondition that was violated.
+type StructuralFailureReason string
+
+const (
+	// StructuralReasonSchemaDrift: the database does not have the object the
+	// code named. The binary and the schema describe different databases.
+	StructuralReasonSchemaDrift StructuralFailureReason = "schema_drift"
+	// StructuralReasonNoMerchantScope: the job reached merchant-scoped work on a
+	// context that never had a merchant resolved onto it — a wiring bug.
+	StructuralReasonNoMerchantScope StructuralFailureReason = "no_merchant_scope"
+)
+
+// StructuralFailureError wraps the underlying failure with its class, so the
+// cancelled job row says WHY it will never be retried.
+type StructuralFailureError struct {
+	Reason StructuralFailureReason
+	Kind   string
+	Err    error
+}
+
+func (e *StructuralFailureError) Error() string {
+	return "structural precondition failure (" + string(e.Reason) + ") in " + e.Kind +
+		"; retrying cannot fix it: " + e.Err.Error()
+}
+
+func (e *StructuralFailureError) Unwrap() error { return e.Err }
+
+// structuralSQLStates are the Postgres SQLSTATEs that mean "the code and the
+// schema disagree". Every one of them is deterministic for a given (statement,
+// schema) pair, so an identical retry is guaranteed to fail identically.
+//
+// Deliberately NOT included: connection/administrator-shutdown (class 08/57),
+// serialization failures (40001), lock timeouts, and insufficient_resources —
+// those are genuinely transient and must keep their retries.
+var structuralSQLStates = map[string]struct{}{
+	"42883": {}, // undefined_function
+	"42P01": {}, // undefined_table
+	"42703": {}, // undefined_column
+	"42704": {}, // undefined_object
+	"42P02": {}, // undefined_parameter
+	"3F000": {}, // invalid_schema_name
+	"42601": {}, // syntax_error
+	"42846": {}, // cannot_coerce
+}
+
+// classifyStructural reports whether err is a structural precondition failure,
+// and which class.
+func classifyStructural(err error) (StructuralFailureReason, bool) {
+	if err == nil {
+		return "", false
+	}
+	// A snooze or an already-cancelled job is a deliberate outcome; never
+	// reclassify it.
+	if errors.Is(err, &rivertype.JobSnoozeError{}) {
+		return "", false
+	}
+	var cancelErr *rivertype.JobCancelError
+	if errors.As(err, &cancelErr) {
+		return "", false
+	}
+	if errors.Is(err, merchant.ErrNoMerchant) {
+		return StructuralReasonNoMerchantScope, true
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		if _, ok := structuralSQLStates[pgErr.Code]; ok {
+			return StructuralReasonSchemaDrift, true
+		}
+	}
+	return "", false
+}

--- a/internal/river/structural_failure_integration_test.go
+++ b/internal/river/structural_failure_integration_test.go
@@ -1,0 +1,167 @@
+//go:build integration
+
+package riverjobs
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/riverqueue/river"
+	riverpgxv5 "github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivertype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/db"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/pkg/merchant"
+)
+
+// or#901 end-to-end through a REAL River client: a job that failed on a
+// structural precondition reaches a TERMINAL state with a typed reason on the
+// first attempt, while a genuinely transient failure keeps every one of its
+// retries. This is the defect measured on both standing stacks — 578 retryable
+// openrails.catalog_reconciliation_pull rows, zero completions in 15 days, on
+// two errors (merchant.ErrNoMerchant, then SQLSTATE 42883) that were never once
+// going to succeed.
+
+const (
+	sfDriftKind     = "test.sf_schema_drift"
+	sfNoMerchKind   = "test.sf_no_merchant"
+	sfTransientKind = "test.sf_transient"
+)
+
+type sfDriftArgs struct{}
+
+func (sfDriftArgs) Kind() string { return sfDriftKind }
+
+type sfDriftWorker struct{ river.WorkerDefaults[sfDriftArgs] }
+
+// The exact error the stacks returned once the or#877 fan-out shipped against a
+// schema the or#893 re-squash could no longer reach.
+func (sfDriftWorker) Work(context.Context, *river.Job[sfDriftArgs]) error {
+	return fmt.Errorf("catalog reconciliation: list armed merchants: %w", &pgconn.PgError{
+		Code:     "42883",
+		Message:  "function openrails.psp_rail_merchant_ids(text[], integer) does not exist",
+		Severity: "ERROR",
+	})
+}
+
+type sfNoMerchArgs struct{}
+
+func (sfNoMerchArgs) Kind() string { return sfNoMerchKind }
+
+type sfNoMerchWorker struct{ river.WorkerDefaults[sfNoMerchArgs] }
+
+// The exact error the stacks returned for the 15 days before that: the pull ran
+// on a bare job context, so the rail resolver had no merchant to resolve.
+func (sfNoMerchWorker) Work(ctx context.Context, _ *river.Job[sfNoMerchArgs]) error {
+	if _, err := merchant.Require(ctx); err != nil {
+		return fmt.Errorf("catalog reconciliation: resolve stripe rail: resolve rail stripe: %w", err)
+	}
+	return nil
+}
+
+type sfTransientArgs struct{}
+
+func (sfTransientArgs) Kind() string { return sfTransientKind }
+
+type sfTransientWorker struct{ river.WorkerDefaults[sfTransientArgs] }
+
+// serialization_failure is the control: a Postgres error that IS transient and
+// whose retries must survive the classifier untouched.
+func (sfTransientWorker) Work(context.Context, *river.Job[sfTransientArgs]) error {
+	return fmt.Errorf("write conflict: %w", &pgconn.PgError{
+		Code:     "40001",
+		Message:  "could not serialize access due to concurrent update",
+		Severity: "ERROR",
+	})
+}
+
+func sfJobRow(t *testing.T, dbi *db.DB, kind string) (state string, attempt int, errText string) {
+	t.Helper()
+	ctx := context.Background()
+	err := dbi.Qx(ctx).QueryRow(ctx,
+		`SELECT state::text, attempt, coalesce(errors::text, '') FROM river_job
+		 WHERE kind = $1 ORDER BY id DESC LIMIT 1`, kind).
+		Scan(&state, &attempt, &errText)
+	require.NoError(t, err, "river_job row for %s", kind)
+	return
+}
+
+func sfCleanup(t *testing.T, dbi *db.DB, kinds ...string) {
+	t.Helper()
+	ctx := context.Background()
+	for _, k := range kinds {
+		_, err := dbi.Qx(ctx).Exec(ctx, `DELETE FROM river_job WHERE kind = $1`, k)
+		require.NoError(t, err)
+	}
+}
+
+func TestStructuralFailure_TerminatesPreconditionFailuresAndKeepsTransientRetries(t *testing.T) {
+	dsn := dbtest.SharedPostgresDSN(t)
+	dbi := dbtest.OpenAppDB(t, dsn)
+	pool := dbtest.SharedPGXPool(t)
+	dbtest.EnsureTestMerchant(dbtest.WithTestMerchant(context.Background()), t, dbi.Pool())
+	sfCleanup(t, dbi, sfDriftKind, sfNoMerchKind, sfTransientKind)
+	t.Cleanup(func() { sfCleanup(t, dbi, sfDriftKind, sfNoMerchKind, sfTransientKind) })
+
+	workers := river.NewWorkers()
+	require.NoError(t, river.AddWorkerSafely(workers, &sfDriftWorker{}))
+	require.NoError(t, river.AddWorkerSafely(workers, &sfNoMerchWorker{}))
+	require.NoError(t, river.AddWorkerSafely(workers, &sfTransientWorker{}))
+
+	client, err := river.NewClient(riverpgxv5.New(pool), &river.Config{
+		Queues:            map[string]river.QueueConfig{river.QueueDefault: {MaxWorkers: 4}},
+		Workers:           workers,
+		Middleware:        []rivertype.Middleware{NewStructuralFailureMiddleware()},
+		FetchCooldown:     10 * time.Millisecond,
+		FetchPollInterval: 50 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	events, cancelSub := client.Subscribe(
+		river.EventKindJobCompleted, river.EventKindJobFailed, river.EventKindJobCancelled)
+	t.Cleanup(cancelSub)
+
+	ctx := context.Background()
+	require.NoError(t, client.Start(ctx))
+	t.Cleanup(func() {
+		stopCtx, stop := context.WithTimeout(context.Background(), 10*time.Second)
+		defer stop()
+		_ = client.Stop(stopCtx)
+	})
+
+	// MaxAttempts deliberately > 1 everywhere: a terminal state must come from
+	// CLASSIFICATION, never from exhausting retries.
+	const maxAttempts = 5
+	for _, args := range []river.JobArgs{sfDriftArgs{}, sfNoMerchArgs{}, sfTransientArgs{}} {
+		_, err := client.Insert(ctx, args, &river.InsertOpts{MaxAttempts: maxAttempts})
+		require.NoError(t, err)
+	}
+	awaitJobs(t, events, 3)
+
+	// Schema drift: terminal on attempt 1, with the class named on the row.
+	state, attempt, errText := sfJobRow(t, dbi, sfDriftKind)
+	require.Equal(t, "cancelled", state, "42883 is deterministic; retrying it cannot help")
+	require.Equal(t, 1, attempt, "cancelled by classification, not by exhaustion")
+	require.Contains(t, errText, string(StructuralReasonSchemaDrift))
+	require.Contains(t, errText, "psp_rail_merchant_ids", "the row keeps the underlying cause")
+
+	// Missing merchant scope: same treatment.
+	state, attempt, errText = sfJobRow(t, dbi, sfNoMerchKind)
+	require.Equal(t, "cancelled", state)
+	require.Equal(t, 1, attempt)
+	require.Contains(t, errText, string(StructuralReasonNoMerchantScope))
+
+	// Control: a transient error keeps its retries and never gets reclassified.
+	// The job is either waiting for its backoff (retryable) or already promoted
+	// by River's scheduler (available) — what matters is that it will run again.
+	state, attempt, errText = sfJobRow(t, dbi, sfTransientKind)
+	require.Contains(t, []string{"retryable", "available", "running"}, state,
+		"serialization failures must still retry")
+	require.Equal(t, 1, attempt)
+	require.NotContains(t, errText, "structural precondition failure")
+}


### PR DESCRIPTION
## The observable

`openrails.catalog_reconciliation_pull` has **not completed once in 15 days**. Measured read-only on both standing e2e stacks:

| stack | state | rows | first | last |
|---|---|---|---|---|
| dev (`:29562`) | retryable | 300 | 2026-07-21 10:40 | 2026-08-06 05:14 |
| master (`:31552`) | retryable | 278 | 2026-07-21 09:13 | 2026-08-06 05:14 |

`completed = 0`, `discarded = 0` for the kind's entire history. Found twice by tensorhub's `task release-check` queue_progress check; never root-caused.

## Root cause — two successive causes

**A (the 15 days).** The deployed openrails predated or#877: `Work` ran ONE pass on the bare job context, so `Rails.Armed(ctx, "stripe")` had no merchant and returned `merchant: no merchant resolved on context`. or#877 (4bf37b26) already fixed this; the stacks did not carry the build.

**B (live).** Ten seconds after the dev stack took a deploy (`public.migrations` id 140, `2026-08-06 05:52:20`), attempt 7 of job 241590 changed error:

```
list armed merchants: function openrails.psp_rail_merchant_ids(text[], integer)
does not exist (SQLSTATE 42883)
```

`psp_rail_merchant_ids` was created by a **numbered** migration (or#877 B4) that or#893's re-squash absorbed into a rewritten `0001`. Both stack databases record openrails migrations **1..12**; post-squash the embedded set is `{0001, 0002}` → names `"1"`, `"2"` → both already applied → **migratekit applies nothing**, and the schema stays frozen at the old shape while the binary advances.

`StripeWebhookReconcileWorker` (`jobs_stripe_webhooks.go:80`) calls the same function and is next. Both money-path.

**The hole is one-directional checking.** `migratekit.ApplyMigrations` and `ValidateAllApplied` (v1.4.0) both only ask *embedded ⊆ applied*. Neither ever asks the converse, so a database recording `3`..`12` — names that exist nowhere in the repo — passes both silently. Any re-squash is a silent no-op for every database past the squashed range. Same class as th#1601: a protection that silently stops existing.

## Fixes

**1. Migration drift fence** (`internal/migrate`). `RunPostgres` refuses, with a typed `OrphanedMigrationsError` naming every recorded-but-absent migration, before applying anything.

**2. Structural-failure classification** (`internal/river`). Neither error was ever going to succeed, yet River retried both 25 times apiece — which is why two release-check hits read as transient noise. SQLSTATE class-42 schema drift and `merchant.ErrNoMerchant` now become `river.JobCancel` with a typed reason on the job row plus a loud `structural_job_refusal` log. Installed **per-worker** in `addTrackedWorker` on the or#895 seam, so an embedded host cannot omit it; health bookkeeping stays outermost so it records the refusal the queue acts on.

## Tests — real Postgres, real River client, RED-verified

Both tests fail with the fix disabled and pass with it:

- **fence:** with it disabled, `RunPostgres` returns **`nil`** on the frozen database — and `migratekit.ValidateAllApplied` agrees it is fully migrated. That control assertion is in the test, because it is exactly how this went unseen.
- **classification:** with it disabled, the 42883 job lands `available`/`retryable` instead of `cancelled`. A **control case** proves a transient `40001` keeps every one of its retries and is never reclassified.

No fixed-duration waits; both drive real state transitions.

## NOT done here

The stack databases still need reconciling — both are read-only for this lane and an AOT mint run is live on dev. **The fence will refuse the next deploy until the openrails schema is rebuilt from the current baseline** (or#899's post-squash reset recipe). That is the intended behaviour: a loud deploy-time refusal in place of a silent 15-day money-path outage.

Tracker: or#901.