### PR TITLE
or#904: the drift fence guarded only the standalone path — the embedded host it was written for kept booting frozen

### DIFF
--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -98,9 +98,15 @@ Recreating one:
 | Local compose stack | `task docker-reset` — `down -v` (deletes the `postgres_data` volume) then `docker-up`, which re-runs `openrails-migrate` against an empty server. Plain `task docker-down` keeps the volume and therefore keeps the stale ledger. |
 | A dev/staging server you can't drop the volume of | `DROP DATABASE` + `CREATE DATABASE`, then `openrails migrate up`. |
 | A long-lived hand-rolled test pool | Drop `public.migrations` along with the schema — migratekit reads its ledger there, and a surviving ledger makes it *skip* re-applying the baseline. (The integration suite is unaffected: it creates a fresh per-run database every time.) |
+| An EMBEDDED host's database (one schema inside the host's DB) | `DROP SCHEMA openrails CASCADE` + `DELETE FROM public.migrations WHERE app = 'openrails'`, then restart the host so it re-applies the chain. |
 
-The symptom if you skip this is not a migration error — it is a schema that
-silently lacks whatever the squash folded in.
+You will not have to notice this yourself: the engine REFUSES to start when the
+ledger records migrations the build no longer carries (`OrphanedMigrationsError`,
+or#901/th#1627), on both the standalone `migrate up` path and the embedded
+runtime-init path. Before that fence existed the symptom was not a migration
+error but a schema that silently lacked whatever the squash folded in — th#1627
+was an embedded host answering 500 on every billed admission for hours while
+both of migratekit's checks reported success.
 
 ## Repo layout
 

--- a/embed/migration_drift_integration_test.go
+++ b/embed/migration_drift_integration_test.go
@@ -1,0 +1,99 @@
+//go:build integration
+
+package embed_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/open-rails/migratekit"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-rails/openrails/config"
+	"github.com/open-rails/openrails/embed"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/internal/migrate"
+	postgresmigrations "github.com/open-rails/openrails/migrations/postgres"
+	"github.com/open-rails/openrails/pkg/embedded"
+)
+
+// th#1627 / or#901: an EMBEDDED host must refuse to boot on a database whose
+// migration ledger records names this build no longer carries.
+//
+// or#901 installed the drift fence in migrate.RunPostgres — the STANDALONE
+// binary's entrypoint. An embedded host never calls it: tensorhub applies the
+// migratekit chain itself and depends on the engine's own init-time validation
+// (internal/app.validateDatabase), which only asked migratekit's one question,
+// "is every embedded migration applied?". A re-squashed chain answers yes while
+// applying nothing.
+//
+// The bill was th#1627: tensorhub's dev stack recorded openrails 1..12, the
+// post-squash embedded set is {1, 2}, so the openrails schema stayed frozen at
+// the pre-squash shape. openrails.billing_policies did not exist, and the
+// trust-level ladder sync 500'd at every boot while every billed admission
+// answered `403 credit_authorize_failed ... status=500 admission check failed`.
+// Both ValidatePostgresMigrations and ApplyMigrations reported success
+// throughout.
+func TestEmbeddedRuntimeRefusesOrphanedMigrations(t *testing.T) {
+	ctx := context.Background()
+
+	const schema = config.DefaultSchema
+	orphans := []string{"3", "4", "5", "6", "7", "8", "9", "10", "11", "12"}
+
+	superDSN := dbtest.SharedSuperuserDSN(t)
+	sqlDB, err := sql.Open("pgx", superDSN)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	t.Cleanup(func() {
+		for _, n := range orphans {
+			_, _ = sqlDB.ExecContext(context.Background(),
+				`DELETE FROM public.migrations WHERE app = $1 AND schema = $2 AND name = $3`,
+				config.MigratekitApp, schema, n)
+		}
+	})
+
+	dsn := dbtest.SharedPostgresDSN(t)
+	rdb, _ := dbtest.SharedRedisClient(t)
+	newRuntime := func() (*embed.Runtime, error) {
+		cfg := &config.Config{Env: "dev", TestMode: config.CredentialPostureLive, DB: &config.DBConfig{URL: dsn}}
+		return embed.New(ctx, embed.Options{Options: embedded.Options{
+			Config: cfg, Redis: rdb, River: embedded.RiverManagedByOpenRails(),
+		}})
+	}
+
+	// Control: the same host boots cleanly when the ledger matches the build.
+	rt, err := newRuntime()
+	require.NoError(t, err, "an in-sync database must still boot")
+	require.NoError(t, rt.Close(context.Background()))
+
+	// Make it the stacks' database.
+	for _, n := range orphans {
+		_, err := sqlDB.ExecContext(ctx,
+			`INSERT INTO public.migrations (app, database, name, schema) VALUES ($1, 'postgres', $2, $3)
+			 ON CONFLICT DO NOTHING`,
+			config.MigratekitApp, n, schema)
+		require.NoError(t, err)
+	}
+
+	// This is the hole: migratekit's own validator still calls the frozen
+	// database fully migrated, which is exactly why th#1627 reached production
+	// as 500s instead of a failed deploy.
+	migrations, err := migratekit.LoadFromFS(postgresmigrations.FS)
+	require.NoError(t, err)
+	require.NoError(t,
+		migratekit.NewPostgres(sqlDB, config.MigratekitApp).WithSchema(schema).ValidateAllApplied(ctx, migrations),
+		"migratekit reports a frozen schema as fully migrated — the fence is the only signal")
+
+	drifted, err := newRuntime()
+	if drifted != nil {
+		t.Cleanup(func() { _ = drifted.Close(context.Background()) })
+	}
+	require.Error(t, err, "the embedded engine must refuse a drifted schema, not serve 500s on the money path")
+
+	var orphanErr *migrate.OrphanedMigrationsError
+	require.ErrorAs(t, err, &orphanErr, "the refusal is typed, so a host can act on it")
+	require.Equal(t, schema, orphanErr.Schema)
+	require.Equal(t, orphans, orphanErr.Orphaned, "every orphan named, in numeric order")
+}

