### PR TITLE
or#902: lead the before-images identity unique with merchant_id

### DIFF
--- a/embed/migration_drift_integration_test.go
+++ b/embed/migration_drift_integration_test.go
@@ -5,6 +5,9 @@ package embed_test
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -40,7 +43,13 @@ func TestEmbeddedRuntimeRefusesOrphanedMigrations(t *testing.T) {
 	ctx := context.Background()
 
 	const schema = config.DefaultSchema
-	orphans := []string{"3", "4", "5", "6", "7", "8", "9", "10", "11", "12"}
+	// Orphans start one past the highest prefix the build actually carries, so
+	// adding a real migration never turns this fixture into a live prefix. It
+	// used to be hardcoded from "3", which migration 0003 made real: the INSERT
+	// then shadowed the genuine ledger row and the cleanup DELETE — matched on
+	// (app, schema, name) only — removed it, leaving 0003 recorded as pending
+	// and every later embed.New in the package refusing to boot.
+	orphans := orphanPrefixesPastEmbedded(t, 10)
 
 	superDSN := dbtest.SharedSuperuserDSN(t)
 	sqlDB, err := sql.Open("pgx", superDSN)
@@ -96,4 +105,29 @@ func TestEmbeddedRuntimeRefusesOrphanedMigrations(t *testing.T) {
 	require.ErrorAs(t, err, &orphanErr, "the refusal is typed, so a host can act on it")
 	require.Equal(t, schema, orphanErr.Schema)
 	require.Equal(t, orphans, orphanErr.Orphaned, "every orphan named, in numeric order")
+}
+
+// orphanPrefixesPastEmbedded returns n numeric prefixes starting just past the
+// highest *.up.sql prefix in the embedded postgres migration set.
+func orphanPrefixesPastEmbedded(t *testing.T, n int) []string {
+	t.Helper()
+	entries, err := postgresmigrations.FS.ReadDir(".")
+	require.NoError(t, err)
+	maxPrefix := 0
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".up.sql") {
+			continue
+		}
+		var p int
+		if _, err := fmt.Sscanf(name, "%d_", &p); err == nil && p > maxPrefix {
+			maxPrefix = p
+		}
+	}
+	require.Positive(t, maxPrefix, "no migrations found in the embedded FS")
+	out := make([]string, 0, n)
+	for i := 1; i <= n; i++ {
+		out = append(out, strconv.Itoa(maxPrefix+i))
+	}
+	return out
 }

--- a/internal/db/gen/destructive_before_images.sql.go
+++ b/internal/db/gen/destructive_before_images.sql.go
@@ -25,7 +25,7 @@ WHERE s.merchant_id = $3::uuid
   -- A pruned row is prune's to reverse (or#858), never converge's: capturing
   -- it here would hand the converge rollback an image it must not write back.
   AND s.deleted_at IS NULL
-ON CONFLICT (destructive_run_id, table_name, row_id) DO NOTHING
+ON CONFLICT (merchant_id, destructive_run_id, table_name, row_id) DO NOTHING
 `
 
 type CaptureSubscriptionBeforeImageParams struct {
@@ -69,7 +69,7 @@ WHERE e.merchant_id = $3::uuid
   AND e.source_id = $4::uuid
   AND e.revoked_at IS NULL
   AND e.deleted_at IS NULL
-ON CONFLICT (destructive_run_id, table_name, row_id) DO NOTHING
+ON CONFLICT (merchant_id, destructive_run_id, table_name, row_id) DO NOTHING
 `
 
 type CaptureSubscriptionEntitlementBeforeImagesParams struct {

--- a/internal/db/queries/destructive_before_images.sql
+++ b/internal/db/queries/destructive_before_images.sql
@@ -21,7 +21,7 @@ WHERE s.merchant_id = sqlc.arg(merchant_id)::uuid
   -- A pruned row is prune's to reverse (or#858), never converge's: capturing
   -- it here would hand the converge rollback an image it must not write back.
   AND s.deleted_at IS NULL
-ON CONFLICT (destructive_run_id, table_name, row_id) DO NOTHING;
+ON CONFLICT (merchant_id, destructive_run_id, table_name, row_id) DO NOTHING;
 
 -- name: CaptureSubscriptionEntitlementBeforeImages :execrows
 -- Every LIVE entitlement window the transition is about to revoke or bound.
@@ -40,7 +40,7 @@ WHERE e.merchant_id = sqlc.arg(merchant_id)::uuid
   AND e.source_id = sqlc.arg(subscription_id)::uuid
   AND e.revoked_at IS NULL
   AND e.deleted_at IS NULL
-ON CONFLICT (destructive_run_id, table_name, row_id) DO NOTHING;
+ON CONFLICT (merchant_id, destructive_run_id, table_name, row_id) DO NOTHING;
 
 -- --- intent attribution -------------------------------------------------------
 

--- a/internal/invariantaudit/audit_bundle_rls_integration_test.go
+++ b/internal/invariantaudit/audit_bundle_rls_integration_test.go
@@ -461,6 +461,87 @@ func TestGAP10_UniqueIndexesAreMerchantScoped(t *testing.T) {
 		"ID-11 (was GAP-10): unique index on a merchant-owned table omits merchant_id — one merchant can block another:\n%v", offenders)
 }
 
