### PR TITLE
Keep naming the rail on candidates that fail resolution

### DIFF
--- a/embed/checkout_psp_selector_integration_test.go
+++ b/embed/checkout_psp_selector_integration_test.go
@@ -86,17 +86,22 @@ func TestCheckoutPreGate_PSPKeySelector(t *testing.T) {
 		return resp.StatusCode, string(raw)
 	}
 
+	// The pre-gate's refusal for a rail with nothing armed. Named once: the
+	// negative assertions below only guard the gate while they spell it the
+	// same way the positive one does.
+	const unarmedRailRefusal = "has no armed PSP"
+
 	// PSP key: passes the gate, fails deeper on the fabricated price.
 	status, raw := post("mobius-sandbox")
 	require.Equal(t, http.StatusBadRequest, status, raw)
-	require.NotContains(t, raw, "unsupported rail", "PSP key must pass the pre-gate")
+	require.NotContains(t, raw, unarmedRailRefusal, "PSP key must pass the pre-gate")
 	require.NotContains(t, raw, "ambiguous rail")
 	require.Contains(t, raw, "price not found", raw)
 
 	// Rail kind with exactly one armed PSP: still accepted.
 	status, raw = post("ccbill")
 	require.Equal(t, http.StatusBadRequest, status, raw)
-	require.NotContains(t, raw, "unsupported rail", "unambiguous rail kind must pass the pre-gate")
+	require.NotContains(t, raw, unarmedRailRefusal, "unambiguous rail kind must pass the pre-gate")
 	require.Contains(t, raw, "price not found", raw)
 
 	// Rail kind with two armed PSPs: rejected, NAMING the keys.
@@ -114,5 +119,5 @@ func TestCheckoutPreGate_PSPKeySelector(t *testing.T) {
 	// Rail kind with nothing armed: rejected (fail closed).
 	status, raw = post("solana")
 	require.Equal(t, http.StatusBadRequest, status, raw)
-	require.Contains(t, raw, "unsupported rail", raw)
+	require.Contains(t, raw, unarmedRailRefusal, raw)
 }

--- a/embed/manifest_mode_integration_test.go
+++ b/embed/manifest_mode_integration_test.go
@@ -649,7 +649,7 @@ func TestManifestMode_CheckoutPreGateAcceptsDBArmedRail(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode, string(raw))
-	require.NotContains(t, string(raw), "unsupported rail", "the ccbill pre-gate must pass: an active manifest/DB-armed ccbill account exists")
+	require.NotContains(t, string(raw), "has no armed PSP", "the ccbill pre-gate must pass: an active manifest/DB-armed ccbill account exists")
 	require.Contains(t, string(raw), "price not found", "past the pre-gate, the request fails deeper on the fabricated price_id")
 }
 

--- a/internal/modules/checkout/routing.go
+++ b/internal/modules/checkout/routing.go
@@ -170,6 +170,18 @@ func targetPSPID(target railTarget) uuid.UUID {
 	return target.Scope.ID
 }
 
+// unresolvedRailTarget is what a candidate knows about itself when resolution
+// failed. A bare rail kind ("stripe") is its own rail, so the trace can still
+// name it; a PSP key ("mobius") that did not resolve has no discoverable rail,
+// and an empty one is honest rather than guessed.
+func unresolvedRailTarget(selector string) railTarget {
+	name := strings.ToLower(strings.TrimSpace(selector))
+	if _, ok := knownRails[name]; !ok {
+		return railTarget{}
+	}
+	return railTarget{PSP: name, Rail: name}
+}
+
 // routingOrder resolves the candidate order for these inputs: the first
 // matching merchant rule, else the built-in default.
 func (s *CheckoutSessionService) routingOrder(ctx context.Context, in RoutingInput) ([]string, string, *int, error) {
@@ -241,20 +253,25 @@ func (s *CheckoutSessionService) evaluateCandidate(ctx context.Context, targets 
 		var ambiguous *AmbiguousRailError
 		var unarmed *UnarmedRailError
 		var unknown *UnknownRailError
+		// A skipped candidate still reports which rail it was: the trace lists
+		// every candidate in order with its skip class, and support reads it.
+		// Resolution failure is why the rail is unusable, not grounds to stop
+		// naming it — a bare rail kind names itself even when nothing is armed.
+		skipped := unresolvedRailTarget(selector)
 		switch {
 		case errors.As(err, &ambiguous):
-			return railTarget{}, models.CheckoutRoutingSkipAmbiguousSelector
+			return skipped, models.CheckoutRoutingSkipAmbiguousSelector
 		case errors.As(err, &unarmed):
-			return railTarget{}, models.CheckoutRoutingSkipNotArmed
+			return skipped, models.CheckoutRoutingSkipNotArmed
 		case errors.As(err, &unknown):
 			// A key that resolves to nothing may still be DECLARED and archived.
 			// Say "retired", not "never heard of it" — support reads this.
 			if targets.pspKeyArchived(ctx, selector) {
-				return railTarget{}, models.CheckoutRoutingSkipNotArmed
+				return skipped, models.CheckoutRoutingSkipNotArmed
 			}
-			return railTarget{}, models.CheckoutRoutingSkipUnknownSelector
+			return skipped, models.CheckoutRoutingSkipUnknownSelector
 		default:
-			return railTarget{}, models.CheckoutRoutingSkipResolveFailed
+			return skipped, models.CheckoutRoutingSkipResolveFailed
 		}
 	}
 	accountID := ""


### PR DESCRIPTION
## Summary

`fb04f51e` (#266) introduced `UnarmedRailError`, so an unarmed rail now fails resolution instead of
resolving rail-scoped. `evaluateCandidate` returns an empty `railTarget{}` on every resolution
error, so skipped candidates lost their rail: the default routing trace came back as
`["", "nmi", "ccbill", ""]` instead of `["stripe", "nmi", "ccbill", "solana"]`. `RoutingCandidate.Rail`
is `omitempty`, so the field simply vanished from the trace support reads.

A candidate that failed to resolve now still reports the rail when the selector is a bare rail kind,
which names itself. An unresolved PSP key has no discoverable rail and stays empty rather than
guessed.

Also updates three `embed` assertions still spelling the pre-gate refusal the old way. Two were
`NotContains` guards that still passed but had stopped guarding anything, since a real rejection now
says `has no armed PSP`.

## Verification

- `go test -tags integration ./embed/ ./internal/modules/checkout/ ./cmd/openrails/` all pass
  (`TestCheckoutRoutingDefaultOrderMatchesLegacyPreference` and `TestCheckoutPreGate_PSPKeySelector`
  were failing on master)
- `go vet -tags integration` clean on both packages