### PR TITLE
or#905: bump js-yaml past the quadratic-!!omap CVE (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/web/admin/pnpm-lock.yaml
+++ b/web/admin/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   fast-uri: ^3.1.5
   ip-address: ^10.3.1
   brace-expansion: ^5.0.9
+  js-yaml: ^4.3.1
 
 importers:
 
@@ -1656,8 +1657,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -3590,7 +3591,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -4130,7 +4131,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/web/admin/pnpm-workspace.yaml
+++ b/web/admin/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ overrides:
   fast-uri: ^3.1.5 # GHSA-7p8r-x3mc-p8w7
   ip-address: ^10.3.1 # GHSA-mwp4-54f8-5fhr
   brace-expansion: ^5.0.9 # GHSA-rgw5-rvv9-x895
+  js-yaml: ^4.3.1 # GHSA-5p4m-2wfm-xmqj (dragged in by cosmiconfig)
 
 pmOnFail: error
 ignoreScripts: true


### PR DESCRIPTION
## What

Bumps the transitive `js-yaml` 4.3.0 → 4.3.1 in `web/admin` via a pnpm override.

## Why

`GHSA-5p4m-2wfm-xmqj` / `CVE-2026-59870` (HIGH) — quadratic CPU consumption in `!!omap` resolution. Published upstream on 2026-07-31, so it started failing `trivy` repo-wide: master's next scan fails too, and it is currently red on every open PR. Splitting it out here so the branches it is blocking aren't carrying an unrelated supply-chain fix.

`js-yaml` is transitive (dragged in by `cosmiconfig`), so the fix is an entry in `pnpm-workspace.yaml` `overrides:` — matching the four existing #853 entries, not a `package.json` dependency.

## No suppression warranted

Per the re-check procedure recorded in `.trivyignore`'s header (compare registry `.dist.attestations` for pinned vs fixed before believing any provenance-based suppression):

| version | `.dist.attestations` |
|---|---|
| 4.3.0 (pinned) | `null` |
| 4.3.1 (fixed)  | `null` |

Neither is attested, so there is **no provenance downgrade** for `trustPolicy: no-downgrade` to refuse. 4.3.1 is 7 days old, clearing `minimumReleaseAge: 1440`.

## Verification

Run with **real pnpm 11.0.0** fetched from the registry (the version `pmOnFail: error` pins; a newer local pnpm trips `ERR_PNPM_TRUST_DOWNGRADE` on the committed lockfile):

- `pnpm install --lockfile-only` → 3-line lockfile delta, no collateral resolution churn
- `pnpm install --frozen-lockfile` → clean
- `pnpm run build` (`tsc -b && vite build`) → clean

`trivy` on this PR is the proof of the fix itself.