### PR TITLE
Assert the unarmed-rail refusal by its current wording

### DIFF
--- a/cmd/openrails/runserver_mode1_integration_test.go
+++ b/cmd/openrails/runserver_mode1_integration_test.go
@@ -243,12 +243,17 @@ func TestRunServerMode1BootArmsNMIPSPFromManifest(t *testing.T) {
 		return resp.StatusCode, string(respBody)
 	}
 
+	// The refusal both assertions pivot on. Held in one place because they are
+	// two halves of one contract — an unarmed rail says this, an armed one does
+	// not — and drifted apart once when the wording changed on only one side.
+	const unarmedRailRefusal = "has no armed PSP"
+
 	status, respBody := checkout("stripe")
 	require.Equal(t, http.StatusBadRequest, status, "unarmed rail must be refused: %s", respBody)
-	require.Contains(t, respBody, "unsupported rail")
+	require.Contains(t, respBody, unarmedRailRefusal)
 
 	status, respBody = checkout("nmi")
-	require.NotContains(t, respBody, "unsupported rail",
+	require.NotContains(t, respBody, unarmedRailRefusal,
 		"manifest-armed NMI must pass checkout-rail readiness (status %d)", status)
 	require.NotEqual(t, http.StatusUnauthorized, status, "user token must verify: %s", respBody)
 	require.NotEqual(t, http.StatusForbidden, status, "user token must authorize: %s", respBody)


### PR DESCRIPTION
## Summary

`fb04f51e` (#266) reworded the unarmed-PSP refusal from `unsupported rail` to
`payment rail %q has no armed PSP`, but the mode-1 boot integration test still asserted the old
string, leaving `Validate Code (full)` red on master. The two assertions in that test are two halves
of one contract — an unarmed rail says this, an armed one does not — so they now share a single
constant instead of repeating the literal on both sides, which is how they drifted.

`unsupported rail` is still live elsewhere and those assertions are untouched.

## Verification

- `go test -tags integration ./cmd/openrails/` passes (was failing on
  `TestRunServerMode1BootArmsNMIPSPFromManifest`)
- `go vet -tags integration ./cmd/openrails/` clean