### PR TITLE
feat: enforce exact checkout provider binding

### DIFF
--- a/internal/modules/checkout/merchant_rail_secrets.go
+++ b/internal/modules/checkout/merchant_rail_secrets.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/google/uuid"
@@ -21,10 +20,8 @@ import (
 )
 
 // SetMerchantSecretStore wires the dynamic OpenRails merchant-secret store into
-// checkout money paths. Static rail config remains available only when no
-// PSP resolver is configured; once scoped PSPs are in
-// use, missing scoped secrets fail closed instead of falling back across
-// accounts.
+// checkout money paths. Provider-bound checkout requires scoped PSP resolution;
+// missing identity or credentials fail closed instead of crossing accounts.
 func (s *CheckoutService) SetMerchantSecretStore(store merchants.MerchantSecretReader) {
 	if s == nil {
 		return
@@ -141,6 +138,16 @@ func (e *UnknownRailError) Error() string {
 	return fmt.Sprintf("unknown payment provider %q: not a declared PSP key or a rail (nmi, ccbill, stripe, solana)", e.Selector)
 }
 
+// UnarmedRailError reports a known rail with no armed PSP in the current
+// merchant and environment. It is distinct from a resolver failure so routing
+// can explain configuration absence without treating infrastructure errors as
+// an empty catalog.
+type UnarmedRailError struct{ Rail string }
+
+func (e *UnarmedRailError) Error() string {
+	return fmt.Sprintf("payment rail %q has no armed PSP", e.Rail)
+}
+
 // resolveRailTarget resolves a requested checkout provider name. The name is
 // either a declared PSP key ("mobius"), or a rail kind — reserved gateways
 // (stripe/ccbill/solana) are their own PSP names, and a bare rail kind resolves
@@ -152,18 +159,25 @@ func (s *CheckoutService) resolveRailTarget(ctx context.Context, requested strin
 		return railTarget{}, errors.New("rail is required")
 	}
 	_, isRail := knownRails[name]
+	if s == nil || s.ProviderSecrets == nil {
+		return railTarget{}, errors.New("payment provider resolution is not configured")
+	}
+	tid, err := merchant.Require(ctx)
+	if err != nil {
+		return railTarget{}, fmt.Errorf("resolve payment provider %q: %w", name, err)
+	}
 
 	// Declared PSP key wins (a rail-named account resolves identically).
-	if keys, ok := s.ProviderSecrets.(merchants.PSPKeyResolver); ok {
-		if tid, err := merchant.Require(ctx); err == nil {
-			scope, found, err := keys.PSPScopeByKey(ctx, tid, name, s.pspEnvironment())
-			if err != nil {
-				return railTarget{}, fmt.Errorf("resolve payment provider %q: %w", name, err)
-			}
-			if found {
-				return railTarget{PSP: name, Rail: scope.Rail, Scope: &scope}, nil
-			}
-		}
+	keys, ok := s.ProviderSecrets.(merchants.PSPKeyResolver)
+	if !ok {
+		return railTarget{}, errors.New("payment provider key resolution is not configured")
+	}
+	scope, found, err := keys.PSPScopeByKey(ctx, tid, name, s.pspEnvironment())
+	if err != nil {
+		return railTarget{}, fmt.Errorf("resolve payment provider %q: %w", name, err)
+	}
+	if found {
+		return resolvedRailTarget(name, scope)
 	}
 
 	if !isRail {
@@ -171,50 +185,80 @@ func (s *CheckoutService) resolveRailTarget(ctx context.Context, requested strin
 	}
 
 	// Bare rail kind: arming picks the PSP, and only an unambiguous match may.
-	// The armed account's key becomes the PSP so plan links resolve; an unwired
-	// resolver leaves the rail name (single-account deployments declare links
-	// under it).
-	target := railTarget{PSP: name, Rail: name}
-	adopt := func(scope merchants.PSPScope) {
-		target.Scope = &scope
-		if key := strings.ToLower(strings.TrimSpace(scope.Key)); key != "" {
-			target.PSP = key
+	// The armed account's key becomes the PSP so plan links resolve.
+	lister, ok := s.ProviderSecrets.(merchants.PSPRailScopesResolver)
+	if !ok {
+		return railTarget{}, errors.New("payment provider rail resolution is not configured")
+	}
+	scopes, err := lister.ActivePSPScopesForRail(ctx, tid, name, s.pspEnvironment())
+	if err != nil {
+		return railTarget{}, fmt.Errorf("resolve payment rail %q: %w", name, err)
+	}
+	switch len(scopes) {
+	case 0:
+		return railTarget{}, &UnarmedRailError{Rail: name}
+	case 1:
+		return resolvedRailTarget(name, scopes[0])
+	default:
+		keys := make([]string, 0, len(scopes))
+		for _, scope := range scopes {
+			key := strings.ToLower(strings.TrimSpace(scope.Key))
+			if key == "" {
+				key = scope.AccountID
+			}
+			keys = append(keys, key)
 		}
+		return railTarget{}, &AmbiguousRailError{Rail: name, Keys: keys}
+	}
+}
+
+func resolvedRailTarget(requested string, scope merchants.PSPScope) (railTarget, error) {
+	if scope.ID == uuid.Nil {
+		return railTarget{}, errors.New("payment provider identity is unavailable")
+	}
+	rail := strings.ToLower(strings.TrimSpace(scope.Rail))
+	if _, ok := knownRails[rail]; !ok {
+		return railTarget{}, fmt.Errorf("payment provider %q uses unsupported rail %q", requested, rail)
+	}
+	psp := strings.ToLower(strings.TrimSpace(scope.Key))
+	if psp == "" {
+		psp = strings.ToLower(strings.TrimSpace(requested))
+	}
+	return railTarget{PSP: psp, Rail: rail, Scope: &scope}, nil
+}
+
+// resolveRailTargetForPSP resolves the exact account already owning a
+// provider-bound resource. It never reselects a sibling account from the same
+// rail, which is required for saved methods and existing subscriptions.
+func (s *CheckoutService) resolveRailTargetForPSP(ctx context.Context, rail string, pspID uuid.UUID) (railTarget, error) {
+	rail = strings.ToLower(strings.TrimSpace(rail))
+	if pspID == uuid.Nil {
+		return railTarget{}, errors.New("payment provider identity is unavailable")
+	}
+	if _, ok := knownRails[rail]; !ok {
+		return railTarget{}, fmt.Errorf("unsupported rail %q", rail)
+	}
+	if s == nil || s.ProviderSecrets == nil {
+		return railTarget{}, errors.New("payment provider resolution is not configured")
+	}
+	lister, ok := s.ProviderSecrets.(merchants.PSPRailScopesResolver)
+	if !ok {
+		return railTarget{}, errors.New("payment provider rail resolution is not configured")
 	}
 	tid, err := merchant.Require(ctx)
 	if err != nil {
-		return target, nil
+		return railTarget{}, fmt.Errorf("resolve payment provider account: %w", err)
 	}
-	if lister, ok := s.ProviderSecrets.(merchants.PSPRailScopesResolver); ok {
-		scopes, err := lister.ActivePSPScopesForRail(ctx, tid, name, s.pspEnvironment())
-		switch {
-		case err != nil:
-			log.WithContext(ctx).WithError(err).WithField("rail", strconv.Quote(name)).Debug("checkout: PSP resolution failed; proceeding rail-scoped")
-		case len(scopes) == 1:
-			adopt(scopes[0])
-		case len(scopes) > 1:
-			keys := make([]string, 0, len(scopes))
-			for _, scope := range scopes {
-				key := strings.ToLower(strings.TrimSpace(scope.Key))
-				if key == "" {
-					key = scope.AccountID
-				}
-				keys = append(keys, key)
-			}
-			return railTarget{}, &AmbiguousRailError{Rail: name, Keys: keys}
-		}
-		return target, nil
+	scopes, err := lister.ActivePSPScopesForRail(ctx, tid, rail, s.pspEnvironment())
+	if err != nil {
+		return railTarget{}, fmt.Errorf("resolve payment rail %q: %w", rail, err)
 	}
-	// Legacy resolvers without the list capability: single-account semantics.
-	if scopes, ok := s.ProviderSecrets.(merchants.PSPScopeResolver); ok {
-		scope, found, err := scopes.ActivePSPScope(ctx, tid, name, s.pspEnvironment())
-		if err != nil {
-			log.WithContext(ctx).WithError(err).WithField("rail", strconv.Quote(name)).Debug("checkout: PSP resolution failed; proceeding rail-scoped")
-		} else if found {
-			adopt(scope)
+	for _, scope := range scopes {
+		if scope.ID == pspID {
+			return resolvedRailTarget(rail, scope)
 		}
 	}
-	return target, nil
+	return railTarget{}, fmt.Errorf("payment provider account %s is not armed on rail %q", pspID, rail)
 }
 
 // CheckoutRailUsable reports whether a wire payment.rail selector (a PSP key,
@@ -282,32 +326,21 @@ func (s *CheckoutService) resolveNMIClient(ctx context.Context, provider string)
 	if !rails.IsNMI(models.Rail(target.Rail)) {
 		return nil, fmt.Errorf("missing client")
 	}
-	var value string
-	if target.Scope != nil {
-		// Pinned to the resolved account's own secret, at or above the rotation
-		// version floor that account's PSP row records (or#812).
-		ref, err := target.Scope.SecretRef("security_key")
-		if err != nil {
-			return nil, err
-		}
-		v, ok, err := s.merchantSecretRef(ctx, ref)
-		if err != nil {
-			return nil, fmt.Errorf("load merchant NMI secret: %w", err)
-		}
-		if !ok {
-			return nil, fmt.Errorf("missing scoped merchant NMI secret for PSP")
-		}
-		value = v
-	} else {
-		// Environment follows test_mode, same as the CCBill leg.
-		v, ok, err := s.merchantProviderSecret(ctx, string(models.RailNMI), s.pspEnvironment(), "security_key")
-		if err != nil {
-			return nil, fmt.Errorf("load merchant NMI secret: %w", err)
-		}
-		if !ok {
-			return nil, fmt.Errorf("missing scoped merchant NMI secret for PSP")
-		}
-		value = v
+	if target.Scope == nil {
+		return nil, errors.New("payment provider identity is unavailable")
+	}
+	// Pinned to the resolved account's own secret, at or above the rotation
+	// version floor that account's PSP row records (or#812).
+	ref, err := target.Scope.SecretRef("security_key")
+	if err != nil {
+		return nil, err
+	}
+	value, ok, err := s.merchantSecretRef(ctx, ref)
+	if err != nil {
+		return nil, fmt.Errorf("load merchant NMI secret: %w", err)
+	}
+	if !ok {
+		return nil, fmt.Errorf("missing scoped merchant NMI secret for PSP")
 	}
 	proc := &config.PSPConfig{Rail: models.RailNMI, NMI: &config.NMIRailConfig{SecurityKey: value}}
 	client, err := nmi.NewClient(target.PSP, proc.ToNMIProviderSettings(), s.Config != nil && s.Config.IsTestMode())

--- a/internal/modules/checkout/merchant_rail_secrets_test.go
+++ b/internal/modules/checkout/merchant_rail_secrets_test.go
@@ -3,8 +3,8 @@ package checkout
 import (
 	"context"
 	"errors"
-	"github.com/open-rails/openrails/internal/railresolve"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -15,6 +15,7 @@ import (
 	"github.com/open-rails/openrails/internal/dbtest"
 	"github.com/open-rails/openrails/internal/integrations/ccbill"
 	"github.com/open-rails/openrails/internal/merchants"
+	"github.com/open-rails/openrails/internal/railresolve"
 	"github.com/open-rails/openrails/pkg/merchant"
 )
 
@@ -72,18 +73,38 @@ type checkoutStaticProviderSecretResolver struct {
 	settings    map[string]any
 }
 
+func (r checkoutStaticProviderSecretResolver) scope() merchants.PSPScope {
+	return merchants.PSPScope{
+		ID:          merchants.PspID(r.rail, r.environment, r.accountID),
+		Rail:        r.rail,
+		Environment: r.environment,
+		AccountID:   r.accountID,
+		Key:         r.rail,
+		Settings:    r.settings,
+	}
+}
+
 func (r checkoutStaticProviderSecretResolver) ActivePSPSecretName(_ context.Context, _ merchant.ID, rail, environment, key string) (string, bool, error) {
 	name, err := merchants.PSPSecretName(r.rail, r.environment, r.accountID, key)
 	return name, err == nil, err
 }
 
 func (r checkoutStaticProviderSecretResolver) ActivePSPScope(context.Context, merchant.ID, string, string) (merchants.PSPScope, bool, error) {
-	return merchants.PSPScope{
-		Rail:        r.rail,
-		Environment: r.environment,
-		AccountID:   r.accountID,
-		Settings:    r.settings,
-	}, true, nil
+	return r.scope(), true, nil
+}
+
+func (r checkoutStaticProviderSecretResolver) PSPScopeByKey(_ context.Context, _ merchant.ID, key, _ string) (merchants.PSPScope, bool, error) {
+	if !strings.EqualFold(strings.TrimSpace(key), strings.TrimSpace(r.rail)) {
+		return merchants.PSPScope{}, false, nil
+	}
+	return r.scope(), true, nil
+}
+
+func (r checkoutStaticProviderSecretResolver) ActivePSPScopesForRail(_ context.Context, _ merchant.ID, rail, _ string) ([]merchants.PSPScope, error) {
+	if !strings.EqualFold(strings.TrimSpace(rail), strings.TrimSpace(r.rail)) {
+		return nil, nil
+	}
+	return []merchants.PSPScope{r.scope()}, nil
 }
 
 type checkoutMissingProviderSecretResolver struct{}
@@ -94,6 +115,14 @@ func (checkoutMissingProviderSecretResolver) ActivePSPSecretName(context.Context
 
 func (checkoutMissingProviderSecretResolver) ActivePSPScope(context.Context, merchant.ID, string, string) (merchants.PSPScope, bool, error) {
 	return merchants.PSPScope{}, false, nil
+}
+
+func (checkoutMissingProviderSecretResolver) PSPScopeByKey(context.Context, merchant.ID, string, string) (merchants.PSPScope, bool, error) {
+	return merchants.PSPScope{}, false, nil
+}
+
+func (checkoutMissingProviderSecretResolver) ActivePSPScopesForRail(context.Context, merchant.ID, string, string) ([]merchants.PSPScope, error) {
+	return nil, nil
 }
 
 func TestCheckoutResolvesMobiusClientFromVaultMerchantSecret(t *testing.T) {
@@ -127,7 +156,7 @@ func TestCheckoutWithoutScopedResolutionFailsClosed(t *testing.T) {
 	require.Contains(t, err.Error(), "not configured")
 }
 
-func TestCheckoutPSPResolverMissingMobiusSecretDoesNotUseStaticClient(t *testing.T) {
+func TestCheckoutMissingMobiusPSPFailsClosed(t *testing.T) {
 	ctx := merchant.WithID(context.Background(), dbtest.TestMerchantID)
 	svc := &CheckoutService{Config: checkoutRailConfig(true), Rails: checkoutRailSet("static-mobius-key")}
 	svc.SetMerchantSecretStore(merchants.NewMemorySecretStore())
@@ -135,7 +164,7 @@ func TestCheckoutPSPResolverMissingMobiusSecretDoesNotUseStaticClient(t *testing
 
 	_, err := svc.resolveNMIClient(ctx, "nmi")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "missing scoped merchant NMI secret")
+	require.Contains(t, err.Error(), "has no armed PSP")
 }
 
 func TestCheckoutFailsClosedWhenMerchantSecretBackendUnavailable(t *testing.T) {

--- a/internal/modules/checkout/nmi_provider_test.go
+++ b/internal/modules/checkout/nmi_provider_test.go
@@ -25,9 +25,7 @@ func TestRequireNMIPlanForTarget_ResolvesProviderEntry(t *testing.T) {
 	require.Equal(t, "plan_acme_123", planID)
 }
 
-func TestRequireNMIPlanForTarget_FallsBackToRailNamedEntry(t *testing.T) {
-	// A manifest that declared the link under the rail name still resolves
-	// when the provider is an account key.
+func TestRequireNMIPlanForTarget_ResolvesRailNamedProviderEntry(t *testing.T) {
 	price := &models.Price{
 		ID: uuid.New(),
 		PSPLinks: map[string]map[string]string{
@@ -38,9 +36,24 @@ func TestRequireNMIPlanForTarget_FallsBackToRailNamedEntry(t *testing.T) {
 		},
 	}
 
-	planID, err := requireNMIPlanForTarget(price, railTarget{PSP: "mobius", Rail: "nmi"})
+	planID, err := requireNMIPlanForTarget(price, railTarget{PSP: "nmi", Rail: "nmi"})
 	require.NoError(t, err)
 	require.Equal(t, "plan_rail_default", planID)
+}
+
+func TestRequireNMIPlanForTarget_DoesNotFallbackToRailEntry(t *testing.T) {
+	price := &models.Price{
+		ID: uuid.New(),
+		PSPLinks: map[string]map[string]string{
+			"nmi": {
+				models.RailKeyRail:   "nmi",
+				models.RailKeyPlanID: "plan_rail_default",
+			},
+		},
+	}
+
+	_, err := requireNMIPlanForTarget(price, railTarget{PSP: "mobius", Rail: "nmi"})
+	require.ErrorContains(t, err, "missing NMI plan configuration")
 }
 
 func TestRequireNMIPlanForTarget_NeverCrossesProviders(t *testing.T) {

--- a/internal/modules/checkout/payment_method_resolver.go
+++ b/internal/modules/checkout/payment_method_resolver.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/modules/paymentmethods"
 	"github.com/open-rails/openrails/internal/modules/payments/rails"
@@ -47,6 +48,9 @@ func (s *CheckoutPaymentMethodResolver) ResolvePaymentMethod(ctx context.Context
 		}
 		if !rails.SameRail(pm.Rail, models.Rail(target.Rail)) {
 			return "", "", nil, false, errors.New("payment method belongs to a different payment provider")
+		}
+		if err := paymentMethodMatchesTargetPSP(pm, target); err != nil {
+			return "", "", nil, false, err
 		}
 
 		// NMI-backed only (checked above): vault id = customer-scope handle,
@@ -95,6 +99,19 @@ func (s *CheckoutPaymentMethodResolver) ResolvePaymentMethod(ctx context.Context
 	}
 
 	return pmNew.RailCustomerRef, pmNew.RailMethodRef, pmNew, true, nil
+}
+
+func paymentMethodMatchesTargetPSP(pm *models.PaymentMethod, target railTarget) error {
+	if pm == nil {
+		return errors.New("payment method identity is unavailable")
+	}
+	if target.Scope == nil {
+		return errors.New("payment provider identity is unavailable")
+	}
+	if pm.PspID == uuid.Nil || pm.PspID != target.Scope.ID {
+		return errors.New("payment method belongs to a different payment provider account")
+	}
+	return nil
 }
 
 func ResolveCheckoutFirstName(req *CheckoutRequest, user *UserIdentity) string {

--- a/internal/modules/checkout/payment_method_resolver_test.go
+++ b/internal/modules/checkout/payment_method_resolver_test.go
@@ -1,0 +1,43 @@
+package checkout
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/merchants"
+)
+
+func TestPaymentMethodMatchesTargetPSP(t *testing.T) {
+	targetPSPID := uuid.New()
+	target := railTarget{Scope: &merchants.PSPScope{ID: targetPSPID}}
+
+	tests := []struct {
+		name    string
+		method  *models.PaymentMethod
+		target  railTarget
+		wantErr string
+	}{
+		{name: "exact provider", method: &models.PaymentMethod{PspID: targetPSPID}, target: target},
+		{name: "different provider", method: &models.PaymentMethod{PspID: uuid.New()}, target: target, wantErr: "different payment provider account"},
+		{name: "missing method provider", method: &models.PaymentMethod{}, target: target, wantErr: "different payment provider account"},
+		{name: "missing method", method: nil, target: target, wantErr: "method identity is unavailable"},
+		{name: "unresolved target provider", method: &models.PaymentMethod{PspID: targetPSPID}, target: railTarget{}, wantErr: "identity is unavailable"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := paymentMethodMatchesTargetPSP(tt.method, tt.target)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("paymentMethodMatchesTargetPSP() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("paymentMethodMatchesTargetPSP() error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/modules/checkout/rail_options.go
+++ b/internal/modules/checkout/rail_options.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/open-rails/openrails/config"
 	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/modules/catalog"
@@ -13,9 +14,11 @@ import (
 )
 
 // CheckoutRailOption is a locally ready payment-provider choice for a price.
-// Selector is the exact value checkout accepts; Rail is the canonical gateway.
+// Selector is the exact value checkout accepts, PSPID is the provider's stable
+// internal identity, and Rail is the canonical gateway.
 type CheckoutRailOption struct {
 	Selector string
+	PSPID    uuid.UUID
 	Rail     string
 	Mode     string
 }
@@ -95,6 +98,7 @@ func (s *CheckoutSessionService) listCheckoutRailOptionsForPrice(ctx context.Con
 		}
 		options = append(options, CheckoutRailOption{
 			Selector: candidate.Selector,
+			PSPID:    candidate.PSPID,
 			Rail:     candidate.Rail,
 			Mode:     string(mode),
 		})
@@ -194,7 +198,7 @@ func (s *CheckoutSessionService) checkoutRailSkipReason(price *models.Price, tar
 }
 
 // checkoutPSPLinkForTarget resolves the price link for the same account chosen
-// for credentials. A rail-named fallback preserves single-account manifests.
+// for credentials. It never substitutes another link from the same rail.
 func checkoutPSPLinkForTarget(price *models.Price, target railTarget) map[string]string {
 	if price == nil {
 		return nil
@@ -208,9 +212,6 @@ func checkoutPSPLinkForTarget(price *models.Price, target railTarget) map[string
 	}
 	if link := lookup(target.PSP); link != nil {
 		return link
-	}
-	if target.Scope == nil && target.PSP != target.Rail {
-		return lookup(target.Rail)
 	}
 	return nil
 }

--- a/internal/modules/checkout/rail_options_test.go
+++ b/internal/modules/checkout/rail_options_test.go
@@ -249,20 +249,21 @@ func TestListCheckoutRailOptionsForPrice_ReturnsExecutableSelectors(t *testing.T
 		},
 	}
 	checkoutService := &CheckoutService{
-		Config: &config.Config{ProviderWriteMode: config.ProviderWriteModeFull},
-		Rails:  rails,
+		Config:          &config.Config{ProviderWriteMode: config.ProviderWriteModeFull},
+		Rails:           rails,
+		ProviderSecrets: fakePSPCatalog{scopes: routingScopes(rails)},
 	}
 	svc := &CheckoutSessionService{
 		config:          &config.Config{ProviderWriteMode: config.ProviderWriteModeFull},
 		checkoutService: checkoutService,
 	}
 
-	options, err := svc.listCheckoutRailOptionsForPrice(context.Background(), price, &models.Product{})
+	options, err := svc.listCheckoutRailOptionsForPrice(routingContext(), price, &models.Product{})
 	require.NoError(t, err)
 	require.Equal(t, []CheckoutRailOption{
-		{Selector: "stripe", Rail: "stripe", Mode: "subscription"},
-		{Selector: "nmi", Rail: "nmi", Mode: "subscription"},
-		{Selector: "ccbill", Rail: "ccbill", Mode: "subscription"},
+		{Selector: "stripe", PSPID: merchants.PspID("stripe", "live", "acct_stripe"), Rail: "stripe", Mode: "subscription"},
+		{Selector: "nmi", PSPID: merchants.PspID("nmi", "live", "acct_nmi"), Rail: "nmi", Mode: "subscription"},
+		{Selector: "ccbill", PSPID: merchants.PspID("ccbill", "live", "945280-0000"), Rail: "ccbill", Mode: "subscription"},
 	}, options)
 
 	for _, option := range options {
@@ -283,7 +284,7 @@ func TestListCheckoutRailOptionsForPrice_ReturnsExecutableSelectors(t *testing.T
 			payment.Zip = "12345"
 			payment.Country = "US"
 		}
-		require.NoError(t, svc.validatePayment(context.Background(), option.Selector, payment, &UserIdentity{ID: uuid.NewString()}), option.Selector)
+		require.NoError(t, svc.validatePayment(routingContext(), option.Selector, payment, &UserIdentity{ID: uuid.NewString()}), option.Selector)
 	}
 }
 
@@ -301,13 +302,9 @@ func TestCheckoutPSPLinkForTarget(t *testing.T) {
 	assert.Equal(t, stale, checkoutPSPLinkForTarget(price, railTarget{PSP: "other", Rail: "nmi"}))
 	assert.Nil(t, checkoutPSPLinkForTarget(price, railTarget{PSP: "missing", Rail: "nmi"}))
 
-	railFallback := &models.Price{PSPLinks: map[string]map[string]string{"nmi": active}}
-	assert.Equal(t, active, checkoutPSPLinkForTarget(railFallback, railTarget{PSP: "mobius", Rail: "nmi"}))
-	assert.Nil(t, checkoutPSPLinkForTarget(railFallback, railTarget{
-		PSP:   "mobius",
-		Rail:  "nmi",
-		Scope: &merchants.PSPScope{Key: "mobius", Rail: "nmi"},
-	}))
+	railNamed := &models.Price{PSPLinks: map[string]map[string]string{"nmi": active}}
+	assert.Equal(t, active, checkoutPSPLinkForTarget(railNamed, railTarget{PSP: "nmi", Rail: "nmi"}))
+	assert.Nil(t, checkoutPSPLinkForTarget(railNamed, railTarget{PSP: "mobius", Rail: "nmi"}))
 }
 
 func TestCheckoutSessionServiceRequireProviderWrites(t *testing.T) {

--- a/internal/modules/checkout/rail_target_resolution_test.go
+++ b/internal/modules/checkout/rail_target_resolution_test.go
@@ -2,6 +2,7 @@ package checkout
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -18,7 +19,9 @@ import (
 // capabilities resolveRailTarget consumes: key-first lookup + the #848
 // unambiguous rail-kind list.
 type fakePSPCatalog struct {
-	scopes []merchants.PSPScope
+	scopes  []merchants.PSPScope
+	keyErr  error
+	listErr error
 }
 
 func (f fakePSPCatalog) ActivePSPSecretName(context.Context, merchant.ID, string, string, string) (string, bool, error) {
@@ -26,6 +29,9 @@ func (f fakePSPCatalog) ActivePSPSecretName(context.Context, merchant.ID, string
 }
 
 func (f fakePSPCatalog) PSPScopeByKey(_ context.Context, _ merchant.ID, key, _ string) (merchants.PSPScope, bool, error) {
+	if f.keyErr != nil {
+		return merchants.PSPScope{}, false, f.keyErr
+	}
 	for _, s := range f.scopes {
 		if strings.EqualFold(s.Key, key) {
 			return s, true, nil
@@ -35,6 +41,9 @@ func (f fakePSPCatalog) PSPScopeByKey(_ context.Context, _ merchant.ID, key, _ s
 }
 
 func (f fakePSPCatalog) ActivePSPScopesForRail(_ context.Context, _ merchant.ID, rail, _ string) ([]merchants.PSPScope, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
 	var out []merchants.PSPScope
 	for _, s := range f.scopes {
 		if strings.EqualFold(s.Rail, rail) {
@@ -42,6 +51,16 @@ func (f fakePSPCatalog) ActivePSPScopesForRail(_ context.Context, _ merchant.ID,
 		}
 	}
 	return out, nil
+}
+
+type keyOnlyPSPCatalog struct{}
+
+func (keyOnlyPSPCatalog) ActivePSPSecretName(context.Context, merchant.ID, string, string, string) (string, bool, error) {
+	return "", false, nil
+}
+
+func (keyOnlyPSPCatalog) PSPScopeByKey(context.Context, merchant.ID, string, string) (merchants.PSPScope, bool, error) {
+	return merchants.PSPScope{}, false, nil
 }
 
 func railTargetTestService(scopes ...merchants.PSPScope) *CheckoutService {
@@ -109,6 +128,51 @@ func TestResolveRailTarget_UnknownSelector(t *testing.T) {
 	require.Equal(t, "bogus", unknown.Selector)
 }
 
+func TestResolveRailTarget_FailsClosedWithoutExactPSPIdentity(t *testing.T) {
+	t.Parallel()
+	ctx := merchant.WithID(context.Background(), dbtest.TestMerchantID)
+	lookupErr := errors.New("catalog unavailable")
+
+	tests := []struct {
+		name string
+		svc  *CheckoutService
+		ctx  context.Context
+		want string
+	}{
+		{name: "resolver not wired", svc: &CheckoutService{}, ctx: ctx, want: "resolution is not configured"},
+		{name: "rail list capability missing", svc: &CheckoutService{ProviderSecrets: keyOnlyPSPCatalog{}}, ctx: ctx, want: "rail resolution is not configured"},
+		{name: "key lookup fails", svc: &CheckoutService{ProviderSecrets: fakePSPCatalog{keyErr: lookupErr}}, ctx: ctx, want: "catalog unavailable"},
+		{name: "rail lookup fails", svc: &CheckoutService{ProviderSecrets: fakePSPCatalog{listErr: lookupErr}}, ctx: ctx, want: "catalog unavailable"},
+		{name: "rail has no armed provider", svc: railTargetTestService(), ctx: ctx, want: "has no armed PSP"},
+		{name: "merchant context missing", svc: railTargetTestService(), ctx: context.Background(), want: "no merchant resolved on context"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			target, err := tt.svc.resolveRailTarget(tt.ctx, "nmi")
+			require.ErrorContains(t, err, tt.want)
+			require.Nil(t, target.Scope)
+		})
+	}
+}
+
+func TestResolveRailTargetForPSP_SelectsPersistedAccount(t *testing.T) {
+	t.Parallel()
+	ctx := merchant.WithID(context.Background(), dbtest.TestMerchantID)
+	mobius := merchants.PSPScope{ID: uuid.New(), Rail: "nmi", AccountID: "gw-1", Key: "mobius"}
+	paykings := merchants.PSPScope{ID: uuid.New(), Rail: "nmi", AccountID: "gw-2", Key: "paykings"}
+	svc := railTargetTestService(mobius, paykings)
+
+	target, err := svc.resolveRailTargetForPSP(ctx, "nmi", paykings.ID)
+	require.NoError(t, err)
+	require.Equal(t, "paykings", target.PSP)
+	require.Equal(t, paykings.ID, target.Scope.ID)
+
+	_, err = svc.resolveRailTargetForPSP(ctx, "nmi", uuid.New())
+	require.ErrorContains(t, err, "is not armed")
+}
+
 func TestCheckoutRailUsable(t *testing.T) {
 	ctx := merchant.WithID(context.Background(), dbtest.TestMerchantID)
 	svc := railTargetTestService(
@@ -125,6 +189,6 @@ func TestCheckoutRailUsable(t *testing.T) {
 	require.Contains(t, err.Error(), "mobius-sandbox")
 	require.Contains(t, err.Error(), "paykings")
 
-	require.EqualError(t, svc.CheckoutRailUsable(ctx, "solana"), "unsupported rail", "known rail with nothing armed")
+	require.ErrorContains(t, svc.CheckoutRailUsable(ctx, "solana"), "has no armed PSP", "known rail with nothing armed")
 	require.ErrorContains(t, svc.CheckoutRailUsable(ctx, "bogus"), "unknown payment provider")
 }

--- a/internal/modules/checkout/routing.go
+++ b/internal/modules/checkout/routing.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/modules/catalog"
 	"github.com/open-rails/openrails/internal/modules/merchantconfig"
@@ -49,8 +50,9 @@ type RoutingInput struct {
 
 // RoutingCandidate is one evaluated candidate in preference order.
 type RoutingCandidate struct {
-	Selector string `json:"selector"`
-	Rail     string `json:"rail,omitempty"`
+	Selector string    `json:"selector"`
+	Rail     string    `json:"rail,omitempty"`
+	PSPID    uuid.UUID `json:"-"`
 	// Skip is "" when the candidate is eligible, else its skip class.
 	Skip string `json:"skip,omitempty"`
 }
@@ -133,7 +135,7 @@ func (s *CheckoutSessionService) Route(ctx context.Context, in RoutingInput) (*R
 		return &RoutingDecision{
 			Target:     target,
 			Policy:     models.CheckoutRoutingPolicyExplicit,
-			Candidates: []RoutingCandidate{{Selector: target.PSP, Rail: target.Rail}},
+			Candidates: []RoutingCandidate{{Selector: target.PSP, Rail: target.Rail, PSPID: targetPSPID(target)}},
 		}, nil
 	}
 
@@ -144,7 +146,7 @@ func (s *CheckoutSessionService) Route(ctx context.Context, in RoutingInput) (*R
 	decision := &RoutingDecision{Policy: policy, Rule: rule, Candidates: make([]RoutingCandidate, 0, len(order))}
 	for _, selector := range order {
 		target, skip := s.evaluateCandidate(ctx, targets, in, selector)
-		candidate := RoutingCandidate{Selector: selector, Rail: target.Rail, Skip: skip}
+		candidate := RoutingCandidate{Selector: selector, Rail: target.Rail, PSPID: targetPSPID(target), Skip: skip}
 		if skip == "" {
 			// The resolved PSP key is the answer, not the requested selector: a
 			// rail kind resolves to the armed account's key (#848).
@@ -159,6 +161,13 @@ func (s *CheckoutSessionService) Route(ctx context.Context, in RoutingInput) (*R
 		return decision, ErrNoRoutableProcessor
 	}
 	return decision, nil
+}
+
+func targetPSPID(target railTarget) uuid.UUID {
+	if target.Scope == nil {
+		return uuid.Nil
+	}
+	return target.Scope.ID
 }
 
 // routingOrder resolves the candidate order for these inputs: the first
@@ -230,10 +239,13 @@ func (s *CheckoutSessionService) evaluateCandidate(ctx context.Context, targets 
 	target, err := targets.resolveRailTarget(ctx, selector)
 	if err != nil {
 		var ambiguous *AmbiguousRailError
+		var unarmed *UnarmedRailError
 		var unknown *UnknownRailError
 		switch {
 		case errors.As(err, &ambiguous):
 			return railTarget{}, models.CheckoutRoutingSkipAmbiguousSelector
+		case errors.As(err, &unarmed):
+			return railTarget{}, models.CheckoutRoutingSkipNotArmed
 		case errors.As(err, &unknown):
 			// A key that resolves to nothing may still be DECLARED and archived.
 			// Say "retired", not "never heard of it" — support reads this.

--- a/internal/modules/checkout/routing_test.go
+++ b/internal/modules/checkout/routing_test.go
@@ -10,7 +10,10 @@ import (
 
 	"github.com/open-rails/openrails/config"
 	"github.com/open-rails/openrails/internal/db/models"
+	"github.com/open-rails/openrails/internal/dbtest"
+	"github.com/open-rails/openrails/internal/merchants"
 	"github.com/open-rails/openrails/internal/railresolve"
+	"github.com/open-rails/openrails/pkg/merchant"
 )
 
 // routingFixturePrice is a recurring price linked on all four rails.
@@ -33,8 +36,30 @@ func routingFixturePrice() *models.Price {
 }
 
 func routingFixtureService(armed railresolve.FixedSet) *CheckoutSessionService {
-	checkoutService := &CheckoutService{Config: fullModeConfigUnit(), Rails: armed}
+	checkoutService := &CheckoutService{
+		Config:          fullModeConfigUnit(),
+		Rails:           armed,
+		ProviderSecrets: fakePSPCatalog{scopes: routingScopes(armed)},
+	}
 	return &CheckoutSessionService{config: fullModeConfigUnit(), checkoutService: checkoutService}
+}
+
+func routingContext() context.Context {
+	return merchant.WithID(context.Background(), dbtest.TestMerchantID)
+}
+
+func routingScopes(armed railresolve.FixedSet) []merchants.PSPScope {
+	scopes := make([]merchants.PSPScope, 0, len(armed))
+	for key, processor := range armed {
+		scopes = append(scopes, merchants.PSPScope{
+			ID:          merchants.PspID(string(processor.Rail), "live", processor.AccountID),
+			Rail:        string(processor.Rail),
+			Environment: "live",
+			AccountID:   processor.AccountID,
+			Key:         key,
+		})
+	}
+	return scopes
 }
 
 func fullModeConfigUnit() *config.Config {
@@ -58,7 +83,7 @@ func TestRouteDefaultOrderIsTodaysHardcodedOrder(t *testing.T) {
 	require.Equal(t, []string{"stripe", "nmi", "ccbill", "solana"}, defaultRoutingOrder)
 
 	svc := routingFixtureService(routingArmedAll())
-	decision, err := svc.Route(context.Background(), RoutingInput{
+	decision, err := svc.Route(routingContext(), RoutingInput{
 		Price: routingFixturePrice(),
 		Mode:  models.CheckoutSessionModeSubscription,
 	})
@@ -79,7 +104,7 @@ func TestRouteFallsThroughUnavailableCandidates(t *testing.T) {
 	delete(armed, "stripe") // stripe not armed at all
 
 	svc := routingFixtureService(armed)
-	decision, err := svc.Route(context.Background(), RoutingInput{
+	decision, err := svc.Route(routingContext(), RoutingInput{
 		Price: routingFixturePrice(),
 		Mode:  models.CheckoutSessionModeSubscription,
 	})
@@ -110,7 +135,7 @@ func TestRouteSkipsModeUnsupported(t *testing.T) {
 		"nmi":    {Rail: models.RailNMI, AccountID: "acct_nmi", NMI: &config.NMIRailConfig{SecurityKey: "security_test"}},
 	}
 	svc := routingFixtureService(armed)
-	decision, err := svc.Route(context.Background(), RoutingInput{
+	decision, err := svc.Route(routingContext(), RoutingInput{
 		Price: price,
 		Mode:  models.CheckoutSessionModeOneOff,
 	})
@@ -129,7 +154,7 @@ func TestRouteFailsClosedWithNoEligibleProcessor(t *testing.T) {
 	t.Parallel()
 
 	svc := routingFixtureService(railresolve.FixedSet{})
-	decision, err := svc.Route(context.Background(), RoutingInput{
+	decision, err := svc.Route(routingContext(), RoutingInput{
 		Price: routingFixturePrice(),
 		Mode:  models.CheckoutSessionModeSubscription,
 	})
@@ -145,11 +170,8 @@ func TestRouteFailsClosedWithNoEligibleProcessor(t *testing.T) {
 func TestRouteExplicitSelectorNeverFallsBack(t *testing.T) {
 	t.Parallel()
 
-	armed := routingArmedAll()
-	delete(armed, "ccbill")
-
-	svc := routingFixtureService(armed)
-	decision, err := svc.Route(context.Background(), RoutingInput{
+	svc := routingFixtureService(routingArmedAll())
+	decision, err := svc.Route(routingContext(), RoutingInput{
 		Price:    routingFixturePrice(),
 		Mode:     models.CheckoutSessionModeSubscription,
 		Selector: "ccbill",
@@ -159,6 +181,21 @@ func TestRouteExplicitSelectorNeverFallsBack(t *testing.T) {
 	assert.Equal(t, "ccbill", decision.Selected())
 	assert.Empty(t, decision.Reason().Fallbacks)
 	assert.Empty(t, decision.Reason().Skipped)
+}
+
+func TestRouteExplicitSelectorMustBeArmed(t *testing.T) {
+	t.Parallel()
+
+	armed := routingArmedAll()
+	delete(armed, "ccbill")
+	svc := routingFixtureService(armed)
+
+	_, err := svc.Route(routingContext(), RoutingInput{
+		Price:    routingFixturePrice(),
+		Mode:     models.CheckoutSessionModeSubscription,
+		Selector: "ccbill",
+	})
+	require.ErrorContains(t, err, "has no armed PSP")
 }
 
 func TestRoutingRuleMatches(t *testing.T) {

--- a/internal/modules/checkout/service.go
+++ b/internal/modules/checkout/service.go
@@ -2902,8 +2902,9 @@ func (s *CheckoutService) processTierChangeNMI(
 	}
 
 	// Route to existing methods which handle the heavy lifting. The existing
-	// subscription's rail resolves through arming to its payment provider.
-	target, err := s.resolveRailTarget(ctx, string(existingSub.Rail))
+	// subscription's persisted PSP identity resolves its exact account; a sibling
+	// account on the same rail must never receive its saved payment method.
+	target, err := s.resolveRailTargetForPSP(ctx, string(existingSub.Rail), existingSub.PspID)
 	if err != nil {
 		return nil, err
 	}
@@ -3031,10 +3032,8 @@ func (s *CheckoutService) mapCheckoutToTierChangeResponse(resp *CheckoutResponse
 }
 
 // requireNMIPlanForTarget returns the NMI plan the resolved payment provider
-// charges for this price: the provider's own link entry (by account key), or
-// the rail-named entry when the manifest declared it under the rail. Never a
-// rail-wide scan — with several accounts on a rail, each provider's plan is
-// its own.
+// charges for this price. It never scans or falls back across a rail: with
+// several accounts on one rail, each provider's plan is its own.
 func requireNMIPlanForTarget(price *models.Price, target railTarget) (string, error) {
 	if price == nil {
 		return "", errors.New("price is required")
@@ -3049,11 +3048,6 @@ func requireNMIPlanForTarget(price *models.Price, target railTarget) (string, er
 	}
 	if id, ok := lookup(target.PSP); ok {
 		return id, nil
-	}
-	if target.Scope == nil && target.PSP != target.Rail {
-		if id, ok := lookup(target.Rail); ok {
-			return id, nil
-		}
 	}
 	return "", fmt.Errorf("price %s is missing NMI plan configuration for payment provider %s (rail %s)", price.ID, target.PSP, target.Rail)
 }

--- a/internal/modules/checkout/upgrade_adopt_integration_test.go
+++ b/internal/modules/checkout/upgrade_adopt_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/open-rails/openrails/internal/db/models"
 	"github.com/open-rails/openrails/internal/dbtest"
 	"github.com/open-rails/openrails/internal/integrations/nmi"
+	"github.com/open-rails/openrails/internal/merchants"
 	"github.com/open-rails/openrails/internal/modules/catalog"
 	"github.com/open-rails/openrails/internal/modules/entitlements"
 	"github.com/open-rails/openrails/internal/modules/paymentmethods"
@@ -158,6 +159,7 @@ type upgradeAdoptFixture struct {
 	newPrice    *models.Price
 	newProduct  *models.Product
 	existingSub *models.Subscription
+	target      railTarget
 	ctx         context.Context
 }
 
@@ -276,7 +278,16 @@ func newUpgradeAdoptFixture(t *testing.T) *upgradeAdoptFixture {
 		newPrice:    newPrice,
 		newProduct:  newProduct,
 		existingSub: existingSub,
-		ctx:         ctx,
+		target: railTarget{
+			PSP:  "nmi",
+			Rail: "nmi",
+			Scope: &merchants.PSPScope{
+				ID:   pspID,
+				Key:  "nmi",
+				Rail: "nmi",
+			},
+		},
+		ctx: ctx,
 	}
 }
 
@@ -287,7 +298,7 @@ func TestUpgradeAmbiguousCreateLanded_AdoptsInline(t *testing.T) {
 	fx := newUpgradeAdoptFixture(t)
 	fx.gateway.createMode.Store("ambiguousLanded")
 
-	resp, err := fx.svc.processUpgrade(fx.ctx, fx.req, fx.user, fx.newPrice, fx.newProduct, fx.existingSub, railTarget{PSP: "nmi", Rail: "nmi"})
+	resp, err := fx.svc.processUpgrade(fx.ctx, fx.req, fx.user, fx.newPrice, fx.newProduct, fx.existingSub, fx.target)
 	require.NoError(t, err, "landed-but-lost create must be adopted, not failed")
 	require.Equal(t, "success", resp.Status)
 	require.EqualValues(t, 1, fx.gateway.createCalls.Load(), "never a second blind create")
@@ -313,7 +324,7 @@ func TestUpgradeAmbiguousCreateLost_RetryRecreatesSameOrderID(t *testing.T) {
 	fx := newUpgradeAdoptFixture(t)
 	fx.gateway.createMode.Store("ambiguousLost")
 
-	_, err := fx.svc.processUpgrade(fx.ctx, fx.req, fx.user, fx.newPrice, fx.newProduct, fx.existingSub, railTarget{PSP: "nmi", Rail: "nmi"})
+	_, err := fx.svc.processUpgrade(fx.ctx, fx.req, fx.user, fx.newPrice, fx.newProduct, fx.existingSub, fx.target)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, ErrCheckoutProcessing), "unresolved ambiguity is processing, never a decline: %v", err)
 	require.EqualValues(t, 1, fx.gateway.createCalls.Load())
@@ -328,7 +339,7 @@ func TestUpgradeAmbiguousCreateLost_RetryRecreatesSameOrderID(t *testing.T) {
 	// Provider recovers; the retry (same idempotency key ⇒ retryAfterFailure)
 	// scans the roster first, then re-creates under the ORIGINAL order id.
 	fx.gateway.createMode.Store("approve")
-	resp, err := fx.svc.processUpgrade(fx.ctx, fx.req, fx.user, fx.newPrice, fx.newProduct, fx.existingSub, railTarget{PSP: "nmi", Rail: "nmi"})
+	resp, err := fx.svc.processUpgrade(fx.ctx, fx.req, fx.user, fx.newPrice, fx.newProduct, fx.existingSub, fx.target)
 	require.NoError(t, err)
 	require.Equal(t, "success", resp.Status)
 	require.EqualValues(t, 2, fx.gateway.createCalls.Load())

--- a/pkg/embedded/controlplane/payment_provider.go
+++ b/pkg/embedded/controlplane/payment_provider.go
@@ -13,6 +13,21 @@ import (
 
 type PaymentProviderConfig = merchants.PaymentProviderConfig
 type UpsertPaymentProviderConfigRequest = merchants.UpsertPaymentProviderConfigRequest
+type PublicPSPConfig = merchants.PublicPSPConfig
+
+// ListPublicCheckoutPSPs returns the exact armed PSPs that a browser checkout
+// may offer, including their public browser-driver configuration.
+func ListPublicCheckoutPSPs(ctx context.Context, a *app.App, id merchant.ID, environment string) ([]PublicPSPConfig, error) {
+	providerService, err := paymentProviderService(a)
+	if err != nil {
+		return nil, fmt.Errorf("control plane list public checkout psps: %w", err)
+	}
+	providers, err := providerService.PublicCheckoutPSPs(ctx, id, environment)
+	if err != nil {
+		return nil, fmt.Errorf("control plane list public checkout psps: %w", err)
+	}
+	return providers, nil
+}
 
 // GetPaymentProviderConfig returns one system-owned merchant PSP
 // with credential values redacted.

--- a/pkg/service/payment_method_projection_test.go
+++ b/pkg/service/payment_method_projection_test.go
@@ -1,0 +1,27 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/open-rails/openrails/internal/db/models"
+)
+
+func TestPaymentMethodFromModelCarriesPSPProvenance(t *testing.T) {
+	pspID := uuid.New()
+	method := paymentMethodFromModel(&models.PaymentMethod{
+		ID:    uuid.New(),
+		PspID: pspID,
+		Rail:  models.RailNMI,
+	})
+	if method.PSPID != pspID.String() {
+		t.Fatalf("PSPID = %q, want %q", method.PSPID, pspID)
+	}
+}
+
+func TestPaymentMethodFromModelDoesNotExposeNilUUIDSentinel(t *testing.T) {
+	method := paymentMethodFromModel(&models.PaymentMethod{ID: uuid.New(), Rail: models.RailNMI})
+	if method.PSPID != "" {
+		t.Fatalf("PSPID = %q, want empty identity", method.PSPID)
+	}
+}

--- a/pkg/service/service_user.go
+++ b/pkg/service/service_user.go
@@ -162,8 +162,13 @@ func (s *Service) ListCheckoutRailOptions(ctx context.Context, priceRef string) 
 	}
 	result := make([]CheckoutRailOption, 0, len(options))
 	for _, option := range options {
+		pspID := ""
+		if option.PSPID != uuid.Nil {
+			pspID = option.PSPID.String()
+		}
 		result = append(result, CheckoutRailOption{
 			Selector: option.Selector,
+			PSPID:    pspID,
 			Rail:     option.Rail,
 			Mode:     option.Mode,
 		})
@@ -1355,10 +1360,15 @@ func paymentFromModel(p *models.Payment) Payment {
 }
 
 func paymentMethodFromModel(pm *models.PaymentMethod) PaymentMethod {
+	pspID := ""
+	if pm.PspID != uuid.Nil {
+		pspID = pm.PspID.String()
+	}
 	result := PaymentMethod{
 		ID:      api.FormatPaymentMethodID(pm.ID),
 		Type:    "card",
 		Rail:    string(pm.Rail),
+		PSPID:   pspID,
 		Created: api.ToUnix(pm.CreatedAt),
 	}
 	if pm.LastFour != nil || pm.CardType != nil {

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -90,10 +90,12 @@ type RecurringInfo struct {
 // -------------------------------- Checkout Sessions --------------------------------
 
 // CheckoutRailOption is a locally ready payment-provider choice for a price.
-// Selector is the exact value accepted by CheckoutPayment.Rail; Rail is the
+// Selector is the exact value accepted by CheckoutPayment.Rail; PSPID is the
+// stable provider identity used for server-side method matching; Rail is the
 // canonical gateway and Mode is "one_off" or "subscription".
 type CheckoutRailOption struct {
 	Selector string
+	PSPID    string
 	Rail     string
 	Mode     string
 }
@@ -148,7 +150,7 @@ type CheckoutPayment struct {
 // CheckoutSession represents a checkout session.
 type CheckoutSession struct {
 	ID             string
-	Status         string // "created", "requires_action", "succeeded", "failed", "expired"
+	Status         string // "created", "requires_action", "succeeded", "failed", "expired", "canceled"
 	Mode           string // "subscription", "one_off"
 	PriceID        string
 	Amount         int64
@@ -321,6 +323,7 @@ type PaymentMethod struct {
 	ID             string
 	Type           string // "card"
 	Rail           string // "nmi", "ccbill", "stripe", etc.
+	PSPID          string // Exact payment-provider account that vaulted the method
 	Created        int64  // Unix epoch seconds
 	BillingDetails *BillingDetails
 	Card           *CardDetails

--- a/web/admin/pnpm-lock.yaml
+++ b/web/admin/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   ip-address: ^10.3.1
   brace-expansion: ^5.0.9
   js-yaml: ^4.3.1
+  nanoid: ^3.3.17
 
 importers:
 
@@ -1867,8 +1868,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4288,7 +4289,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -4436,7 +4437,7 @@ snapshots:
 
   postcss@8.5.24:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/web/admin/pnpm-workspace.yaml
+++ b/web/admin/pnpm-workspace.yaml
@@ -12,6 +12,7 @@ overrides:
   ip-address: ^10.3.1 # GHSA-mwp4-54f8-5fhr
   brace-expansion: ^5.0.9 # GHSA-rgw5-rvv9-x895
   js-yaml: ^4.3.1 # GHSA-5p4m-2wfm-xmqj (dragged in by cosmiconfig)
+  nanoid: ^3.3.17 # CVE-2026-67213
 
 pmOnFail: error
 ignoreScripts: true


### PR DESCRIPTION
## Summary

- bind checkout options and saved methods to exact PSP identities
- fail closed when provider resolution is unavailable or ambiguous
- expose exact checkout provider options to embedded hosts
- route existing subscription changes through their persisted PSP

## Validation

- go test ./...
- OpenRails SaaS go test ./... against the local engine workspace
- git diff --check