--- a/internal/app/build_runtime.go
+++ b/internal/app/build_runtime.go
@@ -28,6 +28,7 @@ import (
 	"github.com/open-rails/openrails/internal/integrations/pyth"
 	"github.com/open-rails/openrails/internal/intents"
 	"github.com/open-rails/openrails/internal/merchants"
+	"github.com/open-rails/openrails/internal/migrate"
 	"github.com/open-rails/openrails/internal/modules/abuse"
 	"github.com/open-rails/openrails/internal/modules/admission"
 	"github.com/open-rails/openrails/internal/modules/alerting"
@@ -36,7 +37,6 @@ import (
 	"github.com/open-rails/openrails/internal/modules/copilot"
 	"github.com/open-rails/openrails/internal/modules/dashboard"
 	"github.com/open-rails/openrails/internal/modules/entitlements"
-	"github.com/open-rails/openrails/internal/modules/replaycache"
 	"github.com/open-rails/openrails/internal/modules/merchantconfig"
 	"github.com/open-rails/openrails/internal/modules/metrics"
 	"github.com/open-rails/openrails/internal/modules/money"
@@ -44,6 +44,7 @@ import (
 	"github.com/open-rails/openrails/internal/modules/payments"
 	"github.com/open-rails/openrails/internal/modules/productaccess"
 	"github.com/open-rails/openrails/internal/modules/ratelimit"
+	"github.com/open-rails/openrails/internal/modules/replaycache"
 	solanamodule "github.com/open-rails/openrails/internal/modules/solana"
 	solanatokens "github.com/open-rails/openrails/internal/modules/solana/tokens"
 	"github.com/open-rails/openrails/internal/modules/subscriptions"
@@ -512,10 +513,23 @@ func validateDatabase(cfg *config.Config, database *db.DB) error {
 	// Schema must mirror the apply step's WithSchema (#731): migratekit v1.2.0
 	// filters the ledger by schema, so a schema-less source stops matching rows
 	// applied via WithSchema.
+	//
+	// Never Fatal here: this runs inside embed.New, so os.Exit would take the
+	// HOST process down on a library precondition. Return the error and let the
+	// host refuse to boot with it.
 	if err := migratekit.ValidatePostgresMigrations(context.Background(), sqlDB,
 		migratekit.MigrationSource{App: config.MigratekitApp, FS: postgresmigrations.FS, Schema: cfg.DB.SchemaName()},
 	); err != nil {
-		log.WithError(err).Fatal("Postgres migrations validation failed")
+		log.WithError(err).Error("Postgres migrations validation failed")
+		return err
+	}
+
+	// th#1627/or#901: the CONVERSE check — a database recording migrations this
+	// build no longer carries. migratekit only asks "embedded ⊆ applied", which a
+	// re-squashed chain satisfies while applying nothing, freezing the schema at
+	// the old shape. This is the only migration seam an embedded host cannot skip.
+	if err := migrate.AssertNoOrphanedPostgresMigrations(context.Background(), sqlDB, cfg.DB.SchemaName()); err != nil {
+		log.WithError(err).Error("OpenRails migration drift: refusing to start")
 		return err
 	}
 

--- a/internal/http/handlers/service_admission.go
+++ b/internal/http/handlers/service_admission.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/open-rails/openrails/internal/db/models"
 	httprequest "github.com/open-rails/openrails/internal/http/request"
 	"github.com/open-rails/openrails/internal/modules/abuse"
@@ -124,6 +126,16 @@ func serviceAdmitBatchVerdicts(
 		}
 		res, err := admit(ctx, admitInputFromRequest(item, *payer))
 		if err != nil {
+			// th#1627: the wire string stays stable and non-leaky (it reaches the
+			// host's tenant boundary), but the CAUSE must not be discarded — a 500
+			// whose only content is the constant "admission check failed" cost a
+			// cross-stack bisect to attribute. Operators read this log.
+			log.WithError(err).WithFields(log.Fields{
+				"customer_id": item.CustomerID,
+				"invoker":     item.Invoker,
+				"request_id":  item.RequestID,
+				"source":      item.Source,
+			}).Error("admission check failed")
 			out[i] = serviceAdmitVerdict{Status: http.StatusInternalServerError, Error: "admission check failed"}
 			continue
 		}
@@ -156,7 +168,7 @@ func ServiceAdmitBatch(r *httprequest.Request) {
 	}
 	svc, err := billingservice.New(r.State)
 	if err != nil {
-		r.ErrorJSON(http.StatusInternalServerError, "billing service unavailable")
+		r.InternalError("billing service unavailable", err)
 		return
 	}
 	verdicts := serviceAdmitBatchVerdicts(
@@ -192,12 +204,12 @@ func ServiceGetTrustLevel(r *httprequest.Request) {
 	}
 	svc, err := billingservice.New(r.State)
 	if err != nil {
-		r.ErrorJSON(http.StatusInternalServerError, "billing service unavailable")
+		r.InternalError("billing service unavailable", err)
 		return
 	}
 	trustLevel, err := svc.GetTrustLevel(r.Request.Context(), *payer, currency)
 	if err != nil {
-		r.ErrorJSON(http.StatusInternalServerError, "trust level lookup failed")
+		r.InternalError("trust level lookup failed", err)
 		return
 	}
 	r.SuccessJSON(map[string]any{"currency": currency, "trust_level": trustLevel})
@@ -245,7 +257,7 @@ func ServiceReportWastedSpend(r *httprequest.Request) {
 	}
 	svc, err := billingservice.New(r.State)
 	if err != nil {
-		r.ErrorJSON(http.StatusInternalServerError, "billing service unavailable")
+		r.InternalError("billing service unavailable", err)
 		return
 	}
 	res, err := svc.ReportWastedSpend(r.Request.Context(), billingservice.WastedSpendInput{
@@ -262,7 +274,7 @@ func ServiceReportWastedSpend(r *httprequest.Request) {
 		if serviceIdempotencyConflict(r, err) {
 			return
 		}
-		r.ErrorJSON(http.StatusInternalServerError, "report wasted spend failed")
+		r.InternalError("report wasted spend failed", err)
 		return
 	}
 	r.JSON(http.StatusOK, res)
@@ -301,7 +313,7 @@ func ServiceSetCreditLimit(r *httprequest.Request) {
 	}
 	svc, err := billingservice.New(r.State)
 	if err != nil {
-		r.ErrorJSON(http.StatusInternalServerError, "billing service unavailable")
+		r.InternalError("billing service unavailable", err)
 		return
 	}
 	if err := svc.SetCreditLimit(r.Request.Context(), *payer, currency, req.CreditLimitAmount); err != nil {
@@ -325,7 +337,7 @@ func ServiceGetCreditLimit(r *httprequest.Request) {
 	}
 	svc, err := billingservice.New(r.State)
 	if err != nil {
-		r.ErrorJSON(http.StatusInternalServerError, "billing service unavailable")
+		r.InternalError("billing service unavailable", err)
 		return
 	}
 	currency, ok := serviceRequiredCurrency(r, r.Query("currency"))
@@ -399,22 +411,22 @@ type serviceMerchantProfileConfiguration struct {
 func ServiceGetMerchantSettings(r *httprequest.Request) {
 	svc, err := billingservice.New(r.State)
 	if err != nil {
-		r.ErrorJSON(http.StatusInternalServerError, "billing service unavailable")
+		r.InternalError("billing service unavailable", err)
 		return
 	}
 	cfg, _, err := svc.GetMerchantConfiguration(r.Request.Context())
 	if err != nil {
-		r.ErrorJSON(http.StatusInternalServerError, "get merchant settings failed")
+		r.InternalError("get merchant settings failed", err)
 		return
 	}
 	policies, err := svc.ListBillingPolicies(r.Request.Context())
 	if err != nil {
-		r.ErrorJSON(http.StatusInternalServerError, "get merchant settings failed")
+		r.InternalError("get merchant settings failed", err)
 		return
 	}
 	bindings, err := svc.ListBillingPolicyBindings(r.Request.Context())
 	if err != nil {
-		r.ErrorJSON(http.StatusInternalServerError, "get merchant settings failed")
+		r.InternalError("get merchant settings failed", err)
 		return
 	}
 	r.SuccessJSON(serviceMerchantSettingsRequest{
@@ -447,7 +459,7 @@ func ServiceSetMerchantSettings(r *httprequest.Request) {
 	}
 	svc, err := billingservice.New(r.State)
 	if err != nil {
-		r.ErrorJSON(http.StatusInternalServerError, "billing service unavailable")
+		r.InternalError("billing service unavailable", err)
 		return
 	}
 
@@ -491,7 +503,7 @@ func ServiceSetMerchantSettings(r *httprequest.Request) {
 		CheckoutRouting:                    req.CheckoutRouting,
 		DelegatedInvokerWastedSpendWindows: windows,
 	}); err != nil {
-		r.ErrorJSON(http.StatusInternalServerError, "set merchant settings failed")
+		r.InternalError("set merchant settings failed", err)
 		return
 	}
 
@@ -505,7 +517,7 @@ func ServiceSetMerchantSettings(r *httprequest.Request) {
 			return
 		}
 		if err := svc.SetTrustLevelSchedule(r.Request.Context(), billingidentity.CustomerID{}, currency, schedule.Schedule); err != nil {
-			r.ErrorJSON(http.StatusInternalServerError, "set trust level schedule failed")
+			r.InternalError("set trust level schedule failed", err)
 			return
 		}
 	}
@@ -513,7 +525,7 @@ func ServiceSetMerchantSettings(r *httprequest.Request) {
 	// the bindings FK refuses a name that does not exist yet.
 	for _, policy := range req.BillingPolicies {
 		if err := svc.SetBillingPolicy(r.Request.Context(), policy); err != nil {
-			r.ErrorJSON(http.StatusInternalServerError, "set billing policy failed")
+			r.InternalError("set billing policy failed", err)
 			return
 		}
 	}
@@ -523,7 +535,7 @@ func ServiceSetMerchantSettings(r *httprequest.Request) {
 				r.ErrorJSON(http.StatusBadRequest, err.Error())
 				return
 			}
-			r.ErrorJSON(http.StatusInternalServerError, "bind billing policy failed")
+			r.InternalError("bind billing policy failed", err)
 			return
 		}
 	}

--- a/internal/http/handlers/service_admission_batch_test.go
+++ b/internal/http/handlers/service_admission_batch_test.go
@@ -1,12 +1,14 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
 	"testing"
 
 	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
 	billingidentity "github.com/open-rails/openrails/pkg/identity"
@@ -89,4 +91,39 @@ func TestAdmitInputFromRequest_UsesTrustLevel(t *testing.T) {
 
 	got := admitInputFromRequest(serviceAdmitRequest{TrustLevel: "trusted"}, payer)
 	require.Equal(t, "trusted", got.TrustLevel)
+}
+
+// TestServiceAdmitBatchVerdicts_LogsTheCause is th#1627's regression gate. The
+// verdict's wire string is a deliberate constant — it crosses into the host's
+// tenant-facing error — but the CAUSE must reach the operator log. It did not:
+// `403 credit_authorize_failed ... status=500 admission check failed` was the
+// ONLY signal a billed-invoke outage produced, so attributing it cost a bisect
+// across two standing stacks instead of one grep.
+func TestServiceAdmitBatchVerdicts_LogsTheCause(t *testing.T) {
+	cause := fmt.Errorf(`ERROR: relation "openrails.billing_policy_bindings" does not exist (SQLSTATE 42P01)`)
+
+	var buf bytes.Buffer
+	prevOut, prevLevel := log.StandardLogger().Out, log.GetLevel()
+	log.SetOutput(&buf)
+	log.SetLevel(log.ErrorLevel)
+	t.Cleanup(func() { log.SetOutput(prevOut); log.SetLevel(prevLevel) })
+
+	payer := uuid.NewString()
+	out := serviceAdmitBatchVerdicts(context.Background(),
+		[]serviceAdmitRequest{{CustomerID: payer, Invoker: "user:a", RequestID: "r1", Source: "tensorhub"}},
+		func(billingidentity.CustomerID) bool { return true },
+		func(context.Context, billingservice.AdmitInput) (*billingservice.AdmitResult, error) {
+			return nil, cause
+		},
+	)
+
+	require.Equal(t, http.StatusInternalServerError, out[0].Status)
+	require.Equal(t, "admission check failed", out[0].Error, "the wire string stays stable and non-leaky")
+
+	logged := buf.String()
+	require.Contains(t, logged, "admission check failed")
+	// logrus escapes quotes in the text formatter, so match the payload, not the framing.
+	require.Contains(t, logged, "billing_policy_bindings", "the cause must reach the operator log")
+	require.Contains(t, logged, "42P01", "including the SQLSTATE that names the failure class")
+	require.Contains(t, logged, payer, "and be attributable to a payer")
 }

--- a/internal/http/request/request.go
+++ b/internal/http/request/request.go
@@ -97,6 +97,20 @@ func (r *Request) ErrorJSON(code int, msg string) {
 	r.t.WriteJSON(code, api.SimpleErrorResponse(code, msg))
 }
 
+// InternalError answers 500 with a STABLE, non-leaky msg and logs the cause
+// verbatim against the request id.
+//
+// ErrorJSON(500, "...") drops whatever error the handler was holding, so an
+// internal failure reaches the operator as a bare constant. th#1627: three
+// boot-time `set billing policy failed` lines and a 500 on every billed
+// admission carried no cause at all, and attributing them cost a bisect across
+// two standing stacks. Every 500 that has an error in hand should use this.
+func (r *Request) InternalError(msg string, cause error) {
+	requestID := r.RequestID()
+	logrus.WithError(cause).WithField("request_id", requestID).Error(msg)
+	r.t.WriteJSON(http.StatusInternalServerError, api.SimpleErrorResponse(http.StatusInternalServerError, msg))
+}
+
 func (r *Request) APIError(err *api.APIError) {
 	requestID := r.RequestID()
 	err.WithRequestID(requestID)

--- a/internal/migrate/migrator.go
+++ b/internal/migrate/migrator.go
@@ -118,6 +118,32 @@ func (e *OrphanedMigrationsError) Error() string {
 		e.Schema, strings.Join(e.Orphaned, ", "), strings.Join(e.Embedded, ", "))
 }
 
+// AssertNoOrphanedPostgresMigrations is the drift fence at the seam EVERY
+// runtime crosses — not just the one the CLI takes.
+//
+// or#901 installed the check inside RunPostgres, which only the standalone
+// binary calls. An embedded host applies the migratekit chain itself
+// (tensorhub's runOpenRailsMigrations) and relies on the engine's own
+// init-time validation, so the fence protected exactly the deployment that
+// was never frozen. th#1627 is the bill: tensorhub's dev stack sat on the
+// pre-squash schema, `billing_policies` did not exist, and every billed
+// admission answered 500 while both ValidatePostgresMigrations and
+// ApplyMigrations reported success.
+//
+// sqlDB is any handle on the target database; schema is the effective
+// OpenRails schema (cfg.DB.SchemaName()).
+func AssertNoOrphanedPostgresMigrations(ctx context.Context, sqlDB *sql.DB, schema string) error {
+	migrations, err := migratekit.LoadFromFS(postgresmigrations.FS)
+	if err != nil {
+		return fmt.Errorf("openrails: load migrations: %w", err)
+	}
+	// Names are filename prefixes, so the schema rewrite (DDL text only) is
+	// irrelevant here — only WithSchema matters, since migratekit filters the
+	// ledger by it.
+	m := migratekit.NewPostgres(sqlDB, config.MigratekitApp).WithSchema(schema)
+	return assertNoOrphanedMigrations(ctx, m, schema, migrations)
+}
+
 // assertNoOrphanedMigrations refuses when the database records an applied
 // OpenRails migration that no longer exists in the embedded set.
 //


### PR DESCRIPTION
or#901 put `assertNoOrphanedMigrations` inside `migrate.RunPostgres` — the entrypoint the **standalone** binary takes. An embedded host never calls it: tensorhub applies the migratekit chain itself (`runOpenRailsMigrations`) and depends on the engine's own init-time validation (`internal/app.validateDatabase`), which only ever asked migratekit's one question, *embedded ⊆ applied*. A re-squashed chain answers yes while applying nothing. The fence protected exactly the deployment that was never frozen.

## The bill: tensorhub th#1627, a P0 billing outage

`dev` recorded openrails migrations `1..12`; post-squash the embedded set is `{1, 2}`; the `openrails` schema stayed at the pre-squash shape. `billing_policies` / `billing_policy_bindings` did not exist, so `SetBillingPolicy` 500'd at every hub boot (3× `set billing policy failed`) and `BillingPolicyStore.Resolve` — unconditional on the admission path — 500'd every billed admission, which tensorhub's fail-closed credit path correctly turned into `403 credit_authorize_failed` for every paying tenant. `ValidatePostgresMigrations` and `ApplyMigrations` both reported success throughout.

Not an RLS defect: the same `db_user=openrails_app rls_enforcing=true` role serves billed admits fine once the schema is rebuilt (proven live on `dev`).

## Changes

1. **`migrate.AssertNoOrphanedPostgresMigrations`** — the or#901 check, exported at the seam — called from `internal/app.validateDatabase`, which BOTH runtime construction paths cross (config-built standalone pool and host-injected embedded pool). An embedded host cannot skip it. `validateDatabase` also stops `log.Fatal`-ing: a library must not `os.Exit` its host on a precondition; it returns the typed `*OrphanedMigrationsError`.

2. **Surface the cause.** `serviceAdmitBatchVerdicts` discarded the admit error and answered the constant `"admission check failed"`; the config-sync surface discarded its errors through `ErrorJSON(500, …)`, which logs the message only. New `Request.InternalError(msg, cause)` keeps the wire string stable and non-leaky (it crosses into the host's tenant boundary) and logs the cause verbatim against the request id; every 500 on that surface now uses it.

3. `docs/dev/README.md`: the embedded-host reset row, and the fact that the engine now refuses rather than silently freezing.

## Tests

- `embed.TestEmbeddedRuntimeRefusesOrphanedMigrations` (integration, real Postgres) — **RED-verified**: with the fence disabled the embedded engine boots clean on the drifted ledger while migratekit's own `ValidateAllApplied` calls it fully migrated; with it, boot refuses with the typed error naming every orphan.
- `handlers.TestServiceAdmitBatchVerdicts_LogsTheCause` — the wire string stays `"admission check failed"`, the SQLSTATE + relation reach the log.
- `internal/migrate` or#901 integration test still green.