+// ID-11 in the flesh (or#902). TestGAP10 above is a census; this is the one
+// index it used to EXEMPT, checked by inserting rows rather than by reading a
+// catalogue.
+//
+// 0001 shipped destructive_run_before_images' identity unique as
+// (destructive_run_id, table_name, row_id) — a key spanning merchants on an
+// RLS-FORCED table, which is the exact ID-11 hazard: the conflicting row is
+// invisible to the inserting session, so the victim gets a unique violation
+// naming a row it cannot select. 0003 leads the key with merchant_id.
+//
+// Reaching the shared coordinate at all needs merchant B's image to cite
+// merchant A's run, which destructive_run_before_images_run_fk permits because
+// it references destructive_runs(id) and not (merchant_id, id) — referential
+// integrity checks bypass RLS, so the FK is not a tenant boundary. That is the
+// point, not an oversight in the test: it is precisely the shape the old index
+// turned into a cross-tenant unique violation, and precisely what a
+// merchant-led key makes harmless. Tightening that FK to a composite is the
+// stricter follow-up; if it lands, this second half stops being constructible
+// and should be deleted, leaving the shape assertion.
+func TestID11_BeforeImagesIdentityUniqueIsMerchantLed(t *testing.T) {
+	ctx, super, app := pools(t)
+
+	var def string
+	require.NoError(t, app.QueryRow(ctx, `
+		SELECT indexdef FROM pg_indexes
+		 WHERE schemaname = 'openrails'
+		   AND tablename  = 'destructive_run_before_images'
+		   AND indexname  = 'uq_destructive_run_before_images_identity'`).Scan(&def),
+		"the or#859 undo-evidence identity index is missing entirely")
+	require.Contains(t, def, "(merchant_id, destructive_run_id, table_name, row_id)",
+		"ID-11: the before-images identity unique must LEAD with merchant_id, got: %s", def)
+
+	a, b := uuid.New(), uuid.New()
+	for id, slug := range map[uuid.UUID]string{
+		a: "inv-bi-a-" + uuid.NewString()[:8],
+		b: "inv-bi-b-" + uuid.NewString()[:8],
+	} {
+		_, err := super.Exec(ctx,
+			`INSERT INTO openrails.merchants (id, slug, status) VALUES ($1, $2, 'active')`, id, slug)
+		require.NoError(t, err)
+	}
+
+	// One run, one subject row id: the whole coordinate the old key made global.
+	runID, rowID := uuid.New(), uuid.New()
+	_, err := super.Exec(ctx,
+		`INSERT INTO openrails.destructive_runs (id, merchant_id, kind, actor)
+		 VALUES ($1, $2, 'converge_enforce', 'or902-invariant-audit')`, runID, a)
+	require.NoError(t, err)
+
+	for _, m := range []uuid.UUID{a, b} {
+		tx, err := app.Begin(ctx)
+		require.NoError(t, err)
+		_, err = tx.Exec(ctx, `SELECT set_config('app.merchant_id', $1::text, true)`, m.String())
+		require.NoError(t, err)
+		_, err = tx.Exec(ctx, `
+			INSERT INTO openrails.destructive_run_before_images
+			    (merchant_id, destructive_run_id, table_name, row_id, before)
+			VALUES ($1, $2, 'subscriptions', $3, '{}'::jsonb)`, m, runID, rowID)
+		require.NoErrorf(t, err,
+			"merchant %s could not capture its own before-image on a coordinate another merchant already holds — "+
+				"the identity unique is spanning merchants again (ID-11)", m)
+		require.NoError(t, tx.Commit(ctx))
+	}
+
+	// And the rule the key still has to enforce: WITHIN a merchant it is one
+	// image per (run, table, row), because the second capture inside a run is
+	// the run's own later write and must not displace the state it inherited.
+	tx, err := app.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+	_, err = tx.Exec(ctx, `SELECT set_config('app.merchant_id', $1::text, true)`, a.String())
+	require.NoError(t, err)
+	_, err = tx.Exec(ctx, `
+		INSERT INTO openrails.destructive_run_before_images
+		    (merchant_id, destructive_run_id, table_name, row_id, before)
+		VALUES ($1, $2, 'subscriptions', $3, '{"second":true}'::jsonb)`, a, runID, rowID)
+	require.Error(t, err,
+		"a merchant's SECOND capture of the same (run, table, row) must still be rejected — "+
+			"leading with merchant_id widened the key, it must not have disarmed it")
+}
+
 // GAP-9: org ↔ merchant is 1:1. Enforced on the policy-free merchants
 // directory, so this read is legitimate without a GUC.
 func TestGAP9_PermissionGroupIsUniquePerMerchant(t *testing.T) {

--- a/internal/migrate/orphaned_migrations_integration_test.go
+++ b/internal/migrate/orphaned_migrations_integration_test.go
@@ -5,6 +5,9 @@ package migrate_test
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -50,7 +53,9 @@ func TestRunPostgres_RefusesOrphanedMigrations(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sqlDB.Close() })
 
