### PR TITLE
feat: expose merchant display names to embedded hosts

### DIFF
--- a/internal/db/gen/profiles.sql.go
+++ b/internal/db/gen/profiles.sql.go
@@ -85,6 +85,42 @@ func (q *Queries) GetUserIDByUsername(ctx context.Context, username *string) (uu
 	return id, err
 }
 
+const listMerchantDirectoryRefs = `-- name: ListMerchantDirectoryRefs :many
+SELECT slug, COALESCE(display_name, '')::text AS display_name
+FROM openrails.merchants
+WHERE slug = ANY($1::text[]) AND deleted_at IS NULL
+ORDER BY slug
+`
+
+type ListMerchantDirectoryRefsRow struct {
+	Slug        string
+	DisplayName string
+}
+
+// The read counterpart of the display-name write path: a host that reaches a
+// merchant through a MEMBERSHIP knows only slugs, and needs names to label its
+// own surfaces. openrails.merchants is global/policy-free, so this is an
+// ordinary query. Slugs that do not exist simply do not come back.
+func (q *Queries) ListMerchantDirectoryRefs(ctx context.Context, slugs []string) ([]ListMerchantDirectoryRefsRow, error) {
+	rows, err := q.db.Query(ctx, listMerchantDirectoryRefs, slugs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListMerchantDirectoryRefsRow
+	for rows.Next() {
+		var i ListMerchantDirectoryRefsRow
+		if err := rows.Scan(&i.Slug, &i.DisplayName); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const registerMerchant = `-- name: RegisterMerchant :one
 INSERT INTO openrails.merchants (slug, status, display_name)
 VALUES ($1, 'active', $2)

--- a/internal/db/queries/profiles.sql
+++ b/internal/db/queries/profiles.sql
@@ -24,6 +24,16 @@ SELECT id, slug, status, display_name
 FROM openrails.merchants
 WHERE slug = $1 AND deleted_at IS NULL;
 
+-- name: ListMerchantDirectoryRefs :many
+-- The read counterpart of the display-name write path: a host that reaches a
+-- merchant through a MEMBERSHIP knows only slugs, and needs names to label its
+-- own surfaces. openrails.merchants is global/policy-free, so this is an
+-- ordinary query. Slugs that do not exist simply do not come back.
+SELECT slug, COALESCE(display_name, '')::text AS display_name
+FROM openrails.merchants
+WHERE slug = ANY(sqlc.arg(slugs)::text[]) AND deleted_at IS NULL
+ORDER BY slug;
+
 -- name: RegisterMerchant :one
 -- Register a merchant (billing bucket) from config, idempotently (#480). The
 -- merchant carries ONLY billing/rail state; NO auth. A re-register without a

--- a/internal/merchants/lifecycle.go
+++ b/internal/merchants/lifecycle.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/open-rails/openrails/internal/db"
+	"github.com/open-rails/openrails/internal/db/gen"
 
 	"github.com/open-rails/openrails/pkg/merchant"
 )
@@ -237,6 +238,58 @@ func (s *Service) Get(ctx context.Context, id merchant.ID) (*Merchant, error) {
 // GetBySlug returns the merchant directory row by slug.
 func (s *Service) GetBySlug(ctx context.Context, slug string) (*Merchant, error) {
 	return s.merchantBySlug(ctx, normalizeSlug(slug))
+}
+
+// DirectoryRef is a merchant's public-facing directory identity: the slug it is
+// addressed by and the human-readable name an operator gave it.
+type DirectoryRef struct {
+	Slug        string
+	DisplayName string
+}
+
+// maxDirectoryRefSlugs bounds one directory-ref lookup. It exists so a host
+// forwarding a caller-supplied slug list cannot turn this into an unbounded
+// array scan; it errors rather than truncating, because a silently short answer
+// would read as "those merchants do not exist".
+const maxDirectoryRefSlugs = 200
+
+// ListDirectoryRefs returns the directory identity of each requested slug, for
+// the slugs that exist. It is the read counterpart of SetDisplayName: hosts that
+// hold a merchant membership know only slugs and need names to label their own
+// surfaces. Unknown slugs are omitted rather than erroring — the caller asked
+// about a set, not a specific row. Slugs are normalized and deduped like every
+// other directory lookup, and an empty request is not a query. Soft-deleted
+// merchants never resolve; suspended ones still do, since a host that holds a
+// membership must be able to label it whatever the merchant's status.
+func (s *Service) ListDirectoryRefs(ctx context.Context, slugs []string) ([]DirectoryRef, error) {
+	if len(slugs) > maxDirectoryRefSlugs {
+		return nil, fmt.Errorf("merchants: list directory refs: %d slugs exceeds the %d limit", len(slugs), maxDirectoryRefSlugs)
+	}
+	normalized := make([]string, 0, len(slugs))
+	seen := make(map[string]struct{}, len(slugs))
+	for _, slug := range slugs {
+		slug = normalizeSlug(slug)
+		if slug == "" {
+			continue
+		}
+		if _, dup := seen[slug]; dup {
+			continue
+		}
+		seen[slug] = struct{}{}
+		normalized = append(normalized, slug)
+	}
+	if len(normalized) == 0 {
+		return nil, nil
+	}
+	rows, err := gen.New(s.pool).ListMerchantDirectoryRefs(ctx, normalized)
+	if err != nil {
+		return nil, fmt.Errorf("merchants: list directory refs: %w", err)
+	}
+	refs := make([]DirectoryRef, 0, len(rows))
+	for _, row := range rows {
+		refs = append(refs, DirectoryRef{Slug: row.Slug, DisplayName: row.DisplayName})
+	}
+	return refs, nil
 }
 
 // SetDisplayName sets the human-readable name for an active merchant. An empty

--- a/internal/merchants/lifecycle_integration_test.go
+++ b/internal/merchants/lifecycle_integration_test.go
@@ -396,6 +396,41 @@ func TestSetDisplayName(t *testing.T) {
 	require.ErrorIs(t, svc.SetDisplayName(ctx, tn.ID, "Soft Deleted"), ErrMerchantNotFound)
 }
 
+func TestListDirectoryRefs(t *testing.T) {
+	ctx := context.Background()
+	svc := newSvc(t)
+	named, _, err := svc.Provision(ctx, ProvisionRequest{Slug: "refs-named", PermissionGroupID: "group-refs-named"})
+	require.NoError(t, err)
+	require.NoError(t, svc.SetDisplayName(ctx, named.ID, "Refs Named"))
+	_, _, err = svc.Provision(ctx, ProvisionRequest{Slug: "refs-unnamed", PermissionGroupID: "group-refs-unnamed"})
+	require.NoError(t, err)
+
+	refs, err := svc.ListDirectoryRefs(ctx, []string{"  REFS-NAMED  ", "refs-named", "refs-unnamed", "refs-missing", ""})
+	require.NoError(t, err)
+	require.Equal(t, []DirectoryRef{
+		{Slug: "refs-named", DisplayName: "Refs Named"},
+		{Slug: "refs-unnamed", DisplayName: ""},
+	}, refs, "slugs normalize and dedupe; a merchant without a name still resolves; unknown slugs are omitted")
+
+	empty, err := svc.ListDirectoryRefs(ctx, nil)
+	require.NoError(t, err)
+	require.Empty(t, empty)
+
+	oversized := make([]string, maxDirectoryRefSlugs+1)
+	for i := range oversized {
+		oversized[i] = fmt.Sprintf("refs-bulk-%d", i)
+	}
+	_, err = svc.ListDirectoryRefs(ctx, oversized)
+	require.Error(t, err, "an oversized slug list must error rather than silently truncate")
+
+	_, err = svc.pool.Exec(ctx,
+		`UPDATE openrails.merchants SET deleted_at = current_timestamp WHERE id = $1::uuid`, named.ID.String())
+	require.NoError(t, err)
+	refs, err = svc.ListDirectoryRefs(ctx, []string{"refs-named", "refs-unnamed"})
+	require.NoError(t, err)
+	require.Equal(t, []DirectoryRef{{Slug: "refs-unnamed"}}, refs, "soft-deleted merchants must not surface")
+}
+
 func TestDelete_RequiresExport(t *testing.T) {
 	ctx := context.Background()
 	svc := newSvc(t)

--- a/pkg/embedded/controlplane/merchants_for_subject.go
+++ b/pkg/embedded/controlplane/merchants_for_subject.go
@@ -7,9 +7,10 @@ import (
 	"github.com/open-rails/openrails/internal/app"
 )
 
-// MerchantRef identifies a merchant a customer transacts with (openrails-saas
-// #18): the slug the hosted portal scopes billing to, plus an optional
-// human-facing display name.
+// MerchantRef is a merchant's directory identity as a host sees it: the slug it
+// scopes billing to, plus an optional human-facing display name. It answers both
+// "which merchants does this customer transact with" (ListMerchantsForSubject,
+// openrails-saas #18) and "what are these merchants called" (ListMerchantRefs).
 type MerchantRef struct {
 	Slug        string `json:"slug"`
 	DisplayName string `json:"display_name,omitempty"`

--- a/pkg/embedded/controlplane/profile.go
+++ b/pkg/embedded/controlplane/profile.go
@@ -13,6 +13,34 @@ import (
 // directory update.
 var ErrMerchantNotFound = merchants.ErrMerchantNotFound
 
+// ListMerchantRefs returns the directory identity — slug plus display name — of
+// each requested slug, for the slugs that exist. It is the read counterpart of
+// SetMerchantDisplayName, and the seam a host needs to label merchant surfaces
+// it reaches through a MEMBERSHIP rather than a customer record: AuthKit
+// subject-group membership carries only the instance slug, and the customer-side
+// enumeration (ListMerchantsForSubject) is scoped to customer records, which a
+// merchant's own owner does not hold. Unknown slugs are omitted. This is a
+// privileged host seam; callers must authorize the slugs before use.
+func ListMerchantRefs(ctx context.Context, a *app.App, slugs []string) ([]MerchantRef, error) {
+	cp := Get(a)
+	if cp == nil {
+		return nil, fmt.Errorf("control plane list merchant refs: no control plane attached (call Attach first)")
+	}
+	dir, err := merchants.NewDirectoryService(cp.Pool())
+	if err != nil {
+		return nil, fmt.Errorf("control plane list merchant refs: build merchant directory service: %w", err)
+	}
+	rows, err := dir.ListDirectoryRefs(ctx, slugs)
+	if err != nil {
+		return nil, fmt.Errorf("control plane list merchant refs: %w", err)
+	}
+	out := make([]MerchantRef, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, MerchantRef{Slug: r.Slug, DisplayName: r.DisplayName})
+	}
+	return out, nil
+}
+
 // SetMerchantDisplayName sets an active merchant's human-readable directory
 // name through the attached control plane. Empty names are ignored so hosts can
 // safely retry provisioning without clearing a previously stored name. This is


### PR DESCRIPTION
## Summary

Adds the read counterpart of `SetMerchantDisplayName`. A host that reaches a merchant through a *membership* (AuthKit subject groups carry only the instance slug) had no way to resolve its display name: `embcp` exposed only the setter, and `ListMerchantsForSubject` is scoped to customer records, which a merchant's own owner does not hold.

- `ListMerchantDirectoryRefs` sqlc query — slug + display name for a set of slugs, excluding soft-deleted rows
- `merchants.Service.ListDirectoryRefs` — normalizes and dedupes slugs, then calls the generated query
- `controlplane.ListMerchantRefs` — the host seam, mirroring `SetMerchantDisplayName`

The slug list is capped at 200 and errors rather than truncating, since a silently short answer would read as "those merchants do not exist". Suspended merchants still resolve; only soft-deleted ones do not.

## Verification

- `go build ./...` and `go vet` clean
- `task sqlc` (generate + vet) green; `TestQueryAudit` ok; `migration-lint` clean
- New `TestListDirectoryRefs` green
- Full integration suite (51 packages) run and diffed against clean master: 44 ok, and the 5 failing packages fail identically on master (colima testcontainer networking, live NMI/CCBill probes, known intents flakes)
- `sql-lint.sh` not run locally (needs bash 4 for `mapfile`; macOS ships 3.2) — CI covers it. The new code goes through sqlc, adding no raw SQL.