### PR TITLE
or#903: the wasted-spend claim is a durable row, not a Redis SetNX

### DIFF
--- a/internal/db/models/usage_event.go
+++ b/internal/db/models/usage_event.go
@@ -43,4 +43,11 @@ type UsageEvent struct {
 	Metadata         map[string]any `json:"metadata,omitempty"`
 	OccurredAt       time.Time      `json:"occurred_at"`
 	CreatedAt        time.Time      `json:"created_at"`
+	// Replayed reports that this event's idempotency coordinate was ALREADY
+	// recorded, so the call that returned it metered nothing new and moved no
+	// money — the row described here landed earlier (or#903, same contract as
+	// CreditTransaction.Replayed). Not persisted; it is the answer to "did MY
+	// call apply?", which is what lets a caller derive a cache from a durable
+	// decision instead of keeping a claim table beside it.
+	Replayed bool `json:"replayed,omitempty"`
 }

--- a/internal/modules/abuse/wasted_spend.go
+++ b/internal/modules/abuse/wasted_spend.go
@@ -3,7 +3,6 @@ package abuse
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/open-rails/openrails/internal/modules/ratelimit"
@@ -26,6 +25,14 @@ import (
 //
 // Built on the proven Redis fixed-window limiter (same infra as throughput +
 // velocity); no new store. Everything is generic money amount accounting — no host concepts.
+//
+// or#903: these windows are a CACHE, never the once-only claim for a report.
+// The claim is the durable usage_events row every report writes (see
+// service.ReportWastedSpend); these counters are only advanced once that row
+// has been APPLIED. The guard therefore exposes grading (PayerGraceOverage)
+// separately from consumption (ConsumePayerGrace), and has no idempotency
+// primitive of its own — a Redis key is not a durable idempotency key
+// (DESIGN-RULINGS §4.23).
 type WastedSpendGuard struct {
 	lim *ratelimit.Limiter
 }
@@ -65,25 +72,16 @@ func invokerBase(merchant, payer, invoker, currency string) string {
 	return fmt.Sprintf("wa:%s:%s:%s:%s", merchant, payer, invoker, currency)
 }
 
-// ClaimReport records short-lived idempotency for a host-reported wasted-spend
-// event. The TTL should be the largest active wasted-spend window so retries do
-// not double-add hot counters while the report can affect enforcement.
-func (g *WastedSpendGuard) ClaimReport(ctx context.Context, merchant, payer, currency, source, sourceID string, ttl time.Duration) (bool, error) {
-	if !g.Enabled() {
-		return false, nil
-	}
-	source = strings.TrimSpace(source)
-	sourceID = strings.TrimSpace(sourceID)
-	if source == "" || sourceID == "" {
-		return false, fmt.Errorf("wasted-spend source and source_id required")
-	}
-	return g.lim.ClaimOnce(ctx, fmt.Sprintf("wasted:%s:%s:%s:%s:%s", merchant, payer, currency, source, sourceID), ttl)
-}
-
-// RecordPayerGrace records direct-payer wasted spend against payer grace windows
-// and returns the amount that exceeds the strictest remaining grace window. No
-// windows means no configured grace policy and no chargeable overage.
-func (g *WastedSpendGuard) RecordPayerGrace(ctx context.Context, merchant, payer, currency string, amount int64, windows []WastedWindow) (int64, error) {
+// PayerGraceOverage GRADES a direct-payer report against the payer's grace
+// windows WITHOUT mutating them: it returns the part of amount that exceeds the
+// strictest remaining window. No configured window means no grace policy and no
+// chargeable overage.
+//
+// or#903 split grading from recording. The caller must be able to compute the
+// chargeable number, commit it durably, and only then consume grace — because
+// the durable commit is what decides whether this report has been counted
+// before. Grading and consuming in one call made that ordering unexpressible.
+func (g *WastedSpendGuard) PayerGraceOverage(ctx context.Context, merchant, payer, currency string, amount int64, windows []WastedWindow) (int64, error) {
 	if !g.Enabled() || amount <= 0 || payer == "" {
 		return 0, nil
 	}
@@ -107,18 +105,30 @@ func (g *WastedSpendGuard) RecordPayerGrace(ctx context.Context, merchant, payer
 			hasWindow = true
 		}
 	}
+	if !hasWindow || amount <= freeRemaining {
+		return 0, nil
+	}
+	return amount - freeRemaining, nil
+}
+
+// ConsumePayerGrace adds a graded report's amount to every payer grace window.
+// Call it only after the report's durable record has been APPLIED (not
+// replayed): these counters are a cache, so they must be derived from the
+// durable decision rather than be the decision.
+func (g *WastedSpendGuard) ConsumePayerGrace(ctx context.Context, merchant, payer, currency string, amount int64, windows []WastedWindow) error {
+	if !g.Enabled() || amount <= 0 || payer == "" {
+		return nil
+	}
+	base := payerBase(merchant, payer, currency)
 	for _, w := range windows {
 		if w.Window <= 0 {
 			continue
 		}
 		if _, err := g.lim.AddWindowValue(ctx, base, w.Key, w.Window, amount); err != nil {
-			return 0, err
+			return err
 		}
 	}
-	if !hasWindow || amount <= freeRemaining {
-		return 0, nil
-	}
-	return amount - freeRemaining, nil
+	return nil
 }
 
 // RecordInvokerCutoff records delegated-invoker wasted spend against the flat

--- a/internal/modules/money/usage.go
+++ b/internal/modules/money/usage.go
@@ -45,9 +45,15 @@ type RecordUsageParams struct {
 // RecordUsage durably records a metered usage event AND debits the credit ledger
 // in ONE transaction (issue #289). Idempotent on
 // (merchant, payer, event_type, source, source_id): a replayed request returns the
-// existing event and never double-charges. Concurrency-safe: the balance row is
-// locked FOR UPDATE before the idempotency check, so two concurrent identical
-// records serialize and the second sees the first's event.
+// existing event with Replayed set and never double-charges, while a replay
+// carrying a CHANGED amount is refused (ErrIdempotencyKeyReused).
+// Concurrency-safe: the balance row is locked FOR UPDATE before the idempotency
+// check, so two concurrent identical records serialize and the second sees the
+// first's event.
+//
+// A zero Amount is a legitimate use: it records the event durably (metering
+// dimensions, and or#903's once-only claim for a report whose money outcome is
+// nothing) without touching the ledger.
 //
 // This is the DURABLE side. In FAST mode (#298) it runs write-behind, off the
 // per-request hot path; the synchronous admission decision is the Redis headroom
@@ -111,6 +117,10 @@ func (s *MoneyService) RecordUsage(ctx context.Context, params RecordUsageParams
 					Field: "amount", Committed: ev.Amount, Retried: params.Amount,
 				}
 			}
+			// or#903: say so. A caller that must not repeat a NON-ledger side
+			// effect (a cache counter, a host notification) cannot tell an
+			// applied write from a replayed one without this.
+			ev.Replayed = true
 			return nil
 		}
 		if !errors.Is(gerr, pgx.ErrNoRows) {
@@ -185,6 +195,63 @@ func (s *MoneyService) RecordUsage(ctx context.Context, params RecordUsageParams
 			OccurredAt:       ev.OccurredAt,
 			CreatedAt:        ev.CreatedAt,
 		})
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ev, nil
+}
+
+// FindUsageEvent returns the durable event already recorded at these
+// idempotency coordinates, or (nil, nil) when the key is unclaimed.
+//
+// or#903: this is how a caller asks "has my write already happened?" BEFORE
+// deciding what to write. It exists because some callers derive the amount they
+// are about to record from mutable state (wasted-spend grace), so re-deriving it
+// on a replay produces a different number and RecordUsage's changed-amount
+// refusal would fire on an IDENTICAL retry. The read is not a lock — RecordUsage
+// remains the atomic decision — it only lets the caller stop before it grades.
+func (s *MoneyService) FindUsageEvent(ctx context.Context, payer identity.CustomerID, currency, eventType string, key IdempotencyKey) (*models.UsageEvent, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("money service not initialized")
+	}
+	eventType = strings.TrimSpace(eventType)
+	if eventType == "" {
+		return nil, fmt.Errorf("event_type required")
+	}
+	if err := key.RequireOperation(UsageOperation(eventType)); err != nil {
+		return nil, err
+	}
+	if payer.IsZero() {
+		return nil, fmt.Errorf("payer required")
+	}
+	cur := normalizeCurrency(currency)
+	if err := moneyutil.ValidateCurrency(cur); err != nil {
+		return nil, err
+	}
+	tid, err := merchant.Require(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var ev *models.UsageEvent
+	err = s.db.RunInMerchantConn(ctx, func(ctx context.Context) error {
+		row, gerr := s.db.Gen(ctx).GetUsageEventByCoords(ctx, gen.GetUsageEventByCoordsParams{
+			MerchantID: tid.UUID(), CustomerID: payer.UUID(),
+			Currency:  cur,
+			EventType: eventType, Source: key.Source(), SourceID: key.SourceID(),
+		})
+		if errors.Is(gerr, pgx.ErrNoRows) {
+			return nil
+		}
+		if gerr != nil {
+			return gerr
+		}
+		ev, gerr = usageEventFromGen(row)
+		if gerr != nil {
+			return gerr
+		}
+		ev.Replayed = true
+		return nil
 	})
 	if err != nil {
 		return nil, err

--- a/internal/modules/ratelimit/valuewindow.go
+++ b/internal/modules/ratelimit/valuewindow.go
@@ -3,7 +3,6 @@ package ratelimit
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -61,18 +60,8 @@ func (l *Limiter) WindowValue(ctx context.Context, base, unit string, window tim
 	return n, nil
 }
 
-// ClaimOnce records a short-lived idempotency key. It returns true only for the
-// first caller while ttl is active.
-func (l *Limiter) ClaimOnce(ctx context.Context, key string, ttl time.Duration) (bool, error) {
-	if l == nil || l.rdb == nil {
-		return false, fmt.Errorf("ratelimit: limiter not initialized")
-	}
-	key = strings.TrimSpace(key)
-	if key == "" {
-		return false, fmt.Errorf("ratelimit: key required")
-	}
-	if ttl <= 0 {
-		ttl = time.Hour
-	}
-	return l.rdb.SetNX(ctx, "once:"+key, "1", ttl).Result()
-}
+// or#903 deleted ClaimOnce, the SetNX "short-lived idempotency key". Its only
+// caller was the wasted-spend report claim, and a cache key that expires and
+// does not survive a flush is not an idempotency claim — it only looked like
+// one. Durable once-only belongs to a keyed money write; do not reintroduce
+// this primitive to give some other path the same illusion.

--- a/pkg/service/admission.go
+++ b/pkg/service/admission.go
@@ -609,21 +609,21 @@ func (s *Service) payerWastedWindows(ctx context.Context, payer identity.Custome
 // money.
 //
 // Source+SourceID are required (enforced below) and must be REPRODUCIBLE across
-// retries of the same failed attempt. Read the guarantee precisely, because the
-// two layers differ:
+// retries of the same failed attempt: together with the engine-composed
+// operation "usage:wasted_spend" they ARE the report's identity (or#894 keeps
+// that operation distinct so the charge never aliases the CAPTURE of the same
+// request id).
 //
-//   - The DUPLICATE VERDICT (Duplicate=true, no grace re-accounting) is a Redis
-//     SetNX in abuse.WastedSpendGuard.ClaimReport. It is a cache, not a durable
-//     claim: it expires with the widest configured window and does not survive a
-//     flush. After a flush a replay is re-graded and re-counted against grace.
-//   - The MONEY is durable regardless: the direct-payer overage charge posts
-//     through money.RecordUsage at operation "usage:wasted_spend" over
-//     (source, source_id), whose key is structural, so a replay cannot
-//     double-charge and a replay with a changed amount is refused
-//     (money.ErrIdempotencyKeyReused). The operation is engine-composed, so the
-//     charge never aliases the CAPTURE of the same request id (or#894).
+// ONE guarantee now, not two layers (or#903). Every report writes a durable
+// usage_events row under a structural unique key, so the duplicate verdict, the
+// no-re-accounting-of-grace property and the money are all the same fact: a
+// replay is answered Duplicate with no side effect however long ago the first
+// one landed and whatever happened to Redis in between, and a replay whose
+// chargeable amount changed is refused with money.ErrIdempotencyKeyReused
+// rather than silently dropped. There is no TTL to reason about, and a host
+// needs no claim table of its own.
 //
-// Reported measurements: or#891, and DESIGN-RULINGS §4.23.
+// Reported measurements: or#891, or#903, and DESIGN-RULINGS §4.23.
 type WastedSpendInput struct {
 	CustomerID  identity.CustomerID
 	Invoker     string
@@ -654,9 +654,36 @@ type WastedSpendResult struct {
 
 // ReportWastedSpend records host-reported WASTED $ (#497): delegated invokers
 // accrue against their flat Redis cutoff, while direct payer credentials accrue
-// against trust-level-graduated payer grace and charge overage through the normal usage
-// ledger. No high-volume Postgres event table is written for free/delegated
-// reports.
+// against trust-level-graduated payer grace and charge overage through the normal
+// usage ledger.
+//
+// # or#903 — the ordering, and why it is this way round
+//
+// Every report writes ONE durable usage_events row at operation
+// "usage:wasted_spend" over (source, source_id), whatever its money outcome:
+// the charged overage, a fully forgiven report (amount 0) and a delegated
+// invoker's report (amount 0) all land the same row under the same unique
+// index. That row IS the once-only claim, and the Redis windows are advanced
+// only when it APPLIES. Before or#903 the order was inverted — a SetNX claimed
+// the report and the ledger was reached only for a chargeable overage — so the
+// claim was a cache: it expired, it did not survive a flush, and a replay after
+// a flush was re-graded and re-counted against the payer's grace. It also made
+// the engine's own changed-amount refusal unreachable inside the TTL, which is
+// why hosts grew claim tables of their own (th#1464's outbox fingerprint).
+//
+// Consequences worth stating, because they are the contract now:
+//
+//   - A replay is answered Duplicate=true and consumes no grace, forever, not
+//     for a TTL, and across a Redis flush.
+//   - A replay whose chargeable amount CHANGED is refused with
+//     money.ErrIdempotencyKeyReused instead of being silently dropped.
+//   - A crash between the durable row and the counter advance leaves grace
+//     UNCONSUMED, never double-consumed: the residual error is in the payer's
+//     favour.
+//   - The free/delegated path now writes a Postgres row per report. That is a
+//     deliberate reversal of "no event table for free reports": a report the
+//     platform cannot recognise as already-seen is not free, it is just
+//     unaccounted somewhere else.
 func (s *Service) ReportWastedSpend(ctx context.Context, in WastedSpendInput) (*WastedSpendResult, error) {
 	ctx, release, pinErr := s.pin(ctx)
 	if pinErr != nil {
@@ -713,12 +740,26 @@ func (s *Service) ReportWastedSpend(ctx context.Context, in WastedSpendInput) (*
 	if err != nil {
 		return nil, err
 	}
-	claimed, err := guard.ClaimReport(ctx, tid.UUID().String(), in.CustomerID.UUID().String(), cur, in.Source, in.SourceID, maxWastedWindowTTL(payerWindows, invokerWindows))
+	merchantID := tid.UUID().String()
+	payerID := in.CustomerID.UUID().String()
+
+	// or#894: the row posts at operation "usage:wasted_spend", NOT at the bare
+	// (source, source_id) the caller reported. Without the operation it aliased
+	// the CAPTURE of the same rendered request — the capture then moved 0 micros
+	// and returned the waste transfer.
+	wasteKey, err := money.NewIdempotencyKey(money.UsageOperation(wastedSpendEventType), in.Source, in.SourceID)
 	if err != nil {
 		return nil, err
 	}
-	if !claimed {
-		return &WastedSpendResult{Currency: cur, Action: "duplicate", Duplicate: true}, nil
+
+	// THE CLAIM CHECK, ahead of everything that reads or writes a counter.
+	// Grading consumes nothing, but it READS the grace window, and the window
+	// already contains this report's own first application — so a replay grades
+	// to a different chargeable amount than the one on file. Deciding "already
+	// seen" from the durable row instead of from the re-derived number is what
+	// makes an identical retry a duplicate rather than a spurious conflict.
+	if claimed, err := s.claimedWasteReport(ctx, in, cur, wasteKey); err != nil || claimed != nil {
+		return claimed, err
 	}
 
 	if identity.IsDirectPayerInvoker(in.InvokerType) {
@@ -726,7 +767,9 @@ func (s *Service) ReportWastedSpend(ctx context.Context, in WastedSpendInput) (*
 		if err != nil {
 			return nil, err
 		}
-		chargeablePolicy, err := guard.RecordPayerGrace(ctx, tid.UUID().String(), in.CustomerID.UUID().String(), payerPolicyCurrency, policyAmount, payerWindows)
+		// GRADE against grace without consuming it — the durable row below
+		// decides whether this report gets to consume anything at all.
+		chargeablePolicy, err := guard.PayerGraceOverage(ctx, merchantID, payerID, payerPolicyCurrency, policyAmount, payerWindows)
 		if err != nil {
 			return nil, err
 		}
@@ -749,36 +792,38 @@ func (s *Service) ReportWastedSpend(ctx context.Context, in WastedSpendInput) (*
 			PolicyChargedAmount:  chargeablePolicy,
 			Action:               "forgiven",
 		}
+		// The durable claim. Amount is the overage (often 0) and the ledger is
+		// debited only when it is positive, but the ROW is written either way:
+		// that is what makes a forgiven report as replay-proof as a charged one.
+		ev, err := s.moneyService().RecordUsage(ctx, money.RecordUsageParams{
+			Payer:     &in.CustomerID,
+			Invoker:   strings.TrimSpace(in.Invoker),
+			Currency:  cur,
+			EventType: wastedSpendEventType,
+			Amount:     chargeable,
+			Key:        wasteKey,
+			Dimensions: map[string]int64{wastedReportedDimension: in.Amount},
+			Metadata: map[string]any{
+				"reason":                   in.Reason,
+				"reported_amount":          in.Amount,
+				"forgiven_amount":          res.ForgivenAmount,
+				"policy_currency":          payerPolicyCurrency,
+				"policy_amount":            policyAmount,
+				"policy_chargeable_amount": chargeablePolicy,
+				"invoker_type":             string(identity.InvokerTypePayer),
+				"chargeable_amount":        chargeable,
+			},
+		})
+		if err != nil {
+			return s.wasteWriteRaceLost(ctx, in, cur, wasteKey, err)
+		}
+		if ev.Replayed {
+			return &WastedSpendResult{Currency: cur, Action: "duplicate", Duplicate: true}, nil
+		}
+		if err := guard.ConsumePayerGrace(ctx, merchantID, payerID, payerPolicyCurrency, policyAmount, payerWindows); err != nil {
+			return nil, err
+		}
 		if chargeable > 0 {
-			// or#894: the overage charge posts at operation "usage:wasted_spend",
-			// NOT at the bare (source, source_id) the caller reported. Without the
-			// operation it aliased the CAPTURE of the same rendered request — the
-			// capture then moved 0 micros and returned the waste transfer.
-			wasteKey, kerr := money.NewIdempotencyKey(money.UsageOperation(wastedSpendEventType), in.Source, in.SourceID)
-			if kerr != nil {
-				return nil, kerr
-			}
-			_, err = s.moneyService().RecordUsage(ctx, money.RecordUsageParams{
-				Payer:     &in.CustomerID,
-				Invoker:   strings.TrimSpace(in.Invoker),
-				Currency:  cur,
-				EventType: wastedSpendEventType,
-				Amount:    chargeable,
-				Key:       wasteKey,
-				Metadata: map[string]any{
-					"reason":                   in.Reason,
-					"reported_amount":          in.Amount,
-					"forgiven_amount":          res.ForgivenAmount,
-					"policy_currency":          payerPolicyCurrency,
-					"policy_amount":            policyAmount,
-					"policy_chargeable_amount": chargeablePolicy,
-					"invoker_type":             string(identity.InvokerTypePayer),
-					"chargeable_amount":        chargeable,
-				},
-			})
-			if err != nil {
-				return nil, err
-			}
 			res.Action = "charged"
 		}
 		return res, nil
@@ -788,25 +833,82 @@ func (s *Service) ReportWastedSpend(ctx context.Context, in WastedSpendInput) (*
 	if err != nil {
 		return nil, err
 	}
-	if err := guard.RecordInvokerCutoff(ctx, tid.UUID().String(), in.CustomerID.UUID().String(), in.Invoker, invokerPolicyCurrency, policyAmount, invokerWindows); err != nil {
+	// A delegated invoker is never charged, so the durable row carries amount 0.
+	// It exists for one reason: to be the thing that says "already seen" when the
+	// flat cutoff counter — a cache — cannot.
+	ev, err := s.moneyService().RecordUsage(ctx, money.RecordUsageParams{
+		Payer:     &in.CustomerID,
+		Invoker:   strings.TrimSpace(in.Invoker),
+		Currency:  cur,
+		EventType: wastedSpendEventType,
+		Amount:     0,
+		Key:        wasteKey,
+		Dimensions: map[string]int64{wastedReportedDimension: in.Amount},
+		Metadata: map[string]any{
+			"reason":          in.Reason,
+			"reported_amount": in.Amount,
+			"policy_currency": invokerPolicyCurrency,
+			"policy_amount":   policyAmount,
+			"invoker_type":    strings.TrimSpace(in.InvokerType),
+		},
+	})
+	if err != nil {
+		return s.wasteWriteRaceLost(ctx, in, cur, wasteKey, err)
+	}
+	if ev.Replayed {
+		return &WastedSpendResult{Currency: cur, Action: "duplicate", Duplicate: true}, nil
+	}
+	if err := guard.RecordInvokerCutoff(ctx, merchantID, payerID, in.Invoker, invokerPolicyCurrency, policyAmount, invokerWindows); err != nil {
 		return nil, err
 	}
 	return &WastedSpendResult{Currency: cur, PolicyCurrency: invokerPolicyCurrency, RecordedAmount: in.Amount, PolicyRecordedAmount: policyAmount, Action: "invoker_cutoff_tracked"}, nil
 }
 
-func maxWastedWindowTTL(groups ...[]abuse.WastedWindow) time.Duration {
-	var max time.Duration
-	for _, group := range groups {
-		for _, w := range group {
-			if w.Window > max {
-				max = w.Window
-			}
+// wastedReportedDimension carries the REPORTED wasted amount on the durable
+// row. It is a typed dimension rather than a metadata entry because it is
+// compared on every replay: metadata round-trips through JSONB as float64, and
+// a money comparison must not go anywhere near a float.
+const wastedReportedDimension = "reported_amount"
+
+// claimedWasteReport answers whether this report's key is already claimed.
+//
+//   - unclaimed            -> (nil, nil), the caller proceeds
+//   - claimed, same body   -> the duplicate verdict, no side effect
+//   - claimed, CHANGED body-> money.ErrIdempotencyKeyReused
+//
+// The comparison is on the REPORTED amount, not on what was charged: two
+// different reports can both be fully forgiven, and answering the second with
+// "duplicate" would silently drop a real number. This is the refusal a host
+// used to have to build itself out of a body fingerprint.
+func (s *Service) claimedWasteReport(ctx context.Context, in WastedSpendInput, cur string, key money.IdempotencyKey) (*WastedSpendResult, error) {
+	ev, err := s.moneyService().FindUsageEvent(ctx, in.CustomerID, cur, wastedSpendEventType, key)
+	if err != nil || ev == nil {
+		return nil, err
+	}
+	if committed, ok := ev.Dimensions[wastedReportedDimension]; ok && committed != in.Amount {
+		return nil, &money.IdempotencyConflict{
+			Operation: string(key.Operation()), Source: key.Source(), SourceID: key.SourceID(),
+			Field: wastedReportedDimension, Committed: committed, Retried: in.Amount,
 		}
 	}
-	if max <= 0 {
-		return time.Hour
+	return &WastedSpendResult{Currency: cur, Action: "duplicate", Duplicate: true}, nil
+}
+
+// wasteWriteRaceLost interprets a refusal from the durable write. Two identical
+// reports racing each other grade against the same window, so they normally
+// agree and the loser is answered Replayed; but if the winner's ConsumePayerGrace
+// lands between the loser's grading and its write, the loser computes a larger
+// overage and is refused for an amount that is not actually a changed body. Only
+// the durable row can tell those apart, so ask it.
+func (s *Service) wasteWriteRaceLost(ctx context.Context, in WastedSpendInput, cur string, key money.IdempotencyKey, cause error) (*WastedSpendResult, error) {
+	if !errors.Is(cause, money.ErrIdempotencyKeyReused) {
+		return nil, cause
 	}
-	return max + time.Second
+	claimed, err := s.claimedWasteReport(ctx, in, cur, key)
+	if err != nil || claimed == nil {
+		return nil, cause
+	}
+	return claimed, nil
 }
 
 func serviceWastedCurrency(requestCurrency string, windows []abuse.WastedWindow) (string, error) {

--- a/pkg/service/merchant_configuration_integration_test.go
+++ b/pkg/service/merchant_configuration_integration_test.go
@@ -51,6 +51,15 @@ func requireBoundBadSpendPolicy(t *testing.T, svc *billingservice.Service, ctx c
 // run end-to-end) and a freshly seeded payer.
 func wastedSvcEnv(t *testing.T) (*billingservice.Service, *money.MoneyService, identity.CustomerID, context.Context) {
 	t.Helper()
+	svc, ms, payer, ctx, _ := wastedSvcEnvWithRedis(t)
+	return svc, ms, payer, ctx
+}
+
+// wastedSvcEnvWithRedis is the same environment, handing back the Redis client
+// so a test can FLUSH it mid-run — the only way to prove a claim is durable
+// rather than merely cached (or#903).
+func wastedSvcEnvWithRedis(t *testing.T) (*billingservice.Service, *money.MoneyService, identity.CustomerID, context.Context, *redis.Client) {
+	t.Helper()
 	ctx := context.Background()
 	dbi := dbtest.OpenMerchantDB(t, dbtest.TestMerchantID.UUID())
 	pool := dbi.Pool()
@@ -96,7 +105,7 @@ func wastedSvcEnv(t *testing.T) (*billingservice.Service, *money.MoneyService, i
 	ms := money.NewMoneyService(dbi)
 	_, err = ms.Deposit(ctx, money.DepositParams{CustomerID: &payer, Invoker: payer.UUID().String(), Currency: money.DefaultCurrency, Amount: 100_000_000, Source: "seed"})
 	require.NoError(t, err)
-	return svc, ms, payer, ctx
+	return svc, ms, payer, ctx, rdb
 }
 
 func grantDelegatedSpend(t *testing.T, svc *billingservice.Service, ctx context.Context, payer identity.CustomerID, invoker string) {

--- a/pkg/service/or903_waste_durable_claim_integration_test.go
+++ b/pkg/service/or903_waste_durable_claim_integration_test.go
@@ -1,0 +1,176 @@
+//go:build integration
+
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/internal/modules/money"
+	"github.com/open-rails/openrails/pkg/identity"
+	billingservice "github.com/open-rails/openrails/pkg/service"
+)
+
+// or#903 — the wasted-spend report's once-only claim is the durable
+// usage_events row, not a Redis SetNX.
+//
+// The defect these tests close: ClaimReport ran BEFORE any ledger call and its
+// verdict was returned as the answer. It was a cache — it expired, and it did
+// not survive a flush — so a replay after a flush was re-graded, re-consumed
+// the payer's grace, and the engine's own changed-amount refusal could never
+// fire inside the TTL. Hosts compensated with claim tables of their own
+// (tensorhub th#1464's outbox fingerprint); this is what retires them.
+//
+// FLUSHING IS THE POINT. Every proof below flushes Redis between the two
+// reports, because that is exactly the difference between "deduped" and
+// "deduped for a while".
+
+func or903WasteInput(payer identity.CustomerID, invokerType, requestID string, amount int64) billingservice.WastedSpendInput {
+	return billingservice.WastedSpendInput{
+		CustomerID:  payer,
+		Invoker:     payer.UUID().String(),
+		InvokerType: invokerType,
+		Currency:    money.DefaultCurrency,
+		Amount:      amount,
+		Source:      "invoke",
+		SourceID:    requestID,
+		Reason:      "worker_failed",
+	}
+}
+
+// or903WasteEventCount is the durable row count for this payer — the claim
+// itself, read from the table rather than inferred from the verdict that is
+// under test. Each test uses a freshly minted payer, so this counts only its
+// own reports.
+func or903WasteEventCount(t *testing.T, ctx context.Context, ms *money.MoneyService, payer identity.CustomerID) int64 {
+	t.Helper()
+	rows, err := ms.AggregateUsage(ctx, payer, money.DefaultCurrency, time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	for _, r := range rows {
+		if r.EventType == "wasted_spend" {
+			return r.EventCount
+		}
+	}
+	return 0
+}
+
+// A FORGIVEN report — the common case, and the one that never touched Postgres
+// before — is claimed durably. Flush Redis, replay it, and the engine still
+// says duplicate.
+func TestOr903_ForgivenWasteReportIsClaimedAcrossARedisFlush(t *testing.T) {
+	svc, ms, payer, ctx, rdb := wastedSvcEnvWithRedis(t)
+	requestID := uuid.NewString()
+	// Grace far above the report, so nothing is chargeable and the whole
+	// question is about ACCOUNTING, not about money.
+	requireBoundBadSpendPolicy(t, svc, ctx, "free", 10_000_000)
+
+	first, err := svc.ReportWastedSpend(ctx, or903WasteInput(payer, "payer", requestID, 1_000_000))
+	require.NoError(t, err)
+	require.Equal(t, "forgiven", first.Action)
+	require.False(t, first.Duplicate)
+	require.Equal(t, int64(1_000_000), first.ForgivenAmount)
+	require.Equal(t, int64(1), or903WasteEventCount(t, ctx, ms, payer))
+
+	// Everything the old claim lived in is gone.
+	require.NoError(t, rdb.FlushAll(ctx).Err())
+
+	second, err := svc.ReportWastedSpend(ctx, or903WasteInput(payer, "payer", requestID, 1_000_000))
+	require.NoError(t, err)
+	require.True(t, second.Duplicate,
+		"a replayed waste report must be answered duplicate AFTER a Redis flush — before or#903 the claim was a SetNX and this replay was accepted as new")
+	require.Equal(t, "duplicate", second.Action)
+	require.Equal(t, int64(1), or903WasteEventCount(t, ctx, ms, payer),
+		"the replay must not write a second durable row")
+}
+
+// The same report, replayed after a flush, must not consume the payer's grace
+// twice. This is the harm the SetNX could not prevent: grace is a budget, and
+// re-consuming it charges a payer sooner than their policy says.
+func TestOr903_AReplayAfterAFlushDoesNotReconsumeGrace(t *testing.T) {
+	svc, ms, payer, ctx, rdb := wastedSvcEnvWithRedis(t)
+	// Grace sized so ONE report fits and one-and-a-half do not: 1_500_000 with
+	// two 1_000_000 reports. Post-flush the counter is empty, so the new report
+	// is inside grace — unless the replay put 1_000_000 back into it, which
+	// leaves only 500_000 free and charges the difference.
+	requireBoundBadSpendPolicy(t, svc, ctx, "free", 1_500_000)
+
+	reqA := uuid.NewString()
+	first, err := svc.ReportWastedSpend(ctx, or903WasteInput(payer, "payer", reqA, 1_000_000))
+	require.NoError(t, err)
+	require.Equal(t, int64(0), first.ChargedAmount)
+
+	require.NoError(t, rdb.FlushAll(ctx).Err())
+
+	// The replay: refused as a duplicate, so it adds nothing to the window.
+	replay, err := svc.ReportWastedSpend(ctx, or903WasteInput(payer, "payer", reqA, 1_000_000))
+	require.NoError(t, err)
+	require.True(t, replay.Duplicate)
+
+	// A genuinely NEW report of the same size. The flush wiped the window, so the
+	// only spend the counter should have seen since is this one — inside grace,
+	// rather than pushed over it by a replay that had already been counted.
+	balanceBefore := or894Balance(t, ms, ctx, payer)
+	reqB := uuid.NewString()
+	other, err := svc.ReportWastedSpend(ctx, or903WasteInput(payer, "payer", reqB, 1_000_000))
+	require.NoError(t, err)
+	require.Equal(t, int64(0), other.ChargedAmount,
+		"the replay consumed grace it had already consumed — a distinct report is now being charged for it")
+	require.Equal(t, balanceBefore, or894Balance(t, ms, ctx, payer))
+}
+
+// A replay carrying a CHANGED chargeable amount is REFUSED, not answered
+// duplicate with the change dropped. Under the SetNX this was unreachable
+// inside the TTL, which is the whole reason a host kept a body fingerprint.
+func TestOr903_AChangedWasteAmountIsRefusedNotDropped(t *testing.T) {
+	svc, _, payer, ctx, rdb := wastedSvcEnvWithRedis(t)
+	requestID := uuid.NewString()
+	// No grace: every reported micro is chargeable, so a changed report is a
+	// changed CHARGE and the ledger's own key must reject it.
+	requireBoundBadSpendPolicy(t, svc, ctx, "free", 1)
+
+	first, err := svc.ReportWastedSpend(ctx, or903WasteInput(payer, "payer", requestID, 500_000))
+	require.NoError(t, err)
+	require.Equal(t, "charged", first.Action)
+
+	require.NoError(t, rdb.FlushAll(ctx).Err())
+
+	_, err = svc.ReportWastedSpend(ctx, or903WasteInput(payer, "payer", requestID, 900_000))
+	require.ErrorIs(t, err, money.ErrIdempotencyKeyReused,
+		"a corrected waste amount under a claimed key must be refused, not silently dropped")
+
+	// The identical replay is still an idempotent duplicate, not an error.
+	same, err := svc.ReportWastedSpend(ctx, or903WasteInput(payer, "payer", requestID, 500_000))
+	require.NoError(t, err)
+	require.True(t, same.Duplicate)
+}
+
+// The delegated-invoker path is claimed the same way. It writes amount 0 and
+// charges nothing, so before or#903 it had no durable trace at all and its flat
+// cutoff counter was double-added by any retry that crossed the TTL or a flush.
+func TestOr903_DelegatedInvokerReportIsClaimedAcrossARedisFlush(t *testing.T) {
+	svc, ms, payer, ctx, rdb := wastedSvcEnvWithRedis(t)
+	invoker := "user:" + uuid.NewString()
+	grantDelegatedSpend(t, svc, ctx, payer, invoker)
+	requestID := uuid.NewString()
+
+	in := or903WasteInput(payer, "delegated_user", requestID, 750_000)
+	in.Invoker = invoker
+
+	first, err := svc.ReportWastedSpend(ctx, in)
+	require.NoError(t, err)
+	require.Equal(t, "invoker_cutoff_tracked", first.Action)
+	require.False(t, first.Duplicate)
+	require.Equal(t, int64(1), or903WasteEventCount(t, ctx, ms, payer))
+
+	require.NoError(t, rdb.FlushAll(ctx).Err())
+
+	second, err := svc.ReportWastedSpend(ctx, in)
+	require.NoError(t, err)
+	require.True(t, second.Duplicate,
+		"a delegated invoker's report is claimed by the same durable row; a flush must not reopen it")
+	require.Equal(t, int64(1), or903WasteEventCount(t, ctx, ms, payer))
+}


### PR DESCRIPTION
`ReportWastedSpend` claimed a report with `abuse.WastedSpendGuard.ClaimReport` — a SetNX — **before any ledger call**, and returned that verdict as the answer. So the claim was a cache: it expired with the widest window, it did not survive a flush, and the engine's own changed-amount refusal could never fire inside its TTL.

Measured consequences:
- a replay after a Redis flush was re-graded and **re-consumed the payer's grace**;
- a replay carrying a corrected amount was answered `duplicate` and the number was dropped;
- hosts compensated with claim tables of their own (tensorhub th#1464's outbox fingerprint) — two once-only mechanisms for one fact, neither of them the ledger's.

## The inversion

Every report now writes **one durable `usage_events` row** at operation `usage:wasted_spend` over `(source, source_id)`, whatever its money outcome — a charged overage, a fully forgiven report (amount 0) and a delegated invoker's report (amount 0) all land under the same unique index. That row **is** the claim; the Redis windows are advanced only once it applies, so they are derived from a durable decision instead of being the decision.

- `abuse.ClaimReport` deleted. `RecordPayerGrace` splits into `PayerGraceOverage` (grade, read-only) and `ConsumePayerGrace` (advance the counter), because grading must happen before the durable write and consumption after it.
- `ratelimit.ClaimOnce` deleted with its only caller, and a comment left in its place: a SetNX that expires is not an idempotency key.
- `money.RecordUsage` marks a replay with `UsageEvent.Replayed` (same contract as `CreditTransaction.Replayed`, or#892). `money.FindUsageEvent` lets the caller ask "already claimed?" **before** it grades — necessary because grace is mutable, so re-deriving the amount on a replay yields a different number and would trip the changed-amount refusal on an *identical* retry.
- The refusal binds the **reported** amount, carried as a typed dimension rather than metadata: two different reports can both be fully forgiven, so comparing what was *charged* would silently drop a real number, and a money comparison must not round-trip through a JSON float.
- Residual crash window is one operation wide and falls the payer's way — a crash between the durable row and the counter advance leaves grace **unconsumed**.

Deliberate reversal: the free/delegated path now writes a Postgres row per report. "No event table for free reports" bought nothing — a report the platform cannot recognise as already-seen is not free, it is unaccounted somewhere else.

## Proof

`pkg/service/or903_waste_durable_claim_integration_test.go` — four integration tests that **flush Redis between two reports**: the forgiven report stays claimed, the payer's grace is not re-consumed, a changed amount is refused with `ErrIdempotencyKeyReused`, and the delegated path dedupes too. Flushing is the point: it is the difference between deduped and deduped for a while.

Full `pkg/service` integration suite green (313s); `go build ./...`, `go vet ./...`, `go vet -tags integration ./...`, unit suite green.

Tracker: or#903. Host follow-up: tensorhub th#1622 deletes `settlement.wasteFingerprint` on top of this.