-	orphans := []string{"3", "4", "5", "6", "7", "8", "9", "10", "11", "12"}
+	// Orphans start one past the highest prefix the build actually carries, so
+	// adding a real migration never turns this fixture into a live prefix.
+	orphans := orphanPrefixesPastEmbedded(t, 10)
 	t.Cleanup(func() {
 		for _, n := range orphans {
 			_, _ = sqlDB.ExecContext(context.Background(),
@@ -89,4 +94,29 @@ func TestRunPostgres_RefusesOrphanedMigrations(t *testing.T) {
 	m := migratekit.NewPostgres(sqlDB, config.MigratekitApp).WithSchema(orphanedSchema)
 	require.NoError(t, m.ValidateAllApplied(ctx, migrations),
 		"this is the hole or#901 closes: migratekit reports a frozen schema as fully migrated")
+}
+
+// orphanPrefixesPastEmbedded returns n numeric prefixes starting just past the
+// highest *.up.sql prefix in the embedded postgres migration set.
+func orphanPrefixesPastEmbedded(t *testing.T, n int) []string {
+	t.Helper()
+	entries, err := postgresmigrations.FS.ReadDir(".")
+	require.NoError(t, err)
+	maxPrefix := 0
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".up.sql") {
+			continue
+		}
+		var p int
+		if _, err := fmt.Sscanf(name, "%d_", &p); err == nil && p > maxPrefix {
+			maxPrefix = p
+		}
+	}
+	require.Positive(t, maxPrefix, "no migrations found in the embedded FS")
+	out := make([]string, 0, n)
+	for i := 1; i <= n; i++ {
+		out = append(out, strconv.Itoa(maxPrefix+i))
+	}
+	return out
 }

--- a/migrations/postgres/0003_before_images_merchant_led_unique.down.sql
+++ b/migrations/postgres/0003_before_images_merchant_led_unique.down.sql
@@ -1,0 +1,20 @@
+-- Restore the 0001 index pair: the cross-merchant unique identity plus the
+-- separate (merchant_id, destructive_run_id) lookup index it subsumed.
+--
+-- This can fail, and that is correct. Going back re-narrows the key, so it
+-- rejects any row pair two merchants legitimately created while 0003 was
+-- applied (same run id, same table, same row, different merchants). There is
+-- nothing to reconcile automatically — the down migration is the statement that
+-- the cross-merchant unique is back, and a deployment holding rows that need it
+-- gone should not silently lose one.
+
+SET LOCAL statement_timeout = '60s';
+SET LOCAL lock_timeout = '10s';
+
+DROP INDEX openrails.uq_destructive_run_before_images_identity;
+
+CREATE UNIQUE INDEX uq_destructive_run_before_images_identity
+    ON openrails.destructive_run_before_images USING btree (destructive_run_id, table_name, row_id);
+
+CREATE INDEX idx_destructive_run_before_images_merchant_run
+    ON openrails.destructive_run_before_images USING btree (merchant_id, destructive_run_id);

--- a/migrations/postgres/0003_before_images_merchant_led_unique.up.sql
+++ b/migrations/postgres/0003_before_images_merchant_led_unique.up.sql
@@ -1,0 +1,41 @@
+-- or#902 / ID-11 (was GAP-10, SEC-24): make the before-images identity unique
+-- merchant-led.
+--
+-- 0001 shipped it as (destructive_run_id, table_name, row_id) — a UNIQUE that
+-- spans merchants, on a table that is RLS-FORCED. Under RLS the conflicting row
+-- is invisible to the inserting session, so a collision surfaces as a unique
+-- violation naming a row the victim cannot select: indistinguishable from a bug
+-- from the inside, and an existence oracle for whoever provoked it.
+--
+-- Reachability today is narrow, and worth stating honestly: destructive_runs.id
+-- is a GLOBAL primary key, so two merchants cannot open the same run, and the
+-- only way to land on the same key is a before-image pointing at another
+-- merchant's run — which destructive_run_before_images_run_fk permits (it
+-- references destructive_runs(id), not (merchant_id, id)) but no code path does.
+-- That is why the exemption looked defensible. It is still the wrong shape: a
+-- tenancy invariant on THIS table should not rest on another table's key
+-- choice. Leading with merchant_id states the rule the table actually means —
+-- one image per row per run, WITHIN a merchant — and makes it true regardless
+-- of how run ids are minted.
+--
+-- Strictly weaker than what it replaces: the new key is the old key plus a
+-- leading column, so every row set the 0001 index accepted the new one accepts.
+-- No deployment can hold data that fails this.
+--
+-- idx_destructive_run_before_images_merchant_run goes with it, subsumed rather
+-- than merely redundant: (merchant_id, destructive_run_id) is the new key's
+-- leading prefix, and every read the reverse performs — restore, invalidate,
+-- mark-restored, count — filters exactly those two columns. Keeping both would
+-- cost a second index write on the capture, which is one INSERT per
+-- subscription inside a mass enforce pass.
+
+SET LOCAL statement_timeout = '60s';
+SET LOCAL lock_timeout = '10s';
+
+DROP INDEX openrails.idx_destructive_run_before_images_merchant_run;
+DROP INDEX openrails.uq_destructive_run_before_images_identity;
+
+CREATE UNIQUE INDEX uq_destructive_run_before_images_identity
+    ON openrails.destructive_run_before_images USING btree (merchant_id, destructive_run_id, table_name, row_id);
+
+COMMENT ON INDEX openrails.uq_destructive_run_before_images_identity IS 'ID-11: merchant-led. One image per (run, table, row) WITHIN a merchant — the second capture inside a run is the run''s own later write, not the state it inherited, and must never displace the first (the capture is ON CONFLICT DO NOTHING for that reason). Also serves the by-run reads of the reverse, so no separate (merchant_id, destructive_run_id) index is kept.';

--- a/migrations/postgres/merchant_aware_schema_test.go
+++ b/migrations/postgres/merchant_aware_schema_test.go
@@ -133,6 +133,27 @@ type schemaIndex struct {
 	// counts as its first argument, so 0017/0020's total-index technique is
 	// recognised as scoping by that column.
 	cols []string
+	// pos is the declaration's byte offset in the concatenated schema — i.e.
+	// its position in apply order. RENAME/DROP are replayed against it so a
+	// name can be reused by a later migration; see indexEvent.
+	pos int
+}
+
+// indexEvent is a RENAME or a DROP of an index, with the file-order position it
+// happens at. These are replayed IN ORDER against declarations that PRECEDE
+// them, which is the one place this derivation cannot be set-based.
+//
+// or#902 found why: correcting a bad index means dropping it and recreating it
+// under the same name in a later migration. A set-based drop matches on name
+// alone, so it deletes the recreation too and the guard sees NO index — the
+// unique-scope check then passes vacuously on the very edit it exists to
+// review, and the RLS index-backing check fails on an index that is really
+// there. Ordering by position makes "drop the old shape, create the corrected
+// one" mean what it says.
+type indexEvent struct {
+	pos      int
+	drop     bool
+	from, to string
 }
 
 // scopedBy reports whether the index constrains uniqueness within col.
@@ -203,7 +224,16 @@ func leadingColumn(colList string) string {
 	return ""
 }
 
-func parseIndex(name, colsAndTail string, unique bool) schemaIndex {
+// group returns submatch n of a FindAllStringSubmatchIndex result, or "" when
+// that group did not participate (reInlineKey's CONSTRAINT name is optional).
+func group(s string, m []int, n int) string {
+	if 2*n+1 >= len(m) || m[2*n] < 0 {
+		return ""
+	}
+	return s[m[2*n]:m[2*n+1]]
+}
+
+func parseIndex(name, colsAndTail string, unique bool, pos int) schemaIndex {
 	cols, tail := splitTopLevel(colsAndTail)
 	names := make([]string, 0, len(cols))
 	for _, c := range cols {
@@ -217,6 +247,7 @@ func parseIndex(name, colsAndTail string, unique bool) schemaIndex {
 		partial: strings.Contains(strings.ToUpper(tail), "WHERE"),
 		unique:  unique,
 		cols:    names,
+		pos:     pos,
 	}
 }
 
@@ -271,37 +302,52 @@ func deriveSchemaTables(t *testing.T, schema string) schemaTables {
 		rlsExemptMarked: map[string]bool{},
 		indexes:         map[string][]schemaIndex{},
 	}
-	for _, m := range reCreateTable.FindAllStringSubmatch(schema, -1) {
-		s.blocks[m[1]] = m[2]
-		if reMerchantIDCol.MatchString(m[2]) {
-			s.merchantScoped[m[1]] = true
+	for _, m := range reCreateTable.FindAllStringSubmatchIndex(schema, -1) {
+		tbl, body := schema[m[2]:m[3]], schema[m[4]:m[5]]
+		s.blocks[tbl] = body
+		if reMerchantIDCol.MatchString(body) {
+			s.merchantScoped[tbl] = true
 		}
-		for _, k := range reInlineKey.FindAllStringSubmatch(m[2], -1) {
-			s.indexes[m[1]] = append(s.indexes[m[1]], parseIndex(k[1], k[2], isUniqueDecl(k[0])))
-		}
-	}
-	for _, m := range reCreateIndex.FindAllStringSubmatch(schema, -1) {
-		s.indexes[m[2]] = append(s.indexes[m[2]], parseIndex(m[1], m[3], isUniqueDecl(m[0][:strings.Index(strings.ToUpper(m[0]), "INDEX")])))
-	}
-	for _, m := range reAlterKey.FindAllStringSubmatch(schema, -1) {
-		s.indexes[m[1]] = append(s.indexes[m[1]], parseIndex(m[2], m[3], isUniqueDecl(m[0])))
-	}
-	// Renames before drops: 0003's psps hardcut renames indexes that a later
-	// migration drops by their NEW name.
-	for _, m := range reRenameIndex.FindAllStringSubmatch(schema, -1) {
-		for _, ixs := range s.indexes {
-			for i := range ixs {
-				if ixs[i].name == m[1] {
-					ixs[i].name = m[2]
-				}
-			}
+		for _, k := range reInlineKey.FindAllStringSubmatchIndex(body, -1) {
+			// Offsets are body-relative; rebase onto the whole schema so an
+			// in-body key sorts against CREATE/DROP INDEX statements correctly.
+			s.indexes[tbl] = append(s.indexes[tbl],
+				parseIndex(group(body, k, 1), group(body, k, 2), isUniqueDecl(group(body, k, 0)), m[4]+k[0]))
 		}
 	}
-	for _, m := range reDropIndex.FindAllStringSubmatch(schema, -1) {
+	for _, m := range reCreateIndex.FindAllStringSubmatchIndex(schema, -1) {
+		decl := group(schema, m, 0)
+		s.indexes[group(schema, m, 2)] = append(s.indexes[group(schema, m, 2)],
+			parseIndex(group(schema, m, 1), group(schema, m, 3),
+				isUniqueDecl(decl[:strings.Index(strings.ToUpper(decl), "INDEX")]), m[0]))
+	}
+	for _, m := range reAlterKey.FindAllStringSubmatchIndex(schema, -1) {
+		s.indexes[group(schema, m, 1)] = append(s.indexes[group(schema, m, 1)],
+			parseIndex(group(schema, m, 2), group(schema, m, 3), isUniqueDecl(group(schema, m, 0)), m[0]))
+	}
+	// RENAME/DROP replayed in FILE ORDER against the declarations before them.
+	// A rename retains its declaration's position, so a later drop by the NEW
+	// name still finds it — which is what the psps hardcut needed — while a
+	// migration that drops an index and recreates it under the same name keeps
+	// the recreation (or#902; see indexEvent).
+	var events []indexEvent
+	for _, m := range reRenameIndex.FindAllStringSubmatchIndex(schema, -1) {
+		events = append(events, indexEvent{pos: m[0], from: group(schema, m, 1), to: group(schema, m, 2)})
+	}
+	for _, m := range reDropIndex.FindAllStringSubmatchIndex(schema, -1) {
+		events = append(events, indexEvent{pos: m[0], drop: true, from: group(schema, m, 1)})
+	}
+	sort.Slice(events, func(i, j int) bool { return events[i].pos < events[j].pos })
+	for _, ev := range events {
 		for tbl, ixs := range s.indexes {
 			kept := ixs[:0]
 			for _, ix := range ixs {
-				if ix.name != m[1] {
+				if ix.name != ev.from || ix.pos > ev.pos {
+					kept = append(kept, ix)
+					continue
+				}
+				if !ev.drop {
+					ix.name = ev.to
 					kept = append(kept, ix)
 				}
 			}
@@ -671,6 +717,86 @@ func TestUniqueIndexesAreMerchantScoped(t *testing.T) {
 			"so one merchant can block another's insert and squat its provider reference (GAP-10 / SEC-24). "+
 			"Lead the index with merchant_id (COALESCE a nullable PSP dimension to the nil uuid, as 0017/0020 do), "+
 			"or add it to CrossMerchantUniqueExemptions with a reason.", v)
+	}
+}
+
+// TestIndexLifecycleIsReplayedInFileOrder pins the derivation's one ordered
+// step. Everything else here is set-based on purpose; index RENAME/DROP cannot
+// be, and 0003 is the migration that shows why: correcting a bad index means
+// dropping it and recreating it under the SAME name in a later file.
+//
+// A name-only drop pass deletes the recreation too. That is not a cosmetic
+// miss — it is a guard reporting a pass it did not earn, because
+// TestUniqueIndexesAreMerchantScoped only ever sees indexes that exist, so an
+// index it cannot see is an index it cannot fault.
+func TestIndexLifecycleIsReplayedInFileOrder(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		schema string
+		want   []string // "indexname:col,col" per surviving index on `widgets`
+	}{
+		{
+			name: "drop then recreate under the same name keeps the recreation",
+			schema: `CREATE TABLE openrails.widgets (
+    id uuid NOT NULL,
+    merchant_id uuid NOT NULL,
+    code text NOT NULL
+);
+CREATE UNIQUE INDEX uq_widgets_code ON openrails.widgets USING btree (code);
+DROP INDEX openrails.uq_widgets_code;
+CREATE UNIQUE INDEX uq_widgets_code ON openrails.widgets USING btree (merchant_id, code);
+`,
+			want: []string{"uq_widgets_code:merchant_id,code"},
+		},
+		{
+			name: "a plain drop still removes the index",
+			schema: `CREATE TABLE openrails.widgets (
+    id uuid NOT NULL,
+    merchant_id uuid NOT NULL,
+    code text NOT NULL
+);
+CREATE UNIQUE INDEX uq_widgets_code ON openrails.widgets USING btree (code);
+DROP INDEX openrails.uq_widgets_code;
+`,
+			want: nil,
+		},
+		{
+			name: "a drop by the NEW name still finds a renamed index",
+			schema: `CREATE TABLE openrails.widgets (
+    id uuid NOT NULL,
+    merchant_id uuid NOT NULL,
+    code text NOT NULL
+);
+CREATE UNIQUE INDEX uq_widgets_old ON openrails.widgets USING btree (code);
+ALTER INDEX openrails.uq_widgets_old RENAME TO uq_widgets_new;
+DROP INDEX openrails.uq_widgets_new;
+`,
+			want: nil,
+		},
+		{
+			name: "a drop BEFORE the declaration does not reach forward",
+			schema: `CREATE TABLE openrails.widgets (
+    id uuid NOT NULL,
+    merchant_id uuid NOT NULL,
+    code text NOT NULL
+);
+DROP INDEX IF EXISTS openrails.uq_widgets_code;
+CREATE UNIQUE INDEX uq_widgets_code ON openrails.widgets USING btree (merchant_id, code);
+`,
+			want: []string{"uq_widgets_code:merchant_id,code"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := deriveSchemaTables(t, tc.schema)
+			var got []string
+			for _, ix := range s.indexes["widgets"] {
+				got = append(got, ix.name+":"+strings.Join(ix.cols, ","))
+			}
+			sort.Strings(got)
+			if strings.Join(got, " | ") != strings.Join(tc.want, " | ") {
+				t.Fatalf("index inventory = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/migrations/postgres/unique_scope_exemptions.go
+++ b/migrations/postgres/unique_scope_exemptions.go
@@ -41,7 +41,15 @@ var CrossMerchantUniqueExemptions = map[string]string{
 	"uq_subscription_reprices_one_scheduled":      "subscription_id FKs a merchant-owned subscription",
 	"uq_subscriptions_customer_tier_group_active": "customer_id FKs a merchant-owned customer (ID-3's one-live-per-tier-group rule)",
 	"unique_prices_product_amount_window":         "product_id FKs a merchant-owned product (ID-5 price financial substance)",
-	"uq_destructive_run_before_images_identity":   "destructive_run_id FKs a merchant-owned destructive_runs row (or#859 undo evidence)",
+	// uq_destructive_run_before_images_identity was here on that reasoning and
+	// is NOT any more (or#902): 0003 leads it with merchant_id, so it needs no
+	// exemption. The reasoning was not wrong, it was second-hand — the index was
+	// safe because destructive_runs.id happens to be a GLOBAL primary key, and
+	// because destructive_run_before_images_run_fk references destructive_runs(id)
+	// rather than (merchant_id, id) the safety was never enforced on this table
+	// at all. An entry in this class is only sound while the FK it leans on
+	// cannot be satisfied across the tenant boundary; check that before adding
+	// one, and prefer leading with merchant_id, which needs no such argument.
 
 	// Genuinely global identifiers, unique across the install by construction.
 	"solana_subscriptions_subscription_pda_key": "a Solana PDA is globally unique on-chain; two merchants CANNOT share one",


### PR DESCRIPTION
## The defect

`openrails.destructive_run_before_images` (or#859 undo evidence) shipped in the squashed baseline with

```sql
CREATE UNIQUE INDEX uq_destructive_run_before_images_identity
    ON openrails.destructive_run_before_images USING btree (destructive_run_id, table_name, row_id);
```

— a UNIQUE that does not lead with `merchant_id`, on a table that is RLS-FORCED. Reproduced as `openrails_app` against a DB built from `migrations/`:

```
--- merchant A captures its before-image ---            OK
--- merchant B tries the same coordinate ---
ERROR:  duplicate key value violates unique constraint "uq_destructive_run_before_images_identity"
--- what merchant B can SEE of the row that blocked it ---
 visible_conflicting_rows
--------------------------
                        0
```

The victim gets a unique violation naming a row it can select **zero** of.

This is the GAP-10/SEC-24 fix from the orphaned `chaos-wip-859` branch (`da384f12`) that never landed. Its migration was 0030, which the or#893 squash deleted, so it lands as a new migration.

## The fix

`0003_before_images_merchant_led_unique` swaps the key to `(merchant_id, destructive_run_id, table_name, row_id)` and drops `idx_destructive_run_before_images_merchant_run`, which the new key's leading prefix subsumes — restore / invalidate / mark-restored / count all filter exactly those two columns, and the capture is one INSERT per subscription inside a mass enforce pass. The new key is the old key plus a leading column, so it is strictly weaker and no deployment can hold data that fails it. The two capture queries' `ON CONFLICT` targets follow; `sqlc generate` touches only those two lines.

## Honest scope of the hazard

`destructive_runs.id` is a **global** primary key, so two merchants cannot open the same run. The shared coordinate is only reachable via a before-image citing another merchant's run — which `destructive_run_before_images_run_fk` permits, because it references `destructive_runs(id)` and not `(merchant_id, id)`, and RI checks bypass RLS. No code path does this today.

That is exactly why the ID-11 exemption looked defensible. It is still the wrong shape: it made a tenancy invariant on *this* table depend on another table's key choice, and nothing on this table enforced it. Fixed rather than re-justified.

**Follow-up worth filing:** tighten `destructive_run_before_images_run_fk` to a composite `(merchant_id, destructive_run_id) -> destructive_runs(merchant_id, id)` (needs a `UNIQUE (merchant_id, id)` on `destructive_runs`; the repo already uses composite merchant FKs in five places). That makes the cross-tenant citation structurally impossible. If it lands, the row-level half of the new test stops being constructible and should go.

## Why the guard did not catch it

Not a blind spot in the check — `uq_destructive_run_before_images_identity` was in `CrossMerchantUniqueExemptions`, in the "keyed on a surrogate uuid that is itself merchant-owned" class. Both guards (migration-text and live-`pg_indexes`) share that one list, so both were silenced. The entry is removed, with a note on when that class is and is not sound.

There *was* a real latent blind spot, and this migration is the first to hit it. `deriveSchemaTables` replayed index RENAME/DROP **set-based**, matching on name alone. Correcting a bad index means dropping it and recreating it under the same name, and a name-only drop deletes the recreation too — leaving `TestUniqueIndexesAreMerchantScoped` with no index to fault, i.e. passing vacuously on precisely the edit it exists to review. RENAME/DROP are now replayed in file order against the declarations that precede them.

Verified load-bearing — with the old logic restored:

```
--- FAIL: TestMerchantIsolationPolicyIsIndexBacked
    table "destructive_run_before_images" ... no NON-partial index leading with merchant_id (merchant_id-leading indexes: [])
--- FAIL: TestIndexLifecycleIsReplayedInFileOrder/drop_then_recreate_under_the_same_name_keeps_the_recreation
    index inventory = [], want [uq_widgets_code:merchant_id,code]
```

## Proof

`TestID11_BeforeImagesIdentityUniqueIsMerchantLed` (`internal/invariantaudit`, live DB, as `openrails_app`, not superuser, not BYPASSRLS): asserts the index shape from `pg_indexes`, then has two merchants insert the **same** `(destructive_run_id, table_name, row_id)` and requires both to succeed — and requires a merchant's *second* capture of its own `(run, table, row)` to still be rejected, because widening the key must not disarm it.

## The rest of `da384f12`

Checked hunk by hunk; everything else landed by other routes and is correct on master:

| hunk | status |
|---|---|
| `ON CONFLICT` targets, migration index shape | **the only thing missing** — this PR |
| `AND s.deleted_at IS NULL` on capture + restore | landed, with better comments |
| `Runs: &PGDestructiveRunRecorder{...}` in 4 test files | landed (all, plus two more) |
| `stubDestructiveRunRecorder` in `engine_test.go` | landed as the equivalent `fakeRunRecorder` |
| `docs/operations.md` `converge rollback` | **superseded** — master unified on `undo-run --run <id>`, which dispatches on run kind |

## Gates

`sqlc generate` + `sqlc vet`, `TestQueryAudit`, `sql-lint`, `migration-lint` (squawk clean on 2 files, no inline exemption needed — `require-concurrent-index-*` are already unsatisfiable-and-excluded), `golangci-lint` (0 issues), `go test ./...`, and integration (`-p 1`) for `internal/invariantaudit`, `migrations/postgres`, `internal/reconcile`, `internal/db/querytest`. Stack torn down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)